### PR TITLE
docs(research): add ast-grep integration plan

### DIFF
--- a/docs/brainstorms/2026-03-06-ast-grep-parallel-mcp-research-plugin-brainstorm.md
+++ b/docs/brainstorms/2026-03-06-ast-grep-parallel-mcp-research-plugin-brainstorm.md
@@ -1,0 +1,299 @@
+# Brainstorm: Add ast-grep MCP to yellow-research and Verify Parallel Task MCP
+
+**Date:** 2026-03-06
+**Status:** Approved
+**Chosen approach:** B -- Bundle ast-grep directly into yellow-research
+
+---
+
+## What We're Building
+
+Bundle the **ast-grep MCP server** as a 5th MCP server in yellow-research's
+`plugin.json`, providing AST-level structural code search to research workflows.
+Additionally, add a **Parallel Task MCP connectivity check** to `/research:setup`
+and clean up documentation around the existing `mcp__grep__searchGitHub`
+references (which are a separate, unrelated tool from grep.app).
+
+### Deliverables
+
+1. Add ast-grep MCP server entry to `plugins/yellow-research/.claude-plugin/plugin.json`
+2. Add all 4 ast-grep tools to research agent `allowed-tools` lists
+3. Document `uv` and `ast-grep` binary as prerequisites in CLAUDE.md
+4. Add ast-grep binary/uv availability check to `/research:setup`
+5. Add Parallel Task MCP connectivity check to `/research:setup`
+6. Clarify `mcp__grep__searchGitHub` references (different tool, stays as-is)
+7. Update research-conductor triage logic to incorporate ast-grep tools
+
+---
+
+## Why This Approach
+
+### Approach chosen: B -- Bundle in yellow-research
+
+The user chose to bundle ast-grep directly into yellow-research rather than
+creating a separate plugin. While a separate plugin (Approach A) follows the
+established pattern of yellow-morph/WarpGrep, the user prefers the simpler
+wiring of having all research-relevant MCP servers in a single plugin.json.
+
+**Key tradeoffs accepted:**
+- Mixed runtime: `uvx` (Python) alongside `npx` (Node) in one plugin
+- Users who only want web research APIs will need `uv` + `ast-grep` installed,
+  or accept graceful degradation (ast-grep tools unavailable, other tools work)
+- ast-grep tools are less easily available to non-research plugins (they would
+  need cross-plugin `allowed-tools` references back to yellow-research)
+
+**Why not Approach A (separate yellow-ast-grep plugin):**
+- User wants minimal plugin count and simpler integration
+- Avoids creating a new plugin with its own package.json, CLAUDE.md, README
+
+**Why not Approach C (defer ast-grep, health checks only):**
+- User wants ast-grep integration now, not deferred
+- There is a concrete use case: AST-aware code search in research workflows
+
+### Parallel Task MCP stays in yellow-research
+
+The Parallel Task MCP (`https://task-mcp.parallel.ai/mcp`) remains in
+yellow-research. It is a research orchestration primitive whose tools
+(`createDeepResearch`, `createTaskGroup`, `getStatus`, `getResultMarkdown`)
+are tightly coupled to the research-conductor's async fan-out logic. It has
+zero local dependencies (HTTP server, no binary, no API key) and no value
+outside research workflows. Extracting it would create a plugin with a single
+HTTP entry and no commands -- pure overhead.
+
+---
+
+## Key Decisions
+
+### 1. ast-grep MCP server configuration
+
+**Package:** `ast-grep-mcp` from `git+https://github.com/ast-grep/ast-grep-mcp`
+**Runtime:** `uvx` (Python, via `uv`)
+**Binary prerequisite:** `ast-grep` (installed via `brew install ast-grep`,
+`cargo install ast-grep --locked`, or `nix-shell -p ast-grep`)
+
+**plugin.json entry:**
+```json
+"ast-grep": {
+  "command": "uvx",
+  "args": [
+    "--from",
+    "git+https://github.com/ast-grep/ast-grep-mcp",
+    "ast-grep-server"
+  ]
+}
+```
+
+**Tool names when bundled** (plugin-namespaced):
+- `mcp__plugin_yellow-research_ast-grep__find_code`
+- `mcp__plugin_yellow-research_ast-grep__find_code_by_rule`
+- `mcp__plugin_yellow-research_ast-grep__dump_syntax_tree`
+- `mcp__plugin_yellow-research_ast-grep__test_match_code_rule`
+
+### 2. ast-grep is NOT the same as grep.app searchGitHub
+
+During the brainstorm, a critical clarification emerged: the user wanted
+**ast-grep** (AST-level structural code search, local), not the **grep.app
+MCP** (`mcp__grep__searchGitHub`, GitHub web code search, remote).
+
+These are completely different tools:
+
+| Aspect | ast-grep MCP | grep.app MCP |
+|--------|-------------|--------------|
+| What it does | Local AST pattern matching | GitHub code search via web |
+| Tool name | `find_code`, `find_code_by_rule`, etc. | `searchGitHub` |
+| Runtime | `uvx` (Python) + `ast-grep` binary | Global MCP config |
+| Scope | Files on disk in current project | All public GitHub repos |
+| API key | None | None |
+
+**Decision:** The existing `mcp__grep__searchGitHub` references in CLAUDE.md,
+`research-conductor.md`, `deep.md`, and `setup.md` remain as-is. They refer
+to a different tool. CLAUDE.md documentation should be updated to clarify the
+distinction.
+
+### 3. All 4 ast-grep tools exposed to research agents
+
+All 4 tools will be added to the `allowed-tools` lists in:
+- `plugins/yellow-research/agents/research/research-conductor.md`
+- `plugins/yellow-research/commands/research/deep.md`
+- `plugins/yellow-research/commands/research/code.md` (if it exists)
+
+The research-conductor will decide which tools to use based on query complexity:
+- `find_code` -- simple structural pattern searches during code research
+- `find_code_by_rule` -- complex multi-condition AST searches
+- `dump_syntax_tree` -- when the conductor needs to understand AST structure
+  to build a better search query
+- `test_match_code_rule` -- when the conductor wants to validate a rule before
+  running it across the codebase
+
+### 4. Research-conductor triage updates
+
+The existing triage logic (Simple/Moderate/Complex) should be extended:
+
+- **When researching code patterns or codebase structure:** Use ast-grep tools
+  alongside or instead of text-based search
+- **When the query involves "find all X that Y"** (structural code patterns):
+  Prefer `find_code_by_rule` over text grep
+- **When building complex AST rules:** Use `dump_syntax_tree` first to
+  understand structure, then `test_match_code_rule` to validate, then
+  `find_code_by_rule` to search
+
+This does NOT change the Simple/Moderate/Complex fan-out for web research.
+ast-grep is a **code search** tool that complements the existing **web research**
+tools.
+
+### 5. Parallel Task MCP health check in /research:setup
+
+Add a new entry to Step 3.5 (MCP Source Health Checks) in `setup.md`:
+
+```text
+**Parallel Task MCP** (bundled HTTP — async research orchestration):
+
+ToolSearch keyword: "createDeepResearch"
+Tool name: mcp__plugin_yellow-research_parallel__createDeepResearch
+Test: ToolSearch probe only (do not create an actual task).
+If tool is found in ToolSearch results, record as ACTIVE.
+If not found, record as UNAVAILABLE.
+```
+
+The health check should be ToolSearch-only (no live call) because:
+- `createDeepResearch` creates real tasks with real compute cost
+- `getStatus` requires a valid task_id
+- Finding the tool in ToolSearch confirms the HTTP MCP connection is live
+
+### 6. ast-grep health check in /research:setup
+
+Add ast-grep checks to both Step 1 (prerequisites) and Step 3.5 (MCP sources):
+
+**Step 1 addition:**
+```bash
+command -v ast-grep >/dev/null 2>&1 && printf 'ast-grep: ok\n' || printf 'ast-grep: NOT FOUND\n'
+command -v uv >/dev/null 2>&1 && printf 'uv:       ok\n' || printf 'uv:       NOT FOUND\n'
+```
+
+**Step 3.5 addition:**
+```text
+**ast-grep MCP** (bundled stdio — AST structural code search):
+
+ToolSearch keyword: "find_code"
+Tool name: mcp__plugin_yellow-research_ast-grep__find_code
+Test call: mcp__plugin_yellow-research_ast-grep__find_code
+  with pattern: "function $NAME() {}", lang: "javascript", path: "."
+```
+
+### 7. CLAUDE.md documentation updates
+
+Update the optional dependencies section to:
+- Clarify that `mcp__grep__searchGitHub` is the **grep.app** GitHub code search
+  (global MCP, optional, separate from ast-grep)
+- Document ast-grep as a **bundled** MCP server (not optional -- it ships with
+  the plugin but requires system prerequisites)
+- Add `uv` and `ast-grep` binary to the prerequisites section
+- Note graceful degradation: if `ast-grep` binary is missing, the MCP server
+  will fail to start but other servers are unaffected
+
+---
+
+## Open Questions
+
+1. **ast-grep version pinning:** The current `uvx` invocation pulls from
+   `git+https://github.com/ast-grep/ast-grep-mcp` (latest main). Should we pin
+   to a specific commit or tag for reproducibility? The repo has no releases/tags
+   yet (0 releases on GitHub). Monitor for a PyPI package or versioned releases.
+
+2. **ast-grep binary version:** Should `/research:setup` check the ast-grep
+   binary version and warn if it is below a minimum? The MCP server README does
+   not specify a minimum version.
+
+3. **sgconfig.yaml support:** ast-grep MCP supports custom configuration via
+   `--config` flag or `AST_GREP_CONFIG` env var. Should we expose this in
+   plugin.json's env section for users who have project-specific ast-grep configs?
+
+4. **Cross-plugin consumption:** If other plugins (yellow-debt, yellow-review,
+   yellow-semgrep) want ast-grep tools, they will need cross-plugin
+   `allowed-tools` references like
+   `mcp__plugin_yellow-research_ast-grep__find_code`. This works but couples
+   those plugins to yellow-research. If demand grows, revisit extracting to a
+   standalone yellow-ast-grep plugin (Approach A from this brainstorm).
+
+5. **grep.app searchGitHub future:** The `mcp__grep__searchGitHub` tool is
+   currently a global MCP config with no plugin owning it. Should it eventually
+   be bundled into a plugin, or is global config acceptable long-term? Not
+   blocking for this work.
+
+---
+
+## Brainstorm Dialogue Summary
+
+### Phase 0: Topic Confirmation
+- Initial topic: "Add Grep MCP to yellow-research and confirm Parallel Task MCP"
+- Refined: user clarified they want ast-grep (AST structural search), NOT
+  grep.app (GitHub code search)
+
+### Phase 1: Questions
+
+**Q1: Clean break vs backward compat for tool naming?**
+A: Clean break -- bundle in yellow-research only, update all allowed-tools
+references, remove global config instructions. (This was before the ast-grep
+clarification; the principle still applies to ast-grep bundling.)
+
+**Q2: What is the exact package for "Grep MCP"?**
+A: User clarified this is **ast-grep MCP** from
+`https://github.com/ast-grep/ast-grep-mcp`, not grep.app searchGitHub.
+
+**Q3: Bundle in yellow-research vs separate plugin?**
+A: User chose bundle (Approach B). Mixed runtime (uvx + npx) is acceptable.
+Recommendation was separate plugin (Approach A) based on yellow-morph precedent,
+but user preferred simpler wiring.
+
+**Q4: Which ast-grep tools to expose to research?**
+A: All 4 tools (`find_code`, `find_code_by_rule`, `dump_syntax_tree`,
+`test_match_code_rule`). Let research-conductor decide based on complexity.
+
+**Q5: What does "confirm Parallel Task MCP working" mean?**
+A: Add connectivity check to `/research:setup` (ToolSearch probe, no live task
+creation). Also confirmed Parallel Task MCP should stay in yellow-research
+(not its own plugin) because it is a research orchestration primitive with
+zero local dependencies and no value outside research workflows.
+
+### Research
+
+**External research (RESEARCH_ROUND=1):** Crawled
+`https://github.com/ast-grep/ast-grep-mcp` via EXA. Key findings:
+- Python-based server using FastMCP framework
+- 308 stars, MIT license, 53 commits
+- Requires `ast-grep` binary + `uv` runtime
+- 4 tools: `dump_syntax_tree`, `test_match_code_rule`, `find_code`,
+  `find_code_by_rule`
+- Run via `uvx --from git+https://github.com/ast-grep/ast-grep-mcp ast-grep-server`
+- No API keys, no env vars required (optional `AST_GREP_CONFIG`)
+- No PyPI package or versioned releases yet
+
+### Approaches Considered
+
+| Approach | Description | Chosen? |
+|----------|-------------|---------|
+| A: Separate yellow-ast-grep plugin | Own plugin.json, optional research dep | No |
+| B: Bundle in yellow-research | 5th MCP server in existing plugin.json | Yes |
+| C: Defer, health checks only | No ast-grep, just setup improvements | No |
+
+---
+
+## Implementation Checklist
+
+- [ ] Add `ast-grep` MCP server entry to `plugins/yellow-research/.claude-plugin/plugin.json`
+- [ ] Add 4 ast-grep tools to `allowed-tools` in `research-conductor.md`
+- [ ] Add 4 ast-grep tools to `allowed-tools` in `research/deep.md`
+- [ ] Add 4 ast-grep tools to `allowed-tools` in `research/code.md` (if exists)
+- [ ] Update `research-conductor.md` triage logic for ast-grep tool usage
+- [ ] Add `ast-grep` and `uv` prerequisite checks to `/research:setup` Step 1
+- [ ] Add ast-grep MCP health check to `/research:setup` Step 3.5
+- [ ] Add Parallel Task MCP health check to `/research:setup` Step 3.5
+- [ ] Update `/research:setup` Step 4 report table (add ast-grep + Parallel rows)
+- [ ] Update `/research:setup` Step 5 install instructions for ast-grep
+- [ ] Update CLAUDE.md prerequisites section (add `uv`, `ast-grep` binary)
+- [ ] Update CLAUDE.md optional dependencies to clarify grep.app vs ast-grep
+- [ ] Update CLAUDE.md MCP servers section to list ast-grep as bundled
+- [ ] Update `package.json` keywords if applicable
+- [ ] Test: verify `uvx --from git+https://github.com/ast-grep/ast-grep-mcp ast-grep-server` starts
+- [ ] Test: run `/research:setup` and confirm all health checks pass
+- [ ] Test: run `/research:deep` on a code-related topic and confirm ast-grep tools are available

