### PR TITLE
docs: fix P1 audit findings — add yellow-docs to README, update CHANGELOG, add package READMEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,44 @@ and this project adheres to
 
 ---
 
+## [1.2.0] - 2026-03-12
+
+### Added
+
+- **yellow-docs** — Documentation audit, generation, and Mermaid diagram
+  creation for any repository. 3 agents, 5 commands, 1 skill.
+- **yellow-morph** — Intelligent code editing and search via Morph Fast Apply
+  and WarpGrep MCP. 2 commands, 1 MCP.
+- **yellow-semgrep** — Semgrep security finding remediation — fetch, fix, and
+  verify findings from the Semgrep platform. 2 agents, 5 commands, 1 skill,
+  1 MCP.
+- **yellow-research** — Added ast-grep MCP server (5th MCP source).
+- **yellow-devin** — Added `/devin:review-prs` command for multi-agent PR
+  review and remediation of Devin-authored PRs.
+- **yellow-ci** — Added `/ci:report-linear` command for CI failure Linear issue
+  creation.
+- **yellow-core** — Added `/setup:all` command to validate all installed plugin
+  prerequisites at once.
+- **gt-workflow** — Added `/gt-amend` command, `smart-submit` command, and
+  Graphite MCP server integration.
+
+### Changed
+
+- Consolidated CI from 3 workflows to 1 unified `version-packages.yml`.
+- All agent definitions now use `tools:` frontmatter (migrated from `allowed-tools:`).
+- Per-plugin independent versioning via changesets is now fully operational.
+
+### Totals
+
+- **14 plugins** across 5 categories
+- **51 agents** for autonomous task execution
+- **81 commands** for manual workflows
+- **19 skills** for shared conventions and patterns
+- **9 hooks** for automated event-driven behavior
+- **14 MCP server integrations**
+
+---
+
 ## [1.1.0] - 2026-02-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # yellow-plugins
 
-Personal Claude Code plugin marketplace — 13 plugins for Git workflows, code
-review, CI, research, testing, code editing, and security remediation.
+Personal Claude Code plugin marketplace — 14 plugins for Git workflows, code
+review, CI, research, testing, documentation, code editing, and security
+remediation.
 
 ## Requirements
 
@@ -21,27 +22,29 @@ Add the marketplace, then install individual plugins:
 
 | Plugin                | Description                                                                                                 | Components                                     |
 | --------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
-| `gt-workflow`         | Graphite-native workflow commands for stacked PRs, smart commits, sync, and stack navigation                | 6 commands, 2 hooks                            |
+| `gt-workflow`         | Graphite-native workflow commands for stacked PRs, smart commits, sync, and stack navigation                | 6 commands, 2 hooks, 1 MCP                     |
 | `yellow-browser-test` | Autonomous web app testing with agent-browser — auto-discovery, structured flows, and bug reporting         | 3 agents, 4 commands, 2 skills                 |
 | `yellow-chatprd`      | ChatPRD MCP integration with document management and Linear bridging                                        | 4 agents, 6 commands, 1 skill, 1 MCP           |
-| `yellow-ci`           | CI failure diagnosis, workflow linting, and runner health management for self-hosted GitHub Actions runners | 4 agents, 8 commands, 2 skills, 3 hooks        |
+| `yellow-ci`           | CI failure diagnosis, workflow linting, and runner health management for self-hosted GitHub Actions runners | 4 agents, 8 commands, 2 skills, 1 hook         |
 | `yellow-core`         | Dev toolkit with review agents, research agents, and workflow commands for TS/Py/Rust/Go                    | 13 agents, 7 commands, 4 skills, 1 MCP         |
 | `yellow-debt`         | Technical debt audit and remediation with parallel scanner agents for AI-generated code patterns            | 7 agents, 6 commands, 1 skill, 1 hook          |
-| `yellow-devin`        | Devin.AI V3 API integration — delegate tasks, manage sessions, research codebases via DeepWiki              | 1 agent, 8 commands, 1 skill, 2 MCPs           |
+| `yellow-devin`        | Devin.AI V3 API integration — delegate tasks, manage sessions, research codebases via DeepWiki              | 1 agent, 9 commands, 1 skill, 2 MCPs           |
+| `yellow-docs`         | Documentation audit, generation, and Mermaid diagram creation for any repository                            | 3 agents, 5 commands, 1 skill                  |
 | `yellow-linear`       | Linear MCP integration with PM workflows for issues, projects, initiatives, cycles, and documents           | 3 agents, 9 commands, 1 skill, 1 MCP           |
 | `yellow-morph`        | Intelligent code editing and search via Morph Fast Apply and WarpGrep                                       | 2 commands, 1 MCP                              |
 | `yellow-research`     | Deep research with Perplexity, Tavily, EXA, Parallel Task, and ast-grep MCPs                                | 2 agents, 4 commands, 1 skill, 5 MCPs          |
 | `yellow-review`       | Multi-agent PR review with adaptive agent selection, parallel comment resolution, and stack review          | 7 agents, 4 commands, 1 skill                  |
