### PR TITLE
fix(yellow-research): switch parallel MCP server from API key to OAuth

### DIFF
--- a/plugins/yellow-research/.claude-plugin/plugin.json
+++ b/plugins/yellow-research/.claude-plugin/plugin.json
@@ -52,10 +52,7 @@
     },
     "parallel": {
       "type": "http",
-      "url": "https://task-mcp.parallel.ai/mcp",
-      "headers": {
-        "Authorization": "Bearer ${PARALLEL_API_KEY}"
-      }
+      "url": "https://task-mcp.parallel.ai/mcp"
     }
   }
 }

--- a/plugins/yellow-research/CLAUDE.md
+++ b/plugins/yellow-research/CLAUDE.md
@@ -35,7 +35,7 @@ Off-by-default tools (enable by adding them to the `tools=` arg in `plugin.json`
 - `deep_researcher_start` — Start async EXA deep research report
 - `deep_researcher_check` — Poll async research status
 
-### parallel — `PARALLEL_API_KEY` (HTTP Bearer auth)
+### parallel — OAuth (auto-managed by Claude Code)
 
 - `createDeepResearch` — Launch async research; returns task ID
 - `createTaskGroup` — Parallel enrichment for multiple items
@@ -82,11 +82,13 @@ Add to `~/.zshrc`:
 export EXA_API_KEY="..."
 export TAVILY_API_KEY="..."
 export PERPLEXITY_API_KEY="..."
-export PARALLEL_API_KEY="..."
 ```
 
 Source or restart shell after setting. Keys are passed to MCP servers at
 startup — restart Claude Code after adding new keys.
+
+The **parallel** server uses OAuth — Claude Code handles authentication
+automatically (no API key needed). You'll be prompted to authorize on first use.
 
 ## Optional Dependencies
 

--- a/plugins/yellow-research/README.md
+++ b/plugins/yellow-research/README.md
@@ -25,10 +25,12 @@ Add to your shell config (`~/.zshrc` or `~/.bashrc`):
 export EXA_API_KEY="..."          # https://exa.ai/
 export TAVILY_API_KEY="..."       # https://tavily.com/
 export PERPLEXITY_API_KEY="..."   # https://www.perplexity.ai/settings/api
-export PARALLEL_API_KEY="..."     # https://platform.parallel.ai/
 ```
 
 Restart Claude Code after setting keys.
+
+The **Parallel Task** server uses OAuth — Claude Code handles authentication
+automatically. You'll be prompted to authorize on first use (no API key needed).
 
 ## Usage
 

--- a/plugins/yellow-research/skills/research-patterns/SKILL.md
+++ b/plugins/yellow-research/skills/research-patterns/SKILL.md
@@ -90,14 +90,15 @@ Add to `~/.zshrc` (or equivalent shell config):
 export EXA_API_KEY="your-key-here"
 export TAVILY_API_KEY="your-key-here"
 export PERPLEXITY_API_KEY="your-key-here"
-export PARALLEL_API_KEY="your-key-here"
 ```
 
 Get keys from:
 - EXA: https://exa.ai/
 - Tavily: https://tavily.com/
 - Perplexity: https://www.perplexity.ai/settings/api
-- Parallel: https://platform.parallel.ai/
+
+The **Parallel Task** server uses OAuth (no API key needed). Claude Code handles
+authentication automatically — you'll be prompted to authorize on first use.
 
 After adding keys: source `~/.zshrc` and restart Claude Code.
 


### PR DESCRIPTION
The Parallel Task MCP server uses OAuth, not Bearer token auth. Removed PARALLEL_API_KEY env var from plugin.json headers config and updated all docs (CLAUDE.md, README.md, SKILL.md) to reflect that Claude Code handles OAuth automatically.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/yellow-plugins/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switches Parallel Task MCP server authentication from API key to OAuth, updating `plugin.json` and documentation to reflect this change.
> 
>   - **Behavior**:
>     - Switches Parallel Task MCP server authentication from API key to OAuth in `plugin.json`.
>     - Removes `PARALLEL_API_KEY` from environment variable setup in `CLAUDE.md`, `README.md`, and `SKILL.md`.
>     - Updates documentation to indicate OAuth is auto-managed by Claude Code, prompting authorization on first use.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=KingInYellows%2Fyellow-plugins&utm_source=github&utm_medium=referral)<sup> for d6d3b83c76e277738dae4ba018ba7ae9913bb727. You can [customize](https://app.ellipsis.dev/KingInYellows/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrects authentication method for Parallel Task MCP server from Bearer token to OAuth. The PR systematically removes the `PARALLEL_API_KEY` environment variable from all user-facing documentation and removes the Bearer token headers configuration from `plugin.json`. All documentation consistently explains that Claude Code handles OAuth automatically.

**Changes:**
- Removed `headers` with Bearer auth from parallel server config in `plugin.json`
- Updated all documentation to reflect OAuth instead of API key authentication
- Removed `PARALLEL_API_KEY` from environment setup instructions across CLAUDE.md, README.md, and SKILL.md
- Added clear explanations that users will be prompted to authorize OAuth on first use

**Note:** A historical plan document (`docs/plans/2026-02-21-feat-yellow-research-plugin-plan.md`) still references the old Bearer auth method. This appears intentional since it's dated historical documentation, but consider adding a note about the auth correction if this plan is referenced frequently.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Clean configuration and documentation fix with no logic changes. All modifications are consistent, well-coordinated across files, and properly switch from incorrect Bearer token auth to correct OAuth implementation. No code execution paths are modified.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/yellow-research/.claude-plugin/plugin.json | Removed Bearer token authentication headers for parallel server, switching to OAuth |
| plugins/yellow-research/CLAUDE.md | Updated parallel server documentation from API key to OAuth, removed PARALLEL_API_KEY from env setup |
| plugins/yellow-research/README.md | Removed PARALLEL_API_KEY from environment setup, added OAuth authentication explanation |
| plugins/yellow-research/skills/research-patterns/SKILL.md | Removed PARALLEL_API_KEY from API key setup section, added OAuth clarification |

</details>



<sub>Last reviewed commit: d6d3b83</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Parallel Task server authentication now uses OAuth with automatic handling by Claude Code
  * No API key configuration required; authorization occurs on first use

<!-- end of auto-generated comment: release notes by coderabbit.ai -->