--- a/plans/add-ast-grep-mcp-to-yellow-research.md
+++ b/plans/add-ast-grep-mcp-to-yellow-research.md
@@ -1,0 +1,298 @@
+# Feature: Add ast-grep MCP to yellow-research & Parallel Task MCP Health Check
+
+## Problem Statement
+
+The yellow-research plugin bundles 4 MCP servers (Perplexity, Tavily, EXA, Parallel Task)
+but lacks AST-level structural code search. The ast-grep MCP server provides pattern-based
+code search using abstract syntax trees — valuable for research workflows that analyze
+codebases. Additionally, the Parallel Task MCP has no health check in `/research:setup`,
+and the `mcp__grep__searchGitHub` references in docs need clarification (it is a separate
+tool from ast-grep).
+
+<!-- deepen-plan: external -->
+> **Research:** ast-grep MCP handles missing `ast-grep` binary gracefully — the check is
+> **lazy** (not at startup). The server starts successfully and advertises all 4 tools even
+> if `ast-grep` is not installed. Tools fail with a descriptive `RuntimeError` on first
+> invocation: `"Command 'ast-grep' not found. Please ensure ast-grep is installed and in PATH."`
+> The MCP server process continues running after this error.
+<!-- /deepen-plan -->
+
+## Current State
+
+- `plugin.json` has 4 MCP servers: `perplexity` (npx), `tavily` (npx), `exa` (npx), `parallel` (HTTP)
+- `research-conductor.md` and `deep.md` reference `mcp__grep__searchGitHub` (grep.app, unrelated to ast-grep)
+- `/research:setup` checks 4 MCP sources (Context7, Grep MCP, WarpGrep, DeepWiki) but NOT Parallel Task
+- ast-grep MCP is Python-based (`uvx`), requires `ast-grep` binary + `uv` runtime
+- Source: https://github.com/ast-grep/ast-grep-mcp — 4 tools, no API key needed
+
+<!-- deepen-plan: external -->
+> **Research:** ast-grep-mcp requires **Python >= 3.13** (hard constraint in `pyproject.toml`:
+> `requires-python = ">=3.13"`). This is a strict constraint — `uvx` will fail to install if
+> only Python 3.12 or earlier is available. This should be documented as a prerequisite
+> alongside `uv` and the `ast-grep` binary.
+<!-- /deepen-plan -->
+
+## Proposed Solution
+
+Bundle ast-grep MCP as a 5th server in yellow-research's `plugin.json` using `uvx`.
+Add all 4 tools to research agent allowed-tools. Add health checks for both ast-grep
+and Parallel Task MCP to `/research:setup`. Update CLAUDE.md documentation.
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** The `yellow-semgrep` plugin already uses `uvx` as an MCP server command
+> (`plugins/yellow-semgrep/.claude-plugin/plugin.json`), confirming `uvx` is an accepted
+> pattern in this ecosystem. However, semgrep-mcp is a published PyPI package, whereas
+> ast-grep-mcp uses a `git+https://` URL — less stable but the only option available.
+<!-- /deepen-plan -->
+
+<!-- deepen-plan: external -->
+> **Research:** ast-grep-mcp is **NOT published to PyPI**. The package name in
+> `pyproject.toml` is `sg-mcp` v0.1.0 (pre-release). Git+https is the only installation
+> method. If PyPI publication occurs, the name would likely be `sg-mcp`. Pinning to a
+> specific commit is possible: `uvx --from "git+https://github.com/ast-grep/ast-grep-mcp@COMMITHASH" ast-grep-server`
+<!-- /deepen-plan -->
+
+<!-- deepen-plan: external -->
+> **Research:** The server explicitly ignores SIGINT for multi-session stability:
+> `signal.signal(signal.SIGINT, sigint_handler)`. This means it survives Claude Code
+> session restarts without being killed — good for long-running MCP server usage.
+> Transport modes: `stdio` (default, correct for plugin.json) and `sse` (port 3101).
+<!-- /deepen-plan -->
+
+## Implementation Plan
+
+### Phase 1: Plugin Configuration
+
+- [ ] 1.1: Add ast-grep MCP server entry to `plugins/yellow-research/.claude-plugin/plugin.json`
+  ```json
+  "ast-grep": {
+    "command": "uvx",
+    "args": [
+      "--from",
+      "git+https://github.com/ast-grep/ast-grep-mcp",
+      "ast-grep-server"
+    ]
+  }
+  ```
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** **Risk: hyphenated server key is untested.** All existing server keys in the
+> repo are single words (`perplexity`, `tavily`, `exa`, `parallel`, `morph`, `semgrep`,
+> `ruvector`, `context7`). The `ast-grep` key introduces a hyphen. While Claude Code uses
+> `__` as delimiter (not hyphens), this has not been empirically verified. **Recommendation:**
+> After adding the entry, start the MCP server and check ToolSearch output to confirm tool
+> names resolve as `mcp__plugin_yellow-research_ast-grep__find_code`. If hyphens cause
+> issues, consider `astgrep` (no hyphen) as the server key.
+<!-- /deepen-plan -->
+
+- [ ] 1.2: Update `plugins/yellow-research/package.json` — add `"ast-grep"` to keywords, update description
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** The current `package.json` has NO `keywords` field (only `name`, `version`,
+> `private`, `description`). A `keywords` array needs to be **created**, not updated.
+<!-- /deepen-plan -->
+
+### Phase 2: Agent & Command Wiring
+
+- [ ] 2.1: Add 4 ast-grep tools to `allowed-tools` in `plugins/yellow-research/agents/research/research-conductor.md`:
+  - `mcp__plugin_yellow-research_ast-grep__find_code`
+  - `mcp__plugin_yellow-research_ast-grep__find_code_by_rule`
+  - `mcp__plugin_yellow-research_ast-grep__dump_syntax_tree`
+  - `mcp__plugin_yellow-research_ast-grep__test_match_code_rule`
+- [ ] 2.2: Update research-conductor triage logic — add guidance for when to use ast-grep:
+  - Code pattern queries → prefer `find_code` / `find_code_by_rule` over text grep
+  - Complex AST rules → `dump_syntax_tree` first, `test_match_code_rule` to validate, then `find_code_by_rule`
+  - ast-grep is a **code search** complement, does NOT change Simple/Moderate/Complex web research fan-out
+- [ ] 2.3: Add 4 ast-grep tools to `allowed-tools` in `plugins/yellow-research/commands/research/deep.md`
+- [ ] 2.4: Add 4 ast-grep tools to `allowed-tools` in `plugins/yellow-research/agents/research/code-researcher.md`
+- [ ] 2.5: Update code-researcher source routing table — add row for AST/structural code patterns → ast-grep tools
+- [ ] 2.6: Add 4 ast-grep tools to `allowed-tools` in `plugins/yellow-research/commands/research/code.md`
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** **Gap found:** `commands/research/code.md` was missing from the original file
+> list. It has its own `allowed-tools` frontmatter (lines 5-17) with explicit MCP tool entries
+> (EXA, Context7, grep, Perplexity). Since it lists tools directly (not just delegating to
+> the agent), ast-grep tools are needed here too. Added as task 2.6.
+<!-- /deepen-plan -->
+
+### Phase 3: Setup Health Checks
+
+- [ ] 3.1: Add `ast-grep` binary, `uv`, and Python version prerequisite checks to `/research:setup` Step 1:
+  ```bash
+  command -v ast-grep >/dev/null 2>&1 && printf 'ast-grep: ok\n' || printf 'ast-grep: NOT FOUND\n'
+  command -v uv >/dev/null 2>&1 && printf 'uv:       ok\n' || printf 'uv:       NOT FOUND\n'
+  python3 --version 2>/dev/null | grep -qE '3\.(1[3-9]|[2-9][0-9])' && printf 'python:   ok (>=3.13)\n' || printf 'python:   NEEDS >=3.13\n'
+  ```
+
+<!-- deepen-plan: external -->
+> **Research:** Python >= 3.13 is a hard requirement. The setup check should verify this
+> since `uvx` will fail to install ast-grep-mcp without it. The `.python-version` file in
+> the ast-grep-mcp repo also specifies `3.13`.
+<!-- /deepen-plan -->
+
+- [ ] 3.2: Add ast-grep MCP health check to Step 3.5:
+  ```text
+  **ast-grep MCP** (bundled stdio — AST structural code search):
+  ToolSearch keyword: "find_code"
+  Tool name: mcp__plugin_yellow-research_ast-grep__find_code
+  Test call: find_code with pattern: "function $NAME() {}", lang: "javascript"
+  ```
+
+<!-- deepen-plan: external -->
+> **Research:** Since the binary check is lazy (server starts even without `ast-grep`),
+> the health check test call will be the true validation. If `ast-grep` is missing, the
+> test call will fail with `"Command 'ast-grep' not found"` — record as FAIL with a note
+> to install the binary. The ToolSearch probe alone is insufficient to confirm functionality.
+<!-- /deepen-plan -->
+
+- [ ] 3.3: Add Parallel Task MCP health check to Step 3.5:
+  ```text
+  **Parallel Task MCP** (bundled HTTP — async research orchestration):
+  ToolSearch keyword: "createDeepResearch"
+  Tool name: mcp__plugin_yellow-research_parallel__createDeepResearch
+  Test: ToolSearch probe only (do not create actual tasks — they have compute cost)
+  ```
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** The ToolSearch-only approach for Parallel Task is a justified deviation from
+> the existing pattern (all 4 current checks do both ToolSearch + test call). Parallel Task
+> tools create real tasks with real compute cost and `getStatus` requires a valid task_id.
+> Document this rationale in setup.md so future maintainers understand why.
+<!-- /deepen-plan -->
+
+- [ ] 3.4: Update Step 4 report table — add ast-grep and Parallel Task rows to MCP Sources section, update source counts (now 6 MCP sources, not 4)
+- [ ] 3.5: Update Step 5 install instructions — add ast-grep/uv install guidance:
+  ```text
+  ast-grep:  brew install ast-grep  (or: cargo install ast-grep --locked, or: pip install ast-grep-cli)
+  uv:        curl -LsSf https://astral.sh/uv/install.sh | sh
+  python:    Requires >= 3.13 (check with python3 --version)
+  ```
+
+<!-- deepen-plan: external -->
+> **Research:** The `ast-grep` binary can also be installed via `pip install ast-grep-cli`
+> (currently at v0.41.0 on PyPI). This is an additional install path worth documenting
+> alongside brew and cargo.
+<!-- /deepen-plan -->
+
+- [ ] 3.6: Add ast-grep and Parallel Task to `allowed-tools` in `plugins/yellow-research/commands/research/setup.md` frontmatter
+
+### Phase 4: Documentation
+
+- [ ] 4.1: Update `plugins/yellow-research/CLAUDE.md`:
+  - Add `ast-grep` section under MCP Servers listing 4 tools
+  - Add `uv`, Python >= 3.13, and `ast-grep` binary to prerequisites section
+  - Note graceful degradation: missing `ast-grep` binary → server starts but tools fail on invocation; other servers unaffected
+  - Clarify in optional dependencies that `mcp__grep__searchGitHub` is grep.app (GitHub web search), distinct from ast-grep (local AST search)
+- [ ] 4.2: Update `plugins/yellow-research/README.md` — add ast-grep row to MCP servers table and update description line
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** README.md has an MCP servers table at lines 59-67 with 4 rows. The
+> description at line 3 says "Bundles Perplexity, Tavily, EXA, and Parallel Task MCP
+> servers" — both need updating to include ast-grep as the 5th server.
+<!-- /deepen-plan -->
+
+- [ ] 4.3: Update `plugins/yellow-research/.claude-plugin/plugin.json` description to mention ast-grep
+- [ ] 4.4: Update `plugins/yellow-research/skills/research-patterns/SKILL.md` source selection guide table — add ast-grep row
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** **Gap found:** The research-patterns skill at
+> `plugins/yellow-research/skills/research-patterns/SKILL.md` has a "Source Selection Guide"
+> table (lines 57-65) and "MCP Tool Name Verification" section (lines 105-121). Both should
+> be updated with ast-grep entries. Added as task 4.4.
+<!-- /deepen-plan -->
+
+- [ ] 4.5: Update `.claude-plugin/marketplace.json` description for yellow-research entry
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** **Gap found:** The marketplace.json description (line 116) says "Deep research
+> plugin with Perplexity, Tavily, EXA, and Parallel Task MCP servers." This must stay in sync
+> with plugin.json per the three-way versioning model. Added as task 4.5.
+<!-- /deepen-plan -->
+
+### Phase 5: Versioning & CI
+
+- [ ] 5.1: Run `pnpm changeset` — select yellow-research with `minor` bump type (new MCP server = new capability)
+- [ ] 5.2: Run `pnpm apply:changesets` to apply version bump
+- [ ] 5.3: Run `node scripts/sync-manifests.js` to propagate version to plugin.json and marketplace.json
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** **Gap found:** Per the repo's `docs/CLAUDE.md`: "Always run `pnpm changeset`
+> before committing plugin file changes. CI blocks PRs that modify `plugins/*/` without a
+> `.changeset/*.md` file." A `minor` changeset is required (adding a new MCP server is a new
+> capability). Added as Phase 5.
+<!-- /deepen-plan -->
+
+## Technical Details
+
+### Files to Modify
+
+- `plugins/yellow-research/.claude-plugin/plugin.json` — add ast-grep server entry + update description
+- `plugins/yellow-research/package.json` — update description, add keywords array
+- `plugins/yellow-research/agents/research/research-conductor.md` — allowed-tools + triage logic
+- `plugins/yellow-research/agents/research/code-researcher.md` — allowed-tools + source routing
+- `plugins/yellow-research/commands/research/deep.md` — allowed-tools
+- `plugins/yellow-research/commands/research/code.md` — allowed-tools
+- `plugins/yellow-research/commands/research/setup.md` — health checks + allowed-tools
+- `plugins/yellow-research/skills/research-patterns/SKILL.md` — source selection guide
+- `plugins/yellow-research/CLAUDE.md` — documentation
+- `plugins/yellow-research/README.md` — MCP server table + description
+- `.claude-plugin/marketplace.json` — yellow-research description
+
+### No Files to Create
+
+All changes are modifications to existing files.
+
+### Dependencies
+
+- `ast-grep` binary (system) — `brew install ast-grep` or `cargo install ast-grep --locked` or `pip install ast-grep-cli`
+- `uv` (system) — `curl -LsSf https://astral.sh/uv/install.sh | sh`
+- Python >= 3.13 (system) — hard requirement from ast-grep-mcp's `pyproject.toml`
+- `ast-grep-mcp` (Python, fetched by uvx at runtime) — `git+https://github.com/ast-grep/ast-grep-mcp`
+
+### Tool Names When Bundled
+
+```
+mcp__plugin_yellow-research_ast-grep__find_code
+mcp__plugin_yellow-research_ast-grep__find_code_by_rule
+mcp__plugin_yellow-research_ast-grep__dump_syntax_tree
+mcp__plugin_yellow-research_ast-grep__test_match_code_rule
+```
+
+## Acceptance Criteria
+
+1. `plugin.json` contains ast-grep server entry with `uvx` command
+2. All 4 ast-grep tools appear in allowed-tools for research-conductor, code-researcher, deep.md, and code.md
+3. `/research:setup` checks for `ast-grep` binary, `uv`, Python >= 3.13, ast-grep MCP tools, and Parallel Task MCP tools
+4. Setup report table shows 6 MCP sources (Context7, Grep MCP, WarpGrep, DeepWiki, ast-grep, Parallel Task)
+5. CLAUDE.md documents ast-grep as bundled, lists prerequisites (including Python >= 3.13), and clarifies grep.app vs ast-grep distinction
+6. Research-conductor knows when to use ast-grep tools (code pattern queries)
+7. Graceful degradation: missing ast-grep binary does not affect other MCP servers (server starts, tools fail on invocation)
+8. SKILL.md source selection guide includes ast-grep row
+9. marketplace.json description updated
+10. Changeset created with minor bump
+
+## Edge Cases
+
+- `ast-grep` binary missing → MCP server starts successfully but tools fail on invocation with descriptive error; setup reports FAIL; other servers unaffected
+- `uv` missing → `uvx` command not found; ast-grep server doesn't start; other servers unaffected
+- Python < 3.13 → `uvx` fails to install ast-grep-mcp; setup reports NEEDS >=3.13
+- No versioned releases of ast-grep-mcp → `uvx` pulls latest from main; monitor for PyPI package (would be `sg-mcp`)
+- `mcp__grep__searchGitHub` references stay as-is — different tool, different purpose
+- Hyphenated server key `ast-grep` — untested in this repo; verify empirically after adding; fallback: use `astgrep`
+
+<!-- deepen-plan: external -->
+> **Research:** The `ast-grep` binary check is lazy — the MCP server starts and advertises
+> all 4 tools even without the binary installed. Errors only surface on tool invocation.
+> This means ToolSearch will find the tools, but health check test calls will fail.
+> The setup health check design correctly uses a test call (not just ToolSearch) to detect this.
+<!-- /deepen-plan -->
+
+## References
+
+- Brainstorm: `docs/brainstorms/2026-03-06-ast-grep-parallel-mcp-research-plugin-brainstorm.md`
+- ast-grep MCP repo: https://github.com/ast-grep/ast-grep-mcp
+- ast-grep MCP pyproject.toml: package name `sg-mcp`, requires Python >= 3.13, entry point `ast-grep-server = "main:run_mcp_server"`
+- Parallel Task MCP: https://task-mcp.parallel.ai/mcp
+- ast-grep-cli on PyPI: https://pypi.org/project/ast-grep-cli/ (v0.41.0, alternative binary install)
+- Recall finding (score 0.70): MCP cold-start latency matters — ToolSearch finding a tool doesn't guarantee server is running
+- Codebase precedent: yellow-semgrep uses `uvx` for its MCP server (`plugins/yellow-semgrep/.claude-plugin/plugin.json`)


