### PR TITLE
ci: migrate workflows to self-hosted runner pools and fix lint findings

### DIFF
--- a/.github/workflows/validate-schemas-fork.yml
+++ b/.github/workflows/validate-schemas-fork.yml
@@ -240,6 +240,7 @@ jobs:
   ci-status:
     name: CI Status (Fork)
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     if: always() && github.event.pull_request.head.repo.full_name != github.repository
     needs:
       [

--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -40,7 +40,7 @@ jobs:
   validate-schemas:
     name: Validate Schemas (${{ matrix.target }})
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, ubuntu24]
+    runs-on: [self-hosted, pool:atlas]
     timeout-minutes: 2 # NFR-MAINT-002: Critical path budget
 
     strategy:
@@ -68,6 +68,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install ${PNPM_INSTALL_FLAGS}
@@ -222,7 +223,7 @@ jobs:
   lint-and-typecheck:
     name: Lint & TypeCheck
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, ubuntu24]
+    runs-on: [self-hosted, pool:atlas]
     timeout-minutes: 3
 
     steps:
@@ -240,6 +241,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install ${PNPM_INSTALL_FLAGS}
@@ -295,7 +297,7 @@ jobs:
   unit-tests:
     name: Unit Tests
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, ubuntu24]
+    runs-on: [self-hosted, pool:atlas]
     timeout-minutes: 5
     needs: [lint-and-typecheck]
 
@@ -314,6 +316,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install ${PNPM_INSTALL_FLAGS}
@@ -365,7 +368,7 @@ jobs:
   integration-tests:
     name: Integration Tests
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, ubuntu24]
+    runs-on: [self-hosted, pool:ares]
     timeout-minutes: 8
     needs: [unit-tests]
 
@@ -384,6 +387,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install ${PNPM_INSTALL_FLAGS}
@@ -435,7 +439,7 @@ jobs:
   contract-drift:
     name: Contract Drift Check
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, ubuntu24]
+    runs-on: [self-hosted, pool:atlas]
     timeout-minutes: 3
     needs: [validate-schemas]
 
@@ -455,6 +459,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install ${PNPM_INSTALL_FLAGS}
@@ -560,7 +565,7 @@ jobs:
   security-audit:
     name: Security Audit
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, ubuntu24]
+    runs-on: [self-hosted, pool:atlas]
     timeout-minutes: 5
 
     steps:
@@ -578,6 +583,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install ${PNPM_INSTALL_FLAGS}
@@ -647,7 +653,7 @@ jobs:
   # ============================================================================
   build:
     name: Build Verification
-    runs-on: [self-hosted, Linux, X64, ubuntu24]
+    runs-on: [self-hosted, pool:ares]
     timeout-minutes: 5
     if: github.ref == 'refs/heads/main' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     needs: [validate-schemas, lint-and-typecheck, unit-tests]
@@ -667,6 +673,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install ${PNPM_INSTALL_FLAGS}
@@ -718,7 +725,7 @@ jobs:
   validate-versions:
     name: Version Consistency Check
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, ubuntu24]
+    runs-on: [self-hosted, pool:atlas]
     timeout-minutes: 2
 
     steps:
@@ -740,7 +747,7 @@ jobs:
   # ============================================================================
   changeset-check:
     name: Changeset Required
-    runs-on: [self-hosted, Linux, X64, ubuntu24]
+    runs-on: [self-hosted, pool:atlas]
     timeout-minutes: 2
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
 
@@ -784,7 +791,8 @@ jobs:
   # ============================================================================
   report-metrics:
     name: Aggregate CI Metrics
-    runs-on: [self-hosted, Linux, X64, ubuntu24]
+    runs-on: [self-hosted, pool:atlas]
+    timeout-minutes: 5
     if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     needs:
       [
@@ -874,7 +882,8 @@ jobs:
   # ============================================================================
   ci-status:
     name: CI Status Summary
-    runs-on: [self-hosted, Linux, X64, ubuntu24]
+    runs-on: [self-hosted, pool:atlas]
+    timeout-minutes: 2
     if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     needs:
       [

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -41,7 +41,7 @@ jobs:
   # ==========================================================================
   version-or-publish:
     name: Version or Publish
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, pool:ares]
     timeout-minutes: 15
 
     outputs:
@@ -53,6 +53,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          clean: true
           # Full history required for changeset to build CHANGELOG entries
           # and for release-tags.sh to diff plugin tags.
           fetch-depth: 0
@@ -144,15 +145,17 @@ jobs:
   # ==========================================================================
   build-and-release:
     name: Build and Release
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, pool:ares]
     timeout-minutes: 15
     needs: [version-or-publish]
