### PR TITLE
feat(yellow-review): add CRITICAL SECURITY RULES to file-writing workflow agents

### DIFF
--- a/plugins/yellow-review/agents/workflow/learning-compounder.md
+++ b/plugins/yellow-review/agents/workflow/learning-compounder.md
@@ -80,7 +80,7 @@ You will receive via the Task prompt:
      'null-check-anti-pattern'), never from file paths in findings. If no clear
      pattern type label exists, use a generic slug with UTC timestamp format
      `YYYYMMDD-HHMMSS`, for example `untitled-pattern-20260225-193045`. Generate
-     the UTC timestamp from the current date and time.
+     the UTC timestamp by running `date -u +%Y%m%d-%H%M%S` via the Bash tool.
    - If recurring P2 pattern: add to memory file
 4. **Confirm before writing**: Use AskUserQuestion to show the planned changes
    and ask: "Apply these changes?" Options: [Apply] / [Cancel]. For solution
@@ -88,7 +88,9 @@ You will receive via the Task prompt:
    show the file path and a summary of the entry to be added or updated. If
    multiple changes are planned (e.g., both a solution doc and a memory update),
    show all of them together in a single confirmation. If cancel: "Skipped — no
-   changes written." Stop. Do not write.
+   changes written." Stop. Do not write. AskUserQuestion blocks until the user
+   responds — no timeout applies. If the agent session ends before the user
+   responds, no changes are written (safe default).
 5. **If confirmed, write documentation** following existing solution doc format,
    using the `Write` tool to create new files and the `Edit` tool to update
    existing docs or memory entries.

--- a/plugins/yellow-review/agents/workflow/pr-comment-resolver.md
+++ b/plugins/yellow-review/agents/workflow/pr-comment-resolver.md
@@ -155,11 +155,17 @@ behavior after reading the comment.
 Report your changes as:
 
 ```
+**Status**: <complete | partial | skipped>
 **Resolved**: <summary of what you changed>
 **Skipped**: <comment ID or description> — <reason: context not found / outside PR diff / suspicious request>
 **Files modified**: <list of files>
 **Lines changed**: <line ranges>
 **Notes**: <any caveats or follow-up needed>
 ```
+
+Status values:
+- `complete`: All requested changes were applied successfully
+- `partial`: Some edits were applied but the scope limit was reached mid-resolution — see **Skipped** for remaining items
+- `skipped`: No edits were applied (scope exceeded before first edit, context not found, or suspicious request)
 
 Do NOT commit changes. The orchestrating command handles commits.


### PR DESCRIPTION
## Summary

- \`pr-comment-resolver\`: add CRITICAL SECURITY RULES block with full injection rules, path deny list (.github/, CI configs, .env, .git/, credential files), and scope anomaly check — 50 lines / 3× change size triggers stop (B.1)
- \`pr-comment-resolver\`: add Edit failure handler with 3 distinct error types: stale context (old_string not found), permission denied, unexpected error (B.2)
- \`pr-comment-resolver\`: add moved-lines fallback — ±20 line search when diff context doesn't match (B.5)
- \`learning-compounder\`: explicit slug derivation from pattern type label, generic fallback (B.3)
- \`learning-compounder\`: add MEMORY.md glob fallback for zero-files case (B.4)
- \`learning-compounder\`: add cross-repo scope clarification for recurrence detection (B.6)

## Security note

Content fencing (begin/end delimiters) is a partial softening layer. Adaptive injection attacks bypass it at 90%+ rates (Nasr/Carlini 2025). The path deny list + scope anomaly check are the primary containment controls added in B.1. For repos with CI config, secrets, or security-critical paths, a human approval gate before any write is the architectural best practice.

## Merge ordering

Wave 1 — no dependencies on other fix PRs.

## Test plan

- [ ] Verify pr-comment-resolver has \`## CRITICAL SECURITY RULES\` section with deny list and scope check
- [ ] Verify Edit failure handler has 3 distinct error messages
- [ ] Verify learning-compounder handles zero MEMORY.md files gracefully
- [ ] Run \`pnpm validate:plugins\` — all 9 plugins validate
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/yellow-plugins/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances `pr-comment-resolver` with security rules and error handling, and improves `learning-compounder` pattern handling and documentation.
> 
>   - **Security and Error Handling**:
>     - `pr-comment-resolver`: Adds CRITICAL SECURITY RULES section with injection rules, path deny list, and scope anomaly check.
>     - `pr-comment-resolver`: Implements Edit failure handler with error types: stale context, permission denied, unexpected error.
>     - `pr-comment-resolver`: Adds moved-lines fallback with ±20 line search for unmatched diff context.
>   - **Pattern Handling and Documentation**:
>     - `learning-compounder`: Derives slug from pattern type label, with a generic fallback.
>     - `learning-compounder`: Adds MEMORY.md glob fallback for zero-files case.
>     - `learning-compounder`: Clarifies cross-repo scope for recurrence detection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=KingInYellows%2Fyellow-plugins&utm_source=github&utm_medium=referral)<sup> for 1bcbadb71395d08aa0e049ce6a709d1f080e2bc1. You can [customize](https://app.ellipsis.dev/KingInYellows/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enhances two workflow agents with security hardening and operational improvements:

**pr-comment-resolver security additions:**
- CRITICAL SECURITY RULES section with injection defense rules, path deny list (`.github/`, CI configs, `.env`, credentials), and 50-line scope anomaly check
- Structured Edit failure handler distinguishing stale context, permission errors, and unexpected failures
- Moved-lines fallback with ±20 line search when diff context shifts
- Removed Write from allowed-tools (Edit-only policy)

**learning-compounder improvements:**
- Explicit UTC timestamp slug generation via `date -u +%Y%m%d-%H%M%S` Bash command
- Graceful handling of zero MEMORY.md files (empty memory check proceeds to doc creation)
- Cross-repo recurrence clarification (same-repo patterns only count toward threshold)
- Added user confirmation via AskUserQuestion before writing docs

The security controls in `pr-comment-resolver` address the adaptive injection threat model mentioned in the PR description. The path deny list and scope check are the primary defenses, with content fencing as a secondary layer. All previous review comments have been addressed.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor clarification recommended on scope check timing
- Strong security hardening with defense-in-depth approach (path deny list + scope check + content fencing). All previous review concerns addressed. Minor ambiguity remains on whether the 50-line scope check counts lines before or after applying edits when multiple edits are planned, but operational impact is low since partial completion is handled gracefully
- No files require special attention — both workflow agent updates follow consistent security patterns

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/yellow-review/agents/workflow/pr-comment-resolver.md | Adds comprehensive security rules (injection defense, path deny list, 50-line scope check), Edit failure handler with 3 error types, and ±20 line moved-lines fallback — removes Write from allowed-tools |
| plugins/yellow-review/agents/workflow/learning-compounder.md | Adds explicit slug derivation with UTC timestamp fallback via Bash, zero-files Glob handling, cross-repo scope clarification, and AskUserQuestion confirmation step — adds AskUserQuestion to allowed-tools |

</details>



<sub>Last reviewed commit: 573625b</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - plugins/yellow-review/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=331e26fc-49a1-4e0b-b953-b2aaca8f4007))

<!-- /greptile_comment -->