### PR TITLE
feat(yellow-debt): rewrite triage as prose instructions with AskUserQuestion flow

### DIFF
--- a/plugins/yellow-debt/commands/debt/triage.md
+++ b/plugins/yellow-debt/commands/debt/triage.md
@@ -1,14 +1,14 @@
 ---
 name: debt:triage
-description:
-  'Interactive review and prioritization of pending debt findings. Use when you
-  need to accept, reject, or defer findings from an audit.'
+description: 'Interactive review and prioritization of pending debt findings. Use when you need to accept, reject, or defer findings from an audit.'
 argument-hint: '[--category <name>] [--priority <level>]'
 allowed-tools:
   - Bash
   - Read
-  - Write
   - AskUserQuestion
+  # Note: Write is intentionally absent — all file transitions happen via
+  # transition_todo_state() in validate.sh using Bash shell I/O (>, mv, rm),
+  # not via the Claude Code Write tool.
 ---
 
 # Technical Debt Triage Command
@@ -16,245 +16,192 @@ allowed-tools:
 Interactively review pending technical debt findings and decide to accept
 (ready), reject (deleted), or defer (deferred) each one.
 
-## Arguments
+## Step 1: Prerequisites
 
-- `--category <name>` — Filter to specific category: ai-patterns, complexity,
-  duplication, architecture, security
-- `--priority <level>` — Filter to minimum priority: p1, p2, p3, p4
-
-## Implementation
+Verify `yq` is available and is the kislyuk/yq variant (required for YAML
+frontmatter manipulation — `mikefarah/yq` uses incompatible flags):
 
 ```bash
-#!/usr/bin/env bash
-set -euo pipefail
-
-# Source shared validation library for extract_frontmatter and transition helpers
-# shellcheck source=../../lib/validate.sh
-. "$(dirname "${BASH_SOURCE[0]}")/../../lib/validate.sh"
-
-# Parse arguments
-CATEGORY_FILTER=""
-PRIORITY_FILTER=""
-
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --category)
-      CATEGORY_FILTER="$2"
-      validate_category "$CATEGORY_FILTER" || {
-        printf 'ERROR: Invalid category "%s"\n' "$CATEGORY_FILTER" >&2
-        exit 1
-      }
-      shift 2
-      ;;
-    --priority)
-      PRIORITY_FILTER="$2"
-      case "$PRIORITY_FILTER" in
-        p1|p2|p3|p4) ;;
-        *)
-          printf 'ERROR: Invalid priority "%s". Must be: p1, p2, p3, p4\n' "$PRIORITY_FILTER" >&2
-          exit 1
-          ;;
-      esac
-      shift 2
-      ;;
-    *)
-      printf 'ERROR: Unknown argument "%s"\n' "$1" >&2
-      exit 1
-      ;;
-  esac
-done
-
-# Load all pending todo files
-mapfile -t TODO_FILES < <(find todos/debt -name '*-pending-*.md' 2>/dev/null | sort)
-
-if [ ${#TODO_FILES[@]} -eq 0 ]; then
-  printf 'No pending findings to triage.\n'
-  printf 'Run /debt:audit to generate findings.\n'
-  exit 0
-fi
-
-# Apply filters
-FILTERED_FILES=()
-for todo_path in "${TODO_FILES[@]}"; do
-  # Validate file structure
-  if [ ! -f "$todo_path" ]; then
-    printf '[triage] WARNING: Skipping corrupted file: %s\n' "$todo_path" >&2
-    continue
-  fi
-
-  # Extract frontmatter
-  CATEGORY=$(extract_frontmatter "$todo_path" | yq '.category' 2>/dev/null || echo "")
-  PRIORITY=$(extract_frontmatter "$todo_path" | yq '.priority' 2>/dev/null || echo "")
-
-  # Apply category filter
-  if [ -n "$CATEGORY_FILTER" ] && [ "$CATEGORY" != "$CATEGORY_FILTER" ]; then
-    continue
-  fi
-
-  # Apply priority filter (p1 > p2 > p3 > p4)
-  if [ -n "$PRIORITY_FILTER" ]; then
-    case "$PRIORITY_FILTER" in
-      p1)
-        [ "$PRIORITY" = "p1" ] || continue
-        ;;
-      p2)
-        [[ "$PRIORITY" =~ ^p[12]$ ]] || continue
-        ;;
-      p3)
-        [[ "$PRIORITY" =~ ^p[123]$ ]] || continue
-        ;;
-      p4)
-        # Include all priorities
-        ;;
-    esac
-  fi
-
-  FILTERED_FILES+=("$todo_path")
-done
-
-if [ ${#FILTERED_FILES[@]} -eq 0 ]; then
-  printf 'No pending findings match the filter criteria.\n'
-  exit 0
-fi
-
-# Sort by severity descending (critical first)
-# Note: This is a simplified sort; actual implementation would use yq to extract severity
-
-printf 'Found %d pending finding(s) to triage.\n\n' "${#FILTERED_FILES[@]}"
-
-# Triage loop
-TRIAGED_COUNT=0
-ACCEPTED_COUNT=0
-REJECTED_COUNT=0
-DEFERRED_COUNT=0
-
-for todo_path in "${FILTERED_FILES[@]}"; do
-  # Extract metadata
-  TITLE=$(extract_frontmatter "$todo_path" | yq -r '.title // "Untitled"' 2>/dev/null)
-  CATEGORY=$(extract_frontmatter "$todo_path" | yq -r '.category' 2>/dev/null)
-  SEVERITY=$(extract_frontmatter "$todo_path" | yq -r '.severity' 2>/dev/null)
-  EFFORT=$(extract_frontmatter "$todo_path" | yq -r '.effort' 2>/dev/null)
-  AFFECTED_FILES=$(extract_frontmatter "$todo_path" | yq -r '.affected_files[]' 2>/dev/null | head -1)
-
-  # Display finding
-  printf '═════════════════════════════════════════════════════════════\n'
-  printf 'Finding %d/%d\n' $((TRIAGED_COUNT + 1)) "${#FILTERED_FILES[@]}"
-  printf '═════════════════════════════════════════════════════════════\n'
-  printf 'Title: %s\n' "$TITLE"
-  printf 'Category: %s | Severity: %s | Effort: %s\n' "$CATEGORY" "$SEVERITY" "$EFFORT"
-  printf 'Affected: %s\n\n' "$AFFECTED_FILES"
-
-  # Show code context (±5 lines)
-  printf 'Code Context:\n'
-  FILE_PATH=$(echo "$AFFECTED_FILES" | cut -d: -f1)
-  LINE_RANGE=$(echo "$AFFECTED_FILES" | cut -d: -f2)
-  START_LINE=$(echo "$LINE_RANGE" | cut -d- -f1)
-
-  # Validate START_LINE is numeric before arithmetic expansion
-  if [[ ! "$START_LINE" =~ ^[0-9]+$ ]]; then
-    CONTEXT_START=1
-    CONTEXT_END=15
-  else
-    CONTEXT_START=$((START_LINE > 5 ? START_LINE - 5 : 1))
-    CONTEXT_END=$((START_LINE + 10))
-  fi
-
-  if validate_file_path "$FILE_PATH"; then
-    sed -n "${CONTEXT_START},${CONTEXT_END}p" "$FILE_PATH" | head -15
-  else
-    printf '(invalid or unauthorized file path: %s)\n' "$FILE_PATH"
-  fi
-
-  printf '\n'
-
-  # Read finding description
-  printf 'Finding Description:\n'
-  sed -n '/^## Finding$/,/^## /p' "$todo_path" | sed '$d' | tail -n +2
-  printf '\n'
-
-  # Read suggested remediation
-  printf 'Suggested Remediation:\n'
-  sed -n '/^## Suggested Remediation$/,/^## /p' "$todo_path" | sed '$d' | tail -n +2
-  printf '\n'
-
-  # Decision prompt (use AskUserQuestion in actual implementation)
-  printf 'Decision:\n'
-  printf '  Accept  - Mark as ready for remediation\n'
-  printf '  Reject  - Mark as false positive (will be deleted)\n'
-  printf '  Defer   - Postpone decision with reason\n'
-  printf '\n'
-
-  # Placeholder for AskUserQuestion
-  # In actual implementation, use:
-  # AskUserQuestion with options: Accept / Reject / Defer
-  #
-  # For now, show manual transition command:
-  printf 'To triage this finding, use transition_todo_state:\n'
-  printf '  Accept: transition_todo_state "%s" ready\n' "$todo_path"
-  printf '  Reject: transition_todo_state "%s" deleted\n' "$todo_path"
-  printf '  Defer:  transition_todo_state "%s" deferred\n' "$todo_path"
-  printf '\n'
-
-  TRIAGED_COUNT=$((TRIAGED_COUNT + 1))
-done
-
-# Final summary
-printf '\n═════════════════════════════════════════════════════════════\n'
-printf 'Triage Summary\n'
-printf '═════════════════════════════════════════════════════════════\n'
-printf 'Total processed: %d findings\n' "$TRIAGED_COUNT"
-printf 'Accepted: %d | Rejected: %d | Deferred: %d\n' "$ACCEPTED_COUNT" "$REJECTED_COUNT" "$DEFERRED_COUNT"
-printf '\nNext steps:\n'
-printf '  - Run /debt:fix to remediate accepted findings\n'
-printf '  - Run /debt:status to see current debt levels\n'
+command -v yq >/dev/null 2>&1 || {
+  printf '[debt:triage] Error: yq is required. Install: pip install yq\n' >&2
+  exit 1
+}
+yq --help 2>&1 | grep -qi 'jq wrapper\|kislyuk' || {
+  printf '[debt:triage] Error: kislyuk/yq required (pip install yq). mikefarah/yq is incompatible.\n' >&2
+  exit 1
+}
 ```
 