### PR DESCRIPTION
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/yellow-plugins/pull/144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two documentation-only files — a brainstorm record and a detailed implementation plan — for integrating the `ast-grep` MCP server into the `yellow-research` plugin as its 5th bundled MCP server, and for adding a `Parallel Task MCP` health check to `/research:setup`. No production code is changed yet; the plan drives a future implementation PR.

The documents are well-researched, with inline `deepen-plan` annotations capturing key findings (Python >= 3.13 hard requirement, lazy binary check, hyphenated server key risk, PyPI absence). The chosen approach (bundle in `yellow-research`) is clearly justified with tradeoffs against a separate plugin or deferral.

**Key points:**
- The ast-grep health check test call is missing the `path: "."` parameter in the plan (present in the brainstorm), which should be reconciled before implementation to avoid a broken health check
- The Python >= 3.13 prerequisite check uses the system `python3`, but `uv` can manage its own Python version independently — this could produce misleading PASS/FAIL results for the check; the setup doc should note this limitation
- The open question about commit hash pinning is valid and worth resolving before the implementation PR lands, given `ast-grep-mcp` has no PyPI releases or git tags yet
- Phase 5 (changeset / versioning) correctly captures the repo CI requirement to run `pnpm changeset` before any plugin file changes

<h3>Confidence Score: 5/5</h3>

