### PR TITLE
fix: correct MCP tool prefixes across 5 plugins and fix overlapping folded scalar descriptions

### DIFF
--- a/plugins/yellow-chatprd/agents/workflow/document-assistant.md
+++ b/plugins/yellow-chatprd/agents/workflow/document-assistant.md
@@ -1,25 +1,20 @@
 ---
 name: document-assistant
 model: inherit
-description: >
-  ChatPRD document management assistant. Use when user wants to create, find,
-  read, or update product documents in ChatPRD. Triggers on "write a PRD",
-  "create a spec", "draft a one-pager", "what does the PRD say about", "find the
-  spec for", "update the requirements", or any ChatPRD document interaction that
-  does NOT involve Linear.
+description: "ChatPRD document management assistant. Use when user wants to create, find, read, or update product documents in ChatPRD. Triggers on \"write a PRD\", \"create a spec\", \"draft a one-pager\", \"what does the PRD say about\", \"find the spec for\", \"update the requirements\", or any ChatPRD document interaction that does NOT involve Linear."
 allowed-tools:
   - Read
   - Grep
   - Bash
   - AskUserQuestion
   - ToolSearch
-  - mcp__plugin_chatprd_chatprd__create_document
-  - mcp__plugin_chatprd_chatprd__update_document
-  - mcp__plugin_chatprd_chatprd__search_documents
-  - mcp__plugin_chatprd_chatprd__list_organization_documents
-  - mcp__plugin_chatprd_chatprd__get_document
-  - mcp__plugin_chatprd_chatprd__list_templates
-  - mcp__plugin_chatprd_chatprd__list_projects
+  - mcp__plugin_yellow-chatprd_chatprd__create_document
+  - mcp__plugin_yellow-chatprd_chatprd__update_document
+  - mcp__plugin_yellow-chatprd_chatprd__search_documents
+  - mcp__plugin_yellow-chatprd_chatprd__list_organization_documents
+  - mcp__plugin_yellow-chatprd_chatprd__get_document
+  - mcp__plugin_yellow-chatprd_chatprd__list_templates
+  - mcp__plugin_yellow-chatprd_chatprd__list_projects
 ---
 
 <examples>

--- a/plugins/yellow-chatprd/agents/workflow/linear-prd-bridge.md
+++ b/plugins/yellow-chatprd/agents/workflow/linear-prd-bridge.md
@@ -1,26 +1,21 @@
 ---
 name: linear-prd-bridge
 model: inherit
-description: >
-  Bridge ChatPRD documents to Linear issues. Use when user explicitly mentions
-  both PRD/document AND Linear together, such as "link PRD to Linear", "create
-  Linear issues from PRD", "create issues from PRD", or "turn this spec into
-  Linear issues". Only triggers when Linear is explicitly mentioned alongside
-  document context.
+description: "Bridge ChatPRD documents to Linear issues. Use when user explicitly mentions both PRD/document AND Linear together, such as \"link PRD to Linear\", \"create Linear issues from PRD\", \"create issues from PRD\", or \"turn this spec into Linear issues\". Only triggers when Linear is explicitly mentioned alongside document context."
 allowed-tools:
   - Read
   - Grep
   - Bash
   - AskUserQuestion
   - ToolSearch
-  - mcp__plugin_chatprd_chatprd__search_documents
-  - mcp__plugin_chatprd_chatprd__get_document
-  - mcp__plugin_linear_linear__create_issue
-  - mcp__plugin_linear_linear__list_teams
-  - mcp__plugin_linear_linear__list_issues
-  - mcp__plugin_linear_linear__list_issue_statuses
-  - mcp__plugin_linear_linear__get_issue
-  - mcp__plugin_linear_linear__update_issue
+  - mcp__plugin_yellow-chatprd_chatprd__search_documents
+  - mcp__plugin_yellow-chatprd_chatprd__get_document
+  - mcp__plugin_yellow-linear_linear__create_issue
+  - mcp__plugin_yellow-linear_linear__list_teams
+  - mcp__plugin_yellow-linear_linear__list_issues
+  - mcp__plugin_yellow-linear_linear__list_issue_statuses
+  - mcp__plugin_yellow-linear_linear__get_issue
+  - mcp__plugin_yellow-linear_linear__update_issue
 ---
 
 <examples>
@@ -55,7 +50,7 @@ mapping and input validation.
 
 ### Step 1: Check Linear MCP Availability
 
-Attempt to call `mcp__plugin_linear_linear__list_teams`:
+Attempt to call `mcp__plugin_yellow-linear_linear__list_teams`:
 
 - If successful: Linear MCP is available, proceed with bridging flow
 - If error "tool not found": report "yellow-linear plugin not installed. Install

--- a/plugins/yellow-chatprd/commands/chatprd/create.md
+++ b/plugins/yellow-chatprd/commands/chatprd/create.md
@@ -1,9 +1,6 @@
 ---
 name: chatprd:create