-| `yellow-ruvector`     | Persistent vector memory and semantic code search for Claude Code agents via ruvector                       | 2 agents, 6 commands, 3 skills, 6 hooks, 1 MCP |
+| `yellow-ruvector`     | Persistent vector memory and semantic code search for Claude Code agents via ruvector                       | 2 agents, 6 commands, 3 skills, 5 hooks, 1 MCP |
 | `yellow-semgrep`      | Semgrep security finding remediation — fetch, fix, and verify "to fix" findings from the Semgrep platform   | 2 agents, 5 commands, 1 skill, 1 MCP           |
 
 ## MCP Servers & Authentication
 
-Eight plugins connect to MCP servers. Authentication requirements vary by
+Nine plugins connect to MCP servers. Authentication requirements vary by
 server.
 
 | Plugin            | MCP Server | Auth                                                                |
 | ----------------- | ---------- | ------------------------------------------------------------------- |
+| `gt-workflow`     | Graphite   | Local stdio (`gt mcp`) — requires Graphite CLI login                |
 | `yellow-core`     | Context7   | Free (no key); optional API key for higher rate limits              |
 | `yellow-chatprd`  | ChatPRD    | OAuth (browser popup on first use)                                  |
 | `yellow-devin`    | DeepWiki   | Free for public repos; `DEVIN_SERVICE_USER_TOKEN` for private repos |
@@ -253,18 +256,19 @@ yellow-plugins/
 ├── .claude-plugin/
 │   └── marketplace.json       # Plugin catalog
 ├── plugins/
-│   ├── gt-workflow/           # Graphite workflow (6 commands, 2 hooks)
+│   ├── gt-workflow/           # Graphite workflow (6 commands, 2 hooks, 1 MCP)
 │   ├── yellow-browser-test/   # Browser testing (3 agents, 4 commands, 2 skills)
 │   ├── yellow-chatprd/        # ChatPRD integration (4 agents, 6 commands, 1 skill, 1 MCP)
-│   ├── yellow-ci/             # CI toolkit (4 agents, 8 commands, 2 skills, 3 hooks)
+│   ├── yellow-ci/             # CI toolkit (4 agents, 8 commands, 2 skills, 1 hook)
 │   ├── yellow-core/           # Dev toolkit (13 agents, 7 commands, 4 skills, 1 MCP)
 │   ├── yellow-debt/           # Debt audit (7 agents, 6 commands, 1 skill, 1 hook)
-│   ├── yellow-devin/          # Devin.AI (1 agent, 8 commands, 1 skill, 2 MCPs)
+│   ├── yellow-devin/          # Devin.AI (1 agent, 9 commands, 1 skill, 2 MCPs)
+│   ├── yellow-docs/           # Documentation (3 agents, 5 commands, 1 skill)
 │   ├── yellow-linear/         # Linear PM (3 agents, 9 commands, 1 skill, 1 MCP)
 │   ├── yellow-morph/          # Morph code editing and search (2 commands, 1 MCP)
 │   ├── yellow-research/       # Deep research (2 agents, 4 commands, 1 skill, 5 MCPs)
 │   ├── yellow-review/         # PR review (7 agents, 4 commands, 1 skill)
-│   ├── yellow-ruvector/       # Vector memory (2 agents, 6 commands, 3 skills, 6 hooks, 1 MCP)
+│   ├── yellow-ruvector/       # Vector memory (2 agents, 6 commands, 3 skills, 5 hooks, 1 MCP)
 │   └── yellow-semgrep/        # Semgrep remediation (2 agents, 5 commands, 1 skill, 1 MCP)
 ├── packages/                  # Validation tooling (domain, infrastructure, cli)
 ├── schemas/                   # JSON schemas

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,19 @@
+# @yellow-plugins/cli
+
+Minimal CLI for validating marketplace and plugin schemas.
+
+## Usage
+
+```bash
+pnpm --filter @yellow-plugins/cli dev -- validate              # Validate marketplace.json + show plugin validator path
+pnpm --filter @yellow-plugins/cli dev -- validate:marketplace  # Validate only .claude-plugin/marketplace.json
+pnpm --filter @yellow-plugins/cli dev -- validate:plugins      # Show how to run the plugin manifest validator script
+```
+
+## Dependencies
+
+- `@yellow-plugins/infrastructure` — AJV schema validation
+
+## Exports
+
+- `version` — Package version string

--- a/packages/domain/README.md
+++ b/packages/domain/README.md
@@ -1,0 +1,15 @@
+# @yellow-plugins/domain
+
+Domain layer — validation types and error catalog for the plugin marketplace.
+
+## Exports
+
+- `ValidationStatus`, `ErrorSeverity`, `ErrorCategory` — Enums for validation results
+- `DomainValidationError`, `DomainValidationResult` — Types for structured validation output
+- `IValidator`, `PluginCompatibility`, `SystemEnvironment` — Contracts and system types
+- `ERROR_CODES`, `ValidationErrorFactory`, `getErrorCodesByCategory` — Error catalog and factory
+- `version` — Package version string
+
+## Dependencies
+
+None (pure domain layer).

