### PR TITLE
chore(ci): pin actions to commit SHAs and add credential cleanup

### DIFF
--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           clean: true
           fetch-depth: 0
@@ -65,7 +65,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js with pnpm cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -202,7 +202,7 @@ jobs:
 
       - name: Upload validation metrics
         if: env.CI_UPLOAD_ARTIFACTS == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: metrics-validate-${{ matrix.target }}
           path: .ci-metrics/validate-${{ matrix.target }}.prom
@@ -210,7 +210,7 @@ jobs:
 
       - name: Upload validation logs
         if: env.CI_UPLOAD_ARTIFACTS == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: logs-validate-${{ matrix.target }}
           path: .ci-logs/validate-${{ matrix.target }}.log
@@ -228,7 +228,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           clean: true
 
@@ -238,7 +238,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js with cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -283,7 +283,7 @@ jobs:
 
       - name: Upload lint artifacts
         if: env.CI_UPLOAD_ARTIFACTS == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: metrics-lint
           path: |
@@ -303,7 +303,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           clean: true
 
@@ -313,7 +313,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js with cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -354,7 +354,7 @@ jobs:
 
       - name: Upload unit test artifacts
         if: env.CI_UPLOAD_ARTIFACTS == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: metrics-unit-tests
           path: |
@@ -374,7 +374,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           clean: true
 
@@ -384,7 +384,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js with cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -425,7 +425,7 @@ jobs:
 
       - name: Upload integration test artifacts
         if: env.CI_UPLOAD_ARTIFACTS == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: metrics-integration-tests
           path: |
@@ -445,7 +445,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           clean: true
           fetch-depth: 0 # Need history for drift detection
@@ -456,7 +456,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js with cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -551,7 +551,7 @@ jobs:
 
       - name: Upload contract drift artifacts
         if: env.CI_UPLOAD_ARTIFACTS == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: metrics-contract-drift
           path: |
@@ -570,7 +570,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           clean: true
 
@@ -580,7 +580,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js with cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -640,7 +640,7 @@ jobs:
 
       - name: Upload security artifacts
         if: env.CI_UPLOAD_ARTIFACTS == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: metrics-security-audit
           path: |
@@ -660,7 +660,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           clean: true
 
@@ -670,7 +670,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js with cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -711,7 +711,7 @@ jobs:
 
       - name: Upload build artifacts
         if: env.CI_UPLOAD_ARTIFACTS == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: metrics-build
           path: |
@@ -730,12 +730,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           clean: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -753,7 +753,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           clean: true
           fetch-depth: 0
@@ -810,7 +810,7 @@ jobs:
     steps:
       - name: Download all metrics artifacts
         if: env.CI_UPLOAD_ARTIFACTS == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: metrics-*
           path: all-metrics/
@@ -834,7 +834,7 @@ jobs:
 
       - name: Upload aggregated metrics
         if: env.CI_UPLOAD_ARTIFACTS == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ci-metrics-aggregated
           path: aggregated-metrics/ci-metrics.prom

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -140,6 +140,16 @@ jobs:
 
           echo "Catalog version: $VERSION"
 
+      - name: Cleanup credentials
+        if: always()
+        run: |
+          # Remove git credential helpers written by actions/checkout
+          git config --unset-all credential.helper 2>/dev/null || true
+          # Remove any cached tokens from the runner temp directory
+          rm -f "$RUNNER_TEMP/.npmrc" 2>/dev/null || true
+          # Remove temporary files from release-tags.sh
+          rm -f /tmp/plugin-tags-before.txt /tmp/plugin-tags-after.txt 2>/dev/null || true
+
   # ==========================================================================
   # BUILD ARTIFACTS + GITHUB RELEASE + NPM PUBLISH
   # ==========================================================================
@@ -230,6 +240,16 @@ jobs:
           pnpm -r publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Cleanup credentials