-description: >
-  Create a new document in ChatPRD. Use when user wants to "write a PRD",
-  "create a spec", "draft a one-pager", "make an API doc", or create any product
-  document in ChatPRD.
+description: "Create a new document in ChatPRD. Use when user wants to \"write a PRD\", \"create a spec\", \"draft a one-pager\", \"make an API doc\", or create any product document in ChatPRD."
 argument-hint: '[description of what to create]'
 allowed-tools:
   - Read
@@ -11,10 +8,10 @@ allowed-tools:
   - Bash
   - AskUserQuestion
   - ToolSearch
-  - mcp__plugin_chatprd_chatprd__create_document
-  - mcp__plugin_chatprd_chatprd__search_documents
-  - mcp__plugin_chatprd_chatprd__list_templates
-  - mcp__plugin_chatprd_chatprd__list_projects
+  - mcp__plugin_yellow-chatprd_chatprd__create_document
+  - mcp__plugin_yellow-chatprd_chatprd__search_documents
+  - mcp__plugin_yellow-chatprd_chatprd__list_templates
+  - mcp__plugin_yellow-chatprd_chatprd__list_projects
 ---
 
 # Create ChatPRD Document

--- a/plugins/yellow-chatprd/commands/chatprd/link-linear.md
+++ b/plugins/yellow-chatprd/commands/chatprd/link-linear.md
@@ -1,9 +1,6 @@
 ---
 name: chatprd:link-linear
-description: >
-  Create Linear issues from a ChatPRD document. Use when user wants to "link PRD
-  to Linear", "create issues from spec", "turn PRD into Linear issues", or
-  bridge any ChatPRD document to Linear.
+description: "Create Linear issues from a ChatPRD document. Use when user wants to \"link PRD to Linear\", \"create issues from spec\", \"turn PRD into Linear issues\", or bridge any ChatPRD document to Linear."
 argument-hint: '[document title or search query]'
 allowed-tools:
   - Read
@@ -11,14 +8,14 @@ allowed-tools:
   - Bash
   - AskUserQuestion
   - ToolSearch
-  - mcp__plugin_chatprd_chatprd__search_documents
-  - mcp__plugin_chatprd_chatprd__get_document
-  - mcp__plugin_linear_linear__create_issue
-  - mcp__plugin_linear_linear__list_teams
-  - mcp__plugin_linear_linear__list_issues
-  - mcp__plugin_linear_linear__list_issue_statuses
-  - mcp__plugin_linear_linear__get_issue
-  - mcp__plugin_linear_linear__update_issue
+  - mcp__plugin_yellow-chatprd_chatprd__search_documents
+  - mcp__plugin_yellow-chatprd_chatprd__get_document
+  - mcp__plugin_yellow-linear_linear__create_issue
+  - mcp__plugin_yellow-linear_linear__list_teams
+  - mcp__plugin_yellow-linear_linear__list_issues
+  - mcp__plugin_yellow-linear_linear__list_issue_statuses
+  - mcp__plugin_yellow-linear_linear__get_issue
+  - mcp__plugin_yellow-linear_linear__update_issue
 ---
 
 # Link ChatPRD Document to Linear
@@ -30,7 +27,7 @@ selection, and rate-limited batch creation.
 
 ### Step 1: Check Linear Availability (Fail-Fast)
 
-Call `mcp__plugin_linear_linear__list_teams` to verify the yellow-linear plugin
+Call `mcp__plugin_yellow-linear_linear__list_teams` to verify the yellow-linear plugin
 is available:
 
 - **If successful:** Store the teams list for Step 6.

--- a/plugins/yellow-chatprd/commands/chatprd/list.md
+++ b/plugins/yellow-chatprd/commands/chatprd/list.md
@@ -1,17 +1,15 @@
 ---
 name: chatprd:list
-description: >
-  List documents in ChatPRD workspace. Use when user wants to "show my PRDs",
-  "list documents", "what docs do I have", or browse their ChatPRD workspace.
+description: "List documents in ChatPRD workspace. Use when user wants to \"show my PRDs\", \"list documents\", \"what docs do I have\", or browse their ChatPRD workspace."
 argument-hint: '[optional: project name or filter]'
 allowed-tools:
   - Bash
   - Read
   - AskUserQuestion
   - ToolSearch
-  - mcp__plugin_chatprd_chatprd__list_organization_documents
-  - mcp__plugin_chatprd_chatprd__list_projects
-  - mcp__plugin_chatprd_chatprd__get_document
+  - mcp__plugin_yellow-chatprd_chatprd__list_organization_documents
+  - mcp__plugin_yellow-chatprd_chatprd__list_projects
+  - mcp__plugin_yellow-chatprd_chatprd__get_document
 ---
 
 # List ChatPRD Documents

--- a/plugins/yellow-chatprd/commands/chatprd/search.md
+++ b/plugins/yellow-chatprd/commands/chatprd/search.md
@@ -1,17 +1,14 @@
 ---
 name: chatprd:search
-description: >
-  Search ChatPRD workspace for documents. Use when user wants to "find a PRD",
-  "search for docs about", "look up the spec for", or find any existing ChatPRD
-  document.
+description: "Search ChatPRD workspace for documents. Use when user wants to \"find a PRD\", \"search for docs about\", \"look up the spec for\", or find any existing ChatPRD document."
 argument-hint: '[search query]'
 allowed-tools:
   - Bash
   - Read
   - AskUserQuestion
   - ToolSearch
