### PR TITLE
docs: capture session learnings — AJV strict mode and CRLF PR merge unblocking

### DIFF
--- a/docs/solutions/build-errors/ajv-cli-v8-strict-mode-unknown-format.md
+++ b/docs/solutions/build-errors/ajv-cli-v8-strict-mode-unknown-format.md
@@ -1,0 +1,127 @@
+---
+title: "AJV CLI v8 strict mode rejects format keywords without ajv-formats"
+category: build-errors
+date: 2026-02-17
+tags:
+  - ajv
+  - ajv-cli
+  - json-schema
+  - ci
+  - github-actions
+  - schema-validation
+problem_type: ci-configuration
+components:
+  - .github/workflows/validate-schemas.yml
+  - schemas/plugin.schema.json
+severity:
+  critical: 1
+  important: 0
+  nice_to_have: 0
+  total: 1
+---
+
+# AJV CLI v8 strict mode rejects format keywords without ajv-formats
+
+## Problem Symptom
+
+All CI schema validation jobs fail with:
+
+```
+schema schemas/plugin.schema.json is invalid
+error: unknown format "email" ignored in schema at path
+       "#/properties/author/oneOf/1/properties/email"
+Process completed with exit code 1.
+```
+
+Every PR triggers `UNSTABLE` CI status on the `Validate Schemas` jobs (marketplace, plugins, examples targets).
+
+## Root Cause
+
+`ajv-cli@5.0.0` uses AJV v8 internally. AJV v8 in **strict mode** (`--strict=true`) treats unregistered format keywords as errors instead of silently ignoring them. The format `"email"` in the plugin schema requires the `ajv-formats` plugin to be registered — but it was not being loaded.
+
+The CI workflow installed `ajv-cli` globally but did not install or load `ajv-formats`:
+
+```yaml
+# ❌ What was in CI — missing ajv-formats
+- name: Install AJV CLI
+  run: npm install -g ajv-cli@5.0.0
+
+# ajv validate calls used --strict=true without -c ajv-formats
+ajv validate \
+  -s schemas/plugin.schema.json \
+  -d "$manifest" \
+  --strict=true \
+  --all-errors
+```
+
+The TypeScript infrastructure code (`packages/infrastructure/src/validation/ajvFactory.ts`) correctly loaded `ajv-formats` via `applyFormats(this.ajv)`, but this only applied to the Node.js validation scripts — not the `ajv` CLI binary used in CI.
+
+## Working Solution
+
+Install `ajv-formats` alongside `ajv-cli` and pass `-c ajv-formats` to all `ajv validate` calls that use `--strict=true`.
+
+### Step 1: Update the `Install AJV CLI` steps
+
+Both `validate-schemas` job and `contract-drift` job install `ajv-cli`. Pin `ajv-formats` version for reproducibility:
+
+```yaml
+- name: Install AJV CLI
+  run: npm install -g ajv-cli@5.0.0 ajv-formats@3.0.1
+```
+
+### Step 2: Add `-c ajv-formats` to every `ajv validate --strict=true` call
+
+```yaml
+# Marketplace validation
+ajv validate \
+  -s schemas/marketplace.schema.json \
+  -d .claude-plugin/marketplace.json \
+  -c ajv-formats \
+  --strict=true \
+  --all-errors
+
+# Plugin manifest validation (in loop)
+ajv validate \
+  -s schemas/plugin.schema.json \
+  -d "$manifest" \
+  -c ajv-formats \
+  --strict=true \
+  --all-errors
+
+# Example files
+ajv validate \
+  -s schemas/marketplace.schema.json \
+  -d examples/marketplace.example.json \
+  -c ajv-formats \
+  --strict=true \
+  --all-errors
+
+ajv validate \
+  -s schemas/plugin.schema.json \
+  -d "$example" \
+  -c ajv-formats \
+  --strict=true \
+  --all-errors
+```
+
+### How `-c` works in ajv-cli v5
+
+The `-c` flag tells ajv-cli to `require(module)(ajv)` — it loads the module and calls it with the ajv instance. `ajv-formats` exports `function addFormats(ajv, opts)`, so this works directly.
+
+The module must be resolvable from the global node_modules where ajv-cli is installed. Installing both with `npm install -g ajv-cli ajv-formats` puts them in the same global prefix.
+
+## Alternative: Remove format keyword from schema
+
+If you don't need email format validation, remove `"format": "email"` from the schema entirely. AJV v8 strict mode only complains about unknown formats that appear in schemas — if the keyword isn't there, no error.
+
+## Prevention
+
+- When upgrading from `ajv-cli@4.x` (AJV v6) to `ajv-cli@5.x` (AJV v8), always check for format keywords in your schemas. AJV v6 silently ignored unknown formats; AJV v8 strict mode treats them as errors.
+- Pair `ajv-cli@5` installs with `ajv-formats` in any CI workflow using `--strict=true`.
+- Consider linting the CI workflow YAML to ensure both packages are always installed together.
+
+## Related
+
+- AJV v8 migration guide: https://ajv.js.org/v8-migration.html#formats
+- ajv-formats package: https://www.npmjs.com/package/ajv-formats
+- PR #21 in yellow-plugins: `fix: load ajv-formats in CI to satisfy AJV v8 strict mode format keywords`

