### PR TITLE
docs: update README for yellow-research plugin and fix component counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Use pnpm only (`preinstall` enforces this).
 - If plugin behavior changes, update corresponding `README.md`, `CLAUDE.md`, and marketplace/plugin manifests as needed.
 
 ## Security & Configuration Tips
-- Never commit credentials (for example `DEVIN_API_TOKEN`).
+- Never commit credentials (for example `DEVIN_SERVICE_USER_TOKEN`).
 - Validate manifests and schema changes locally before pushing.
 
 ## Critical Agent Authoring Rules

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ server.
 | `yellow-research` | Perplexity  | `PERPLEXITY_API_KEY` required                                  |
 | `yellow-research` | Tavily      | `TAVILY_API_KEY` required                                      |
 | `yellow-research` | EXA         | `EXA_API_KEY` required                                         |
-| `yellow-research` | Parallel    | OAuth (auto-managed by Claude Code)                            |
+| `yellow-research` | Parallel    | No API key — auto-authenticated by Claude Code                 |
 | `yellow-ruvector` | ruvector    | Local stdio — no auth required                                 |
 
 ### Context7 (yellow-core)
@@ -111,7 +111,7 @@ environment variables at startup.
 - **Perplexity:** [perplexity.ai/settings/api](https://www.perplexity.ai/settings/api)
 - **Tavily:** [app.tavily.com](https://app.tavily.com)
 - **EXA:** [dashboard.exa.ai](https://dashboard.exa.ai)
-- **Parallel Task MCP:** OAuth only — Claude Code handles it automatically
+- **Parallel Task MCP:** No API key needed — Claude Code handles authentication automatically
 
 Plugins degrade gracefully: if a key is missing, that provider is skipped and
 research continues with the remaining sources.


### PR DESCRIPTION
- Add yellow-research plugin (Perplexity, Tavily, EXA, Parallel MCPs)
- Add setup guide for yellow-research API keys
- Correct component counts across all plugins (agents, commands, skills, hooks)
- Expand MCP table from 6 to 10 rows covering all servers
- Update plugin count from 10 to 11
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/yellow-plugins/pull/98" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates README to add `yellow-research` plugin, correct component counts, and include setup for new API keys.
> 
>   - **New Plugin**:
>     - Adds `yellow-research` plugin for deep research with Perplexity, Tavily, EXA, and Parallel Task MCPs.
>   - **Component Counts**:
>     - Corrects component counts for `gt-workflow`, `yellow-chatprd`, `yellow-ci`, `yellow-core`, `yellow-debt`, `yellow-devin`, `yellow-linear`, `yellow-review`, and `yellow-ruvector`.
>   - **API Keys**:
>     - Adds setup guide for `yellow-research` API keys: `PERPLEXITY_API_KEY`, `TAVILY_API_KEY`, `EXA_API_KEY`.
>   - **Misc**:
>     - Updates plugin count from 10 to 11 in `README.md`.
>     - Expands MCP table from 6 to 10 rows to cover all servers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=KingInYellows%2Fyellow-plugins&utm_source=github&utm_medium=referral)<sup> for 7e3efdee3221c4219d087c31f2f84b3d39128f74. You can [customize](https://app.ellipsis.dev/KingInYellows/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plugin catalog from 10 to 11 plugins with expanded table structure
  * Restructured documentation sections for improved clarity and organization
  * Added new authentication and API key sources reference information
  * Enhanced plugin usage examples with additional command and namespace references
  * Improved project structure documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated documentation to reflect the addition of `yellow-research` plugin and corrected component counts across all plugins.

- Added `yellow-research` plugin row in main table with details on Perplexity, Tavily, EXA, and Parallel Task MCP integrations
- Corrected component counts for 9 plugins (`gt-workflow`, `yellow-chatprd`, `yellow-ci`, `yellow-core`, `yellow-debt`, `yellow-devin`, `yellow-linear`, `yellow-review`, `yellow-ruvector`)
- Expanded MCP authentication table from 6 to 10 rows covering all servers
- Updated Devin authentication from `DEVIN_API_TOKEN` to `DEVIN_SERVICE_USER_TOKEN` with added `DEVIN_ORG_ID` requirement
- Added comprehensive setup guide for yellow-research API keys with links to provider dashboards
- Updated plugin count from 10 to 11 throughout the documentation

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Documentation-only changes with verified accurate component counts, consistent API key naming updates, and comprehensive setup instructions. No code modifications or potential runtime impact.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| AGENTS.md | Updated `DEVIN_API_TOKEN` reference to `DEVIN_SERVICE_USER_TOKEN` in security tips |
| README.md | Added yellow-research plugin documentation, corrected component counts, expanded MCP auth table, and updated API key instructions |

</details>



<sub>Last reviewed commit: eda7809</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->