-  - mcp__plugin_chatprd_chatprd__search_documents
-  - mcp__plugin_chatprd_chatprd__get_document
+  - mcp__plugin_yellow-chatprd_chatprd__search_documents
+  - mcp__plugin_yellow-chatprd_chatprd__get_document
 ---
 
 # Search ChatPRD Documents

--- a/plugins/yellow-chatprd/commands/chatprd/setup.md
+++ b/plugins/yellow-chatprd/commands/chatprd/setup.md
@@ -1,9 +1,6 @@
 ---
 name: chatprd:setup
-description: >
-  Configure ChatPRD workspace — set default organization and project for all
-  commands. Use when first installing the plugin, when documents are landing in
-  the wrong workspace, or when switching to a different org or project.
+description: Configure ChatPRD workspace — set default organization and project for all commands. Use when first installing the plugin, when documents are landing in the wrong workspace, or when switching to a different org or project.
 argument-hint: ''
 allowed-tools:
   - Bash
@@ -11,8 +8,8 @@ allowed-tools:
   - Write
   - AskUserQuestion
   - ToolSearch
-  - mcp__plugin_chatprd_chatprd__list_user_organizations
-  - mcp__plugin_chatprd_chatprd__list_projects
+  - mcp__plugin_yellow-chatprd_chatprd__list_user_organizations
+  - mcp__plugin_yellow-chatprd_chatprd__list_projects
 ---
 
 # Set Up ChatPRD Workspace

--- a/plugins/yellow-chatprd/commands/chatprd/update.md
+++ b/plugins/yellow-chatprd/commands/chatprd/update.md
@@ -1,9 +1,6 @@
 ---
 name: chatprd:update
-description: >
-  Update an existing ChatPRD document. Use when user wants to "update the PRD",
-  "add requirements to", "revise the spec", or modify any existing ChatPRD
-  document.
+description: "Update an existing ChatPRD document. Use when user wants to \"update the PRD\", \"add requirements to\", \"revise the spec\", or modify any existing ChatPRD document."
 argument-hint: '[document title or description of changes]'
 allowed-tools:
   - Bash
@@ -11,9 +8,9 @@ allowed-tools:
   - Grep
   - AskUserQuestion
   - ToolSearch
-  - mcp__plugin_chatprd_chatprd__search_documents
-  - mcp__plugin_chatprd_chatprd__get_document
-  - mcp__plugin_chatprd_chatprd__update_document
+  - mcp__plugin_yellow-chatprd_chatprd__search_documents
+  - mcp__plugin_yellow-chatprd_chatprd__get_document
+  - mcp__plugin_yellow-chatprd_chatprd__update_document
 ---
 
 # Update ChatPRD Document

--- a/plugins/yellow-ci/commands/ci/report-linear.md
+++ b/plugins/yellow-ci/commands/ci/report-linear.md
@@ -8,11 +8,11 @@ allowed-tools:
   - AskUserQuestion
   - Task
   - ToolSearch
-  - mcp__plugin_linear_linear__list_teams
-  - mcp__plugin_linear_linear__list_issues
-  - mcp__plugin_linear_linear__list_issue_labels
-  - mcp__plugin_linear_linear__create_issue
-  - mcp__plugin_linear_linear__create_issue_label
+  - mcp__plugin_yellow-linear_linear__list_teams
+  - mcp__plugin_yellow-linear_linear__list_issues
+  - mcp__plugin_yellow-linear_linear__list_issue_labels
+  - mcp__plugin_yellow-linear_linear__create_issue
+  - mcp__plugin_yellow-linear_linear__create_issue_label
 ---
 
 # CI Report to Linear

--- a/plugins/yellow-debt/commands/debt/sync.md
+++ b/plugins/yellow-debt/commands/debt/sync.md
@@ -6,12 +6,12 @@ allowed-tools:
   - Bash
   - AskUserQuestion
   - ToolSearch
-  - mcp__plugin_linear_linear__list_teams
-  - mcp__plugin_linear_linear__list_projects
-  - mcp__plugin_linear_linear__list_issues
-  - mcp__plugin_linear_linear__list_issue_labels
-  - mcp__plugin_linear_linear__create_issue
-  - mcp__plugin_linear_linear__create_issue_label
+  - mcp__plugin_yellow-linear_linear__list_teams
+  - mcp__plugin_yellow-linear_linear__list_projects
+  - mcp__plugin_yellow-linear_linear__list_issues
+  - mcp__plugin_yellow-linear_linear__list_issue_labels
+  - mcp__plugin_yellow-linear_linear__create_issue
+  - mcp__plugin_yellow-linear_linear__create_issue_label
 ---
 
 # Technical Debt Linear Sync

--- a/plugins/yellow-devin/commands/devin/wiki.md
+++ b/plugins/yellow-devin/commands/devin/wiki.md
@@ -7,12 +7,12 @@ allowed-tools:
   - Skill
   - ToolSearch
   - AskUserQuestion
