### PR TITLE
docs(yellow-symphony): add brainstorm and implementation plan for Symphony orchestration plugin

### DIFF
--- a/docs/brainstorms/2026-04-01-symphony-plugin-brainstorm.md
+++ b/docs/brainstorms/2026-04-01-symphony-plugin-brainstorm.md
@@ -1,14 +1,22 @@
 # Symphony-Style Orchestration Plugin Brainstorm
 
 **Date:** 2026-04-01 (updated 2026-04-02)
-**Status:** Draft — revised after architectural pivot
+**Status:** Finalized — plan at [plans/yellow-symphony-plugin.md](../../plans/yellow-symphony-plugin.md)
+**Approach:** Thin management layer over OpenClaw-hosted daemon (revised from full reimplementation)
 **Source:** OpenAI Symphony SPEC.md (Draft v1, language-agnostic)
 
 > **Architectural Pivot (2026-04-02):** After research, Symphony orchestration
 > belongs as an **OpenClaw plugin** (capability extension on Proxmox VM), not a
-> reimplementation inside Claude Code. The Claude Code plugin (`yellow-symphony`)
-> becomes a **thin remote management layer** over the OpenClaw-hosted daemon. See
-> "Revised Architecture" section below.
+> reimplementation inside Claude Code. The Claude Code plugin
+> (`yellow-symphony`) becomes a **thin remote management layer** over the
+> OpenClaw-hosted daemon. See "Revised Architecture" section below.
+
+## What We're Building
+
+A thin Claude Code management plugin (`yellow-symphony`) that provides SSH-based
+status queries, config validation, and remote control over a Symphony
+orchestration daemon hosted as an OpenClaw plugin on a Proxmox VM. No
+orchestration logic lives in this plugin.
 
 ## Symphony Architecture Summary
 
@@ -16,32 +24,47 @@ Symphony is a long-running daemon that polls Linear, creates an isolated
 workspace per issue, and runs a coding agent session inside each workspace until
 the issue reaches a handoff state. Core loop: **poll -> filter eligible -> claim
 -> create workspace -> render prompt from WORKFLOW.md -> launch agent -> stream
-events -> reconcile -> retry or release**. The orchestrator owns scheduling state
-in-memory (no database) and recovers from filesystem + tracker state on restart.
-Runtime behavior lives in a repo-owned `WORKFLOW.md`: YAML front matter (tracker
-config, polling interval, workspace root, hooks, concurrency, Codex settings)
-plus a Markdown prompt template with Liquid-style interpolation. Symphony is a
-scheduler/runner and tracker *reader* only -- ticket writes (status transitions,
-PR links, comments) are the coding agent's job.
+events -> reconcile -> retry or release**. The orchestrator owns scheduling
+state in-memory (no database) and recovers from filesystem + tracker state on
+restart. Runtime behavior lives in a repo-owned `WORKFLOW.md`: YAML front matter
+(tracker config, polling interval, workspace root, hooks, concurrency, Codex
+settings) plus a Markdown prompt template with Liquid-style interpolation.
+Symphony is a scheduler/runner and tracker _reader_ only -- ticket writes
+(status transitions, PR links, comments) are the coding agent's job.
 
 ## Component Mapping Table
 
-| Symphony Component | Claude Code Equivalent | Gap |
-|---|---|---|
-| **Workflow Loader** | Command reads repo-local `SYMPHONY.md`, parses front matter + prompt | Direct mapping |
-| **Config Layer** | Front matter parsed via bash `yq`; subset of Symphony schema | Define our own schema; no dynamic reload for MVP |
-| **Issue Tracker Client** | **yellow-linear** MCP tools (`list_issues`, `get_issue`, `update_issue`) | Reuse entirely. Gap: MCP-only, no raw GraphQL |
-| **Orchestrator** | New `/symphony:run` command or external daemon script | Core new work: poll, dispatch, concurrency, retry |
-| **Workspace Manager** | `git worktree` per issue under configurable root | Partial reuse of gt-workflow patterns |
-| **Agent Runner** | `claude --headless` per issue (or `codex exec` via yellow-codex) | No app-server protocol; see DECISION-5 |
-| **Prompt Builder** | Bash heredoc/envsubst with `issue.*` + `attempt` variables | Simpler than Liquid; sufficient for MVP |
-| **Status Surface** | `/symphony:status` command reading log files | Skip LiveView entirely |
-| **Logging** | Log files under `~/symphony-logs/<issue-id>/` | Standard approach |
-| **linear_graphql tool** | yellow-linear MCP tools already in Claude Code sessions | Direct equivalent |
+| Symphony Component       | OpenClaw Responsibility                                                  | Claude Code (yellow-symphony)                     |
+| ------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------- |
+| **Workflow Loader**      | Reads repo-local `SYMPHONY.md`, parses front matter + prompt at dispatch | `/symphony:config` validates the same schema      |
+| **Config Layer**         | Loads YAML front matter at runtime; full Symphony schema                 | Validates subset via bash `case`/`if`; no dynamic reload |
+| **Issue Tracker Client** | Direct Linear API calls for poll/claim/update                            | yellow-linear MCP tools for status queries (optional) |
+| **Orchestrator**         | Core daemon: poll, claim, dispatch, concurrency, retry                   | `/symphony:status` queries state via SSH          |
+| **Workspace Manager**    | `git worktree` per issue on the VM                                       | Not involved — OpenClaw manages worktrees         |
+| **Agent Runner**         | OpenClaw Agent Runtime (configurable: Claude, Codex, etc.)               | Not involved — runner choice is daemon config     |
+| **Prompt Builder**       | Renders prompt from `SYMPHONY.md` template with issue variables          | Not involved — scaffolds template only            |
+| **Status Surface**       | Exposes `status --json` CLI subcommand                                   | `/symphony:status` queries via SSH, formats table |
+| **Logging**              | Log files on VM under daemon-managed paths                               | `/symphony:logs` tails via SSH                    |
+| **linear_graphql tool**  | Direct Linear API (daemon-side)                                          | yellow-linear MCP tools (Claude Code-side)        |
+
+## Why This Approach
+
+**Capability extension over reimplementation.** After researching Symphony's
+architecture, the orchestration daemon (poll/claim/dispatch/reconcile) belongs as
+an OpenClaw plugin — OpenClaw already provides cron scheduling, a plugin system,
+Agent Runtime, and systemd lifecycle. Reimplementing this inside Claude Code
+would duplicate infrastructure for zero benefit. The Claude Code plugin becomes a
+remote management layer only.
+
+**Rejected alternatives:**
+- **Full reimplementation in Claude Code**: Duplicates OpenClaw infra, no
+  persistent daemon support
+- **Sidecar alongside OpenClaw**: Doubles operational overhead (two services, two
+  log streams) for zero isolation benefit on a single VM
 
 ## Revised Architecture
 
-```
+```text
 Proxmox VM (OpenClaw plugin)              Claude Code (yellow-symphony)
 ┌──────────────────────────────┐          ┌──────────────────────────────┐
 │ openclaw-symphony plugin     │          │ yellow-symphony plugin       │
@@ -55,22 +78,32 @@ Proxmox VM (OpenClaw plugin)              Claude Code (yellow-symphony)
 ```
 
 **Why capability extension, not sidecar:**
-- OpenClaw already has cron scheduling, plugin system, Agent Runtime, and systemd lifecycle
-- Symphony's orchestrator is intentionally stateless — recovers from tracker + filesystem
-- Sidecar doubles operational overhead (two services, two log streams, duplicated credentials) for zero isolation benefit on a single VM
-- Clean internal interface between tracker/state-machine and dispatch enables future sidecar extraction if needed
+
+- OpenClaw already has cron scheduling, plugin system, Agent Runtime, and
+  systemd lifecycle
+- Symphony's orchestrator is intentionally stateless — recovers from tracker +
+  filesystem
+- Sidecar doubles operational overhead (two services, two log streams,
+  duplicated credentials) for zero isolation benefit on a single VM
+- Clean internal interface between tracker/state-machine and dispatch enables
+  future sidecar extraction if needed
 
 **Scope split:**
-- **OpenClaw plugin** (separate repo): poll/claim/dispatch/reconcile/log/recover — the daemon
-- **yellow-symphony** (this repo): remote status/config/control + workflow contract authoring conventions
+
+- **OpenClaw plugin** (separate repo): poll/claim/dispatch/reconcile/log/recover
+  — the daemon
+- **yellow-symphony** (this repo): remote status/config/control + workflow
+  contract authoring conventions
 
 ## Plugin Structure (Revised — thin management layer)
 
-```
+```text
 plugins/yellow-symphony/
   .claude-plugin/plugin.json
   package.json
   CLAUDE.md
+  CHANGELOG.md
+  README.md
   commands/symphony/
     setup.md         # Validate SSH to Proxmox, OpenClaw running, plugin installed
     status.md        # Query daemon state (running sessions, queue, completions)
@@ -80,54 +113,82 @@ plugins/yellow-symphony/
     logs.md          # Tail logs for a specific issue run
   skills/symphony-conventions/
     SKILL.md         # SYMPHONY.md schema, prompt template patterns, conventions
-  templates/
-    SYMPHONY.md.example  # Starter workflow contract for new repos
 ```
 
 ## Decision Points
 
 ### DECISION-1: Reimplement orchestrator or wrap Elixir reference?
-**RESOLVED → A: Reimplement as OpenClaw plugin (Node.js).** SPEC.md says "implement your own hardened version." OpenClaw's Gateway is already Node.js. No Elixir dependency.
+
+**RESOLVED → A: Reimplement as OpenClaw plugin (Node.js).** SPEC.md says
+"implement your own hardened version." OpenClaw's Gateway is already Node.js. No
+Elixir dependency.
 
 ### DECISION-2: Persistent daemon or on-demand session?
-**RESOLVED → OpenClaw capability extension.** The orchestrator runs inside OpenClaw's Gateway process as a cron-scheduled plugin action. Persistent by default (systemd manages OpenClaw). Claude Code plugin is management-only — no daemon responsibility.
+
+**RESOLVED → OpenClaw capability extension.** The orchestrator runs inside
+OpenClaw's Gateway process as a cron-scheduled plugin action. Persistent by
+default (systemd manages OpenClaw). Claude Code plugin is management-only — no
+daemon responsibility.
 
 ### DECISION-3: Linear-only or abstract tracker?
-**RESOLVED → A: Linear-only.** YAGNI. OpenClaw plugin talks to Linear API directly. Claude Code side uses yellow-linear MCP for status queries.
+
+**RESOLVED → A: Linear-only.** YAGNI. OpenClaw plugin talks to Linear API
+directly. Claude Code side uses yellow-linear MCP for status queries.
 
 ### DECISION-4: Workspace isolation strategy
-**RESOLVED → A: git worktree per issue.** OpenClaw plugin manages worktree creation/cleanup on the VM. Claude Code plugin has no workspace responsibilities.
+
+**RESOLVED → A: git worktree per issue.** OpenClaw plugin manages worktree
+creation/cleanup on the VM. Claude Code plugin has no workspace
+responsibilities.
 
 ### DECISION-5: Agent runner — what replaces Codex app-server?
-**RESOLVED → OpenClaw Agent Runtime.** The dispatch bridge uses OpenClaw's existing Agent Runtime rather than spawning raw subprocesses. Runner type (Claude, Codex, etc.) is configurable in SYMPHONY.md. Claude Code plugin not involved in execution.
+
+**RESOLVED → OpenClaw Agent Runtime.** The dispatch bridge uses OpenClaw's
+existing Agent Runtime rather than spawning raw subprocesses. Runner type
+(Claude, Codex, etc.) is configurable in SYMPHONY.md. Claude Code plugin not
+involved in execution.
 
 ### DECISION-6: Proof of Work validation
-**OPEN.** Still applies to the OpenClaw plugin side. MVP: agent-driven (prompt instructs agent to run tests, create PR). Target: hybrid with orchestrator-side hook verification.
+
+**OPEN.** Still applies to the OpenClaw plugin side. MVP: agent-driven (prompt
+instructs agent to run tests, create PR). Target: hybrid with orchestrator-side
+hook verification.
 
 ### DECISION-7: Coexistence with OpenClaw
-**RESOLVED → Symphony IS an OpenClaw capability.** No coexistence problem — the orchestration logic is a plugin within OpenClaw, using the same Agent Runtime, credentials, and infrastructure. Label-based partitioning may still be useful to distinguish Symphony-managed issues from manually-triggered OpenClaw sessions.
+
+**RESOLVED → Symphony IS an OpenClaw capability.** No coexistence problem — the
+orchestration logic is a plugin within OpenClaw, using the same Agent Runtime,
+credentials, and infrastructure. Label-based partitioning may still be useful to
+distinguish Symphony-managed issues from manually-triggered OpenClaw sessions.
 
 ### DECISION-8: WORKFLOW.md location
-**RESOLVED → A: Repo-root `SYMPHONY.md`.** Upstream convention; version-controlled with code. The Claude Code `/symphony:config` command validates and edits this file.
+
+**RESOLVED → A: Repo-root `SYMPHONY.md`.** Upstream convention;
+version-controlled with code. The Claude Code `/symphony:config` command
+validates and edits this file.
 
 ## Integration Points (Revised)
 