--- a/packages/infrastructure/README.md
+++ b/packages/infrastructure/README.md
@@ -1,0 +1,16 @@
+# @yellow-plugins/infrastructure
+
+Infrastructure layer — AJV schema validation for plugin marketplace manifests.
+
+## Exports
+
+- `AjvValidatorFactory`, `sharedValidatorFactory` — AJV validator factory and singleton
+- `SchemaValidator`, `createValidator` — High-level validator for marketplace and plugin schemas
+- `ValidationError`, `ValidationResult` — Result types
+- `version` — Package version string
+
+## Dependencies
+
+- `@yellow-plugins/domain` — Validation types and error catalog
+- `ajv` + `ajv-formats` — JSON Schema validation
+- `semver` — Semver range checking


### PR DESCRIPTION
- Add yellow-docs plugin to README plugin table, MCP table, and project structure tree
- Fix plugin count from 13 to 14
- Add CHANGELOG [1.2.0] entry reflecting current state (14 plugins, 51 agents, 82 commands)
- Add README.md for packages/cli, packages/domain, packages/infrastructure

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/yellow-plugins/pull/205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added yellow-docs plugin providing documentation capabilities with agents and commands.

* **Documentation**
  * Introduced CLI package documentation with schema validation and validation command guides.
  * Added domain and infrastructure layer documentation describing exports and package dependencies.

* **Updates**
  * Released version 1.2.0 with expanded marketplace containing 14 plugins.
  * Updated plugin configurations, command counts, and MCP server integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This documentation-only PR fixes P1 audit findings by adding the `yellow-docs` plugin to the root `README.md`, publishing a `CHANGELOG.md` entry for version 1.2.0, and adding `README.md` files for the three packages under `packages/`. Component counts for `yellow-ci` (3 hooks → 1) and `yellow-ruvector` (6 hooks → 5) have also been corrected to reflect actual plugin configuration — both were verified accurate against the plugins' `hooks.json` and `plugin.json` files.

Key changes:
- `README.md`: Plugin count updated 13 → 14; `yellow-docs` row added to plugin table, MCP table entry added for `gt-workflow`, and project structure tree updated consistently.
- `CHANGELOG.md`: New `[1.2.0]` entry documents all additions since 1.1.0; totals (51 agents, 81 commands, 19 skills, 9 hooks, 14 MCPs) are internally consistent with the revised plugin table.
- `packages/cli/README.md`, `packages/domain/README.md`, `packages/infrastructure/README.md`: New files documenting exports, dependencies, and usage for each package layer.
- One open discussion exists in a prior review thread regarding the MCP count text ("Nine") — no new findings to add beyond what has already been raised there.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after resolving the open MCP count discussion in the prior thread.
- All numeric counts in README and CHANGELOG were cross-verified against actual plugin files and are accurate. The hook-count corrections for yellow-ci and yellow-ruvector are confirmed correct. The only open item is the MCP plugin count text ("Nine") discussed in a previous review thread — no new blocking issues were found in this pass.
- README.md — pending resolution of the "Nine plugins connect to MCP servers" count discussed in the prior thread.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | New [1.2.0] entry added; totals (51 agents, 81 commands, 19 skills, 9 hooks, 14 MCPs) verified as internally consistent with the updated README plugin table. |
| README.md | Plugin count updated 13→14, yellow-docs added, component counts corrected for yellow-ci (3 hooks→1) and yellow-ruvector (6 hooks→5), both verified accurate against actual plugin.json and hooks.json files. MCP count update "Eight"→"Nine" is discussed in a prior thread. |
| packages/cli/README.md | New README for @yellow-plugins/cli; documents three validate sub-commands. The description of validate:plugins ("Show how to run the plugin manifest validator script") correctly reflects that this command is advisory rather than directly executing the validator. |
| packages/domain/README.md | New README for @yellow-plugins/domain; clearly documents exported types, enums, and factory utilities with an accurate "no dependencies" note for this pure domain layer. |
| packages/infrastructure/README.md | New README for @yellow-plugins/infrastructure; accurately lists AJV/semver dependencies and exported validator factories. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR #205 — docs: fix P1 audit findings] --> B[README.md]
    A --> C[CHANGELOG.md]
    A --> D[packages/*/README.md]

    B --> B1[Plugin count 13 → 14]
    B --> B2[Add yellow-docs row]
    B --> B3[Add gt-workflow to MCP table]
    B --> B4[Fix yellow-ci hooks 3 → 1]
    B --> B5[Fix yellow-ruvector hooks 6 → 5]

    C --> C1[New 1.2.0 entry]
    C1 --> C2[14 plugins / 51 agents]
    C1 --> C3[81 commands / 19 skills]
    C1 --> C4[9 hooks / 14 MCPs]

    D --> D1[packages/cli/README.md]
    D --> D2[packages/domain/README.md]
    D --> D3[packages/infrastructure/README.md]

    B4 -. verified against .-> E[yellow-ci/hooks/hooks.json\n1 hook: SessionStart]
    B5 -. verified against .-> F[yellow-ruvector/plugin.json\n5 hooks: PreToolUse, PostToolUse,\nUserPromptSubmit, SessionStart, Stop]
```

<sub>Last reviewed commit: d7c8569</sub>

<!-- /greptile_comment -->