-  - mcp__plugin_deepwiki_deepwiki__ask_question
-  - mcp__plugin_deepwiki_deepwiki__read_wiki_structure
-  - mcp__plugin_deepwiki_deepwiki__read_wiki_contents
-  - mcp__plugin_devin_devin__ask_question
-  - mcp__plugin_devin_devin__read_wiki_structure
-  - mcp__plugin_devin_devin__read_wiki_contents
+  - mcp__plugin_yellow-devin_deepwiki__ask_question
+  - mcp__plugin_yellow-devin_deepwiki__read_wiki_structure
+  - mcp__plugin_yellow-devin_deepwiki__read_wiki_contents
+  - mcp__plugin_yellow-devin_devin__ask_question
+  - mcp__plugin_yellow-devin_devin__read_wiki_structure
+  - mcp__plugin_yellow-devin_devin__read_wiki_contents
 ---
 
 # Query Repository Documentation
@@ -64,7 +64,7 @@ calls fail with auth errors, announce the fallback to DeepWiki.
   `read_wiki_structure`, `read_wiki_contents`)
 
 **Important:** MCP tool names follow the pattern
-`mcp__plugin_<server_key>_<server_key>__<tool>`. Verify exact names via
+`mcp__plugin_{pluginName}_{serverName}__{toolName}`. Verify exact names via
 ToolSearch during first use — the actual registered names may differ.
 
 ### Step 4: Present Results

--- a/plugins/yellow-linear/agents/research/linear-explorer.md
+++ b/plugins/yellow-linear/agents/research/linear-explorer.md
@@ -1,19 +1,15 @@
 ---
 name: linear-explorer
-description: >
-  Deep search and analysis of Linear backlog. Use when user asks to search,
-  analyze, or explore Linear issues, projects, or backlog. Also use when user
-  says "search linear", "has anyone reported", "find similar issues", "is this a
-  duplicate", "what's in the backlog", or "related issues".
+description: "Deep search and analysis of Linear backlog. Use when user asks to search, analyze, or explore Linear issues, projects, or backlog. Also use when user says \"search linear\", \"has anyone reported\", \"find similar issues\", \"is this a duplicate\", \"what's in the backlog\", or \"related issues\"."
 model: inherit
 allowed-tools:
   - Bash
   - ToolSearch
-  - mcp__plugin_linear_linear__list_issues
-  - mcp__plugin_linear_linear__list_projects
-  - mcp__plugin_linear_linear__list_teams
-  - mcp__plugin_linear_linear__list_users
-  - mcp__plugin_linear_linear__list_cycles
+  - mcp__plugin_yellow-linear_linear__list_issues
+  - mcp__plugin_yellow-linear_linear__list_projects
+  - mcp__plugin_yellow-linear_linear__list_teams
+  - mcp__plugin_yellow-linear_linear__list_users
+  - mcp__plugin_yellow-linear_linear__list_cycles
 ---
 
 <examples>

--- a/plugins/yellow-linear/agents/workflow/linear-issue-loader.md
+++ b/plugins/yellow-linear/agents/workflow/linear-issue-loader.md
@@ -5,9 +5,9 @@ model: inherit
 allowed-tools:
   - Bash
   - ToolSearch
-  - mcp__plugin_linear_linear__get_issue
-  - mcp__plugin_linear_linear__list_comments
-  - mcp__plugin_linear_linear__list_teams
+  - mcp__plugin_yellow-linear_linear__get_issue
+  - mcp__plugin_yellow-linear_linear__list_comments
+  - mcp__plugin_yellow-linear_linear__list_teams
 ---
 
 <examples>

--- a/plugins/yellow-linear/agents/workflow/linear-pr-linker.md
+++ b/plugins/yellow-linear/agents/workflow/linear-pr-linker.md
@@ -1,21 +1,16 @@
 ---
 name: linear-pr-linker
-description: >
-  Suggest linking pull requests to Linear issues and syncing status. Use when
-  user creates a pull request via gt submit (Graphite) or mentions submitting a
-  PR and the branch name contains a Linear issue identifier. Also use when user
-  says "link to linear", "update issue from PR", or "sync status". IMPORTANT:
-  Always confirm with user before updating Linear issue status.
+description: "Suggest linking pull requests to Linear issues and syncing status. Use when user creates a pull request via gt submit (Graphite) or mentions submitting a PR and the branch name contains a Linear issue identifier. Also use when user says \"link to linear\", \"update issue from PR\", or \"sync status\". IMPORTANT: Always confirm with user before updating Linear issue status."
 model: inherit
 allowed-tools:
   - Bash
   - AskUserQuestion
   - ToolSearch
-  - mcp__plugin_linear_linear__get_issue
-  - mcp__plugin_linear_linear__update_issue
-  - mcp__plugin_linear_linear__create_comment
-  - mcp__plugin_linear_linear__list_comments
-  - mcp__plugin_linear_linear__list_issue_statuses
+  - mcp__plugin_yellow-linear_linear__get_issue
+  - mcp__plugin_yellow-linear_linear__update_issue
+  - mcp__plugin_yellow-linear_linear__create_comment
+  - mcp__plugin_yellow-linear_linear__list_comments
+  - mcp__plugin_yellow-linear_linear__list_issue_statuses
 ---
 
 <examples>