-| System | Role | Mechanism |
-|---|---|---|
-| **OpenClaw (Proxmox)** | Hosts the orchestrator plugin | SSH from Claude Code for status/control |
-| **yellow-linear** | Status queries from Claude Code side | MCP tools (`list_issues`, `get_issue`) |
-| **yellow-review** | Review PRs created by Symphony runs | `/review:pr` on PRs tagged `symphony` |
-| **gt-workflow** | Not used by this plugin | OpenClaw manages worktrees directly on VM |
-| **yellow-codex** | Not used by this plugin | Runner choice is OpenClaw plugin config |
+| System                 | Role                                 | Mechanism                                 |
+| ---------------------- | ------------------------------------ | ----------------------------------------- |
+| **OpenClaw (Proxmox)** | Hosts the orchestrator plugin        | SSH from Claude Code for status/control   |
+| **yellow-linear**      | Status queries from Claude Code side | MCP tools (`list_issues`, `get_issue`)    |
+| **yellow-review**      | Review PRs created by Symphony runs  | `/review:pr` on PRs tagged `symphony`     |
+| **gt-workflow**        | Not used by this plugin              | OpenClaw manages worktrees directly on VM |
+| **yellow-codex**       | Not used by this plugin              | Runner choice is OpenClaw plugin config   |
 
 ## MVP Scope (Revised — thin management layer only)
 
 **Ships first (Phase 1) — Claude Code plugin:**
 
-- `/symphony:setup` — validate SSH connectivity to Proxmox VM, OpenClaw running, symphony plugin installed, `SYMPHONY.md` exists in current repo
-- `/symphony:status` — SSH to daemon, query running sessions, queue depth, recent completions, display formatted table
-- `/symphony:config` — parse and validate repo-local `SYMPHONY.md` against schema, offer guided editing
-- `symphony-conventions` skill — SYMPHONY.md schema reference, prompt template patterns
+- `/symphony:setup` — validate SSH connectivity to Proxmox VM, OpenClaw running,
+  symphony plugin installed, `SYMPHONY.md` exists in current repo
+- `/symphony:status` — SSH to daemon, query running sessions, queue depth,
+  recent completions, display formatted table
+- `/symphony:config` — parse and validate repo-local `SYMPHONY.md` against
+  schema, offer guided editing
+- `symphony-conventions` skill — SYMPHONY.md schema reference, prompt template
+  patterns
 - `SYMPHONY.md.example` template — starter workflow contract
 
 **Phase 2 — remote control:**
@@ -140,25 +201,36 @@ plugins/yellow-symphony/
 - Auto-review: hook into yellow-review when Symphony PRs land
 - Metrics: token spend, success rate, time-to-PR per issue
 
-**Out of scope for this repo:** poll loop, issue claiming, worktree management, agent dispatch, retry/reconciliation — all OpenClaw plugin responsibilities.
+**Out of scope for this repo:** poll loop, issue claiming, worktree management,
+agent dispatch, retry/reconciliation — all OpenClaw plugin responsibilities.
 
 ## Risk Register (Revised)
 
-| Risk | Impact | Mitigation |
-|---|---|---|
-| SSH connectivity to Proxmox unreliable | Medium | `/symphony:setup` validates; show clear error with reconnect instructions |
-| OpenClaw symphony plugin API changes | Medium | Version the status/control protocol; pin to known OpenClaw plugin version |
-| SYMPHONY.md schema drift between repos | Low | Skill documents canonical schema; `/symphony:config` validates |
-| User edits SYMPHONY.md without validation | Low | Pre-commit hook (optional) or `/symphony:config` as primary edit path |
-| OpenClaw daemon down, no feedback in Claude Code | Medium | `/symphony:status` shows daemon health; recommend systemd alerting |
-| Prompt injection via issue descriptions | High | Document fencing requirement in symphony-conventions skill; enforcement is OpenClaw plugin's job |
+| Risk                                             | Impact | Mitigation                                                                                       |
+| ------------------------------------------------ | ------ | ------------------------------------------------------------------------------------------------ |
+| SSH connectivity to Proxmox unreliable           | Medium | `/symphony:setup` validates; show clear error with reconnect instructions                        |
+| OpenClaw symphony plugin API changes             | Medium | Version the status/control protocol; pin to known OpenClaw plugin version                        |
+| SYMPHONY.md schema drift between repos           | Low    | Skill documents canonical schema; `/symphony:config` validates                                   |
+| User edits SYMPHONY.md without validation        | Low    | Pre-commit hook (optional) or `/symphony:config` as primary edit path                            |
+| OpenClaw daemon down, no feedback in Claude Code | Medium | `/symphony:status` shows daemon health; recommend systemd alerting                               |
+| Prompt injection via issue descriptions          | High   | Document fencing requirement in symphony-conventions skill; enforcement is OpenClaw plugin's job |
 
 ## Open Questions (Revised)
 
-1. **OpenClaw plugin API contract:** What status/control interface should the OpenClaw symphony plugin expose? REST endpoint? Unix socket? CLI command? This determines how `/symphony:status` queries the daemon.
-2. **SSH vs API for remote control:** SSH is simplest but requires key management. Alternative: OpenClaw exposes an HTTP API (authenticated). Which does OpenClaw support?
-3. **SYMPHONY.md schema:** Define the exact YAML front matter schema for the workflow contract. What fields from Symphony SPEC.md are relevant when OpenClaw manages dispatch?
-4. **Log format/location:** Where does the OpenClaw plugin write logs? Structured JSON for parsing, or plain text for `tail`?
-5. **SPEC.md stability:** Draft v1 may have breaking changes. Pin to specific behaviors or stay loose?
-6. **Cross-repo workflow contracts:** Can one SYMPHONY.md reference another repo's config, or is it strictly per-repo?
-7. **Auth for status queries:** If OpenClaw exposes an HTTP API, what auth mechanism? API key? mTLS? Bearer token from existing credentials?
+1. **OpenClaw plugin API contract:** ~~What status/control interface should the
+   OpenClaw symphony plugin expose? REST endpoint? Unix socket? CLI command?~~
+   **RESOLVED → CLI subcommands over SSH.** See plan Assumptions section.
+2. **SSH vs API for remote control:** ~~SSH is simplest but requires key
+   management.~~ **RESOLVED → SSH + CLI.** Key management handled by setup
+   wizard. See plan Assumptions section.
+3. **SYMPHONY.md schema:** Define the exact YAML front matter schema for the
+   workflow contract. What fields from Symphony SPEC.md are relevant when
+   OpenClaw manages dispatch?
+4. **Log format/location:** Where does the OpenClaw plugin write logs?
+   Structured JSON for parsing, or plain text for `tail`?
+5. **SPEC.md stability:** Draft v1 may have breaking changes. Pin to specific
+   behaviors or stay loose?
+6. **Cross-repo workflow contracts:** Can one SYMPHONY.md reference another
+   repo's config, or is it strictly per-repo?
+7. **Auth for status queries:** If OpenClaw exposes an HTTP API, what auth
+   mechanism? API key? mTLS? Bearer token from existing credentials?

--- a/docs/brainstorms/2026-04-01-symphony-plugin-brainstorm.md
+++ b/docs/brainstorms/2026-04-01-symphony-plugin-brainstorm.md
@@ -1,7 +1,7 @@
 # Symphony-Style Orchestration Plugin Brainstorm
 
 **Date:** 2026-04-01 (updated 2026-04-02)
-**Status:** Finalized — plan at [plans/yellow-symphony-plugin.md](../../plans/yellow-symphony-plugin.md)
+**Status:** Finalized -- plan at [plans/yellow-symphony-plugin.md](../../plans/yellow-symphony-plugin.md)
 **Approach:** Thin management layer over OpenClaw-hosted daemon (revised from full reimplementation)
 **Source:** OpenAI Symphony SPEC.md (Draft v1, language-agnostic)
 
@@ -214,6 +214,7 @@ agent dispatch, retry/reconciliation — all OpenClaw plugin responsibilities.
 | User edits SYMPHONY.md without validation        | Low    | Pre-commit hook (optional) or `/symphony:config` as primary edit path                            |
 | OpenClaw daemon down, no feedback in Claude Code | Medium | `/symphony:status` shows daemon health; recommend systemd alerting                               |
 | Prompt injection via issue descriptions          | High   | Document fencing requirement in symphony-conventions skill; enforcement is OpenClaw plugin's job |
+| OpenClaw plugin CLI contract defined unilaterally | High   | Plan defines assumed contract explicitly (Assumptions section); validate against OpenClaw spec when available; keep commands thin to minimize rewrite surface |
 
 ## Open Questions (Revised)
 
@@ -232,5 +233,6 @@ agent dispatch, retry/reconciliation — all OpenClaw plugin responsibilities.
    behaviors or stay loose?
 6. **Cross-repo workflow contracts:** Can one SYMPHONY.md reference another
    repo's config, or is it strictly per-repo?