-## Example Usage
+If the above exits non-zero, stop. Do not proceed.
+
+## Step 2: Discover Findings
+
+Find all pending todo files, anchored to git root:
 
 ```bash
-# Triage all pending findings
-$ARGUMENTS
-
-# Triage only complexity findings
-$ARGUMENTS --category complexity
-
-# Triage high priority findings (p1-p2)
-$ARGUMENTS --priority p2
+GIT_ROOT="$(git rev-parse --show-toplevel)" || {
+  printf '[debt:triage] Error: not inside a git repository\n' >&2
+  exit 1
+}
+find "$GIT_ROOT/todos/debt" -name '*-pending-*.md' 2>/dev/null | sort
 ```
+
+If no files found: report "No pending findings to triage. Run /debt:audit to
+generate findings." and stop.
+
+## Step 3: Parse Arguments and Filter
+
+Parse `$ARGUMENTS` for optional filters:
+
+- `--category <name>` — filter to: ai-patterns, complexity, duplication,
+  architecture, security
+- `--priority <level>` — filter to minimum priority: p1, p2, p3, p4
+
+Guard against `--flag` missing value: if the next argument starts with `--` or
+is empty, report the error and stop.
+
+Apply filters by reading each file's frontmatter. After filtering, if no files
+remain: report "No pending findings match the filter criteria." and stop.
+
+## Step 4: Sort by Severity
+
+Sort filtered findings by severity: critical first, then high, medium, low.
+Extract severity from the filename pattern
+(`{id}-{status}-{severity}-{slug}-{hash}.md`) or from frontmatter if the
+pattern doesn't match.
+
+## Step 5: Pre-Loop Overview (M3 Pattern)
+
+Always present a summary first using AskUserQuestion before starting the loop:
+
+"Found N findings (X critical, Y high, Z medium, W low). Proceed with triage?"
+
+Options:
+- "Yes, start triage"
+- "Cancel"
+
+If user selects Cancel: output "Triage cancelled." and stop. Do not proceed.
+
+## Step 6: Triage Loop
+
+For each finding in severity order, maintain running counts of
+accepted/rejected/deferred in your conversation context (NOT as shell variables
+— each Bash tool call is a separate subprocess).
+
+### Per-Finding Steps
+
+1. **Read the todo file** using the Read tool to get its full content.
+
+2. **Present finding summary** using AskUserQuestion:
+
+   Show the finding title, category, severity, effort, affected files, finding
+   description, and suggested remediation.
+
+   Options:
+   - "Accept — mark as ready for remediation"
+   - "Reject — mark as false positive (will be deleted)"
+   - "Defer — postpone with reason"
+   - "Stop — end triage session"
+
+3. **Handle user choice:**
+
+   In each bash command below, replace `$TODO_PATH` with the actual absolute
+   path of the current finding file (from Step 2's discovery results).
+
+   **On Accept:**
+   ```bash
+   . "${CLAUDE_PLUGIN_ROOT}/lib/validate.sh"
+   transition_todo_state "/absolute/path/to/file.md" ready || {
+     printf '[debt:triage] Error: transition failed\n' >&2
+     exit 1
+   }
+   ```
+   If the above exits non-zero, stop. Report the error. Do not increment any count.
+   Otherwise increment your accepted count.
+
+   **On Reject:**
+   ```bash
+   . "${CLAUDE_PLUGIN_ROOT}/lib/validate.sh"
+   transition_todo_state "/absolute/path/to/file.md" deleted || {
+     printf '[debt:triage] Error: transition failed\n' >&2
+     exit 1
+   }
+   ```
+   If the above exits non-zero, stop. Report the error. Do not increment any count.
+   Otherwise increment your rejected count.
+
+   **On Defer:**
+   Use AskUserQuestion:
+   - Prompt: "Why defer this finding? (Max 200 characters — leave blank to skip reason)"
+   - Options: "Other" / "Cancel — go back without deferring"
+
+   The "Other" option opens a free-text input field — use the entered text as the
+   defer reason.
+
+   **On Defer — Cancel:** Do not run `transition_todo_state`. Return to the
+   same finding's main options (Accept/Reject/Defer/Stop). Do not increment
+   any count.
+
+   **On Defer — Submit reason:** Use a heredoc to pass the reason safely
+   (avoids quoting issues with special characters). Use `__EOF_DEFER_REASON__`
+   as the delimiter (avoids collision if the reason text contains common words).
+   Ensure the closing delimiter is at column 0 with no leading whitespace:
+   ```bash
+. "${CLAUDE_PLUGIN_ROOT}/lib/validate.sh"
+DEFER_REASON=$(cat <<'__EOF_DEFER_REASON__'
+<paste the actual defer reason text verbatim here>
+__EOF_DEFER_REASON__
+)
+DEFER_REASON=$(printf '%s' "$DEFER_REASON" | tr -d '\n\r')
+transition_todo_state "/absolute/path/to/file.md" deferred "$DEFER_REASON" || {
+  printf '[debt:triage] Error: transition failed\n' >&2
+  exit 1
+}
+   ```
+   If the above exits non-zero, stop. Report the error. Do not increment any count.
+   Otherwise increment your deferred count.
+
+   **On Defer — empty reason (blank "Other" input):** Call without third argument:
+   ```bash
+. "${CLAUDE_PLUGIN_ROOT}/lib/validate.sh"
+transition_todo_state "/absolute/path/to/file.md" deferred || {
+  printf '[debt:triage] Error: transition failed\n' >&2
+  exit 1
+}
+   ```
+   If the above exits non-zero, stop. Report the error. Do not increment any count.
+   Otherwise increment your deferred count.
+
+   **On Stop:**
+   Break out of the loop and proceed to the summary.
+
+## Step 7: Final Summary
+
+Present totals:
+
+"Triage complete: N accepted, M rejected, P deferred, Q remaining.
+Run /debt:fix to begin remediation of accepted findings."
 
 ## Triage Decisions
 
 **Accept** → Transitions to `ready` state
-
 - Finding is valid and should be fixed
 - Will appear in `/debt:fix` workflow
 - Can be synced to Linear via `/debt:sync`
 
 **Reject** → Transitions to `deleted` state
-
 - Finding is false positive
 - File will be removed from todos/debt/
 - Can be recovered from git history if needed
 
-**Defer** → Transitions to `deferred` state
-
+**Defer** → Transitions to `deferred` state with reason
 - Valid finding but not addressing now
-- Requires reason and optional date
+- Optional reason (validated: no newlines, max 200 chars)
 - Will be re-evaluated in next audit
-
-## Atomic Transitions
-
-All state changes use the `transition_todo_state()` function from
-`lib/validate.sh` which provides:
-
-- TOCTOU protection via `flock`
-- Transition validation (only legal state changes allowed)
-- Atomic rename (filename prefix updated atomically with frontmatter)
 
 ## Error Recovery
 
 If triage is interrupted:
-
-- All decisions made so far are persisted
+- All decisions made so far are persisted (atomic state transitions via flock)
 - Re-run `/debt:triage` to continue from remaining pending findings
 - Previously triaged items won't be shown again

--- a/plugins/yellow-debt/skills/debt-conventions/SKILL.md
+++ b/plugins/yellow-debt/skills/debt-conventions/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: debt-conventions
-description:
-  Technical debt scoring framework and scanner patterns. Use when scanner agents
-  need scoring rubrics, category definitions, safety rules, or output schemas.
+description: "Technical debt scoring framework and scanner patterns. Use when scanner agents need scoring rubrics, category definitions, safety rules, or output schemas."
 user-invokable: false
 ---
 
@@ -251,7 +249,8 @@ Todo files must use one of the following status values:
 - `ready` — Approved for remediation
 - `in-progress` — Fix work has started
 - `complete` — Fix completed
-- `deferred` — Postponed to future sprint
+- `deferred` — Postponed to future sprint (includes optional `defer_reason`
+  field in frontmatter)
 - `deleted` — Rejected or no longer relevant
 
 **Remediation**: Run `lib/validate.sh` validation functions to check status


### PR DESCRIPTION
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/yellow-plugins/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Rewrites `debt:triage` command to use prose instructions and AskUserQuestion flow, updating `transition_todo_state` and `debt-conventions` for deferred states.
> 
>   - **Behavior**:
>     - Rewrites `debt:triage` command in `triage.md` to use prose instructions and AskUserQuestion flow instead of Bash script.
>     - Introduces structured steps for triage: prerequisites, discovery, filtering, sorting, and user interaction.
>     - Uses AskUserQuestion for user decisions on findings: Accept, Reject, Defer, or Stop.
>   - **Functions**:
>     - Updates `transition_todo_state()` in `validate.sh` to handle `deferred` state with optional `defer_reason`.
>   - **Skills**:
>     - Updates `debt-conventions` in `SKILL.md` to include `defer_reason` and `defer_until` fields for `deferred` status.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=KingInYellows%2Fyellow-plugins&utm_source=github&utm_medium=referral)<sup> for 8da5d0c36ae3e46aa4b942255aaa34e09558e10b. You can [customize](https://app.ellipsis.dev/KingInYellows/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactors the `debt:triage` command from a self-contained bash script to prose instructions that guide Claude through an interactive AskUserQuestion workflow. The `transition_todo_state()` function in `validate.sh` now accepts an optional `defer_reason` parameter that's sanitized (stripped of newlines, truncated to 200 chars) and stored in frontmatter when deferring findings.

**Key improvements:**
- Prose-based instructions enable interactive user decisions via AskUserQuestion instead of hardcoded script logic
- Proper handling of defer reasons with input sanitization
- Atomic state transitions via flock remain intact
- Documentation updated to reflect new `defer_reason` field

**Issues from previous review threads:**
- Path handling, heredoc delimiters, UTF-8 safety, and defer reason validation issues already identified
- Empty defer reason silently deletes existing `defer_reason` field (validate.sh:160)

**New findings:**
- Undefined "M3 Pattern" terminology in Step 5
- Step 3 lacks implementation code for argument parsing/filtering, creating inconsistency with other steps that provide explicit bash commands

<h3>Confidence Score: 3/5</h3>

- Safe to merge with attention to previous review threads — most issues are non-critical documentation and implementation guidance improvements
- Score reflects the architectural shift from script to prose instructions. Several previous review comments identify edge cases (UTF-8 handling, empty defer reasons, truncation feedback) that should be addressed. The new issues found are documentation gaps rather than functional bugs. Core logic is sound with proper error handling and atomic transitions.
- plugins/yellow-debt/commands/debt/triage.md requires clarification on M3 Pattern and argument parsing implementation

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/yellow-debt/commands/debt/triage.md | Rewrites triage command as prose instructions with AskUserQuestion flow. Several previous review comments about path handling, heredoc delimiters, and truncation. New issue: undefined "M3 Pattern" term and missing argument parsing implementation. |
| plugins/yellow-debt/lib/validate.sh | Adds `defer_reason` parameter to `transition_todo_state()` with proper sanitization. Previous comments note potential defer_reason deletion when deferring without reason, and UTF-8 locale dependency. |
| plugins/yellow-debt/skills/debt-conventions/SKILL.md | Updates documentation to include `defer_reason` field for deferred status. Clean documentation change with no issues. |

</details>



<sub>Last reviewed commit: 5205ac7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->