--- a/plugins/yellow-linear/commands/linear/create.md
+++ b/plugins/yellow-linear/commands/linear/create.md
@@ -1,9 +1,6 @@
 ---
 name: linear:create
-description: >
-  Create a Linear issue from current context. Use when user describes a bug,
-  requests a feature, says "file an issue", "track this", or "create ticket for
-  X".
+description: "Create a Linear issue from current context. Use when user describes a bug, requests a feature, says \"file an issue\", \"track this\", or \"create ticket for X\"."
 argument-hint: '[title]'
 allowed-tools:
   - Read
@@ -11,12 +8,12 @@ allowed-tools:
   - Grep
   - AskUserQuestion
   - ToolSearch
-  - mcp__plugin_linear_linear__create_issue
-  - mcp__plugin_linear_linear__list_teams
-  - mcp__plugin_linear_linear__get_team
-  - mcp__plugin_linear_linear__list_issue_labels
-  - mcp__plugin_linear_linear__list_issue_statuses
-  - mcp__plugin_linear_linear__list_projects
+  - mcp__plugin_yellow-linear_linear__create_issue
+  - mcp__plugin_yellow-linear_linear__list_teams
+  - mcp__plugin_yellow-linear_linear__get_team
+  - mcp__plugin_yellow-linear_linear__list_issue_labels
+  - mcp__plugin_yellow-linear_linear__list_issue_statuses
+  - mcp__plugin_yellow-linear_linear__list_projects
 ---
 
 # Create Linear Issue

--- a/plugins/yellow-linear/commands/linear/delegate.md
+++ b/plugins/yellow-linear/commands/linear/delegate.md
@@ -6,11 +6,11 @@ allowed-tools:
   - Bash
   - AskUserQuestion
   - ToolSearch
-  - mcp__plugin_linear_linear__get_issue
-  - mcp__plugin_linear_linear__list_issue_statuses
-  - mcp__plugin_linear_linear__update_issue
-  - mcp__plugin_linear_linear__create_comment
-  - mcp__plugin_linear_linear__list_comments
+  - mcp__plugin_yellow-linear_linear__get_issue
+  - mcp__plugin_yellow-linear_linear__list_issue_statuses
+  - mcp__plugin_yellow-linear_linear__update_issue
+  - mcp__plugin_yellow-linear_linear__create_comment
+  - mcp__plugin_yellow-linear_linear__list_comments
 ---
 
 # Delegate Linear Issue to Devin

--- a/plugins/yellow-linear/commands/linear/plan-cycle.md
+++ b/plugins/yellow-linear/commands/linear/plan-cycle.md
@@ -1,21 +1,18 @@
 ---
 name: linear:plan-cycle
-description: >
-  Plan sprint cycle by selecting backlog issues. Use when user says "plan the
-  sprint", "fill the cycle", "what should we work on next", or "sprint
-  planning".
+description: "Plan sprint cycle by selecting backlog issues. Use when user says \"plan the sprint\", \"fill the cycle\", \"what should we work on next\", or \"sprint planning\"."
 argument-hint: '[cycle name]'
 allowed-tools:
   - Bash
   - AskUserQuestion
   - ToolSearch
-  - mcp__plugin_linear_linear__list_cycles
-  - mcp__plugin_linear_linear__list_issues
-  - mcp__plugin_linear_linear__get_issue
-  - mcp__plugin_linear_linear__update_issue
-  - mcp__plugin_linear_linear__list_teams
-  - mcp__plugin_linear_linear__list_users
-  - mcp__plugin_linear_linear__list_issue_statuses
+  - mcp__plugin_yellow-linear_linear__list_cycles
+  - mcp__plugin_yellow-linear_linear__list_issues
+  - mcp__plugin_yellow-linear_linear__get_issue
+  - mcp__plugin_yellow-linear_linear__update_issue
+  - mcp__plugin_yellow-linear_linear__list_teams
+  - mcp__plugin_yellow-linear_linear__list_users
+  - mcp__plugin_yellow-linear_linear__list_issue_statuses
 ---
 
 # Plan Sprint Cycle

--- a/plugins/yellow-linear/commands/linear/status.md
+++ b/plugins/yellow-linear/commands/linear/status.md
@@ -1,22 +1,20 @@
 ---
 name: linear:status
-description: >
-  Generate project and initiative health report. Use when user asks "project
-  status", "how are we tracking", "what's blocked", or "sprint health".
+description: "Generate project and initiative health report. Use when user asks \"project status\", \"how are we tracking\", \"what's blocked\", or \"sprint health\"."
 argument-hint: ''
 allowed-tools:
   - Bash
   - AskUserQuestion
   - ToolSearch
