### PR TITLE
fix: convert remaining folded scalar descriptions to single-line strings

### DIFF
--- a/plugins/yellow-browser-test/commands/browser-test/explore.md
+++ b/plugins/yellow-browser-test/commands/browser-test/explore.md
@@ -1,9 +1,6 @@
 ---
 name: browser-test:explore
-description: >
-  Run autonomous exploratory browser testing. Use when user says "explore the
-  app", "find bugs", "test everything", "autonomous testing", or wants the agent
-  to freely navigate and discover issues without predefined test flows.
+description: "Run autonomous exploratory browser testing. Use when user says \"explore the app\", \"find bugs\", \"test everything\", \"autonomous testing\", or wants the agent to freely navigate and discover issues without predefined test flows."
 argument-hint: '[starting-route]'
 allowed-tools:
   - Bash

--- a/plugins/yellow-browser-test/commands/browser-test/report.md
+++ b/plugins/yellow-browser-test/commands/browser-test/report.md
@@ -1,9 +1,6 @@
 ---
 name: browser-test:report
-description: >
-  Generate a test report from the most recent results. Use when user says
-  "generate report", "show test results", "create test report", or wants to view
-  or share the results of a previous test run.
+description: "Generate a test report from the most recent results. Use when user says \"generate report\", \"show test results\", \"create test report\", or wants to view or share the results of a previous test run."
 argument-hint: ''
 allowed-tools:
   - Bash

--- a/plugins/yellow-browser-test/commands/browser-test/setup.md
+++ b/plugins/yellow-browser-test/commands/browser-test/setup.md
@@ -1,9 +1,6 @@
 ---
 name: browser-test:setup
-description: >
-  Install agent-browser and discover app configuration. Use when user says "set
-  up browser testing", "install agent-browser", "configure testing", or wants to
-  initialize browser testing for a web project.
+description: "Install agent-browser and discover app configuration. Use when user says \"set up browser testing\", \"install agent-browser\", \"configure testing\", or wants to initialize browser testing for a web project."
 argument-hint: ''
 allowed-tools:
   - Bash

--- a/plugins/yellow-browser-test/commands/browser-test/test.md
+++ b/plugins/yellow-browser-test/commands/browser-test/test.md
@@ -1,9 +1,6 @@
 ---
 name: browser-test:test
-description: >
-  Run structured browser test suite. Use when user says "test the app", "run
-  browser tests", "check if the UI works", "verify routes", or wants to run the
-  full structured test suite against discovered routes.
+description: "Run structured browser test suite. Use when user says \"test the app\", \"run browser tests\", \"check if the UI works\", \"verify routes\", or wants to run the full structured test suite against discovered routes."
 argument-hint: '[route-filter]'
 allowed-tools:
   - Bash

--- a/plugins/yellow-ci/agents/ci/failure-analyst.md
+++ b/plugins/yellow-ci/agents/ci/failure-analyst.md
@@ -1,10 +1,6 @@
 ---
 name: failure-analyst
-description: >
-  CI failure diagnosis specialist that analyzes GitHub Actions logs against a
-  failure pattern library (F01-F12). Use when CI builds fail and you need to
-  identify root cause, when user asks "why did CI fail?", "diagnose the build",
-  "what broke?", or when analyzing exit codes from failed runs.
+description: "CI failure diagnosis specialist that analyzes GitHub Actions logs against a failure pattern library (F01-F12). Use when CI builds fail and you need to identify root cause, when user asks \"why did CI fail?\", \"diagnose the build\", \"what broke?\", or when analyzing exit codes from failed runs."
 model: inherit
 color: red
 allowed-tools:

--- a/plugins/yellow-ci/agents/ci/workflow-optimizer.md
+++ b/plugins/yellow-ci/agents/ci/workflow-optimizer.md
@@ -1,10 +1,6 @@
 ---
 name: workflow-optimizer