+        if: always()
+        run: |
+          # Remove git credential helpers written by actions/checkout
+          git config --unset-all credential.helper 2>/dev/null || true
+          # Remove .npmrc written by actions/setup-node with registry-url
+          rm -f "$HOME/.npmrc" "$RUNNER_TEMP/.npmrc" 2>/dev/null || true
+          # Remove any cached tokens from the runner temp directory
+          rm -f /tmp/plugin-tags-before.txt /tmp/plugin-tags-after.txt 2>/dev/null || true
 
   # ==========================================================================
   # FAILURE NOTIFICATION


### PR DESCRIPTION
- Pin all actions in validate-schemas.yml to commit SHAs matching
  version-packages.yml (actions/checkout, setup-node, upload-artifact,
  download-artifact, pnpm/action-setup) to prevent supply-chain attacks
  on persistent self-hosted runners
- Add post-job credential cleanup steps to version-or-publish and
  build-and-release in version-packages.yml (git credential helper,
  .npmrc, /tmp artifacts)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/yellow-plugins/pull/208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens CI security on persistent self-hosted runners through two changes: (1) pinning all `actions/*` and `pnpm/action-setup` references in `validate-schemas.yml` to full commit SHAs — matching the pinning already present in `version-packages.yml` — and (2) adding post-job credential cleanup steps with `if: always()` to the `version-or-publish` and `build-and-release` jobs in `version-packages.yml`.

The SHA-pinning in `validate-schemas.yml` is correct and complete. However, the credential cleanup steps contain a critical gap: `git config --unset-all credential.helper` is called **without** the `--global` flag. Since `actions/checkout@v4` writes the credential helper to the global git config (`~/.gitconfig`), the cleanup only targets the local `.git/config` and will silently fail to remove the persisted `GITHUB_TOKEN` credentials — which is the exact threat the PR aims to address. Both `version-or-publish` (line 147) and `build-and-release` (line 248) are affected.

Key changes:
- `validate-schemas.yml`: 14 action `@v4` tag references replaced with locked commit SHAs — correct and safe
- `version-packages.yml` (`version-or-publish`): Cleanup step added but `git config --unset-all credential.helper` lacks `--global`, leaving global credentials intact on the runner between jobs
- `version-packages.yml` (`build-and-release`): Same `--global` omission in the highest-privilege job (NPM publish and GitHub Release creation)
- `validate-schemas.yml` jobs (9 jobs running on self-hosted pool `atlas`) receive no credential cleanup, inconsistent with the stated goals of this PR

<h3>Confidence Score: 3/5</h3>