+    environment: production
     if: needs.version-or-publish.outputs.should_publish == 'true'
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          clean: true
           # Full history needed for generate-release-notes.js changelog parsing.
           fetch-depth: 0
 


### PR DESCRIPTION
- Route lightweight jobs (lint, validate, status) to pool:atlas (size:s, always-on)
- Route heavy jobs (build, integration tests, release) to pool:ares (size:m, auto-scaling)
- Add cache: 'pnpm' to all setup-node steps missing it (W02)
- Add timeout-minutes to report-metrics, ci-status, and fork ci-status (W01)
- Add clean: true to version-packages.yml checkout steps on self-hosted (W10)
- Add environment: production to build-and-release job (W12)
- Fork workflow intentionally unchanged (ubuntu-latest for security)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/yellow-plugins/pull/207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure to improve build reliability and performance: standardized runner usage across workflows, migrated several jobs to pool-based runners, and added cleaner checkout settings for release flows.
  * Enabled and standardized dependency caching, added explicit cache steps, and increased job timeouts to reduce flakiness and improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates CI/CD jobs to self-hosted runner pools (`pool:atlas` for lightweight jobs, `pool:ares` for heavy jobs), adds `cache: 'pnpm'` to all `setup-node` steps that were missing it, adds missing `timeout-minutes` to aggregation and status jobs, and introduces `environment: production` on the release job. The changes are generally well-structured and the `pnpm` cache additions are applied correctly (only to jobs that actually run `pnpm install`).