-description: >
-  GitHub Actions workflow optimization specialist. Use when analyzing CI
-  performance, suggesting caching strategies, or improving workflow efficiency.
-  Triggers on "optimize workflows", "why is CI slow?", "add caching", or when
-  lint finds optimization opportunities (W02, W04, W08).
+description: "GitHub Actions workflow optimization specialist. Use when analyzing CI performance, suggesting caching strategies, or improving workflow efficiency. Triggers on \"optimize workflows\", \"why is CI slow?\", \"add caching\", or when lint finds optimization opportunities (W02, W04, W08)."
 model: inherit
 color: cyan
 allowed-tools:

--- a/plugins/yellow-ci/agents/maintenance/runner-diagnostics.md
+++ b/plugins/yellow-ci/agents/maintenance/runner-diagnostics.md
@@ -1,11 +1,6 @@
 ---
 name: runner-diagnostics
-description: >
-  Deep runner diagnostics specialist for self-hosted GitHub Actions runners. Use
-  when runner infrastructure issues are suspected (not application failures).
-  Triggers on "check runner health", "runner offline", "investigate runner", or
-  when failure-analyst identifies runner-side patterns (F02 disk full, F04
-  Docker, F09 runner agent).
+description: "Deep runner diagnostics specialist for self-hosted GitHub Actions runners. Use when runner infrastructure issues are suspected (not application failures). Triggers on \"check runner health\", \"runner offline\", \"investigate runner\", or when failure-analyst identifies runner-side patterns (F02 disk full, F04 Docker, F09 runner agent)."
 model: inherit
 color: yellow
 allowed-tools:

--- a/plugins/yellow-ci/commands/ci/diagnose.md
+++ b/plugins/yellow-ci/commands/ci/diagnose.md
@@ -1,9 +1,6 @@
 ---
 name: ci:diagnose
-description: >
-  Diagnose CI failure and suggest fixes. Use when user wants to analyze a failed
-  GitHub Actions run, understand why CI broke, or get actionable fix
-  suggestions.
+description: Diagnose CI failure and suggest fixes. Use when user wants to analyze a failed GitHub Actions run, understand why CI broke, or get actionable fix suggestions.
 argument-hint: '[run-id] [--repo owner/name]'
 allowed-tools:
   - Bash

--- a/plugins/yellow-ci/commands/ci/lint-workflows.md
+++ b/plugins/yellow-ci/commands/ci/lint-workflows.md
@@ -1,9 +1,6 @@
 ---
 name: ci:lint-workflows
-description: >
-  Lint GitHub Actions workflows for self-hosted runner issues. Use when user
-  wants to check workflows before pushing, asks "lint CI", "check workflows", or
-  wants to find common pitfalls in their GitHub Actions configuration.
+description: "Lint GitHub Actions workflows for self-hosted runner issues. Use when user wants to check workflows before pushing, asks \"lint CI\", \"check workflows\", or wants to find common pitfalls in their GitHub Actions configuration."
 argument-hint: '[workflow-file.yml]'
 allowed-tools:
   - Bash

--- a/plugins/yellow-ci/commands/ci/runner-cleanup.md
+++ b/plugins/yellow-ci/commands/ci/runner-cleanup.md
@@ -1,9 +1,6 @@
 ---
 name: ci:runner-cleanup
-description: >
-  Clean Docker images/containers, old logs, and caches on self-hosted runner.
-  Destructive operation with dry-run preview and confirmation. Use when runner
-  disk is full, Docker space needs freeing, or old CI logs need pruning.
+description: Clean Docker images/containers, old logs, and caches on self-hosted runner. Destructive operation with dry-run preview and confirmation. Use when runner disk is full, Docker space needs freeing, or old CI logs need pruning.
 argument-hint: '[runner-name]'
 allowed-tools:
   - Bash

--- a/plugins/yellow-ci/commands/ci/runner-health.md
+++ b/plugins/yellow-ci/commands/ci/runner-health.md
@@ -1,9 +1,6 @@
 ---
 name: ci:runner-health
-description: >
-  Check self-hosted runner health via SSH. Use when user asks "runner status",
-  "is runner healthy", "check runner", or wants to verify infrastructure before
-  diagnosing CI failures.
+description: "Check self-hosted runner health via SSH. Use when user asks \"runner status\", \"is runner healthy\", \"check runner\", or wants to verify infrastructure before diagnosing CI failures."
 argument-hint: '[runner-name]'
 allowed-tools:
   - Bash