-  - mcp__plugin_linear_linear__list_projects
-  - mcp__plugin_linear_linear__get_project
-  - mcp__plugin_linear_linear__list_issues
-  - mcp__plugin_linear_linear__list_initiatives
-  - mcp__plugin_linear_linear__get_initiative
-  - mcp__plugin_linear_linear__list_initiative_updates
-  - mcp__plugin_linear_linear__create_initiative_update
-  - mcp__plugin_linear_linear__list_teams
-  - mcp__plugin_linear_linear__list_issue_statuses
+  - mcp__plugin_yellow-linear_linear__list_projects
+  - mcp__plugin_yellow-linear_linear__get_project
+  - mcp__plugin_yellow-linear_linear__list_issues
+  - mcp__plugin_yellow-linear_linear__list_initiatives
+  - mcp__plugin_yellow-linear_linear__get_initiative
+  - mcp__plugin_yellow-linear_linear__list_initiative_updates
+  - mcp__plugin_yellow-linear_linear__create_initiative_update
+  - mcp__plugin_yellow-linear_linear__list_teams
+  - mcp__plugin_yellow-linear_linear__list_issue_statuses
 ---
 
 # Project & Initiative Status Report
@@ -50,12 +48,12 @@ Present as a table:
 
 ### Step 2: Fetch Initiative Health
 
-Query active initiatives via `mcp__plugin_linear_linear__list_initiatives`.
+Query active initiatives via `mcp__plugin_yellow-linear_linear__list_initiatives`.
 
 For each initiative:
 
-- Fetch details via `mcp__plugin_linear_linear__get_initiative`
-- Fetch recent updates via `mcp__plugin_linear_linear__list_initiative_updates`
+- Fetch details via `mcp__plugin_yellow-linear_linear__get_initiative`
+- Fetch recent updates via `mcp__plugin_yellow-linear_linear__list_initiative_updates`
 - Show: name, status, last update date, health indicator
 
 ### Step 3: Surface Blockers and Risks
@@ -94,10 +92,10 @@ Use `AskUserQuestion` to ask:
 If yes:
 
 - Select which initiative to update via `AskUserQuestion`
-- **Validate access (C1):** Call `mcp__plugin_linear_linear__get_initiative`
+- **Validate access (C1):** Call `mcp__plugin_yellow-linear_linear__get_initiative`
   with the selected initiative ID to verify it exists and belongs to the user's
   workspace. If validation fails, report the error and stop.
-- Post via `mcp__plugin_linear_linear__create_initiative_update` with the report
+- Post via `mcp__plugin_yellow-linear_linear__create_initiative_update` with the report
   content
 
 ## Error Handling

--- a/plugins/yellow-linear/commands/linear/sync-all.md
+++ b/plugins/yellow-linear/commands/linear/sync-all.md
@@ -6,11 +6,11 @@ allowed-tools:
   - Bash
   - AskUserQuestion
   - ToolSearch
-  - mcp__plugin_linear_linear__list_teams
-  - mcp__plugin_linear_linear__list_issue_statuses
-  - mcp__plugin_linear_linear__list_issues
-  - mcp__plugin_linear_linear__get_issue
-  - mcp__plugin_linear_linear__update_issue
+  - mcp__plugin_yellow-linear_linear__list_teams
+  - mcp__plugin_yellow-linear_linear__list_issue_statuses
+  - mcp__plugin_yellow-linear_linear__list_issues
+  - mcp__plugin_yellow-linear_linear__get_issue
+  - mcp__plugin_yellow-linear_linear__update_issue
 ---
 
 # Linear Sync-All

--- a/plugins/yellow-linear/commands/linear/sync.md
+++ b/plugins/yellow-linear/commands/linear/sync.md
@@ -1,20 +1,17 @@
 ---
 name: linear:sync
-description: >
-  Sync current branch with its Linear issue — load context, link PR, update
-  status. Use when user says "sync with linear", "link my branch", or "update
-  issue status".
+description: "Sync current branch with its Linear issue — load context, link PR, update status. Use when user says \"sync with linear\", \"link my branch\", or \"update issue status\"."
 argument-hint: '[issue-id]'
 allowed-tools:
   - Bash
   - Read
   - AskUserQuestion
   - ToolSearch
-  - mcp__plugin_linear_linear__get_issue
-  - mcp__plugin_linear_linear__update_issue
-  - mcp__plugin_linear_linear__list_issue_statuses
-  - mcp__plugin_linear_linear__create_comment
-  - mcp__plugin_linear_linear__list_comments
+  - mcp__plugin_yellow-linear_linear__get_issue
+  - mcp__plugin_yellow-linear_linear__update_issue
+  - mcp__plugin_yellow-linear_linear__list_issue_statuses
+  - mcp__plugin_yellow-linear_linear__create_comment
+  - mcp__plugin_yellow-linear_linear__list_comments
 ---
 
 # Sync Branch with Linear Issue
@@ -42,7 +39,7 @@ If no issue ID found, ask user via AskUserQuestion.
 ### Step 2: Validate Issue Exists
 
 **Security requirement (C1):** Before any operations, call
-`mcp__plugin_linear_linear__get_issue` with the extracted ID to verify:
+`mcp__plugin_yellow-linear_linear__get_issue` with the extracted ID to verify:
 
 - The issue exists
 - It belongs to the user's workspace