- Documentation-only PR with no code changes; safe to merge with the minor inconsistencies flagged as style improvements
- Both files are pure markdown documentation (brainstorm + plan). No production code, tests, configs, or plugin files are modified. The two flagged issues are minor style-level inconsistencies between the two documents — neither would cause any runtime problem since the plan hasn't been implemented yet. The overall plan is technically accurate and well-researched.
- No files require special attention; the minor `path` parameter inconsistency in `plans/add-ast-grep-mcp-to-yellow-research.md` should be resolved before the implementation PR is authored.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/brainstorms/2026-03-06-ast-grep-parallel-mcp-research-plugin-brainstorm.md | New brainstorm document capturing the decision to bundle ast-grep MCP into yellow-research (Approach B), with good coverage of tradeoffs, tool clarifications, and open questions; health check test call for ast-grep includes `path: "."` that is absent from the corresponding plan document. |
| plans/add-ast-grep-mcp-to-yellow-research.md | Detailed implementation plan with phased tasks, deepen-plan research annotations, and accurate edge case coverage; minor inconsistency with the brainstorm on the ast-grep health check test call (missing `path` parameter), and the Python version check may give misleading results since `uv` manages its own Python independently of `python3` on the system PATH. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Setup as /research:setup
    participant Conductor as Research Conductor
    participant AstGrepMCP as ast-grep MCP Server (uvx)
    participant AstGrepBin as ast-grep Binary
    participant WebMCPs as Web Research MCPs (Perplexity/Tavily/EXA)
    participant ParallelMCP as Parallel Task MCP (HTTP)

    User->>Setup: /research:setup
    Setup->>Setup: Step 1 – check ast-grep binary, uv, python >= 3.13
    Setup->>AstGrepMCP: Step 3.5 – ToolSearch "find_code" + test call
    AstGrepMCP->>AstGrepBin: invoke ast-grep binary (lazy check)
    AstGrepBin-->>AstGrepMCP: ok or RuntimeError (binary missing)
    AstGrepMCP-->>Setup: ACTIVE / FAIL
    Setup->>ParallelMCP: Step 3.5 – ToolSearch "createDeepResearch" only
    ParallelMCP-->>Setup: ACTIVE / UNAVAILABLE
    Setup-->>User: Report table (6 MCP sources)

    User->>Conductor: /research:deep "find all X patterns in codebase"
    Conductor->>Conductor: Triage – code pattern query detected
    alt Structural code search
        Conductor->>AstGrepMCP: dump_syntax_tree (understand AST)
        AstGrepMCP->>AstGrepBin: ast-grep dump
        AstGrepBin-->>AstGrepMCP: syntax tree
        AstGrepMCP-->>Conductor: tree output
        Conductor->>AstGrepMCP: test_match_code_rule (validate rule)
        AstGrepMCP-->>Conductor: match results
        Conductor->>AstGrepMCP: find_code_by_rule (full search, path: ".")
        AstGrepMCP-->>Conductor: matching code locations
    else Web research
        Conductor->>WebMCPs: Perplexity / Tavily / EXA queries
        WebMCPs-->>Conductor: web results
    else Async fan-out
        Conductor->>ParallelMCP: createDeepResearch / createTaskGroup
        ParallelMCP-->>Conductor: task_id
        Conductor->>ParallelMCP: getResultMarkdown(task_id)
        ParallelMCP-->>Conductor: aggregated results
    end
    Conductor-->>User: Synthesized research output
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `plans/add-ast-grep-mcp-to-yellow-research.md`, line 444-451 ([link](https://github.com/kinginyellows/yellow-plugins/blob/2bc921349b81662953e9b0388f3278dd3adedf9e/plans/add-ast-grep-mcp-to-yellow-research.md#L444-L451)) 

   **Missing `path` parameter in health check test call**

   The brainstorm document (Section 6) explicitly includes `path: "."` in the ast-grep health check test call, but Step 3.2 here omits it:

   > Brainstorm: `with pattern: "function $NAME() {}", lang: "javascript", path: "."`  
   > Plan: `Test call: find_code with pattern: "function $NAME() {}", lang: "javascript"`

   Without a `path` constraint, `find_code` could attempt to traverse the entire filesystem, potentially causing the health check to time out or return an overwhelming number of results. The brainstorm's spec was intentional here — `path: "."` scopes the test call to the current working directory. This should be added back to Step 3.2 to keep the two documents consistent and ensure the setup.md health check is implemented correctly.

   text
     **ast-grep MCP** (bundled stdio — AST structural code search):
     ToolSearch keyword: "find_code"
     Tool name: mcp__plugin_yellow-research_ast-grep__find_code
     Test call: find_code with pattern: "function $NAME() {}", lang: "javascript", path: "."
     ```
   ```

2. `plans/add-ast-grep-mcp-to-yellow-research.md`, line 444-457 ([link](https://github.com/kinginyellows/yellow-plugins/blob/3fd92e64d41b8926bed281d4e0010c2692e52df7/plans/add-ast-grep-mcp-to-yellow-research.md#L444-L457)) 

   **Missing `path` parameter in health check test call**

   The brainstorm document (section 6) specifies the `find_code` test call with `path: "."` to anchor the search to the current project root:

   ```text
   Test call: mcp__plugin_yellow-research_ast-grep__find_code
     with pattern: "function $NAME() {}", lang: "javascript", path: "."
   ```

   The plan's version at step 3.2 omits `path`, which means the tool will either use an unspecified default or fail when the implementation runs this health check. Since the goal of the test call is to confirm a real end-to-end invocation (not just ToolSearch), including `path: "."` makes the call deterministic and ensures it exercises actual file-system traversal. Recommend aligning with the brainstorm wording:

   text
     **ast-grep MCP** (bundled stdio — AST structural code search):
     ToolSearch keyword: "find_code"
     Tool name: mcp__plugin_yellow-research_ast-grep__find_code
     Test call: find_code with pattern: "function $NAME() {}", lang: "javascript", path: "."
     ```
   ```


3. `plans/add-ast-grep-mcp-to-yellow-research.md`, line 431-436 ([link](https://github.com/kinginyellows/yellow-plugins/blob/3fd92e64d41b8926bed281d4e0010c2692e52df7/plans/add-ast-grep-mcp-to-yellow-research.md#L431-L436)) 

   **Python version check may mislead when `uv` manages its own Python**

   The proposed check:

   ```bash
   python3 --version 2>/dev/null | grep -qE '3\.(1[3-9]|[2-9][0-9])' && printf 'python:   ok (>=3.13)\n' || printf 'python:   NEEDS >=3.13\n'
   ```

   inspects the system-level `python3`. However, `uv` can download and manage its own Python 3.13 environment independently of whatever is on the system `PATH`. This means:
   - A user with system Python 3.12 (fails the check) but `uv` configured to auto-download Python 3.13 will see a false "NEEDS >=3.13" warning, even though `uvx` will succeed.
   - Conversely, a user where `uv` is pinned to an older managed Python could pass the system check but still fail at `uvx` install time.

   Consider adding a note in the setup instructions that this is a best-effort advisory check, or supplement it with `uv python list` to show the uv-managed Python versions available:

   ```bash
   uv python list 2>/dev/null | grep -qE 'cpython-3\.(1[3-9]|[2-9][0-9])' && printf 'uv python: ok (>=3.13 managed)\n' || printf 'uv python: no managed >=3.13 found\n'
   ```

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aplans%2Fadd-ast-grep-mcp-to-yellow-research.md%3A444-457%0A**Missing%20%60path%60%20parameter%20in%20health%20check%20test%20call**%0A%0AThe%20brainstorm%20document%20%28section%206%29%20specifies%20the%20%60find_code%60%20test%20call%20with%20%60path%3A%20%22.%22%60%20to%20anchor%20the%20search%20to%20the%20current%20project%20root%3A%0A%0A%60%60%60text%0ATest%20call%3A%20mcp__plugin_yellow-research_ast-grep__find_code%0A%20%20with%20pattern%3A%20%22function%20%24NAME%28%29%20%7B%7D%22%2C%20lang%3A%20%22javascript%22%2C%20path%3A%20%22.%22%0A%60%60%60%0A%0AThe%20plan's%20version%20at%20step%203.2%20omits%20%60path%60%2C%20which%20means%20the%20tool%20will%20either%20use%20an%20unspecified%20default%20or%20fail%20when%20the%20implementation%20runs%20this%20health%20check.%20Since%20the%20goal%20of%20the%20test%20call%20is%20to%20confirm%20a%20real%20end-to-end%20invocation%20%28not%20just%20ToolSearch%29%2C%20including%20%60path%3A%20%22.%22%60%20makes%20the%20call%20deterministic%20and%20ensures%20it%20exercises%20actual%20file-system%20traversal.%20Recommend%20aligning%20with%20the%20brainstorm%20wording%3A%0A%0A%60%60%60suggestion%0A-%20%5B%20%5D%203.2%3A%20Add%20ast-grep%20MCP%20health%20check%20to%20Step%203.5%3A%0A%20%20%60%60%60text%0A%20%20**ast-grep%20MCP**%20%28bundled%20stdio%20%E2%80%94%20AST%20structural%20code%20search%29%3A%0A%20%20ToolSearch%20keyword%3A%20%22find_code%22%0A%20%20Tool%20name%3A%20mcp__plugin_yellow-research_ast-grep__find_code%0A%20%20Test%20call%3A%20find_code%20with%20pattern%3A%20%22function%20%24NAME%28%29%20%7B%7D%22%2C%20lang%3A%20%22javascript%22%2C%20path%3A%20%22.%22%0A%20%20%60%60%60%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aplans%2Fadd-ast-grep-mcp-to-yellow-research.md%3A431-436%0A**Python%20version%20check%20may%20mislead%20when%20%60uv%60%20manages%20its%20own%20Python**%0A%0AThe%20proposed%20check%3A%0A%0A%60%60%60bash%0Apython3%20--version%202%3E%2Fdev%2Fnull%20%7C%20grep%20-qE%20'3%5C.%281%5B3-9%5D%7C%5B2-9%5D%5B0-9%5D%29'%20%26%26%20printf%20'python%3A%20%20%20ok%20%28%3E%3D3.13%29%5Cn'%20%7C%7C%20printf%20'python%3A%20%20%20NEEDS%20%3E%3D3.13%5Cn'%0A%60%60%60%0A%0Ainspects%20the%20system-level%20%60python3%60.%20However%2C%20%60uv%60%20can%20download%20and%20manage%20its%20own%20Python%203.13%20environment%20independently%20of%20whatever%20is%20on%20the%20system%20%60PATH%60.%20This%20means%3A%0A-%20A%20user%20with%20system%20Python%203.12%20%28fails%20the%20check%29%20but%20%60uv%60%20configured%20to%20auto-download%20Python%203.13%20will%20see%20a%20false%20%22NEEDS%20%3E%3D3.13%22%20warning%2C%20even%20though%20%60uvx%60%20will%20succeed.%0A-%20Conversely%2C%20a%20user%20where%20%60uv%60%20is%20pinned%20to%20an%20older%20managed%20Python%20could%20pass%20the%20system%20check%20but%20still%20fail%20at%20%60uvx%60%20install%20time.%0A%0AConsider%20adding%20a%20note%20in%20the%20setup%20instructions%20that%20this%20is%20a%20best-effort%20advisory%20check%2C%20or%20supplement%20it%20with%20%60uv%20python%20list%60%20to%20show%20the%20uv-managed%20Python%20versions%20available%3A%0A%0A%60%60%60bash%0Auv%20python%20list%202%3E%2Fdev%2Fnull%20%7C%20grep%20-qE%20'cpython-3%5C.%281%5B3-9%5D%7C%5B2-9%5D%5B0-9%5D%29'%20%26%26%20printf%20'uv%20python%3A%20ok%20%28%3E%3D3.13%20managed%29%5Cn'%20%7C%7C%20printf%20'uv%20python%3A%20no%20managed%20%3E%3D3.13%20found%5Cn'%0A%60%60%60%0A%0A&repo=kinginyellows%2Fyellow-plugins"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<sub>Last reviewed commit: 3fd92e6</sub>

<!-- /greptile_comment -->