--- a/plugins/yellow-ci/commands/ci/status.md
+++ b/plugins/yellow-ci/commands/ci/status.md
@@ -1,8 +1,6 @@
 ---
 name: ci:status
-description: >
-  Show recent CI workflow run status. Use when user asks "CI status", "recent
-  builds", "what's running", or needs to find run IDs for diagnosis.
+description: "Show recent CI workflow run status. Use when user asks \"CI status\", \"recent builds\", \"what's running\", or needs to find run IDs for diagnosis."
 allowed-tools:
   - Bash
 model: haiku

--- a/plugins/yellow-review/commands/review/resolve-pr.md
+++ b/plugins/yellow-review/commands/review/resolve-pr.md
@@ -1,9 +1,6 @@
 ---
 name: review:resolve
-description: >
-  Parallel resolution of unresolved PR review comments. Use when you want to
-  address all pending review feedback on a PR by spawning parallel resolver
-  agents.
+description: Parallel resolution of unresolved PR review comments. Use when you want to address all pending review feedback on a PR by spawning parallel resolver agents.
 argument-hint: '[PR#]'
 allowed-tools:
   - Bash

--- a/plugins/yellow-ruvector/commands/ruvector/index.md
+++ b/plugins/yellow-ruvector/commands/ruvector/index.md
@@ -1,9 +1,6 @@
 ---
 name: ruvector:index
-description: >
-  Index codebase for semantic search. Use when user says "index my code", "build
-  search index", "update embeddings", "re-index project", or wants to enable
-  semantic code search.
+description: "Index codebase for semantic search. Use when user says \"index my code\", \"build search index\", \"update embeddings\", \"re-index project\", or wants to enable semantic code search."
 argument-hint: '[path]'
 allowed-tools:
   - Bash

--- a/plugins/yellow-ruvector/commands/ruvector/learn.md
+++ b/plugins/yellow-ruvector/commands/ruvector/learn.md
@@ -1,9 +1,6 @@
 ---
 name: ruvector:learn
-description: >
-  Record a learning, mistake, or pattern for future sessions. Use when user says
-  "remember this", "save this pattern", "record this mistake", "learn from
-  this", "don't forget X", or wants to persist an insight.
+description: "Record a learning, mistake, or pattern for future sessions. Use when user says \"remember this\", \"save this pattern\", \"record this mistake\", \"learn from this\", \"don't forget X\", or wants to persist an insight."
 argument-hint: '[learning description]'
 allowed-tools:
   - ToolSearch

--- a/plugins/yellow-ruvector/commands/ruvector/memory.md
+++ b/plugins/yellow-ruvector/commands/ruvector/memory.md
@@ -1,9 +1,6 @@
 ---
 name: ruvector:memory
-description: >
-  Browse, search, and manage stored memories and learnings. Use when user says
-  "show memories", "what do we know about X", "list learnings", "delete memory",
-  "browse reflexions", or wants to view stored agent knowledge.
+description: "Browse, search, and manage stored memories and learnings. Use when user says \"show memories\", \"what do we know about X\", \"list learnings\", \"delete memory\", \"browse reflexions\", or wants to view stored agent knowledge."
 argument-hint: '[namespace] [filter]'
 allowed-tools:
   - ToolSearch

--- a/plugins/yellow-ruvector/commands/ruvector/search.md
+++ b/plugins/yellow-ruvector/commands/ruvector/search.md
@@ -1,9 +1,6 @@
 ---
 name: ruvector:search
-description: >
-  Search codebase by meaning using vector similarity. Use when user says "find
-  code that does X", "search for implementations of Y", "semantic search", "find
-  similar functions", or "where is X implemented".
+description: "Search codebase by meaning using vector similarity. Use when user says \"find code that does X\", \"search for implementations of Y\", \"semantic search\", \"find similar functions\", or \"where is X implemented\"."
 argument-hint: '<query>'
 allowed-tools:
   - ToolSearch

--- a/plugins/yellow-ruvector/commands/ruvector/setup.md
+++ b/plugins/yellow-ruvector/commands/ruvector/setup.md
@@ -1,9 +1,6 @@
 ---
 name: ruvector:setup