-7. **Auth for status queries:** If OpenClaw exposes an HTTP API, what auth
-   mechanism? API key? mTLS? Bearer token from existing credentials?
+7. ~~**Auth for status queries:** If OpenClaw exposes an HTTP API, what auth
+   mechanism?~~ **RESOLVED -- N/A.** SSH transport chosen (Open Questions #1/#2);
+   no HTTP API.

--- a/docs/brainstorms/2026-04-01-symphony-plugin-brainstorm.md
+++ b/docs/brainstorms/2026-04-01-symphony-plugin-brainstorm.md
@@ -37,7 +37,7 @@ Symphony is a scheduler/runner and tracker _reader_ only -- ticket writes
 | Symphony Component       | OpenClaw Responsibility                                                  | Claude Code (yellow-symphony)                     |
 | ------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------- |
 | **Workflow Loader**      | Reads repo-local `SYMPHONY.md`, parses front matter + prompt at dispatch | `/symphony:config` validates the same schema      |
-| **Config Layer**         | Loads YAML front matter at runtime; full Symphony schema                 | Validates subset via bash `case`/`if`; no dynamic reload |
+| **Config Layer**         | Loads YAML front matter at runtime; full Symphony schema                 | Validates subset (`tracker.*`, `polling.*`, `agent.*`, `workspace.*`) via bash `case`/`if`; no dynamic reload |
 | **Issue Tracker Client** | Direct Linear API calls for poll/claim/update                            | yellow-linear MCP tools for status queries (optional) |
 | **Orchestrator**         | Core daemon: poll, claim, dispatch, concurrency, retry                   | `/symphony:status` queries state via SSH          |
 | **Workspace Manager**    | `git worktree` per issue on the VM                                       | Not involved — OpenClaw manages worktrees         |
@@ -57,6 +57,7 @@ would duplicate infrastructure for zero benefit. The Claude Code plugin becomes 
 remote management layer only.
 
 **Rejected alternatives:**
+
 - **Full reimplementation in Claude Code**: Duplicates OpenClaw infra, no
   persistent daemon support
 - **Sidecar alongside OpenClaw**: Doubles operational overhead (two services, two

--- a/docs/brainstorms/2026-04-01-symphony-plugin-brainstorm.md
+++ b/docs/brainstorms/2026-04-01-symphony-plugin-brainstorm.md
@@ -1,0 +1,164 @@
+# Symphony-Style Orchestration Plugin Brainstorm
+
+**Date:** 2026-04-01 (updated 2026-04-02)
+**Status:** Draft — revised after architectural pivot
+**Source:** OpenAI Symphony SPEC.md (Draft v1, language-agnostic)
+
+> **Architectural Pivot (2026-04-02):** After research, Symphony orchestration
+> belongs as an **OpenClaw plugin** (capability extension on Proxmox VM), not a
+> reimplementation inside Claude Code. The Claude Code plugin (`yellow-symphony`)
+> becomes a **thin remote management layer** over the OpenClaw-hosted daemon. See
+> "Revised Architecture" section below.
+
+## Symphony Architecture Summary
+
+Symphony is a long-running daemon that polls Linear, creates an isolated
+workspace per issue, and runs a coding agent session inside each workspace until
+the issue reaches a handoff state. Core loop: **poll -> filter eligible -> claim
+-> create workspace -> render prompt from WORKFLOW.md -> launch agent -> stream
+events -> reconcile -> retry or release**. The orchestrator owns scheduling state
+in-memory (no database) and recovers from filesystem + tracker state on restart.
+Runtime behavior lives in a repo-owned `WORKFLOW.md`: YAML front matter (tracker
+config, polling interval, workspace root, hooks, concurrency, Codex settings)
+plus a Markdown prompt template with Liquid-style interpolation. Symphony is a
+scheduler/runner and tracker *reader* only -- ticket writes (status transitions,
+PR links, comments) are the coding agent's job.
+
+## Component Mapping Table
+
+| Symphony Component | Claude Code Equivalent | Gap |
+|---|---|---|
+| **Workflow Loader** | Command reads repo-local `SYMPHONY.md`, parses front matter + prompt | Direct mapping |
+| **Config Layer** | Front matter parsed via bash `yq`; subset of Symphony schema | Define our own schema; no dynamic reload for MVP |
+| **Issue Tracker Client** | **yellow-linear** MCP tools (`list_issues`, `get_issue`, `update_issue`) | Reuse entirely. Gap: MCP-only, no raw GraphQL |
+| **Orchestrator** | New `/symphony:run` command or external daemon script | Core new work: poll, dispatch, concurrency, retry |
+| **Workspace Manager** | `git worktree` per issue under configurable root | Partial reuse of gt-workflow patterns |
+| **Agent Runner** | `claude --headless` per issue (or `codex exec` via yellow-codex) | No app-server protocol; see DECISION-5 |
+| **Prompt Builder** | Bash heredoc/envsubst with `issue.*` + `attempt` variables | Simpler than Liquid; sufficient for MVP |
+| **Status Surface** | `/symphony:status` command reading log files | Skip LiveView entirely |
+| **Logging** | Log files under `~/symphony-logs/<issue-id>/` | Standard approach |
+| **linear_graphql tool** | yellow-linear MCP tools already in Claude Code sessions | Direct equivalent |
+
+## Revised Architecture
+
+```
+Proxmox VM (OpenClaw plugin)              Claude Code (yellow-symphony)
+┌──────────────────────────────┐          ┌──────────────────────────────┐
+│ openclaw-symphony plugin     │          │ yellow-symphony plugin       │
+│  ├─ poll Linear (cron 30s)   │          │  ├─ /symphony:status         │
+│  ├─ claim + state machine    │  ←ssh→   │  ├─ /symphony:config         │
+│  ├─ create worktree          │          │  ├─ /symphony:pause/resume   │
+│  ├─ dispatch agent runtime   │          │  ├─ /symphony:logs           │
+│  ├─ log + reconcile          │          │  └─ symphony-conventions     │
+│  └─ cleanup on terminal      │          │     (SYMPHONY.md schema ref) │
+└──────────────────────────────┘          └──────────────────────────────┘
+```
+
+**Why capability extension, not sidecar:**
+- OpenClaw already has cron scheduling, plugin system, Agent Runtime, and systemd lifecycle
+- Symphony's orchestrator is intentionally stateless — recovers from tracker + filesystem
+- Sidecar doubles operational overhead (two services, two log streams, duplicated credentials) for zero isolation benefit on a single VM
+- Clean internal interface between tracker/state-machine and dispatch enables future sidecar extraction if needed
+
+**Scope split:**
+- **OpenClaw plugin** (separate repo): poll/claim/dispatch/reconcile/log/recover — the daemon
+- **yellow-symphony** (this repo): remote status/config/control + workflow contract authoring conventions
+
+## Plugin Structure (Revised — thin management layer)
+
+```
+plugins/yellow-symphony/
+  .claude-plugin/plugin.json
+  package.json
+  CLAUDE.md
+  commands/symphony/
+    setup.md         # Validate SSH to Proxmox, OpenClaw running, plugin installed
+    status.md        # Query daemon state (running sessions, queue, completions)
+    config.md        # Validate + edit repo-local SYMPHONY.md
+    pause.md         # Toggle daemon polling off
+    resume.md        # Toggle daemon polling on
+    logs.md          # Tail logs for a specific issue run
+  skills/symphony-conventions/
+    SKILL.md         # SYMPHONY.md schema, prompt template patterns, conventions
+  templates/
+    SYMPHONY.md.example  # Starter workflow contract for new repos
+```
+
+## Decision Points
+
+### DECISION-1: Reimplement orchestrator or wrap Elixir reference?
+**RESOLVED → A: Reimplement as OpenClaw plugin (Node.js).** SPEC.md says "implement your own hardened version." OpenClaw's Gateway is already Node.js. No Elixir dependency.
+
+### DECISION-2: Persistent daemon or on-demand session?
+**RESOLVED → OpenClaw capability extension.** The orchestrator runs inside OpenClaw's Gateway process as a cron-scheduled plugin action. Persistent by default (systemd manages OpenClaw). Claude Code plugin is management-only — no daemon responsibility.
+
+### DECISION-3: Linear-only or abstract tracker?
+**RESOLVED → A: Linear-only.** YAGNI. OpenClaw plugin talks to Linear API directly. Claude Code side uses yellow-linear MCP for status queries.
+
+### DECISION-4: Workspace isolation strategy
+**RESOLVED → A: git worktree per issue.** OpenClaw plugin manages worktree creation/cleanup on the VM. Claude Code plugin has no workspace responsibilities.
+
+### DECISION-5: Agent runner — what replaces Codex app-server?
+**RESOLVED → OpenClaw Agent Runtime.** The dispatch bridge uses OpenClaw's existing Agent Runtime rather than spawning raw subprocesses. Runner type (Claude, Codex, etc.) is configurable in SYMPHONY.md. Claude Code plugin not involved in execution.
+
+### DECISION-6: Proof of Work validation
+**OPEN.** Still applies to the OpenClaw plugin side. MVP: agent-driven (prompt instructs agent to run tests, create PR). Target: hybrid with orchestrator-side hook verification.
+
+### DECISION-7: Coexistence with OpenClaw
+**RESOLVED → Symphony IS an OpenClaw capability.** No coexistence problem — the orchestration logic is a plugin within OpenClaw, using the same Agent Runtime, credentials, and infrastructure. Label-based partitioning may still be useful to distinguish Symphony-managed issues from manually-triggered OpenClaw sessions.
+
+### DECISION-8: WORKFLOW.md location
+**RESOLVED → A: Repo-root `SYMPHONY.md`.** Upstream convention; version-controlled with code. The Claude Code `/symphony:config` command validates and edits this file.
+
+## Integration Points (Revised)
+
+| System | Role | Mechanism |
+|---|---|---|
+| **OpenClaw (Proxmox)** | Hosts the orchestrator plugin | SSH from Claude Code for status/control |
+| **yellow-linear** | Status queries from Claude Code side | MCP tools (`list_issues`, `get_issue`) |
+| **yellow-review** | Review PRs created by Symphony runs | `/review:pr` on PRs tagged `symphony` |
+| **gt-workflow** | Not used by this plugin | OpenClaw manages worktrees directly on VM |
+| **yellow-codex** | Not used by this plugin | Runner choice is OpenClaw plugin config |
+
+## MVP Scope (Revised — thin management layer only)
+
+**Ships first (Phase 1) — Claude Code plugin:**
+
+- `/symphony:setup` — validate SSH connectivity to Proxmox VM, OpenClaw running, symphony plugin installed, `SYMPHONY.md` exists in current repo
+- `/symphony:status` — SSH to daemon, query running sessions, queue depth, recent completions, display formatted table
+- `/symphony:config` — parse and validate repo-local `SYMPHONY.md` against schema, offer guided editing
+- `symphony-conventions` skill — SYMPHONY.md schema reference, prompt template patterns
+- `SYMPHONY.md.example` template — starter workflow contract
+
+**Phase 2 — remote control:**
+
+- `/symphony:pause` / `/symphony:resume` — toggle daemon polling via SSH command
+- `/symphony:logs` — tail/search logs for a specific issue ID
+
+**Phase 3 — integration:**
+
+- Auto-review: hook into yellow-review when Symphony PRs land
+- Metrics: token spend, success rate, time-to-PR per issue
+
+**Out of scope for this repo:** poll loop, issue claiming, worktree management, agent dispatch, retry/reconciliation — all OpenClaw plugin responsibilities.
+
+## Risk Register (Revised)
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| SSH connectivity to Proxmox unreliable | Medium | `/symphony:setup` validates; show clear error with reconnect instructions |
+| OpenClaw symphony plugin API changes | Medium | Version the status/control protocol; pin to known OpenClaw plugin version |
+| SYMPHONY.md schema drift between repos | Low | Skill documents canonical schema; `/symphony:config` validates |
+| User edits SYMPHONY.md without validation | Low | Pre-commit hook (optional) or `/symphony:config` as primary edit path |
+| OpenClaw daemon down, no feedback in Claude Code | Medium | `/symphony:status` shows daemon health; recommend systemd alerting |
+| Prompt injection via issue descriptions | High | Document fencing requirement in symphony-conventions skill; enforcement is OpenClaw plugin's job |
+
+## Open Questions (Revised)
+
+1. **OpenClaw plugin API contract:** What status/control interface should the OpenClaw symphony plugin expose? REST endpoint? Unix socket? CLI command? This determines how `/symphony:status` queries the daemon.
+2. **SSH vs API for remote control:** SSH is simplest but requires key management. Alternative: OpenClaw exposes an HTTP API (authenticated). Which does OpenClaw support?
+3. **SYMPHONY.md schema:** Define the exact YAML front matter schema for the workflow contract. What fields from Symphony SPEC.md are relevant when OpenClaw manages dispatch?
+4. **Log format/location:** Where does the OpenClaw plugin write logs? Structured JSON for parsing, or plain text for `tail`?
+5. **SPEC.md stability:** Draft v1 may have breaking changes. Pin to specific behaviors or stay loose?
+6. **Cross-repo workflow contracts:** Can one SYMPHONY.md reference another repo's config, or is it strictly per-repo?
+7. **Auth for status queries:** If OpenClaw exposes an HTTP API, what auth mechanism? API key? mTLS? Bearer token from existing credentials?

--- a/docs/brainstorms/2026-04-01-symphony-plugin-brainstorm.md
+++ b/docs/brainstorms/2026-04-01-symphony-plugin-brainstorm.md
@@ -163,8 +163,8 @@ distinguish Symphony-managed issues from manually-triggered OpenClaw sessions.
 
 ### DECISION-8: WORKFLOW.md location
 
-**RESOLVED → A: Repo-root `SYMPHONY.md`.** Upstream convention;
-version-controlled with code. The Claude Code `/symphony:config` command
+**RESOLVED → A: Repo-root `SYMPHONY.md`.** Chosen for namespace clarity (upstream
+uses `WORKFLOW.md`); version-controlled with code. The Claude Code `/symphony:config` command
 validates and edits this file.
 
 ## Integration Points (Revised)

--- a/plans/yellow-symphony-plugin.md
+++ b/plans/yellow-symphony-plugin.md
@@ -113,7 +113,14 @@ yellow-ci's runner-health command. Config stored in
     - `.claude/yellow-symphony.local.md` exists OR wizard creates it
   - **SSH validation:**
     - Normalize ssh_key before SSH calls: `ssh_key="${ssh_key/#\~/$HOME}"`
-    - `timeout 10 ssh -i "$ssh_key" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=3 user@host 'echo OK'`
+    - Validate connectivity:
+      ```bash
+      timeout 10 ssh -i "$ssh_key" \
+        -o StrictHostKeyChecking=accept-new \
+        -o BatchMode=yes \
+        -o ConnectTimeout=3 \
+        user@host 'echo OK'
+      ```
   - **Daemon check:** `ssh ... 'openclaw symphony status'`
 
 <!-- deepen-plan: codebase -->
@@ -378,9 +385,11 @@ yellow-ci's runner-health command. Config stored in
   wizard should warn: "Add `.claude/*.local.md` to `.gitignore`."
 - **Output fencing**: All daemon output (including logs that may contain
   attacker-controlled Linear issue content) is wrapped in `--- begin/end ---`
-  fences with `(reference only)` advisory before LLM reasoning. Fencing wraps
-  the entire raw SSH stdout; individual fields must not be extracted and
-  displayed outside the fence.
+  fences with `(reference only)` advisory before LLM reasoning. Always include
+  the full raw SSH stdout inside the fence. For commands that parse JSON
+  (e.g., `/symphony:status`), a parsed summary table may be shown outside the
+  fence only after strict JSON parsing succeeds. On parse failure, show fenced
+  raw output only — do not extract individual fields from unparseable output.
 
 ## Edge Cases
 

--- a/plans/yellow-symphony-plugin.md
+++ b/plans/yellow-symphony-plugin.md
@@ -1,12 +1,14 @@
 # Feature: yellow-symphony — Thin Management Layer for Symphony Orchestration
 
+**Status:** Draft — not started
+
 ## Problem Statement
 
-Symphony-style orchestration (poll Linear, claim issues, dispatch autonomous agent
-runs) lives as an OpenClaw plugin on a Proxmox VM. Claude Code users need
+Symphony-style orchestration (poll Linear, claim issues, dispatch autonomous
+agent runs) lives as an OpenClaw plugin on a Proxmox VM. Claude Code users need
 visibility and control over that daemon without SSH-ing manually. This plugin
-provides status queries, config validation, and remote control — no orchestration
-logic.
+provides status queries, config validation, and remote control — no
+orchestration logic.
 
 ## Current State
 
@@ -17,23 +19,32 @@ side of the interface contract so both sides can be built independently.
 
 ## Proposed Solution
 
-A standard Claude Code plugin with 5 commands, 1 skill, and 1 template.
+A standard Claude Code plugin with 6 commands and 1 skill.
 Communicates with the OpenClaw daemon over SSH using the same patterns as
-yellow-ci's runner-health command. Config stored in `.claude/yellow-symphony.local.md`
-(YAML frontmatter with SSH host/user/key).
+yellow-ci's runner-health command. Config stored in
+`.claude/yellow-symphony.local.md` (YAML frontmatter with SSH host/user/key).
 
 <!-- deepen-plan: codebase -->
+
 > **Codebase:** SSH pattern at `yellow-ci/commands/ci/runner-health.md:47-66`
 > uses **4** flags, not 3: `StrictHostKeyChecking=accept-new`, `BatchMode=yes`,
-> `ConnectTimeout=3`, `ServerAliveInterval=60`. The plan should include all 4,
-> though `ServerAliveInterval` is more relevant for long-lived connections —
-> consider whether 3s management commands need it.
+> `ConnectTimeout=3`, `ServerAliveInterval=60`.
+>
+> **RESOLVED:** Use 3 flags for short-lived commands (setup, status, config,
+> pause, resume). Add `ServerAliveInterval=60` as a 4th flag for
+> `/symphony:logs` only, since log tailing may transfer larger output. All
+> commands use `timeout 10 ssh ...` to prevent hangs when the daemon accepts the
+> connection but stalls (consistent with yellow-ci's runner-health pattern).
+
 <!-- /deepen-plan -->
 
 <!-- deepen-plan: codebase -->
-> **Codebase:** Commands must use `allowed-tools:` in frontmatter (not `tools:`).
-> `tools:` is for agents only. All reference commands (`ci:setup`, `ci:status`,
-> `ci:runner-health`, `gt-setup`) confirm this. See MEMORY.md "Agent Frontmatter".
+
+> **Codebase:** Commands must use `allowed-tools:` in frontmatter (not
+> `tools:`). `tools:` is for agents only. All reference commands (`ci:setup`,
+> `ci:status`, `ci:runner-health`, `gt-setup`) confirm this. See MEMORY.md
+> "Agent Frontmatter".
+
 <!-- /deepen-plan -->
 
 ## Implementation Plan
@@ -41,39 +52,45 @@ yellow-ci's runner-health command. Config stored in `.claude/yellow-symphony.loc
 ### Phase 1: Scaffold and Setup
 
 - [ ] 1.1: Create plugin directory structure
-  ```
+
+  ```text
   plugins/yellow-symphony/
     .claude-plugin/plugin.json
     package.json
     CLAUDE.md
+    CHANGELOG.md
+    README.md
     commands/symphony/
       setup.md
       status.md
       config.md
       pause.md
+      resume.md
       logs.md
     skills/symphony-conventions/
       SKILL.md
-    templates/
-      SYMPHONY.md.example
   ```
 
 - [ ] 1.2: Write `plugin.json` manifest
-  - Fields: name, version (0.1.0), description, author, homepage, repository, license, keywords
+  - Fields: name, version (0.1.0), description, author, homepage, repository,
+    license, keywords
   - No hooks or mcpServers — pure command plugin
 
 <!-- deepen-plan: codebase -->
+
 > **Codebase:** Three-way sync is mandatory. `sync-manifests.js` enforces
 > lockstep between `package.json`, `.claude-plugin/plugin.json`, and the root
 > `.claude-plugin/marketplace.json`. Never edit versions manually. The
 > marketplace entry requires: `name` (must match dir name), `description`,
-> `version`, `author` (`{name, url}`), `source` (e.g., `"./plugins/yellow-symphony"`),
-> `category` (use `"development"`). Currently 16 plugins registered, no
-> "symphony" namespace collision.
+> `version`, `author` (`{name, url}`), `source` (e.g.,
+> `"./plugins/yellow-symphony"`), `category` (use `"development"`). Currently 16
+> plugins registered, no "symphony" namespace collision.
+
 <!-- /deepen-plan -->
 
 - [ ] 1.3: Write `package.json`
-  - Minimal: name (`yellow-symphony`), version (`0.1.0`), private: true, description
+  - Minimal: name (`yellow-symphony`), version (`0.1.0`), private: true,
+    description
 
 - [ ] 1.4: Register in `.claude-plugin/marketplace.json`
 
@@ -85,69 +102,95 @@ yellow-ci's runner-health command. Config stored in `.claude/yellow-symphony.loc
 
 ### Phase 2: Core Commands
 
+> **Note:** The brainstorm deferred pause/resume/logs to a separate Phase 2, but
+> since all 6 commands are thin SSH wrappers (each under 20 lines), implementing
+> them together is lower risk than maintaining a partial release.
+
+
 - [ ] 2.1: Write `commands/symphony/setup.md`
   - **Prereq checks (before any AskUserQuestion):**
     - `ssh` binary exists (hard)
     - `jq` exists (soft — warn, degrade gracefully)
     - `.claude/yellow-symphony.local.md` exists OR wizard creates it
-  - **SSH validation:** `ssh -o BatchMode=yes -o ConnectTimeout=3 user@host 'echo OK'`
-  - **Daemon check:** `ssh ... 'openclaw plugin status symphony'` (or equivalent)
+  - **SSH validation:**
+    `timeout 10 ssh -i "$ssh_key" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=3 user@host 'echo OK'`
+  - **Daemon check:** `ssh ... 'openclaw symphony status'`
 
 <!-- deepen-plan: codebase -->
+
 > **Codebase:** `ci:setup.md` sequences: Step 1 (line 22) all prereq checks in
 > one Bash call → Step 2 (line 42) auth check → Step 3 (line 65) existing config
-> check → **first AskUserQuestion at Step 4 (line 87)**. `gt-setup.md` is even
-> stricter: Phase 1 (lines 18-138) is pure Bash, first AskUserQuestion at
-> Step 5 (line 161). Follow this pattern exactly.
+> check (conditional AskUserQuestion at line 80 if config already exists) →
+> **first unconditional AskUserQuestion at Step 4 (line 87)**. `gt-setup.md` is
+> even stricter: Phase 1 (lines 18-138) is pure Bash, first AskUserQuestion at
+> Step 5 (line 161). Follow this pattern: all hard prereq checks must complete
+> before any user interaction.
+
 <!-- /deepen-plan -->
 
 <!-- deepen-plan: external -->
-> **Research:** SSH CLI best practices recommend `ControlMaster`/`ControlPersist`
-> in `~/.ssh/config` for connection reuse across multiple commands in one session.
-> Also: retry 3x with exponential backoff on connection failure, capture stderr
-> separately from stdout, and support degraded mode (warn on optional checks,
-> fail only critical).
+
+> **Research:** SSH CLI best practices recommend
+> `ControlMaster`/`ControlPersist` in `~/.ssh/config` for connection reuse
+> across multiple commands in one session. Also: retry 3x with exponential
+> backoff on connection failure, capture stderr separately from stdout, and
+> support degraded mode (warn on optional checks, fail only critical).
+
 <!-- /deepen-plan -->
-  - **Config wizard:** AskUserQuestion for host, user, SSH key path, daemon control command
-  - **Write config:** `.claude/yellow-symphony.local.md` with YAML frontmatter:
-    ```yaml
-    ---
-    schema: yellow-symphony/v1
-    host: 192.168.1.x
-    user: openclaw
-    ssh_key: ~/.ssh/id_ed25519
-    daemon_ctl: openclaw symphony  # prefix for status/pause/resume/logs subcommands
-    ---
-    ```
-  - **Final report:** PASS/PARTIAL/FAIL with next-step menu
+
+- **Config wizard:** AskUserQuestion for host, user, SSH key path, daemon
+  control command
+- **Write config:** `.claude/yellow-symphony.local.md` with YAML frontmatter:
+
+  ```yaml
+  ---
+  schema: 1
+  host: 192.168.1.x
+  user: openclaw
+  ssh_key: ~/.ssh/id_ed25519
+  daemon_ctl: openclaw symphony # prefix for status/pause/resume/logs subcommands
+  ---
+  ```
+
+- **Final report:** PASS/PARTIAL/FAIL with next-step menu
 
 - [ ] 2.2: Write `commands/symphony/status.md`
   - Frontmatter: `model: haiku` (pure data retrieval)
   - Read config from `.claude/yellow-symphony.local.md`
-  - SSH to daemon: `ssh ... '$daemon_ctl status --json'`
-  - Fence output: `--- begin symphony-output (reference only) ---`
+  - SSH to daemon: `timeout 10 ssh ... "$daemon_ctl status --json"`
+  - Fence output per Security Considerations
 
 <!-- deepen-plan: codebase -->
-> **Codebase:** Output fencing in `yellow-codex/skills/codex-patterns/SKILL.md`
-> uses two forms: context injection fencing (line 250: `--- begin context
-> (reference data only) ---`) and codex output fencing (line 279: `--- begin
-> codex-output (reference only) ---`). Use `symphony-output` as the fence label.
+
+> **Codebase:** Reuse the repository's existing output-fencing pattern, e.g.
+> `plugins/yellow-semgrep/commands/semgrep/status.md`:
+> `--- begin semgrep-api-response (reference only) ---`. Use `symphony-output`
+> as the fence label.
+
 <!-- /deepen-plan -->
-  - Parse JSON, format as table: Session ID, Issue, Status, Duration, Branch
-  - Show queue depth, last completion, daemon uptime
-  - If SSH fails: clear error with "run /symphony:setup" suggestion
+
+- Parse JSON, format as table: Session ID, Issue, Status, Duration, Branch
+- Show queue depth, last completion, daemon uptime
+- If SSH fails: clear error with "run /symphony:setup" suggestion
 
 - [ ] 2.3: Write `commands/symphony/config.md`
   - Check for `SYMPHONY.md` in repo root
-  - If missing: offer to copy from `templates/SYMPHONY.md.example`
-  - If present: parse YAML front matter, validate required fields:
-    - `tracker` (linear), `project` (Linear project slug), `labels` (array)
-    - `polling_interval` (integer, >= 10), `concurrency` (integer, >= 1)
-    - `workspace_root` (path), `runner` (claude|codex)
-  - Report validation results; offer guided editing via AskUserQuestion for invalid fields
+  - If missing: offer to scaffold via Write tool (template embedded in command)
+  - If present: parse YAML front matter, validate required fields using upstream
+    nested key structure (subset — unknown keys ignored per Symphony convention):
+    - `tracker.kind` (must be `linear`), `tracker.project_slug` (Linear project
+      slug), `tracker.active_states` (array of Linear status names)
+    - `polling.interval_ms` (integer, >= 10000)
+    - `agent.max_concurrent_agents` (integer, >= 1)
+    - `workspace.root` (path)
+  - The embedded starter template and validator must use the same nested keys so
+    a config accepted locally is also valid for the daemon
+  - Report validation results; offer guided editing via AskUserQuestion for
+    invalid fields
   - Bash `case`/`if` validation, not LLM prose branching
 
 <!-- deepen-plan: external -->
+
 > **Research:** Symphony WORKFLOW.md YAML front matter has 6 top-level sections:
 > `tracker` (`kind`, `project_slug`, `active_states`, `terminal_states`),
 > `polling` (`interval_ms`, default 30000), `workspace` (`root`), `hooks`
@@ -157,36 +200,43 @@ yellow-ci's runner-health command. Config stored in `.claude/yellow-symphony.loc
 > compat). Template variables: `issue.id`, `.identifier`, `.title`,
 > `.description`, `.priority`, `.state`, `.branch_name`, `.url`, `.labels`,
 > `.blocked_by`, plus `attempt` (null on first run, integer on retry).
+
 <!-- /deepen-plan -->
 
 <!-- deepen-plan: external -->
+
 > **Research:** For YAML config validation, AJV + JSON Schema is recommended.
 > Ship a `symphony.schema.json` alongside the plugin — enables VS Code Red Hat
 > YAML extension auto-validation with IntelliSense. Use `js-yaml` to parse,
 > compiled AJV schema to validate at runtime in `config` command. Consider
 > adding a `yaml.schemas` entry in the skill docs for IDE setup.
+>
+> **RESOLVED:** Use Bash `case`/`if` field-by-field validation for the `config`
+> command (consistent with every other command in this codebase). AJV + JSON
+> Schema is a future enhancement for CI-time validation via `pnpm validate:schemas`
+> extension, not a runtime command dependency.
+
 <!-- /deepen-plan -->
 
 - [ ] 2.4: Write `commands/symphony/pause.md`
-  - Read config, SSH to daemon: `ssh ... '$daemon_ctl pause && $daemon_ctl status'`
-  - Echo resulting state (action + verify in one call)
-  - Same command handles resume: `pause.md` for pause, separate `resume` is just
-    the same structure with `resume` subcommand — BUT to avoid near-duplicate files,
-    implement as a single command with argument detection:
-    - `/symphony:pause` → pause
-    - User can also say "resume" in conversation → agent uses status to detect paused state and suggests resume
-  - Actually: keep as two separate commands (pause.md + resume.md) for discoverability.
-    Each is <20 lines. Duplication is acceptable for 2 trivial commands.
+  - Read config, SSH to daemon (two separate calls for clarity):
+    `ssh ... "$daemon_ctl pause"` then `ssh ... "$daemon_ctl status --json"`
+  - Check pause exit code before querying status; report failure clearly
+  - Echo resulting state
+  - Two separate commands (pause.md + resume.md) for discoverability. Each is
+    <20 lines; minor duplication is acceptable for trivial commands.
 
 - [ ] 2.5: Write `commands/symphony/resume.md`
   - Mirror of pause.md with `resume` subcommand
 
 - [ ] 2.6: Write `commands/symphony/logs.md`
   - Argument: issue ID (e.g., `ENG-123`)
-  - SSH to daemon: `ssh ... '$daemon_ctl logs ENG-123 --tail 100'`
-  - Get total line count first, then tail N lines
-  - Warn if truncated (per MEMORY.md: "Silent truncation needs count + warning")
-  - Fence output before LLM reasoning
+  - Validate issue ID before SSH: `^[A-Z]{1,10}-[0-9]{1,10}$` (length-bounded)
+  - SSH to daemon (with `ServerAliveInterval=60` for longer transfers):
+    `timeout 30 ssh ... -o ServerAliveInterval=60 "$daemon_ctl logs ENG-123 --tail 100"`
+  - Tail N lines directly (`tail` already handles short files safely)
+  - If the daemon reports truncation metadata, surface a warning in the result
+  - Fence output per Security Considerations
   - If no issue ID provided: AskUserQuestion
 
 ### Phase 3: Skill and Template
@@ -195,114 +245,173 @@ yellow-ci's runner-health command. Config stored in `.claude/yellow-symphony.loc
   - `user-invokable: false` (internal reference for commands)
   - SYMPHONY.md schema documentation (all fields, types, defaults, constraints)
   - SSH connection conventions (BatchMode, ConnectTimeout, fencing)
-  - Daemon control protocol expectations (what the OpenClaw plugin should expose)
+  - Daemon control protocol expectations (what the OpenClaw plugin should
+    expose)
   - Error handling patterns (SSH failure, daemon down, parse errors)
 
-- [ ] 3.2: Write `templates/SYMPHONY.md.example`
-  - Starter YAML front matter with all fields, sensible defaults, inline comments
-  - Markdown prompt template section with placeholder variables (`{{ issue.title }}`,
-    `{{ issue.description }}`, `{{ attempt }}`)
+- [ ] 3.2: Embed `SYMPHONY.md` starter template in `config.md` command
+  - The `config` command scaffolds `SYMPHONY.md` via `Write` tool when missing
+    (no separate `templates/` directory — no existing plugin uses that pattern)
+  - Starter YAML front matter with all fields, sensible defaults, inline
+    comments
+  - Markdown prompt template section with placeholder variables using
+    `{{ issue.title }}`, `{{ issue.description }}`, `{{ attempt }}` syntax
+    (OpenClaw-side Liquid-style interpolation — this plugin scaffolds the
+    template but does not perform interpolation itself)
   - Comments explaining each section
 
-<!-- deepen-plan: codebase -->
-> **Codebase:** No existing plugin ships template files — this is a novel pattern
-> with no precedent. Consider whether `templates/SYMPHONY.md.example` is
-> discoverable enough, or whether the `config` command should embed the template
-> inline and scaffold via `Write` tool when SYMPHONY.md is missing.
-<!-- /deepen-plan -->
-
 <!-- deepen-plan: external -->
+
 > **Research:** Symphony hook lifecycle: `after_create` (workspace init) →
-> `before_run` (pre-attempt, failure aborts run) → agent executes →
-> `after_run` (post-attempt, failure logged) → `before_remove` (pre-deletion).
-> Run phases: `PreparingWorkspace`, `BuildingPrompt`, `LaunchingAgentProcess`,
+> `before_run` (pre-attempt, failure aborts run) → agent executes → `after_run`
+> (post-attempt, failure logged) → `before_remove` (pre-deletion). Run phases:
+> `PreparingWorkspace`, `BuildingPrompt`, `LaunchingAgentProcess`,
 > `StreamingTurn`, `Succeeded`, `Failed`, `TimedOut`, `Stalled`. The template
 > should document these phases so users understand status values.
+
 <!-- /deepen-plan -->
 
 ### Phase 4: Quality
 
 - [ ] 4.1: Run `pnpm validate:schemas` — verify plugin.json + agent authoring
-- [ ] 4.2: Test `/symphony:setup` manually (will fail SSH since no daemon yet — that's expected)
+- [ ] 4.2: Test `/symphony:setup` manually (will fail SSH since no daemon yet —
+      that's expected)
 - [ ] 4.3: Test `/symphony:config` with the example template copied to repo root
 - [ ] 4.4: Create changeset: `pnpm changeset` (minor — new plugin)
 
-## Technical Details
+## Technical Specifications
 
 ### Files to Create
 
-| File | Purpose |
-|---|---|
-| `plugins/yellow-symphony/.claude-plugin/plugin.json` | Plugin manifest |
-| `plugins/yellow-symphony/package.json` | Version source of truth |
-| `plugins/yellow-symphony/CLAUDE.md` | Architecture + conventions |
-| `plugins/yellow-symphony/commands/symphony/setup.md` | SSH + daemon validation wizard |
-| `plugins/yellow-symphony/commands/symphony/status.md` | Query daemon state |
-| `plugins/yellow-symphony/commands/symphony/config.md` | Validate/edit SYMPHONY.md |
-| `plugins/yellow-symphony/commands/symphony/pause.md` | Pause daemon polling |
-| `plugins/yellow-symphony/commands/symphony/resume.md` | Resume daemon polling |
-| `plugins/yellow-symphony/commands/symphony/logs.md` | Tail issue run logs |
-| `plugins/yellow-symphony/skills/symphony-conventions/SKILL.md` | Schema + pattern reference |
-| `plugins/yellow-symphony/templates/SYMPHONY.md.example` | Starter workflow contract |
+| File                                                           | Purpose                        |
+| -------------------------------------------------------------- | ------------------------------ |
+| `plugins/yellow-symphony/.claude-plugin/plugin.json`           | Plugin manifest                |
+| `plugins/yellow-symphony/package.json`                         | Version source of truth        |
+| `plugins/yellow-symphony/CLAUDE.md`                            | Architecture + conventions     |
+| `plugins/yellow-symphony/commands/symphony/setup.md`           | SSH + daemon validation wizard |
+| `plugins/yellow-symphony/commands/symphony/status.md`          | Query daemon state             |
+| `plugins/yellow-symphony/commands/symphony/config.md`          | Validate/edit SYMPHONY.md      |
+| `plugins/yellow-symphony/commands/symphony/pause.md`           | Pause daemon polling           |
+| `plugins/yellow-symphony/commands/symphony/resume.md`          | Resume daemon polling          |
+| `plugins/yellow-symphony/commands/symphony/logs.md`            | Tail issue run logs            |
+| `plugins/yellow-symphony/CHANGELOG.md`                         | Auto-generated by Changesets   |
+| `plugins/yellow-symphony/README.md`                            | Plugin overview + usage        |
+| `plugins/yellow-symphony/skills/symphony-conventions/SKILL.md` | Schema + pattern reference     |
 
 ### Files to Modify
 
-| File | Change |
-|---|---|
-| `.claude-plugin/marketplace.json` | Add yellow-symphony entry |
+| File                                        | Change                                           |
+| ------------------------------------------- | ------------------------------------------------ |
+| `.claude-plugin/marketplace.json`           | Add yellow-symphony entry                        |
+| `plugins/yellow-core/commands/setup/all.md` | Add setup command mapping and inventory coverage |
 
 ### Patterns to Reuse
 
-| Pattern | Source |
-|---|---|
-| SSH connection flags | `yellow-ci/commands/ci/runner-health.md:47-66` |
-| `.local.md` config storage | `yellow-ci/CLAUDE.md:99-113` |
-| Setup wizard flow | `yellow-ci/commands/ci/setup.md` |
-| Status table + `model: haiku` | `yellow-ci/commands/ci/status.md` |
-| Output fencing | `yellow-codex/skills/codex-patterns/SKILL.md` |
-| Prereq-before-prompt | `gt-workflow/commands/gt-setup.md` |
+| Pattern                       | Source                                              |
+| ----------------------------- | --------------------------------------------------- |
+| SSH connection flags          | `yellow-ci/commands/ci/runner-health.md:47-66`      |
+| `.local.md` config storage    | `yellow-ci/CLAUDE.md:99-113`                        |
+| Setup wizard flow             | `yellow-ci/commands/ci/setup.md`                    |
+| Status table + `model: haiku` | `yellow-ci/commands/ci/status.md`                   |
+| Output fencing                | `plugins/yellow-semgrep/commands/semgrep/status.md` |
+| Prereq-before-prompt          | `gt-workflow/commands/gt-setup.md`                  |
 
 ## Acceptance Criteria
 
 1. `pnpm validate:schemas` passes with yellow-symphony included
-2. `/symphony:setup` creates `.claude/yellow-symphony.local.md` via interactive wizard
+2. `/symphony:setup` creates `.claude/yellow-symphony.local.md` via interactive
+   wizard
 3. `/symphony:status` shows clear error when daemon is unreachable (not a crash)
 4. `/symphony:config` validates a SYMPHONY.md and reports field-level errors
 5. `/symphony:pause` and `/symphony:resume` echo resulting state after action
 6. `/symphony:logs ENG-123` shows fenced, truncation-aware output
-7. `SYMPHONY.md.example` is a valid, self-documenting starter template
+7. `/symphony:config` scaffolds a valid, self-documenting `SYMPHONY.md` when missing
+
+## Assumptions
+
+- **SSH + CLI transport**: The plan assumes the OpenClaw daemon exposes CLI
+  subcommands (`status --json`, `pause`, `resume`, `logs <id>`) accessible via
+  SSH. This resolves brainstorm Open Questions #1 and #2. If OpenClaw later
+  exposes an HTTP API, the command files would need rewriting (replacing
+  `ssh ...` with `curl ...`). The `daemon_ctl` config value is a shell command
+  prefix, not a transport abstraction — switching transport is a non-trivial
+  change. This is acceptable for MVP per YAGNI.
+- **SYMPHONY.md schema is stable enough for MVP**: A subset of Symphony SPEC.md
+  fields is sufficient. Full schema will be refined during OpenClaw plugin
+  development (brainstorm Open Question #3).
+
+## Security Considerations
+
+- **SSH key management**: `.claude/yellow-symphony.local.md` stores the SSH key
+  path (not the key itself). The setup wizard validates the key file exists and
+  has correct permissions (`600`/`400`). Key content is never logged or displayed.
+- **Command injection via daemon_ctl**: The `daemon_ctl` config value is used in
+  SSH remote commands. The setup wizard must validate it against an allowlist
+  regex: `^[a-z][a-z0-9 _/-]{0,63}$` (lowercase alphanumeric, spaces, hyphens,
+  underscores, forward slashes). Commands use double-quoted `"$daemon_ctl ..."`
+  to preserve word boundaries (not `eval`). Each subcommand (pause, status, etc.)
+  is passed as a separate SSH call rather than chained with `&&` in a single
+  remote command string, reducing the injection surface.
+- **Prompt injection**: Issue descriptions from Linear may contain adversarial
+  content. Fencing requirements are documented in `symphony-conventions` skill.
+  Enforcement is the OpenClaw plugin's responsibility, not this plugin's.
+- **Shell authoring pitfalls**: Commands must handle tilde expansion in config
+  paths (`ssh_key="${ssh_key/#\~/$HOME}"`) and split `local` from command
+  substitution per
+  `docs/solutions/security-issues/shell-binary-downloader-security-patterns.md`.
+- **Config file exposure**: `.claude/yellow-symphony.local.md` contains SSH
+  host, user, and key path. The setup wizard's final report must advise: "If
+  this is a shared repository, add `.claude/*.local.md` to `.gitignore`."
+- **Output fencing**: All daemon output (including logs that may contain
+  attacker-controlled Linear issue content) is wrapped in `--- begin/end ---`
+  fences with `(reference only)` advisory before LLM reasoning. Fencing wraps
+  the entire raw SSH stdout; individual fields must not be extracted and
+  displayed outside the fence.
 
 ## Edge Cases
 
-- **No `.claude/yellow-symphony.local.md`**: All commands except setup redirect to `/symphony:setup`
-- **SSH key not found**: setup wizard validates key path exists before writing config
-- **Daemon not installed on remote**: setup detects and reports with install instructions
-- **No SYMPHONY.md in repo**: `/symphony:config` offers to scaffold from template
-- **Daemon returns non-JSON**: status command handles gracefully with raw output fallback
-- **Network timeout mid-command**: 3s ConnectTimeout prevents hanging; clear error message
+- **No `.claude/yellow-symphony.local.md`**: All commands except setup redirect
+  to `/symphony:setup`
+- **SSH key not found**: setup wizard validates key path exists before writing
+  config
+- **Daemon not installed on remote**: setup detects and reports with install
+  instructions
+- **No SYMPHONY.md in repo**: `/symphony:config` offers to scaffold from
+  template
+- **Daemon returns non-JSON**: status command handles gracefully with raw output
+  fallback
+- **Host key changed (VM rebuild)**: SSH refuses connection with MITM warning;
+  setup command detects this error and advises `ssh-keygen -R <host>`
+- **Network timeout mid-command**: 3s ConnectTimeout prevents hanging; clear
+  error message
 
 <!-- deepen-plan: external -->
+
 > **Research:** SSH CLI tools should assume plain text from remote and parse
 > client-side. Capture stderr separately (`2>stderr.tmp`). Retry once on parse
 > failure with verbose logging. Support degraded mode: warn on optional checks,
 > fail only on critical path items.
+
 <!-- /deepen-plan -->
 
 ## Dependencies
 
 - **Hard:** `ssh` binary
-- **Soft:** `jq` (for JSON parsing of daemon output), `yq` (for SYMPHONY.md validation)
+- **Soft:** `jq` (for JSON parsing of daemon output)
 - **Cross-plugin:** yellow-linear (optional — enriches status with issue titles)
-- **External:** OpenClaw symphony plugin exposing `status --json`, `pause`, `resume`, `logs <id>` subcommands
+- **External:** OpenClaw symphony plugin exposing `status --json`, `pause`,
+  `resume`, `logs <id>` subcommands
 
 ## Deferred (not in this plan)
 
-- Agent definitions (no agents needed — this is a management plugin, not a runner)
+- Agent definitions (no agents needed — this is a management plugin, not a
+  runner)
 - Hooks (no automated triggers)
 - MCP servers (no external services to wrap)
 - Dashboard/web UI
 - Multi-host support (single daemon target for now)
-- Auto-review integration with yellow-review (Phase 3 in brainstorm, separate plan)
+- Auto-review integration with yellow-review (Phase 3 in brainstorm, separate
+  plan)
 
 ## References
 
@@ -312,12 +421,18 @@ yellow-ci's runner-health command. Config stored in `.claude/yellow-symphony.loc
 - [yellow-ci runner-health (SSH pattern)](../plugins/yellow-ci/commands/ci/runner-health.md)
 - [yellow-ci setup (wizard pattern)](../plugins/yellow-ci/commands/ci/setup.md)
 - [yellow-ci .local.md config](../plugins/yellow-ci/CLAUDE.md)
-- [yellow-codex output fencing](../plugins/yellow-codex/skills/codex-patterns/SKILL.md)
+- [yellow-semgrep output fencing](../plugins/yellow-semgrep/commands/semgrep/status.md)
 - [gt-workflow setup (prereq pattern)](../plugins/gt-workflow/commands/gt-setup.md)
 
 <!-- deepen-plan: external -->
+
 > **Research:** Additional external references:
-> - [AJV JSON Schema validation](https://ajv.js.org/guide/environments.html) — runtime YAML validation
-> - [SSH timeout best practices](https://www.tecmint.com/increase-ssh-connection-timeout/) — ServerAliveInterval patterns
-> - [Docker context pattern](https://docs.docker.com/engine/manage-resources/contexts/) — remote daemon management via CLI
+>
+> - [AJV JSON Schema validation](https://ajv.js.org/guide/environments.html) —
+>   runtime YAML validation
+> - [SSH timeout best practices](https://www.tecmint.com/increase-ssh-connection-timeout/)
+>   — ServerAliveInterval patterns
+> - [Docker context pattern](https://docs.docker.com/engine/manage-resources/contexts/)
+>   — remote daemon management via CLI
+
 <!-- /deepen-plan -->

--- a/plans/yellow-symphony-plugin.md
+++ b/plans/yellow-symphony-plugin.md
@@ -106,14 +106,14 @@ yellow-ci's runner-health command. Config stored in
 > since all 6 commands are thin SSH wrappers (each under 20 lines), implementing
 > them together is lower risk than maintaining a partial release.
 
-
 - [ ] 2.1: Write `commands/symphony/setup.md`
   - **Prereq checks (before any AskUserQuestion):**
     - `ssh` binary exists (hard)
     - `jq` exists (soft — warn, degrade gracefully)
     - `.claude/yellow-symphony.local.md` exists OR wizard creates it
   - **SSH validation:**
-    `timeout 10 ssh -i "$ssh_key" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=3 user@host 'echo OK'`
+    - Normalize ssh_key before SSH calls: `ssh_key="${ssh_key/#\~/$HOME}"`
+    - `timeout 10 ssh -i "$ssh_key" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=3 user@host 'echo OK'`
   - **Daemon check:** `ssh ... 'openclaw symphony status'`
 
 <!-- deepen-plan: codebase -->
@@ -179,7 +179,8 @@ yellow-ci's runner-health command. Config stored in
   - If present: parse YAML front matter, validate required fields using upstream
     nested key structure (subset — unknown keys ignored per Symphony convention):
     - `tracker.kind` (must be `linear`), `tracker.project_slug` (Linear project
-      slug), `tracker.active_states` (array of Linear status names)
+      slug), `tracker.active_states` (array of Linear status names),
+      `tracker.terminal_states` (non-empty array of Linear status names)
     - `polling.interval_ms` (integer, >= 10000)
     - `agent.max_concurrent_agents` (integer, >= 1)
     - `workspace.root` (path)
@@ -231,7 +232,7 @@ yellow-ci's runner-health command. Config stored in
 
 - [ ] 2.6: Write `commands/symphony/logs.md`
   - Argument: issue ID (e.g., `ENG-123`)
-  - Validate issue ID before SSH: `^[A-Z]{1,10}-[0-9]{1,10}$` (length-bounded)
+  - Validate issue ID before SSH: `^[A-Z]{2,5}-[0-9]{1,6}$` (repo-standard Linear format)
   - SSH to daemon (with `ServerAliveInterval=60` for longer transfers):
     `timeout 30 ssh ... -o ServerAliveInterval=60 "$daemon_ctl logs ENG-123 --tail 100"`
   - Tail N lines directly (`tail` already handles short files safely)
@@ -347,8 +348,8 @@ yellow-ci's runner-health command. Config stored in
   has correct permissions (`600`/`400`). Key content is never logged or displayed.
 - **Command injection via daemon_ctl**: The `daemon_ctl` config value is used in
   SSH remote commands. The setup wizard must validate it against an allowlist
-  regex: `^[a-z][a-z0-9 _/-]{0,63}$` (lowercase alphanumeric, spaces, hyphens,
-  underscores, forward slashes). Commands use double-quoted `"$daemon_ctl ..."`
+  regex: `^[a-z][a-z0-9 _-]{0,63}$` (lowercase alphanumeric, spaces, hyphens,
+  underscores). Commands use double-quoted `"$daemon_ctl ..."`
   to preserve word boundaries (not `eval`). Each subcommand (pause, status, etc.)
   is passed as a separate SSH call rather than chained with `&&` in a single
   remote command string, reducing the injection surface.

--- a/plans/yellow-symphony-plugin.md
+++ b/plans/yellow-symphony-plugin.md
@@ -1,6 +1,6 @@
 # Feature: yellow-symphony — Thin Management Layer for Symphony Orchestration
 
-**Status:** Draft — not started
+**Status:** Draft -- not started
 
 ## Problem Statement
 
@@ -157,7 +157,11 @@ yellow-ci's runner-health command. Config stored in
 - [ ] 2.2: Write `commands/symphony/status.md`
   - Frontmatter: `model: haiku` (pure data retrieval)
   - Read config from `.claude/yellow-symphony.local.md`
-  - SSH to daemon: `timeout 10 ssh ... "$daemon_ctl status --json"`
+  - Define common SSH invocation (reused by all commands):
+    `ssh_cmd="timeout 10 ssh -i \"$ssh_key\" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=3 \"$user@$host\""`
+  - SSH to daemon: `$ssh_cmd "$daemon_ctl status --json"` (stderr captured to
+    temp file via `2>ssh_stderr.tmp`; inspected on non-zero exit before fencing
+    stdout)
   - Fence output per Security Considerations
 
 <!-- deepen-plan: codebase -->
@@ -220,6 +224,7 @@ yellow-ci's runner-health command. Config stored in
 <!-- /deepen-plan -->
 
 - [ ] 2.4: Write `commands/symphony/pause.md`
+  - Frontmatter: `model: haiku` (pure data retrieval, same as status)
   - Read config, SSH to daemon (two separate calls for clarity):
     `ssh ... "$daemon_ctl pause"` then `ssh ... "$daemon_ctl status --json"`
   - Check pause exit code before querying status; report failure clearly
@@ -228,9 +233,11 @@ yellow-ci's runner-health command. Config stored in
     <20 lines; minor duplication is acceptable for trivial commands.
 
 - [ ] 2.5: Write `commands/symphony/resume.md`
+  - Frontmatter: `model: haiku` (mirror of pause.md)
   - Mirror of pause.md with `resume` subcommand
 
 - [ ] 2.6: Write `commands/symphony/logs.md`
+  - Frontmatter: `model: haiku` (pure data retrieval)
   - Argument: issue ID (e.g., `ENG-123`)
   - Validate issue ID before SSH: `^[A-Z]{2,5}-[0-9]{1,6}$` (repo-standard Linear format)
   - SSH to daemon (with `ServerAliveInterval=60` for longer transfers):
@@ -251,8 +258,10 @@ yellow-ci's runner-health command. Config stored in
   - Error handling patterns (SSH failure, daemon down, parse errors)
 
 - [ ] 3.2: Embed `SYMPHONY.md` starter template in `config.md` command
+  - Replaces brainstorm's standalone `SYMPHONY.md.example` deliverable —
+    embedding avoids introducing a `templates/` directory pattern that no
+    existing plugin uses
   - The `config` command scaffolds `SYMPHONY.md` via `Write` tool when missing
-    (no separate `templates/` directory — no existing plugin uses that pattern)
   - Starter YAML front matter with all fields, sensible defaults, inline
     comments
   - Markdown prompt template section with placeholder variables using
@@ -348,11 +357,14 @@ yellow-ci's runner-health command. Config stored in
   has correct permissions (`600`/`400`). Key content is never logged or displayed.
 - **Command injection via daemon_ctl**: The `daemon_ctl` config value is used in
   SSH remote commands. The setup wizard must validate it against an allowlist
-  regex: `^[a-z][a-z0-9 _-]{0,63}$` (lowercase alphanumeric, spaces, hyphens,
-  underscores). Commands use double-quoted `"$daemon_ctl ..."`
-  to preserve word boundaries (not `eval`). Each subcommand (pause, status, etc.)
-  is passed as a separate SSH call rather than chained with `&&` in a single
-  remote command string, reducing the injection surface.
+  regex: `^[a-z][a-z0-9 _/-]{0,63}$` (lowercase alphanumeric, spaces, hyphens,
+  underscores, forward slashes — aligned with
+  `docs/solutions/security-issues/ssh-daemon-command-dispatch-security-patterns.md`).
+  Commands use double-quoted `"$daemon_ctl ..."` to preserve word boundaries
+  (not `eval`); the config value is passed as a single quoted SSH remote command
+  string and the remote shell handles word splitting. Each subcommand (pause,
+  status, etc.) is passed as a separate SSH call rather than chained with `&&`
+  in a single remote command string, reducing the injection surface.
 - **Prompt injection**: Issue descriptions from Linear may contain adversarial
   content. Fencing requirements are documented in `symphony-conventions` skill.
   Enforcement is the OpenClaw plugin's responsibility, not this plugin's.
@@ -361,8 +373,9 @@ yellow-ci's runner-health command. Config stored in
   substitution per
   `docs/solutions/security-issues/shell-binary-downloader-security-patterns.md`.
 - **Config file exposure**: `.claude/yellow-symphony.local.md` contains SSH
-  host, user, and key path. The setup wizard's final report must advise: "If
-  this is a shared repository, add `.claude/*.local.md` to `.gitignore`."
+  host, user, and key path. The repo root `.gitignore` already excludes
+  `.claude/`, covering this file. For repos that track `.claude/`, the setup
+  wizard should warn: "Add `.claude/*.local.md` to `.gitignore`."
 - **Output fencing**: All daemon output (including logs that may contain
   attacker-controlled Linear issue content) is wrapped in `--- begin/end ---`
   fences with `(reference only)` advisory before LLM reasoning. Fencing wraps

--- a/plans/yellow-symphony-plugin.md
+++ b/plans/yellow-symphony-plugin.md
@@ -1,0 +1,323 @@
+# Feature: yellow-symphony — Thin Management Layer for Symphony Orchestration
+
+## Problem Statement
+
+Symphony-style orchestration (poll Linear, claim issues, dispatch autonomous agent
+runs) lives as an OpenClaw plugin on a Proxmox VM. Claude Code users need
+visibility and control over that daemon without SSH-ing manually. This plugin
+provides status queries, config validation, and remote control — no orchestration
+logic.
+
+## Current State
+
+No yellow-symphony plugin exists. The brainstorm is at
+`docs/brainstorms/2026-04-01-symphony-plugin-brainstorm.md`. The OpenClaw
+symphony plugin does not exist yet either — this plan defines the Claude Code
+side of the interface contract so both sides can be built independently.
+
+## Proposed Solution
+
+A standard Claude Code plugin with 5 commands, 1 skill, and 1 template.
+Communicates with the OpenClaw daemon over SSH using the same patterns as
+yellow-ci's runner-health command. Config stored in `.claude/yellow-symphony.local.md`
+(YAML frontmatter with SSH host/user/key).
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** SSH pattern at `yellow-ci/commands/ci/runner-health.md:47-66`
+> uses **4** flags, not 3: `StrictHostKeyChecking=accept-new`, `BatchMode=yes`,
+> `ConnectTimeout=3`, `ServerAliveInterval=60`. The plan should include all 4,
+> though `ServerAliveInterval` is more relevant for long-lived connections —
+> consider whether 3s management commands need it.
+<!-- /deepen-plan -->
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Commands must use `allowed-tools:` in frontmatter (not `tools:`).
+> `tools:` is for agents only. All reference commands (`ci:setup`, `ci:status`,
+> `ci:runner-health`, `gt-setup`) confirm this. See MEMORY.md "Agent Frontmatter".
+<!-- /deepen-plan -->
+
+## Implementation Plan
+
+### Phase 1: Scaffold and Setup
+
+- [ ] 1.1: Create plugin directory structure
+  ```
+  plugins/yellow-symphony/
+    .claude-plugin/plugin.json
+    package.json
+    CLAUDE.md
+    commands/symphony/
+      setup.md
+      status.md
+      config.md
+      pause.md
+      logs.md
+    skills/symphony-conventions/
+      SKILL.md
+    templates/
+      SYMPHONY.md.example
+  ```
+
+- [ ] 1.2: Write `plugin.json` manifest
+  - Fields: name, version (0.1.0), description, author, homepage, repository, license, keywords
+  - No hooks or mcpServers — pure command plugin
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Three-way sync is mandatory. `sync-manifests.js` enforces
+> lockstep between `package.json`, `.claude-plugin/plugin.json`, and the root
+> `.claude-plugin/marketplace.json`. Never edit versions manually. The
+> marketplace entry requires: `name` (must match dir name), `description`,
+> `version`, `author` (`{name, url}`), `source` (e.g., `"./plugins/yellow-symphony"`),
+> `category` (use `"development"`). Currently 16 plugins registered, no
+> "symphony" namespace collision.
+<!-- /deepen-plan -->
+
+- [ ] 1.3: Write `package.json`
+  - Minimal: name (`yellow-symphony`), version (`0.1.0`), private: true, description
+
+- [ ] 1.4: Register in `.claude-plugin/marketplace.json`
+
+- [ ] 1.5: Write `CLAUDE.md`
+  - Architecture overview (thin management layer, not orchestrator)
+  - Component inventory (commands, skill, template)
+  - SSH conventions (reuse yellow-ci patterns)
+  - Cross-plugin dependencies: yellow-linear (optional, for issue context)
+
+### Phase 2: Core Commands
+
+- [ ] 2.1: Write `commands/symphony/setup.md`
+  - **Prereq checks (before any AskUserQuestion):**
+    - `ssh` binary exists (hard)
+    - `jq` exists (soft — warn, degrade gracefully)
+    - `.claude/yellow-symphony.local.md` exists OR wizard creates it
+  - **SSH validation:** `ssh -o BatchMode=yes -o ConnectTimeout=3 user@host 'echo OK'`
+  - **Daemon check:** `ssh ... 'openclaw plugin status symphony'` (or equivalent)
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** `ci:setup.md` sequences: Step 1 (line 22) all prereq checks in
+> one Bash call → Step 2 (line 42) auth check → Step 3 (line 65) existing config
+> check → **first AskUserQuestion at Step 4 (line 87)**. `gt-setup.md` is even
+> stricter: Phase 1 (lines 18-138) is pure Bash, first AskUserQuestion at
+> Step 5 (line 161). Follow this pattern exactly.
+<!-- /deepen-plan -->
+
+<!-- deepen-plan: external -->
+> **Research:** SSH CLI best practices recommend `ControlMaster`/`ControlPersist`
+> in `~/.ssh/config` for connection reuse across multiple commands in one session.
+> Also: retry 3x with exponential backoff on connection failure, capture stderr
+> separately from stdout, and support degraded mode (warn on optional checks,
+> fail only critical).
+<!-- /deepen-plan -->
+  - **Config wizard:** AskUserQuestion for host, user, SSH key path, daemon control command
+  - **Write config:** `.claude/yellow-symphony.local.md` with YAML frontmatter:
+    ```yaml
+    ---
+    schema: yellow-symphony/v1
+    host: 192.168.1.x
+    user: openclaw
+    ssh_key: ~/.ssh/id_ed25519
+    daemon_ctl: openclaw symphony  # prefix for status/pause/resume/logs subcommands
+    ---
+    ```
+  - **Final report:** PASS/PARTIAL/FAIL with next-step menu
+
+- [ ] 2.2: Write `commands/symphony/status.md`
+  - Frontmatter: `model: haiku` (pure data retrieval)
+  - Read config from `.claude/yellow-symphony.local.md`
+  - SSH to daemon: `ssh ... '$daemon_ctl status --json'`
+  - Fence output: `--- begin symphony-output (reference only) ---`
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Output fencing in `yellow-codex/skills/codex-patterns/SKILL.md`
+> uses two forms: context injection fencing (line 250: `--- begin context
+> (reference data only) ---`) and codex output fencing (line 279: `--- begin
+> codex-output (reference only) ---`). Use `symphony-output` as the fence label.
+<!-- /deepen-plan -->
+  - Parse JSON, format as table: Session ID, Issue, Status, Duration, Branch
+  - Show queue depth, last completion, daemon uptime
+  - If SSH fails: clear error with "run /symphony:setup" suggestion
+
+- [ ] 2.3: Write `commands/symphony/config.md`
+  - Check for `SYMPHONY.md` in repo root
+  - If missing: offer to copy from `templates/SYMPHONY.md.example`
+  - If present: parse YAML front matter, validate required fields:
+    - `tracker` (linear), `project` (Linear project slug), `labels` (array)
+    - `polling_interval` (integer, >= 10), `concurrency` (integer, >= 1)
+    - `workspace_root` (path), `runner` (claude|codex)
+  - Report validation results; offer guided editing via AskUserQuestion for invalid fields
+  - Bash `case`/`if` validation, not LLM prose branching
+
+<!-- deepen-plan: external -->
+> **Research:** Symphony WORKFLOW.md YAML front matter has 6 top-level sections:
+> `tracker` (`kind`, `project_slug`, `active_states`, `terminal_states`),
+> `polling` (`interval_ms`, default 30000), `workspace` (`root`), `hooks`
+> (`after_create`, `before_run`, `after_run`, `before_remove`, `timeout_ms`),
+> `agent` (`max_concurrent_agents`, `max_retry_backoff_ms`), `codex`
+> (`thread_sandbox`, `turn_timeout_ms`). Unknown keys are ignored (forward
+> compat). Template variables: `issue.id`, `.identifier`, `.title`,
+> `.description`, `.priority`, `.state`, `.branch_name`, `.url`, `.labels`,
+> `.blocked_by`, plus `attempt` (null on first run, integer on retry).
+<!-- /deepen-plan -->
+
+<!-- deepen-plan: external -->
+> **Research:** For YAML config validation, AJV + JSON Schema is recommended.
+> Ship a `symphony.schema.json` alongside the plugin — enables VS Code Red Hat
+> YAML extension auto-validation with IntelliSense. Use `js-yaml` to parse,
+> compiled AJV schema to validate at runtime in `config` command. Consider
+> adding a `yaml.schemas` entry in the skill docs for IDE setup.
+<!-- /deepen-plan -->
+
+- [ ] 2.4: Write `commands/symphony/pause.md`
+  - Read config, SSH to daemon: `ssh ... '$daemon_ctl pause && $daemon_ctl status'`
+  - Echo resulting state (action + verify in one call)
+  - Same command handles resume: `pause.md` for pause, separate `resume` is just
+    the same structure with `resume` subcommand — BUT to avoid near-duplicate files,
+    implement as a single command with argument detection:
+    - `/symphony:pause` → pause
+    - User can also say "resume" in conversation → agent uses status to detect paused state and suggests resume
+  - Actually: keep as two separate commands (pause.md + resume.md) for discoverability.
+    Each is <20 lines. Duplication is acceptable for 2 trivial commands.
+
+- [ ] 2.5: Write `commands/symphony/resume.md`
+  - Mirror of pause.md with `resume` subcommand
+
+- [ ] 2.6: Write `commands/symphony/logs.md`
+  - Argument: issue ID (e.g., `ENG-123`)
+  - SSH to daemon: `ssh ... '$daemon_ctl logs ENG-123 --tail 100'`
+  - Get total line count first, then tail N lines
+  - Warn if truncated (per MEMORY.md: "Silent truncation needs count + warning")
+  - Fence output before LLM reasoning
+  - If no issue ID provided: AskUserQuestion
+
+### Phase 3: Skill and Template
+
+- [ ] 3.1: Write `skills/symphony-conventions/SKILL.md`
+  - `user-invokable: false` (internal reference for commands)
+  - SYMPHONY.md schema documentation (all fields, types, defaults, constraints)
+  - SSH connection conventions (BatchMode, ConnectTimeout, fencing)
+  - Daemon control protocol expectations (what the OpenClaw plugin should expose)
+  - Error handling patterns (SSH failure, daemon down, parse errors)
+
+- [ ] 3.2: Write `templates/SYMPHONY.md.example`
+  - Starter YAML front matter with all fields, sensible defaults, inline comments
+  - Markdown prompt template section with placeholder variables (`{{ issue.title }}`,
+    `{{ issue.description }}`, `{{ attempt }}`)
+  - Comments explaining each section
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** No existing plugin ships template files — this is a novel pattern
+> with no precedent. Consider whether `templates/SYMPHONY.md.example` is
+> discoverable enough, or whether the `config` command should embed the template
+> inline and scaffold via `Write` tool when SYMPHONY.md is missing.
+<!-- /deepen-plan -->
+
+<!-- deepen-plan: external -->
+> **Research:** Symphony hook lifecycle: `after_create` (workspace init) →
+> `before_run` (pre-attempt, failure aborts run) → agent executes →
+> `after_run` (post-attempt, failure logged) → `before_remove` (pre-deletion).
+> Run phases: `PreparingWorkspace`, `BuildingPrompt`, `LaunchingAgentProcess`,
+> `StreamingTurn`, `Succeeded`, `Failed`, `TimedOut`, `Stalled`. The template
+> should document these phases so users understand status values.
+<!-- /deepen-plan -->
+
+### Phase 4: Quality
+
+- [ ] 4.1: Run `pnpm validate:schemas` — verify plugin.json + agent authoring
+- [ ] 4.2: Test `/symphony:setup` manually (will fail SSH since no daemon yet — that's expected)
+- [ ] 4.3: Test `/symphony:config` with the example template copied to repo root
+- [ ] 4.4: Create changeset: `pnpm changeset` (minor — new plugin)
+
+## Technical Details
+
+### Files to Create
+
+| File | Purpose |
+|---|---|
+| `plugins/yellow-symphony/.claude-plugin/plugin.json` | Plugin manifest |
+| `plugins/yellow-symphony/package.json` | Version source of truth |
+| `plugins/yellow-symphony/CLAUDE.md` | Architecture + conventions |
+| `plugins/yellow-symphony/commands/symphony/setup.md` | SSH + daemon validation wizard |
+| `plugins/yellow-symphony/commands/symphony/status.md` | Query daemon state |
+| `plugins/yellow-symphony/commands/symphony/config.md` | Validate/edit SYMPHONY.md |
+| `plugins/yellow-symphony/commands/symphony/pause.md` | Pause daemon polling |
+| `plugins/yellow-symphony/commands/symphony/resume.md` | Resume daemon polling |
+| `plugins/yellow-symphony/commands/symphony/logs.md` | Tail issue run logs |
+| `plugins/yellow-symphony/skills/symphony-conventions/SKILL.md` | Schema + pattern reference |
+| `plugins/yellow-symphony/templates/SYMPHONY.md.example` | Starter workflow contract |
+
+### Files to Modify
+
+| File | Change |
+|---|---|
+| `.claude-plugin/marketplace.json` | Add yellow-symphony entry |
+
+### Patterns to Reuse
+
+| Pattern | Source |
+|---|---|
+| SSH connection flags | `yellow-ci/commands/ci/runner-health.md:47-66` |
+| `.local.md` config storage | `yellow-ci/CLAUDE.md:99-113` |
+| Setup wizard flow | `yellow-ci/commands/ci/setup.md` |
+| Status table + `model: haiku` | `yellow-ci/commands/ci/status.md` |
+| Output fencing | `yellow-codex/skills/codex-patterns/SKILL.md` |
+| Prereq-before-prompt | `gt-workflow/commands/gt-setup.md` |
+
+## Acceptance Criteria
+
+1. `pnpm validate:schemas` passes with yellow-symphony included
+2. `/symphony:setup` creates `.claude/yellow-symphony.local.md` via interactive wizard
+3. `/symphony:status` shows clear error when daemon is unreachable (not a crash)
+4. `/symphony:config` validates a SYMPHONY.md and reports field-level errors
+5. `/symphony:pause` and `/symphony:resume` echo resulting state after action
+6. `/symphony:logs ENG-123` shows fenced, truncation-aware output
+7. `SYMPHONY.md.example` is a valid, self-documenting starter template
+
+## Edge Cases
+
+- **No `.claude/yellow-symphony.local.md`**: All commands except setup redirect to `/symphony:setup`
+- **SSH key not found**: setup wizard validates key path exists before writing config
+- **Daemon not installed on remote**: setup detects and reports with install instructions
+- **No SYMPHONY.md in repo**: `/symphony:config` offers to scaffold from template
+- **Daemon returns non-JSON**: status command handles gracefully with raw output fallback
+- **Network timeout mid-command**: 3s ConnectTimeout prevents hanging; clear error message
+
+<!-- deepen-plan: external -->
+> **Research:** SSH CLI tools should assume plain text from remote and parse
+> client-side. Capture stderr separately (`2>stderr.tmp`). Retry once on parse
+> failure with verbose logging. Support degraded mode: warn on optional checks,
+> fail only on critical path items.
+<!-- /deepen-plan -->
+
+## Dependencies
+
+- **Hard:** `ssh` binary
+- **Soft:** `jq` (for JSON parsing of daemon output), `yq` (for SYMPHONY.md validation)
+- **Cross-plugin:** yellow-linear (optional — enriches status with issue titles)
+- **External:** OpenClaw symphony plugin exposing `status --json`, `pause`, `resume`, `logs <id>` subcommands
+
+## Deferred (not in this plan)
+
+- Agent definitions (no agents needed — this is a management plugin, not a runner)
+- Hooks (no automated triggers)
+- MCP servers (no external services to wrap)
+- Dashboard/web UI
+- Multi-host support (single daemon target for now)
+- Auto-review integration with yellow-review (Phase 3 in brainstorm, separate plan)
+
+## References
+
+- [Brainstorm](../docs/brainstorms/2026-04-01-symphony-plugin-brainstorm.md)
+- [Symphony SPEC.md](https://github.com/openai/symphony/blob/main/SPEC.md)
+- [Symphony elixir/WORKFLOW.md](https://github.com/openai/symphony/blob/main/elixir/WORKFLOW.md)
+- [yellow-ci runner-health (SSH pattern)](../plugins/yellow-ci/commands/ci/runner-health.md)
+- [yellow-ci setup (wizard pattern)](../plugins/yellow-ci/commands/ci/setup.md)
+- [yellow-ci .local.md config](../plugins/yellow-ci/CLAUDE.md)
+- [yellow-codex output fencing](../plugins/yellow-codex/skills/codex-patterns/SKILL.md)
+- [gt-workflow setup (prereq pattern)](../plugins/gt-workflow/commands/gt-setup.md)
+
+<!-- deepen-plan: external -->
+> **Research:** Additional external references:
+> - [AJV JSON Schema validation](https://ajv.js.org/guide/environments.html) — runtime YAML validation
+> - [SSH timeout best practices](https://www.tecmint.com/increase-ssh-connection-timeout/) — ServerAliveInterval patterns
+> - [Docker context pattern](https://docs.docker.com/engine/manage-resources/contexts/) — remote daemon management via CLI
+<!-- /deepen-plan -->


### PR DESCRIPTION
Research OpenAI Symphony framework and design a thin Claude Code management
layer over an OpenClaw-hosted daemon. Includes architectural pivot from
full reimplementation to capability extension, 8 resolved decision points,
component mapping, and enriched implementation plan with 11 codebase/external
research annotations.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/yellow-plugins/pull/240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a finalized architecture/design and a draft implementation plan for a Symphony orchestration plugin and thin remote management layer.
  * Documented user-facing commands (setup, status, config, pause, resume, logs), local config conventions, and a starter SYMPHONY template.
  * Described operational control loop, integration boundaries (SSH vs daemon), acceptance criteria, security considerations, risks, and open questions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a finalized brainstorm and draft implementation plan for the `yellow-symphony` plugin — a thin SSH-based Claude Code management layer over an OpenClaw-hosted Symphony orchestration daemon. The documents reflect a well-reasoned architectural pivot away from full reimplementation toward a capability-extension model, with 8 resolved decision points, a component mapping table, and an enriched 4-phase implementation plan covering 6 commands and 1 skill.

All six issues flagged in prior review rounds have been addressed: the command count is now correct (6), `resume.md` appears in the Phase 1 directory scaffold, config validation uses the upstream nested YAML key structure, the self-contradictory pause/resume reasoning has been removed, the Component Mapping Table reflects OpenClaw ownership post-pivot, and the output fencing requirement for prompt injection mitigation is now documented in the Security Considerations section.

Two minor P2 items remain:
- The SSH stderr capture pattern specifies a hardcoded `ssh_stderr.tmp` filename rather than a `mktemp`-based unique path, which could cause collisions on concurrent invocations.
- `ServerAliveInterval=60` is specified for `logs.md` alongside `timeout 30`, but the alive-interval can never fire within the shorter outer timeout, making the flag a no-op as specified.

<h3>Confidence Score: 5/5</h3>

Safe to merge — docs/plan only, no executable code changed, and all previously flagged issues are resolved.

All six prior review concerns are addressed. The two remaining findings are P2 style suggestions (temp file naming, timeout alignment) that do not affect correctness or block implementation. Per confidence guidance, a P2-only finding set warrants a 5/5.

No files require special attention; both changed files are documentation only.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/brainstorms/2026-04-01-symphony-plugin-brainstorm.md | Finalized brainstorm documenting the architectural pivot to a thin management layer; Component Mapping Table and Risk Register properly updated to reflect OpenClaw ownership of orchestration. |
| plans/yellow-symphony-plugin.md | Well-structured 4-phase implementation plan with 6 commands, rich security considerations, and 11 codebase/external research annotations; two minor plan-level inconsistencies around temp file naming and ServerAliveInterval vs timeout alignment. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User (Claude Code)
    participant YS as yellow-symphony plugin
    participant SSH as SSH Transport
    participant OC as OpenClaw Daemon (Proxmox VM)
    participant LIN as Linear API

    U->>YS: /symphony:setup
    YS->>SSH: validate connectivity (timeout 10)
    SSH->>OC: echo OK
    OC-->>SSH: OK
    SSH-->>YS: ✓ connected
    YS->>U: write .claude/yellow-symphony.local.md

    U->>YS: /symphony:status
    YS->>SSH: $daemon_ctl status --json (timeout 10)
    SSH->>OC: status --json
    OC-->>SSH: JSON payload
    SSH-->>YS: fenced output
    YS->>U: formatted table (Session, Issue, Status, Duration)

    U->>YS: /symphony:config
    YS->>YS: parse SYMPHONY.md (nested YAML)
    YS->>U: validation report / scaffold offer

    U->>YS: /symphony:pause
    YS->>SSH: $daemon_ctl pause (timeout 10)
    SSH->>OC: pause
    OC-->>SSH: OK
    YS->>SSH: $daemon_ctl status --json (timeout 10)
    SSH->>OC: status --json
    OC-->>SSH: paused state
    YS->>U: echo resulting state

    U->>YS: /symphony:logs ENG-123
    YS->>YS: validate issue ID regex
    YS->>SSH: $daemon_ctl logs ENG-123 --tail 100 (timeout 30)
    SSH->>OC: logs ENG-123 --tail 100
    OC-->>SSH: log lines
    SSH-->>YS: fenced output
    YS->>U: fenced log output
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aplans%2Fyellow-symphony-plugin.md%3A168-171%0A**Hardcoded%20stderr%20temp%20file%20path%20risks%20collision**%0A%0AThe%20plan%20specifies%20capturing%20SSH%20stderr%20via%20%602%3Essh_stderr.tmp%60%20%E2%80%94%20a%20hardcoded%20filename%20in%20the%20current%20working%20directory.%20This%20creates%20two%20practical%20problems%3A%0A-%20If%20multiple%20symphony%20commands%20run%20concurrently%20%28or%20a%20user%20reruns%20a%20command%20quickly%29%2C%20both%20invocations%20write%20to%20the%20same%20file%2C%20corrupting%20or%20dropping%20error%20output.%0A-%20The%20file%20persists%20in%20the%20user's%20project%20directory%20on%20failure%2C%20creating%20unexpected%20clutter.%0A%0AThe%20plan%20should%20specify%20using%20%60mktemp%60%20for%20a%20unique%20temp%20file%20per%20invocation%3A%0A%0A%60%60%60bash%0Assh_stderr%3D%24%28mktemp%29%0Atrap%20'rm%20-f%20%22%24ssh_stderr%22'%20EXIT%0Atimeout%2010%20ssh%20...%20%22%24daemon_ctl%20status%20--json%22%202%3E%22%24ssh_stderr%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aplans%2Fyellow-symphony-plugin.md%3A250-251%0A**%60ServerAliveInterval%3D60%60%20is%20unreachable%20within%20%60timeout%2030%60**%0A%0AThe%20%60logs.md%60%20spec%20sets%20%60ServerAliveInterval%3D60%60%20but%20wraps%20the%20call%20in%20%60timeout%2030%60.%20Since%20the%20overall%20timeout%20fires%20at%2030%20seconds%2C%20the%20alive-interval%20probe%20%28which%20fires%20after%2060%20s%20of%20remote%20silence%29%20can%20never%20trigger%20%E2%80%94%20making%20the%20flag%20a%20no-op%20for%20this%20command.%0A%0AThe%20design%20note%20%28line%2034%29%20justifies%20the%20flag%20because%20%22log%20tailing%20may%20transfer%20larger%20output.%22%20If%20the%20intent%20is%20to%20allow%20longer%20streaming%2C%20the%20outer%20%60timeout%60%20should%20be%20raised%20to%20exceed%20the%20interval.%20If%20%60--tail%20100%60%20is%20always%20a%20one-shot%20read%2C%20the%20flag%20adds%20no%20value%20and%20can%20be%20dropped.%0A%0AConsider%20aligning%20the%20values%3A%0A%0A%60%60%60%0A%23%20Option%20A%3A%20one-shot%20read%20%E2%80%94%20drop%20the%20alive%20interval%0Atimeout%2030%20ssh%20-i%20%22%24ssh_key%22%20%5C%0A%20%20-o%20StrictHostKeyChecking%3Daccept-new%20%5C%0A%20%20-o%20BatchMode%3Dyes%20-o%20ConnectTimeout%3D3%20%5C%0A%20%20%22%24user%40%24host%22%20%22%24daemon_ctl%20logs%20%24issue_id%20--tail%20100%22%0A%0A%23%20Option%20B%3A%20larger%20transfer%20%E2%80%94%20raise%20the%20outer%20timeout%0Atimeout%20120%20ssh%20-i%20%22%24ssh_key%22%20%5C%0A%20%20-o%20StrictHostKeyChecking%3Daccept-new%20%5C%0A%20%20-o%20BatchMode%3Dyes%20-o%20ConnectTimeout%3D3%20%5C%0A%20%20-o%20ServerAliveInterval%3D10%20%5C%0A%20%20%22%24user%40%24host%22%20%22%24daemon_ctl%20logs%20%24issue_id%20--tail%20100%22%0A%60%60%60%0A%0A&repo=kinginyellows%2Fyellow-plugins"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: plans/yellow-symphony-plugin.md
Line: 168-171

Comment:
**Hardcoded stderr temp file path risks collision**

The plan specifies capturing SSH stderr via `2>ssh_stderr.tmp` — a hardcoded filename in the current working directory. This creates two practical problems:
- If multiple symphony commands run concurrently (or a user reruns a command quickly), both invocations write to the same file, corrupting or dropping error output.
- The file persists in the user's project directory on failure, creating unexpected clutter.

The plan should specify using `mktemp` for a unique temp file per invocation:

```bash
ssh_stderr=$(mktemp)
trap 'rm -f "$ssh_stderr"' EXIT
timeout 10 ssh ... "$daemon_ctl status --json" 2>"$ssh_stderr"
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: plans/yellow-symphony-plugin.md
Line: 250-251

Comment:
**`ServerAliveInterval=60` is unreachable within `timeout 30`**

The `logs.md` spec sets `ServerAliveInterval=60` but wraps the call in `timeout 30`. Since the overall timeout fires at 30 seconds, the alive-interval probe (which fires after 60 s of remote silence) can never trigger — making the flag a no-op for this command.

The design note (line 34) justifies the flag because "log tailing may transfer larger output." If the intent is to allow longer streaming, the outer `timeout` should be raised to exceed the interval. If `--tail 100` is always a one-shot read, the flag adds no value and can be dropped.

Consider aligning the values:

```
# Option A: one-shot read — drop the alive interval
timeout 30 ssh -i "$ssh_key" \
  -o StrictHostKeyChecking=accept-new \
  -o BatchMode=yes -o ConnectTimeout=3 \
  "$user@$host" "$daemon_ctl logs $issue_id --tail 100"

# Option B: larger transfer — raise the outer timeout
timeout 120 ssh -i "$ssh_key" \
  -o StrictHostKeyChecking=accept-new \
  -o BatchMode=yes -o ConnectTimeout=3 \
  -o ServerAliveInterval=10 \
  "$user@$host" "$daemon_ctl logs $issue_id --tail 100"
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (8): Last reviewed commit: ["fix: resolve PR #240 review comments"](https://github.com/kinginyellows/yellow-plugins/commit/8fe2c2fdf7148b8d7707911cf4548fcac698127c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27186261)</sub>

<!-- /greptile_comment -->