### PR TITLE
fix(yellow-ruvector): replace set -eu with set -uo pipefail and add json_exit helper in all hooks

### DIFF
--- a/plugins/yellow-ruvector/hooks/scripts/session-start.sh
+++ b/plugins/yellow-ruvector/hooks/scripts/session-start.sh
@@ -3,7 +3,19 @@
 # NOTE: SessionStart hooks run in parallel across plugins. This hook must be independent.
 # Receives hook input as JSON on stdin. Must complete within 3 seconds.
 # Uses ruvector's built-in CLI hooks — no manual queue management needed.
-set -eu
+set -uo pipefail
+# Note: -e omitted intentionally — hook must output {"continue": true} on all paths
+
+# --- json_exit: centralized exit for all early-return paths ---
+json_exit() {
+  local msg="${1:-}"
+  [ -n "$msg" ] && printf '[ruvector] %s\n' "$msg" >&2
+  printf '{"continue": true}\n'
+  exit 0
+}
+
+# Require jq for JSON parsing
+command -v jq >/dev/null 2>&1 || json_exit "Warning: jq not found; skipping session-start"
 
 # Read hook input from stdin
 INPUT=$(cat)
@@ -14,8 +26,7 @@ RUVECTOR_DIR="${PROJECT_DIR}/.ruvector"
 
 # Exit silently if ruvector is not initialized in this project
 if [ ! -d "$RUVECTOR_DIR" ]; then
-  printf '{"continue": true}\n'
-  exit 0
+  json_exit
 fi
 
 # Resolve ruvector command: prefer direct binary (62ms) over npx (2700ms)
@@ -24,8 +35,7 @@ if command -v ruvector >/dev/null 2>&1; then
 elif command -v npx >/dev/null 2>&1; then
   RUVECTOR_CMD=(npx --no ruvector)
 else
-  printf '{"continue": true}\n'
-  exit 0
+  json_exit "Warning: neither ruvector nor npx found"
 fi
 
 learnings=""

--- a/plugins/yellow-ruvector/hooks/scripts/stop.sh
+++ b/plugins/yellow-ruvector/hooks/scripts/stop.sh
@@ -1,7 +1,19 @@
 #!/bin/bash
 # stop.sh — Run ruvector's session-end hook for cleanup and metrics export
 # Receives hook input as JSON on stdin. Must complete within 10 seconds.
-set -eu
+set -uo pipefail
+# Note: -e omitted intentionally — hook must output {"continue": true} on all paths
+
+# --- json_exit: centralized exit for all early-return paths ---
+json_exit() {
+  local msg="${1:-}"
+  [ -n "$msg" ] && printf '[ruvector] %s\n' "$msg" >&2
+  printf '{"continue": true}\n'
+  exit 0
+}
+
+# Require jq for JSON parsing
+command -v jq >/dev/null 2>&1 || json_exit "Warning: jq not found; skipping stop"
 
 # Read hook input from stdin
 INPUT=$(cat)
@@ -12,8 +24,7 @@ RUVECTOR_DIR="${PROJECT_DIR}/.ruvector"
 
 # Exit silently if ruvector is not initialized
 if [ ! -d "$RUVECTOR_DIR" ]; then
-  printf '{"continue": true}\n'
-  exit 0
+  json_exit
 fi
 
 # Resolve ruvector command: prefer direct binary (62ms) over npx (2700ms)
@@ -22,8 +33,7 @@ if command -v ruvector >/dev/null 2>&1; then
 elif command -v npx >/dev/null 2>&1; then
   RUVECTOR_CMD=(npx --no ruvector)
 else
-  printf '{"continue": true}\n'
-  exit 0
+  json_exit "Warning: neither ruvector nor npx found"
 fi
 
 # Use ruvector's built-in session-end hook


### PR DESCRIPTION
All 4 hook scripts used set -eu which can exit before printing required
{"continue": true} JSON. Replaced with set -uo pipefail, added json_exit()
helper function, added command -v jq checks, and replaced bare exit 0
calls with json_exit.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/yellow-plugins/pull/78" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces `set -eu` with `set -uo pipefail`, adds `json_exit` function, and checks for `jq` in all yellow-ruvector hook scripts to ensure consistent JSON output and error handling.
> 
>   - **Behavior**:
>     - Replaces `set -eu` with `set -uo pipefail` in all hook scripts to prevent premature exits.
>     - Adds `json_exit()` function to ensure `{"continue": true}` JSON output on all exit paths.
>     - Checks for `jq` command presence in all scripts, exits with warning if not found.
>   - **Scripts**:
>     - `post-tool-use.sh`, `session-start.sh`, `stop.sh`, `user-prompt-submit.sh`: Replace bare `exit 0` with `json_exit()`.
>     - `post-tool-use.sh`, `session-start.sh`, `stop.sh`, `user-prompt-submit.sh`: Add `command -v jq` check and use `json_exit()` if `jq` is missing.
>   - **Misc**:
>     - Minor refactoring for consistent error handling and output across scripts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=KingInYellows%2Fyellow-plugins&utm_source=github&utm_medium=referral)<sup> for ee58d16ce6d7ae9115f222396fc587c49cfafa3b. You can [customize](https://app.ellipsis.dev/KingInYellows/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling consistency across hook scripts for more reliable operation.
  * Enhanced dependency checks with clearer warnings when required tools are unavailable.
  * Fixed exit path handling to ensure graceful behavior and proper output in error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced `set -eu` with `set -uo pipefail` across all 4 hook scripts to prevent premature exit before JSON output, and added a centralized `json_exit()` helper function with early `jq` availability checks.

- Removes `-e` flag that caused immediate exit on error, preventing required `{"continue": true}` JSON output
- Adds `json_exit()` function to standardize early-exit paths with guaranteed JSON output
- Adds `command -v jq` checks to detect missing dependencies before attempting JSON operations
- Replaces all bare `exit 0` preceded by JSON printf with `json_exit` calls

Two files (`session-start.sh` and `user-prompt-submit.sh`) have final `jq` calls without error handling that could still violate the JSON output guarantee if `jq` fails during execution.

<h3>Confidence Score: 4/5</h3>

- This PR is mostly safe to merge with minor edge cases to address
- The changes correctly address the core issue of hooks exiting before JSON output by removing `set -e` and adding a centralized exit handler. However, two files still have unhandled `jq` failures in their final output paths that could violate the hook contract. These are edge cases (jq corruption/OOM) but worth fixing given the PR's purpose.
- `session-start.sh` and `user-prompt-submit.sh` need error handling on final `jq` calls

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/yellow-ruvector/hooks/scripts/post-tool-use.sh | replaced `set -eu` with `set -uo pipefail` and added `json_exit()` helper for guaranteed JSON output on all exit paths |
| plugins/yellow-ruvector/hooks/scripts/stop.sh | replaced `set -eu` with `set -uo pipefail` and added `json_exit()` helper for guaranteed JSON output on all exit paths |
| plugins/yellow-ruvector/hooks/scripts/session-start.sh | replaced `set -eu` with `set -uo pipefail` and added `json_exit()` helper, but final `jq` call on line 71 could fail without outputting JSON |
| plugins/yellow-ruvector/hooks/scripts/user-prompt-submit.sh | replaced `set -eu` with `set -uo pipefail` and added `json_exit()` helper, but final `jq` call on line 78 could fail without outputting JSON |

</details>



<sub>Last reviewed commit: ee58d16</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->