-description: >
-  Install ruvector and initialize vector storage. Use when user says "set up
-  ruvector", "install vector search", "enable semantic search", "initialize
-  ruvector", or wants persistent agent memory for a project.
+description: "Install ruvector and initialize vector storage. Use when user says \"set up ruvector\", \"install vector search\", \"enable semantic search\", \"initialize ruvector\", or wants persistent agent memory for a project."
 argument-hint: ''
 allowed-tools:
   - Bash

--- a/plugins/yellow-ruvector/commands/ruvector/status.md
+++ b/plugins/yellow-ruvector/commands/ruvector/status.md
@@ -1,9 +1,6 @@
 ---
 name: ruvector:status
-description: >
-  Show ruvector health, DB stats, and queue status. Use when user says "ruvector
-  status", "check vector DB", "how many vectors", "is ruvector working", or
-  wants to verify the installation.
+description: "Show ruvector health, DB stats, and queue status. Use when user says \"ruvector status\", \"check vector DB\", \"how many vectors\", \"is ruvector working\", or wants to verify the installation."
 argument-hint: ''
 allowed-tools:
   - Bash


### PR DESCRIPTION
19 files across yellow-ruvector, yellow-browser-test, yellow-ci, and
yellow-review had YAML folded scalar descriptions (description: >) that
Claude Code's frontmatter parser silently truncates at the first newline.

Converted all to single-line strings with proper quoting.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/yellow-plugins/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Converts YAML folded scalar descriptions to single-line strings in 19 files to prevent truncation by Claude Code's parser.
> 
>   - **Behavior**:
>     - Converts YAML folded scalar descriptions to single-line strings in 19 files across `yellow-ruvector`, `yellow-browser-test`, `yellow-ci`, and `yellow-review`.
>     - Ensures compatibility with Claude Code's frontmatter parser, which previously truncated descriptions at the first newline.
>   - **Files**:
>     - `explore.md`, `report.md`, `setup.md` in `yellow-browser-test`.
>     - `failure-analyst.md`, `workflow-optimizer.md`, `runner-diagnostics.md` in `yellow-ci`.
>     - `index.md`, `learn.md`, `memory.md` in `yellow-ruvector`.
>   - **Misc**:
>     - Improves consistency and reliability of YAML parsing across the codebase.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=KingInYellows%2Fyellow-plugins&utm_source=github&utm_medium=referral)<sup> for d6852b731545d2517535d76c1296f501ff8df199. You can [customize](https://app.ellipsis.dev/KingInYellows/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed YAML frontmatter parsing issue across 19 command and agent files. Converted all `description: >` folded scalars to single-line strings with proper quote escaping, preventing Claude Code's frontmatter parser from silently truncating descriptions at the first newline.

- **yellow-ruvector**: 6 command files updated (index, learn, memory, search, setup, status)
- **yellow-browser-test**: 4 command files updated (explore, report, setup, test)
- **yellow-ci**: 8 files updated (2 agents, 6 commands)
- **yellow-review**: 1 command file updated (resolve-pr)

All conversions are syntactically correct with properly escaped internal quotes. The fix ensures command and agent descriptions display correctly in Claude Code's interface.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Mechanical conversion of YAML formatting with no logic changes. All 19 files follow the same pattern: multi-line folded scalars converted to single-line strings with proper quote escaping. Content is preserved exactly, only formatting changed to fix parser compatibility.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/yellow-ruvector/commands/ruvector/index.md | Converted folded YAML description to single-line string with proper quote escaping |
| plugins/yellow-ruvector/commands/ruvector/search.md | Converted folded YAML description to single-line string with proper quote escaping |
| plugins/yellow-browser-test/commands/browser-test/setup.md | Converted folded YAML description to single-line string with proper quote escaping |
| plugins/yellow-ci/agents/ci/failure-analyst.md | Converted folded YAML description to single-line string with proper quote escaping |
| plugins/yellow-review/commands/review/resolve-pr.md | Converted folded YAML description to single-line string with proper quote escaping |

</details>



<sub>Last reviewed commit: d6852b7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->