### PR TITLE
fix: load ajv-formats in CI to satisfy AJV v8 strict mode format keywords

### DIFF
--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -68,7 +68,7 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Install AJV CLI
-        run: npm install -g ajv-cli@5.0.0
+        run: npm install -g ajv-cli@5.0.0 ajv-formats
 
       - name: Start schema validation timer
         run: echo "CI_JOB_START=$(date +%s)" >> $GITHUB_ENV
@@ -87,6 +87,7 @@ jobs:
                 ajv validate \
                   -s schemas/marketplace.schema.json \
                   -d .claude-plugin/marketplace.json \
+                  -c ajv-formats \
                   --strict=true \
                   --all-errors
                 echo "::endgroup::"
@@ -114,6 +115,7 @@ jobs:
                   ajv validate \
                     -s schemas/plugin.schema.json \
                     -d "$manifest" \
+                    -c ajv-formats \
                     --strict=true \
                     --all-errors
                 done
@@ -149,6 +151,7 @@ jobs:
                   ajv validate \
                     -s schemas/marketplace.schema.json \
                     -d examples/marketplace.example.json \
+                    -c ajv-formats \
                     --strict=true \
                     --all-errors
                 fi
@@ -160,6 +163,7 @@ jobs:
                   ajv validate \
                     -s schemas/plugin.schema.json \
                     -d "$example" \
+                    -c ajv-formats \
                     --strict=true \
                     --all-errors
                 done
@@ -438,7 +442,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install AJV CLI
-        run: npm install -g ajv-cli@5.0.0
+        run: npm install -g ajv-cli@5.0.0 ajv-formats
 
       - name: Start contract drift timer
         run: echo "CI_JOB_START=$(date +%s)" >> $GITHUB_ENV


### PR DESCRIPTION
The validate-schemas workflow used ajv-cli@5.0.0 (AJV v8) with --strict=true but did not install or load ajv-formats. AJV v8 strict mode rejects unknown format keywords such as 'email' in schemas/plugin.schema.json, causing the validate-schemas job to fail on all PRs. Fix: install ajv-formats alongside ajv-cli and pass -c ajv-formats to all ajv validate calls that use --strict=true.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/yellow-plugins/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix schema validation failures in CI by installing `ajv-formats` and updating validation commands in `validate-schemas.yml`.
> 
>   - **Behavior**:
>     - Install `ajv-formats` alongside `ajv-cli@5.0.0` in `validate-schemas.yml`.
>     - Update `ajv validate` commands to include `-c ajv-formats` for strict mode validation.
>   - **Files**:
>     - Changes in `validate-schemas.yml` to fix schema validation failures due to unknown format keywords.
>     - Updates in `validate-schemas.yml` for marketplace, plugins, contracts, and examples validation steps.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=KingInYellows%2Fyellow-plugins&utm_source=github&utm_medium=referral)<sup> for 42c5ca9631adee0551bfc42297255f0a5a26a637. You can [customize](https://app.ellipsis.dev/KingInYellows/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed schema validation failures in CI by installing `ajv-formats` package and passing `-c ajv-formats` to all `ajv validate` commands using `--strict=true`. AJV v8 strict mode rejects unknown format keywords like `email`, `uri`, and `date-time` without the ajv-formats plugin. The fix targets all four validation scenarios: marketplace, plugins, and examples schemas.

- Installs `ajv-formats` alongside `ajv-cli@5.0.0` in both the `validate-schemas` and `contract-drift` jobs
- Adds `-c ajv-formats` flag to marketplace schema validation (line 90)
- Adds `-c ajv-formats` flag to plugin schema validation (line 118)
- Adds `-c ajv-formats` flag to example marketplace validation (line 154)
- Adds `-c ajv-formats` flag to example plugin validation (line 166)
- Contract validation commands (lines 493, 501) correctly omit the flag since they don't use `--strict=true`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly addresses a well-defined CI issue by adding the required ajv-formats dependency and configuration flags. All strict mode validation calls have been updated consistently, and non-strict validation calls correctly omit the flag. The change is minimal, targeted, and follows AJV v8 best practices.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/validate-schemas.yml | Added `ajv-formats` installation and `-c ajv-formats` flag to all strict mode validations to fix AJV v8 format keyword errors |

</details>



<sub>Last reviewed commit: 42c5ca9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->