Key concerns:
- **Protection gap in `version-packages.yml`**: Git tags are created inside `version-or-publish` (no environment gate) while only the subsequent `build-and-release` job carries `environment: production`. If the production environment has required reviewers, irreversible git tag pushes occur before any approval is granted — potentially creating orphaned tags if the gated release step is rejected.
- **`unit-tests` on `pool:atlas`** (raised in a prior thread): The unit-test job runs a full test suite with a 5-minute timeout on the small always-on pool rather than the `pool:ares` pool used for integration tests, inconsistent with the stated routing policy.
- **Self-hosted runner for write-token jobs** (raised in a prior thread): `version-or-publish` carries `contents: write` + `pull-requests: write` permissions on a self-hosted runner; the same security rationale used to keep the fork workflow on `ubuntu-latest` applies here.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for infrastructure routing changes, but the tag-vs-release protection gap in the release workflow warrants resolution before trusting the environment gate to enforce release approvals.
- The runner migration and cache additions are mechanically correct. The outstanding concerns — self-hosted runner with write tokens, and the gap where git tags are created outside the `environment: production` gate — represent real risks to release integrity and security posture that were partially raised in prior review threads but not fully resolved.
- `.github/workflows/version-packages.yml` requires the most scrutiny due to the `environment: production` protection gap and the migration of sensitive release jobs to self-hosted runners.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/validate-schemas-fork.yml | Minimal change — adds `timeout-minutes: 2` to the fork `ci-status` job. Fork workflow correctly kept on `ubuntu-latest` for security. No issues found. |
| .github/workflows/validate-schemas.yml | All jobs migrated from `[self-hosted, Linux, X64, ubuntu24]` to `pool:atlas` (lightweight) or `pool:ares` (heavy). `cache: 'pnpm'` correctly added only to jobs that run `pnpm install`; `validate-versions` and `changeset-check` (which don't use pnpm) are correctly left without it. `timeout-minutes` added to `report-metrics` (5 min) and `ci-status` (2 min). Main concern (flagged in prior thread): `unit-tests` on `pool:atlas` instead of `pool:ares`. |
| .github/workflows/version-packages.yml | `version-or-publish` and `build-and-release` migrated from `ubuntu-latest` to `[self-hosted, pool:ares]`. `clean: true` correctly added to both checkout steps. `environment: production` added only to `build-and-release`, creating a protection gap — git tags are pushed in `version-or-publish` before the environment gate. Self-hosted runner with write token (flagged in prior thread) and environment gating concerns remain. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph atlas["pool:atlas (size:s, always-on)"]
        VS[validate-schemas]
        LT[lint-and-typecheck]
        UT[unit-tests]
        CD[contract-drift]
        SA[security-audit]
        VV[validate-versions]
        CC[changeset-check]
        RM[report-metrics]
        CS[ci-status]
    end

    subgraph ares["pool:ares (size:m, auto-scaling)"]
        IT[integration-tests]
        B[build]
        VOP[version-or-publish]
        BAR[build-and-release]
    end

    subgraph ubuntu["ubuntu-latest (GitHub-hosted)"]
        N[notify]
        FORK_CS[ci-status Fork]
    end

    VS --> IT
    LT --> UT
    UT --> IT
    IT --> RM
    B --> RM
    RM --> CS

    VOP -->|"⚠️ tags pushed here (no env gate)"| BAR
    BAR -.->|"environment: production gate"| BAR_ENV["✅ GitHub Release created"]

    style VOP fill:#f9a,stroke:#c66
    style BAR fill:#afa,stroke:#6a6
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fversion-packages.yml%3A148-152%0A**Protection%20gap%3A%20git%20tags%20pushed%20before%20%60environment%3A%20production%60%20gate**%0A%0A%60version-or-publish%60%20creates%20git%20tags%20%28via%20%60changesets%2Faction%20publish%3A%20bash%20scripts%2Fci%2Frelease-tags.sh%60%29%20without%20any%20environment%20protection%2C%20while%20%60build-and-release%60%20is%20gated%20by%20%60environment%3A%20production%60.%20If%20the%20%60production%60%20environment%20has%20required%20reviewers%2C%20this%20leads%20to%3A%0A%0A1.%20%60version-or-publish%60%20completes%20%E2%80%94%20git%20tags%20%28e.g.%20%60yellow-core%401.2.0%60%2C%20%60v1.2.1%60%29%20are%20pushed%20to%20the%20repository%20permanently%0A2.%20%60build-and-release%60%20is%20queued%20and%20waits%20for%20manual%20approval%0A3.%20If%20approval%20is%20denied%20%28or%20times%20out%29%2C%20orphaned%20tags%20exist%20with%20no%20corresponding%20GitHub%20Release%0A%0ASince%20git%20tags%20are%20not%20easy%20to%20remove%20cleanly%20%28especially%20if%20any%20downstream%20system%20has%20already%20observed%20them%29%2C%20the%20tag-push%20operation%20is%20arguably%20the%20most%20irreversible%20step%20in%20the%20release%20flow.%20Protecting%20the%20%60build-and-release%60%20job%20alone%20does%20not%20guard%20the%20earliest%20irreversible%20operation.%0A%0AConsider%20either%3A%0A-%20Moving%20tag%20creation%20into%20%60build-and-release%60%20%28after%20the%20environment%20gate%29%2C%20or%0A-%20Adding%20%60environment%3A%20production%60%20to%20%60version-or-publish%60%20as%20well%20%28accepting%20Phase%201%20will%20also%20require%20approval%29%2C%20or%0A-%20Documenting%20the%20intentional%20design%20choice%20if%20the%20environment%20has%20no%20required%20reviewers%20and%20the%20gate%20is%20purely%20for%20audit%2Fnotification%20purposes%0A%0A&repo=kinginyellows%2Fyellow-plugins"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/version-packages.yml
Line: 148-152

Comment:
**Protection gap: git tags pushed before `environment: production` gate**

`version-or-publish` creates git tags (via `changesets/action publish: bash scripts/ci/release-tags.sh`) without any environment protection, while `build-and-release` is gated by `environment: production`. If the `production` environment has required reviewers, this leads to:

1. `version-or-publish` completes — git tags (e.g. `yellow-core@1.2.0`, `v1.2.1`) are pushed to the repository permanently
2. `build-and-release` is queued and waits for manual approval
3. If approval is denied (or times out), orphaned tags exist with no corresponding GitHub Release

Since git tags are not easy to remove cleanly (especially if any downstream system has already observed them), the tag-push operation is arguably the most irreversible step in the release flow. Protecting the `build-and-release` job alone does not guard the earliest irreversible operation.

Consider either:
- Moving tag creation into `build-and-release` (after the environment gate), or
- Adding `environment: production` to `version-or-publish` as well (accepting Phase 1 will also require approval), or
- Documenting the intentional design choice if the environment has no required reviewers and the gate is purely for audit/notification purposes

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 0a0b40c</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->