--- a/docs/solutions/workflow/wsl2-crlf-pr-merge-unblocking.md
+++ b/docs/solutions/workflow/wsl2-crlf-pr-merge-unblocking.md
@@ -1,0 +1,238 @@
+---
+title: "Unblocking stuck PRs: CRLF git conflicts, mergeStateStatus, and multi-round conflict resolution"
+category: workflow
+date: 2026-02-17
+tags:
+  - git
+  - crlf
+  - wsl2
+  - merge-conflicts
+  - github-pr
+  - graphite
+  - worktree
+problem_type: workflow
+components:
+  - git worktrees
+  - github PR merge state machine
+  - WSL2 line endings
+severity:
+  critical: 2
+  important: 3
+  nice_to_have: 1
+  total: 6
+---
+
+# Unblocking stuck PRs: CRLF git conflicts, mergeStateStatus, and multi-round conflict resolution
+
+## Problem Symptoms
+
+Multiple PRs fail to merge with various blocking states:
+- `mergeStateStatus: DIRTY` — merge conflicts preventing merge
+- `mergeStateStatus: UNSTABLE` — CI checks failing
+- `git merge` / `git rebase` fails with `error: Your local changes to the following files would be overwritten` even though `git status` shows a clean working tree
+- `git rebase` fails with `error: cannot rebase: You have unstaged changes`
+- 80+ files appear as modified (`_M` in `git status`) after a stash/checkout despite no intentional changes
+
+## Root Causes
+
+### 1. WSL2 CRLF files blocking git operations
+
+When files are **committed with CRLF** line endings in a branch (typically because the Write tool on WSL2 creates CRLF files), but `.gitattributes` specifies `eol=lf`, git enters a confused state:
+
+- `git status` reports the working tree as clean (compares working tree to index, both CRLF)
+- `git merge origin/main` reports "Your local changes to the following files would be overwritten" (because git tries to normalize before merging and sees a difference between the CRLF-stored blob and the expected LF-normalized version)
+- `git stash` may appear to save the changes but the working tree still shows unstaged changes afterward
+
+This is a **stat cache invalidation + text normalization** mismatch: the index cached stat entries don't reflect that git wants LF but has CRLF.
+
+### 2. DIRTY mergeStateStatus from actual conflicts
+
+When multiple PRs target the same files and merge to main in sequence, a branch that was previously conflict-free can become `DIRTY` after each new merge. This requires multiple rounds of conflict resolution.
+
+### 3. Stash list shared across worktrees
+
+Git's stash list is global — stashes from one worktree are visible and can be accidentally dropped from another worktree. Stash `stash@{0}` in one worktree context is the same stash as in another.
+
+## GitHub PR mergeStateStatus Reference
+
+| Status | Meaning | Can merge via API? |
+|--------|---------|-------------------|
+| `CLEAN` | Ready to merge | Yes |
+| `UNSTABLE` | CI failing, but not a required check | Yes (if branch protection allows) |
+| `BLOCKED` | Required status check failing | No |
+| `DIRTY` | Merge conflicts exist | No |
+| `DRAFT` | PR is draft | No (mark ready first) |
+| `UNKNOWN` | State being recalculated | Try and see |
+| `BEHIND` | Branch is behind base branch | May need rebase/update |
+
+**Key insight**: `UNSTABLE` means CI failed but the checks are not required by branch protection rules. If `branch protection = {}` (empty), all `UNSTABLE` PRs are mergeable.
+
+Check branch protection:
+```bash
+gh api repos/OWNER/REPO/branches/main/protection 2>&1
+# {} means no required checks
+```
+
+Check PR merge state:
+```bash
+gh pr view NUMBER --json mergeStateStatus,mergeable
+```
+
+## Working Solutions
+
+### Fix WSL2 CRLF blocking merge/rebase
+
+When `git merge` or `git rebase` fails with "unstaged changes" but `git status` is clean:
+
+```bash
+# Step 1: Identify affected files
+git status --short  # Look for _M (unstaged modifications)
+
+# Step 2: Convert CRLF to LF in working tree
+git status --short | awk '{print $2}' | xargs -I{} sed -i 's/\r$//' {}
+
+# Step 3: Stage the normalization
+git add -u
+
+# Step 4: Commit as a separate normalization commit
+git commit -m "chore: normalize CRLF to LF line endings per .gitattributes"
+
+# Step 5: Now merge/rebase can proceed
+git merge origin/main
+```
+
+If there are still many CRLF files after targeting them individually, use `git add --renormalize .` to normalize ALL tracked files and stage them.
+
+**Alternative for fresh checkout**: `git stash drop` all pending stashes first, then retry — stash interference can also cause this symptom.
+
+### Resolve multi-round merge conflicts
+
+When a PR has conflicts that evolve as other PRs merge to main:
+
+```bash
+# Round 1: Check what conflicts exist
+git merge origin/main 2>&1
+
+# Resolve conflicts (see below for file-specific decisions)
+git checkout HEAD -- file1.md file2.json  # keep our version
+git checkout origin/main -- file3.sh      # take their version
+# or manually edit conflict markers
+
+# Stage resolved files
+git add <resolved files>
+git commit --no-edit  # creates merge commit
+
+# Push
+git push origin branch-name
+
+# Wait a few seconds for GitHub to recalculate mergeability
+sleep 5
+gh pr view NUMBER --json mergeStateStatus
+
+# If new PRs merged in the meantime, repeat:
+git fetch origin main
+git merge origin/main 2>&1
+# ... resolve again
+```
+
+**Multi-round example** from this session:
+1. PR #17 was `DIRTY` vs main at `e23f4e5` → resolved `docs/plugin-template.md`, `examples/plugin-minimal.example.json`
+2. PRs #18 and #19 merged → PR #17 became `DIRTY` again vs new main
+3. Second resolution: `.github/workflows/validate-schemas.yml` (ajv version), `plugins/gt-workflow/.claude-plugin/plugin.json` (merge structured author + hooks), `smart-submit.md`, `scripts/export-ci-metrics.sh`
+
+### Merge conflicts in the same file modified by two PRs
+
+When both branches modified the same file (e.g., `validate-schemas.yml`), identify which version is "better":
+
+- **Pinned version** (`ajv-formats@3.0.1`) is better than unpinned (`ajv-formats`) → use HEAD
+- **Both add the same logical feature** → use HEAD, verify no content is lost
+- **One adds extra lines** → manually merge (keep both additions)
+
+```bash
+# Check HEAD version
+git show HEAD:path/to/file | grep pattern
+
+# Check origin/main version
+git show origin/main:path/to/file | grep pattern
+
+# If HEAD is better, use HEAD
+git checkout HEAD -- path/to/file
+
+# If origin/main is better, use their version
+git checkout origin/main -- path/to/file
+
+# If need manual merge, look at the conflict markers:
+grep -n "^<<<<<<\|^=======\|^>>>>>>>" file
+```
+
+### Merge draft PRs
+
+Draft PRs cannot be merged via API even if MERGEABLE:
+
+```bash
+# Mark ready first
+gh pr ready NUMBER
+
+# Then merge
+gh pr merge NUMBER --squash
+```
+
+### Merge UNSTABLE PRs (pre-existing CI failures)
+
+When CI failures are pre-existing/unrelated to the PR content, merge directly:
+
+```bash
+gh pr merge NUMBER --squash
+# GitHub API will succeed for UNSTABLE when no required checks exist
+```
+
+## Prevention
+
+### Prevent CRLF files from being committed
+
+Ensure `.gitattributes` is set up AND that files are normalized before commit:
+
+```gitattributes
+* text=auto eol=lf
+*.md text eol=lf
+*.json text eol=lf
+*.sh text eol=lf
+```
+
+After writing files with the Write tool on WSL2, normalize before staging:
+```bash
+sed -i 's/\r$//' path/to/file.sh
+git add path/to/file.sh
+```
+
+Or use `git add --renormalize <file>` which normalizes per gitattributes before staging.
+
+### Merge PRs in the right order to minimize conflicts
+
+When multiple PRs modify the same files, merge the smallest/most targeted PR first:
+1. Merge targeted fixes (small PRs touching few files)
+2. Merge feature additions (medium PRs)
+3. Merge comprehensive refactors (large PRs touching many files) last
+
+This reduces the number of conflict resolution rounds needed.
+
+### Don't use `git checkout branch -- .` to inspect files
+
+This copies ALL files from the other branch into the current working tree and stages them. Instead:
+
+```bash
+# ✅ Safe: inspect a single file from another branch
+git show other-branch:path/to/file.ext
+
+# ✅ Safe: inspect full tree in isolated environment
+git worktree add /tmp/inspect-branch other-branch
+
+# ❌ Dangerous: copies entire branch into current working tree
+git checkout other-branch -- .
+```
+
+## Related
+
+- See `docs/solutions/build-errors/ajv-cli-v8-strict-mode-unknown-format.md` — CI fix for related PRs
+- See `MEMORY.md` → "CRLF on WSL2" pattern
+- PR #17 (yellow-plugins): Multi-round conflict resolution example