@@ -61,7 +58,7 @@ Present the issue context:
 - **Assignee**
 - **Description** (full text for coding reference)
 
-Fetch recent comments (up to 5) via `mcp__plugin_linear_linear__list_comments`
+Fetch recent comments (up to 5) via `mcp__plugin_yellow-linear_linear__list_comments`
 and display them for context.
 
 ### Step 4: Check for PR
@@ -76,7 +73,7 @@ Note: This works for Graphite-created PRs since they are GitHub PRs underneath.
 
 - **If PR exists:** Check the comments fetched in Step 3 for an existing PR link
   comment matching this PR URL. If already linked, skip. Otherwise, add via
-  `mcp__plugin_linear_linear__create_comment`:
+  `mcp__plugin_yellow-linear_linear__create_comment`:
   ```
   PR linked: [PR Title](PR URL) — State: open/merged
   ```
@@ -86,7 +83,7 @@ Note: This works for Graphite-created PRs since they are GitHub PRs underneath.
 ### Step 5: Update Issue Status
 
 Query valid workflow statuses via
-`mcp__plugin_linear_linear__list_issue_statuses` for the issue's team.
+`mcp__plugin_yellow-linear_linear__list_issue_statuses` for the issue's team.
 
 Determine the appropriate status transition:
 

--- a/plugins/yellow-linear/commands/linear/triage.md
+++ b/plugins/yellow-linear/commands/linear/triage.md
@@ -1,21 +1,19 @@
 ---
 name: linear:triage
-description: >
-  Review and assign incoming Linear issues. Use when user says "triage issues",
-  "assign incoming tickets", "what needs triage", or "review new issues".
+description: "Review and assign incoming Linear issues. Use when user says \"triage issues\", \"assign incoming tickets\", \"what needs triage\", or \"review new issues\"."
 argument-hint: '[filter query]'
 allowed-tools:
   - Bash
   - AskUserQuestion
   - ToolSearch
-  - mcp__plugin_linear_linear__list_issues
-  - mcp__plugin_linear_linear__get_issue
-  - mcp__plugin_linear_linear__update_issue
-  - mcp__plugin_linear_linear__list_teams
-  - mcp__plugin_linear_linear__get_team
-  - mcp__plugin_linear_linear__list_users
-  - mcp__plugin_linear_linear__list_issue_statuses
-  - mcp__plugin_linear_linear__list_issue_labels
+  - mcp__plugin_yellow-linear_linear__list_issues
+  - mcp__plugin_yellow-linear_linear__get_issue
+  - mcp__plugin_yellow-linear_linear__update_issue
+  - mcp__plugin_yellow-linear_linear__list_teams
+  - mcp__plugin_yellow-linear_linear__get_team
+  - mcp__plugin_yellow-linear_linear__list_users
+  - mcp__plugin_yellow-linear_linear__list_issue_statuses
+  - mcp__plugin_yellow-linear_linear__list_issue_labels
 ---
 
 # Triage Incoming Issues

--- a/plugins/yellow-research/CLAUDE.md
+++ b/plugins/yellow-research/CLAUDE.md
@@ -92,12 +92,13 @@ startup — restart Claude Code after adding new keys.
 
 These external tools improve research quality but are not required:
 
-- **compound-engineering plugin** — provides Context7
-  (`mcp__plugin_compound-engineering_context7__resolve-library-id`,
-  `mcp__plugin_compound-engineering_context7__query-docs`) for official library
+- **yellow-core plugin** — provides Context7
+  (`mcp__plugin_yellow-core_context7__resolve-library-id`,
+  `mcp__plugin_yellow-core_context7__query-docs`) for official library
   docs. Used by `/research:code` for library queries. Falls back to EXA if not
   installed.
-  Install: `/plugin marketplace add every-marketplace/compound-engineering`
+  Install: `/plugin marketplace add KingInYellows/yellow-plugins` (select
+  yellow-core)
 - **grep MCP** — provides `mcp__grep__searchGitHub` for GitHub code search.
   Used by `/research:code` and `/research:deep`. No API key required. Configure
   globally in Claude Code MCP settings.

--- a/plugins/yellow-research/agents/research/code-researcher.md
+++ b/plugins/yellow-research/agents/research/code-researcher.md
@@ -10,8 +10,8 @@ allowed-tools:
   - ToolSearch
   - mcp__plugin_yellow-research_exa__get_code_context_exa
   - mcp__plugin_yellow-research_exa__web_search_exa
-  - mcp__plugin_compound-engineering_context7__resolve-library-id
-  - mcp__plugin_compound-engineering_context7__query-docs
+  - mcp__plugin_yellow-core_context7__resolve-library-id
+  - mcp__plugin_yellow-core_context7__query-docs
   - mcp__grep__searchGitHub
   - mcp__plugin_yellow-research_perplexity__perplexity_search
 ---

--- a/plugins/yellow-research/commands/research/code.md
+++ b/plugins/yellow-research/commands/research/code.md
@@ -11,8 +11,8 @@ allowed-tools:
   - ToolSearch
   - mcp__plugin_yellow-research_exa__get_code_context_exa
   - mcp__plugin_yellow-research_exa__web_search_exa