- Safe to merge with caution — the SHA pinning is correct, but the credential cleanup has a logic bug that leaves the primary threat vector (global git credentials on persistent runners) unresolved.
- The `validate-schemas.yml` SHA-pinning changes are low risk and well-executed. However, the credential cleanup steps in `version-packages.yml` — which are the primary security improvement — contain a logic error: the missing `--global` flag means `git config --unset-all credential.helper` only modifies the local repo config, not `~/.gitconfig` where `actions/checkout` actually writes credentials. This directly undermines the intended protection on persistent self-hosted runners and affects the two highest-privilege jobs in the repository.
- `.github/workflows/version-packages.yml` — both cleanup steps need `--global` flag added to the `git config --unset-all` command, and should also unset `http.https://github.com/.extraheader`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/version-packages.yml | Adds post-job credential cleanup to `version-or-publish` and `build-and-release` jobs; both cleanup steps use `git config --unset-all credential.helper` without `--global`, which will not remove credentials written to the global git config by `actions/checkout` on persistent self-hosted runners — defeating the primary purpose of the cleanup. |
| .github/workflows/validate-schemas.yml | Pins all action references (`actions/checkout`, `actions/setup-node`, `actions/upload-artifact`, `actions/download-artifact`) to full commit SHAs matching the versions already used in `version-packages.yml`; no functional logic changes, correct supply-chain hardening for self-hosted runners. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Job starts on self-hosted runner] --> B[actions/checkout runs]
    B --> C["Writes credential helper\nto ~/.gitconfig --global\nand/or .git/config --local"]
    C --> D[Job steps execute\ne.g. pnpm publish, git tag]
    D --> E["Cleanup credentials step\n(if: always())"]
    E --> F{"git config --unset-all\ncredential.helper\n(no --global flag)"}
    F --> G["Only targets .git/config\n(local config)"]
    F -.->|"MISSED"| H["~/.gitconfig\n(global config)\nCredentials persist!"]
    E --> I["rm -f $HOME/.npmrc\n$RUNNER_TEMP/.npmrc\n/tmp/plugin-tags-*.txt"]
    G --> J[Job ends]
    H --> K["Next job on same runner\ncan reuse leftover\nGITHUB_TOKEN credentials"]
    I --> J

    style H fill:#ff6b6b,color:#fff
    style K fill:#ff6b6b,color:#fff
    style G fill:#ffd93d
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0A.github%2Fworkflows%2Fversion-packages.yml%3A147%0A**Missing%20%60--global%60%20flag%20on%20%60git%20config%20--unset-all%60**%0A%0A%60actions%2Fcheckout%40v4%60%20writes%20the%20GitHub%20token%20credential%20helper%20to%20the%20**global**%20git%20config%20%28%60~%2F.gitconfig%60%29%20%E2%80%94%20specifically%20%60git%20config%20--global%20credential.helper%60.%20Without%20the%20%60--global%60%20flag%2C%20%60git%20config%20--unset-all%20credential.helper%60%20only%20targets%20the%20local%20repository%20config%20%28%60.git%2Fconfig%60%29%2C%20so%20this%20cleanup%20step%20will%20silently%20leave%20the%20global%20credential%20entry%20untouched%2C%20completely%20defeating%20its%20purpose%20on%20persistent%20self-hosted%20runners.%0A%0AAdditionally%2C%20%60actions%2Fcheckout%60%20may%20also%20store%20the%20token%20via%20%60http.https%3A%2F%2Fgithub.com%2F.extraheader%60%2C%20which%20is%20not%20targeted%20by%20this%20cleanup%20at%20all.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20git%20config%20--global%20--unset-all%20credential.helper%202%3E%2Fdev%2Fnull%20%7C%7C%20true%0A%20%20%20%20%20%20%20%20%20%20git%20config%20--global%20--unset-all%20http.https%3A%2F%2Fgithub.com%2F.extraheader%202%3E%2Fdev%2Fnull%20%7C%7C%20true%0A%60%60%60%0A%0AThe%20same%20issue%20applies%20to%20the%20identical%20%60git%20config%20--unset-all%20credential.helper%60%20line%20in%20the%20%60build-and-release%60%20job%20%28line%20248%29.%0A%0A%23%23%23%20Issue%202%20of%203%0A.github%2Fworkflows%2Fversion-packages.yml%3A248%0A**Same%20missing%20%60--global%60%20flag%20as%20%60version-or-publish%60**%0A%0ASame%20issue%20as%20the%20identical%20step%20in%20%60version-or-publish%60%20%28line%20147%29%3A%20%60git%20config%20--unset-all%20credential.helper%60%20without%20%60--global%60%20only%20operates%20on%20the%20local%20%60.git%2Fconfig%60%2C%20leaving%20credentials%20in%20%60~%2F.gitconfig%60%20intact.%20This%20is%20the%20job%20that%20publishes%20to%20NPM%20and%20creates%20GitHub%20Releases%2C%20making%20it%20the%20highest-privilege%20job%20in%20the%20repo%20%E2%80%94%20the%20cleanup%20gap%20is%20most%20critical%20here.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20git%20config%20--global%20--unset-all%20credential.helper%202%3E%2Fdev%2Fnull%20%7C%7C%20true%0A%20%20%20%20%20%20%20%20%20%20git%20config%20--global%20--unset-all%20http.https%3A%2F%2Fgithub.com%2F.extraheader%202%3E%2Fdev%2Fnull%20%7C%7C%20true%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0A.github%2Fworkflows%2Fvalidate-schemas.yml%3A57%0A**No%20credential%20cleanup%20added%20for%20self-hosted%20runners**%0A%0A%60validate-schemas.yml%60%20runs%20all%20its%20jobs%20on%20%60%5Bself-hosted%2C%20pool%3Aatlas%5D%60%20and%20uses%20%60actions%2Fcheckout%60%20in%20every%20job%20%289%20total%20job%20definitions%20in%20this%20file%29.%20This%20PR%20adds%20SHA-pinning%20here%2C%20which%20is%20correct%2C%20but%20omits%20the%20corresponding%20credential%20cleanup%20steps%20that%20were%20added%20to%20%60version-packages.yml%60.%20On%20persistent%20self-hosted%20runners%2C%20%60GITHUB_TOKEN%60%20credentials%20written%20by%20%60actions%2Fcheckout%60%20will%20persist%20across%20runs.%0A%0AWhile%20this%20workflow%20doesn't%20use%20high-privilege%20secrets%20like%20%60NPM_TOKEN%60%2C%20the%20%60GITHUB_TOKEN%60%20lingering%20in%20the%20global%20git%20config%20between%20jobs%20is%20still%20a%20credential%20hygiene%20concern%20consistent%20with%20the%20stated%20goals%20of%20this%20PR.%20Consider%20adding%20a%20matching%20post-job%20cleanup%20to%20at%20least%20the%20jobs%20that%20use%20%60fetch-depth%3A%200%60%20%28which%20fetches%20authenticated%20history%29%2C%20such%20as%20%60validate-schemas%60%2C%20%60contract-drift%60%2C%20and%20%60changeset-check%60.%0A%0A&repo=kinginyellows%2Fyellow-plugins"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/version-packages.yml
Line: 147