### PR DESCRIPTION
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/yellow-plugins/pull/22" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds documentation for AJV CLI v8 strict mode issues and CRLF git conflicts, providing solutions and prevention strategies.
> 
>   - **AJV CLI v8 strict mode issue**:
>     - Adds `ajv-cli-v8-strict-mode-unknown-format.md` documenting CI failures due to AJV v8 strict mode rejecting unregistered format keywords.
>     - Solution involves installing `ajv-formats` alongside `ajv-cli` and using `-c ajv-formats` in validation calls.
>     - Alternative solution: remove format keyword from schema if not needed.
>   - **CRLF git conflicts and mergeStateStatus**:
>     - Adds `wsl2-crlf-pr-merge-unblocking.md` documenting issues with CRLF line endings causing git merge/rebase failures.
>     - Provides solutions for fixing CRLF issues, resolving multi-round merge conflicts, and handling GitHub PR mergeStateStatus.
>     - Prevention strategies include setting up `.gitattributes` and merging PRs in the right order.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=KingInYellows%2Fyellow-plugins&utm_source=github&utm_medium=referral)<sup> for 4871142e3ec0e3b6eafba0ef2165eeeb0695d562. You can [customize](https://app.ellipsis.dev/KingInYellows/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds two new documentation files under `docs/solutions/` capturing session learnings: one for the AJV CLI v8 strict mode `ajv-formats` fix, and another for WSL2 CRLF line ending issues that block PR merges. Both follow the existing solution doc conventions (YAML frontmatter, problem/root-cause/solution/prevention structure).

- The AJV doc's "Working Solution" examples reference `schemas/marketplace.schema.json`, but the actual CI workflow validates against `schemas/official-marketplace.schema.json` — this should be corrected to avoid misleading readers.
- The CRLF/workflow doc references a `MEMORY.md` file in its "Related" section that does not exist in the repository.
- Both documents are well-structured with accurate root cause analysis and actionable solutions that align with the codebase (verified against `.github/workflows/validate-schemas.yml`, `packages/infrastructure/src/validation/ajvFactory.ts`, and `.gitattributes`).

<h3>Confidence Score: 4/5</h3>

- Documentation-only PR with no code changes; safe to merge after fixing the schema filename references.
- This is a docs-only PR adding solution knowledge base articles. No runtime code is affected. The schema filename discrepancy in the AJV doc is the only actionable issue — it could mislead someone trying to replicate the fix. The broken MEMORY.md reference is minor.
- `docs/solutions/build-errors/ajv-cli-v8-strict-mode-unknown-format.md` — schema filenames in examples don't match the actual CI workflow.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/solutions/build-errors/ajv-cli-v8-strict-mode-unknown-format.md | New documentation capturing AJV CLI v8 strict mode fix. Well-structured with accurate root cause analysis, but the "Working Solution" examples reference `schemas/marketplace.schema.json` instead of the actual `schemas/official-marketplace.schema.json` used in CI — this could mislead users following the guide. |
| docs/solutions/workflow/wsl2-crlf-pr-merge-unblocking.md | Comprehensive documentation on WSL2 CRLF merge-blocking issues and multi-round conflict resolution. Accurate content with helpful `mergeStateStatus` reference table. Minor issue: references a `MEMORY.md` file that doesn't exist in the repository. |

</details>



<h3>Flowchart</h3>

```mermaid
flowchart TD
    A[CI PR Trigger] --> B{ajv validate --strict=true}
    B -->|format keyword found| C{ajv-formats loaded?}
    C -->|No: old config| D[ERROR: unknown format 'email']
    D --> E[mergeStateStatus: UNSTABLE]
    C -->|Yes: -c ajv-formats| F[Validation passes]
    F --> G{Merge conflicts?}
    G -->|CRLF mismatch| H[mergeStateStatus: DIRTY]
    H --> I[Normalize CRLF→LF]
    I --> J[Resolve conflicts]
    G -->|No conflicts| K[mergeStateStatus: CLEAN]
    J --> K
    K --> L[PR mergeable]
```

<sub>Last reviewed commit: 4871142</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - docs/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=63ee1f64-4111-4591-a098-f5919bbd7dcf))

<!-- /greptile_comment -->