-  - mcp__plugin_compound-engineering_context7__resolve-library-id
-  - mcp__plugin_compound-engineering_context7__query-docs
+  - mcp__plugin_yellow-core_context7__resolve-library-id
+  - mcp__plugin_yellow-core_context7__query-docs
   - mcp__grep__searchGitHub
   - mcp__plugin_yellow-research_perplexity__perplexity_search
 ---


### PR DESCRIPTION
Apply the formula mcp__plugin_{pluginName}_{serverName}__{toolName} to:
- yellow-linear: mcp__plugin_linear_linear__ → mcp__plugin_yellow-linear_linear__
- yellow-chatprd: mcp__plugin_chatprd_chatprd__ → mcp__plugin_yellow-chatprd_chatprd__
- yellow-devin: mcp__plugin_devin_devin__ → mcp__plugin_yellow-devin_devin__
  and mcp__plugin_deepwiki_deepwiki__ → mcp__plugin_yellow-devin_deepwiki__
- yellow-research: rewire context7 from compound-engineering to yellow-core
- yellow-ci/yellow-debt: fix inherited linear prefix in report-linear and sync

Also convert description: > folded scalars to single-line strings in all
files touched by the prefix fix (15 files).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/yellow-plugins/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes MCP tool prefixes across multiple plugins and converts folded scalar descriptions to single-line strings for consistency and clarity.
> 
>   - **Tool Prefix Correction**:
>     - Corrects MCP tool prefixes in `yellow-linear`, `yellow-chatprd`, `yellow-devin`, `yellow-research`, and `yellow-ci/yellow-debt` plugins to follow the `mcp__plugin_{pluginName}_{serverName}__{toolName}` format.
>     - Specific changes include renaming prefixes like `mcp__plugin_linear_linear__` to `mcp__plugin_yellow-linear_linear__` and similar adjustments in other plugins.
>   - **Description Formatting**:
>     - Converts `description: >` folded scalars to single-line strings in 15 files affected by the prefix fix.
>     - Ensures descriptions are concise and formatted as single-line strings for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=KingInYellows%2Fyellow-plugins&utm_source=github&utm_medium=referral)<sup> for 036b2ed553b97275613aadc9c37ec9a9ba869714. You can [customize](https://app.ellipsis.dev/KingInYellows/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR standardizes MCP tool naming across 5 plugins to follow the formula `mcp__plugin_{pluginName}_{serverName}__{toolName}` and converts YAML folded scalar descriptions to single-line strings.

**Key Changes:**
- **yellow-linear**: Updated all tool prefixes from `mcp__plugin_linear_linear__` to `mcp__plugin_yellow-linear_linear__`
- **yellow-chatprd**: Updated all tool prefixes from `mcp__plugin_chatprd_chatprd__` to `mcp__plugin_yellow-chatprd_chatprd__`
- **yellow-devin**: Updated prefixes for both Devin (`mcp__plugin_devin_devin__` → `mcp__plugin_yellow-devin_devin__`) and DeepWiki (`mcp__plugin_deepwiki_deepwiki__` → `mcp__plugin_yellow-devin_deepwiki__`) servers
- **yellow-research**: Rewired Context7 dependency from `compound-engineering` plugin to `yellow-core` plugin
- **yellow-ci/yellow-debt**: Updated inherited Linear tool references to use the new `yellow-linear` prefix
- **Format cleanup**: Converted all `description: >` folded scalars to single-line strings with proper quote escaping

All changes are purely mechanical refactoring with no functional modifications. The naming standardization improves consistency across the plugin ecosystem and makes the plugin name explicit in tool identifiers.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - purely mechanical refactoring with consistent application of naming formula
- All changes are systematic string replacements following a clear naming formula. No logic changes, no new code, no security implications. The changes are consistent across all 24 files, properly escaped, and maintain existing functionality.
- No files require special attention - all changes follow the same mechanical pattern

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/yellow-chatprd/agents/workflow/linear-prd-bridge.md | Updated MCP tool prefixes for both `yellow-chatprd` and `yellow-linear`, converted description to single-line format |
| plugins/yellow-ci/commands/ci/report-linear.md | Updated inherited Linear MCP tool prefixes from `linear` to `yellow-linear` |
| plugins/yellow-debt/commands/debt/sync.md | Updated inherited Linear MCP tool prefixes from `linear` to `yellow-linear` |
| plugins/yellow-devin/commands/devin/wiki.md | Updated MCP tool prefixes for both DeepWiki and Devin servers to use `yellow-devin` plugin name, updated pattern documentation |
| plugins/yellow-linear/commands/linear/status.md | Updated MCP tool prefixes from `linear` to `yellow-linear` in both frontmatter and body content, converted description to single-line format |
| plugins/yellow-research/CLAUDE.md | Rewired Context7 dependency from `compound-engineering` plugin to `yellow-core` plugin, updated documentation accordingly |

</details>



<sub>Last reviewed commit: 036b2ed</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->