Comment:
**Missing `--global` flag on `git config --unset-all`**

`actions/checkout@v4` writes the GitHub token credential helper to the **global** git config (`~/.gitconfig`) — specifically `git config --global credential.helper`. Without the `--global` flag, `git config --unset-all credential.helper` only targets the local repository config (`.git/config`), so this cleanup step will silently leave the global credential entry untouched, completely defeating its purpose on persistent self-hosted runners.

Additionally, `actions/checkout` may also store the token via `http.https://github.com/.extraheader`, which is not targeted by this cleanup at all.

```suggestion
          git config --global --unset-all credential.helper 2>/dev/null || true
          git config --global --unset-all http.https://github.com/.extraheader 2>/dev/null || true
```

The same issue applies to the identical `git config --unset-all credential.helper` line in the `build-and-release` job (line 248).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/version-packages.yml
Line: 248

Comment:
**Same missing `--global` flag as `version-or-publish`**

Same issue as the identical step in `version-or-publish` (line 147): `git config --unset-all credential.helper` without `--global` only operates on the local `.git/config`, leaving credentials in `~/.gitconfig` intact. This is the job that publishes to NPM and creates GitHub Releases, making it the highest-privilege job in the repo — the cleanup gap is most critical here.

```suggestion
          git config --global --unset-all credential.helper 2>/dev/null || true
          git config --global --unset-all http.https://github.com/.extraheader 2>/dev/null || true
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/validate-schemas.yml
Line: 57

Comment:
**No credential cleanup added for self-hosted runners**

`validate-schemas.yml` runs all its jobs on `[self-hosted, pool:atlas]` and uses `actions/checkout` in every job (9 total job definitions in this file). This PR adds SHA-pinning here, which is correct, but omits the corresponding credential cleanup steps that were added to `version-packages.yml`. On persistent self-hosted runners, `GITHUB_TOKEN` credentials written by `actions/checkout` will persist across runs.

While this workflow doesn't use high-privilege secrets like `NPM_TOKEN`, the `GITHUB_TOKEN` lingering in the global git config between jobs is still a credential hygiene concern consistent with the stated goals of this PR. Consider adding a matching post-job cleanup to at least the jobs that use `fetch-depth: 0` (which fetches authenticated history), such as `validate-schemas`, `contract-drift`, and `changeset-check`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 3718308</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->