### PR TITLE
chore: add PR template, Graphite config, and solution docs

### DIFF
--- a/.github/instructions/codacy.instructions.md
+++ b/.github/instructions/codacy.instructions.md
@@ -32,8 +32,8 @@ Configuration for AI behavior when interacting with Codacy's MCP Server
 ## When there are no Codacy MCP Server tools available, or the MCP Server is not reachable
 - Suggest the user the following troubleshooting steps:
  - Try to reset the MCP on the extension
- - If the user is using VSCode, suggest them to review their Copilot > MCP settings in Github, under their organization or personal account. Refer them to Settings > Copilot > Enable MCP servers in Copilot. Suggested URL (https://github.com/settings/copilot/features) or https://github.com/organizations/{organization-name}/settings/copilot/features (This can only be done by their organization admins / owners)
-- If none of the above steps work, suggest the user to contact Codacy support
+ - If the user is using VSCode, suggest them to review their Copilot > MCP settings in GitHub, under their organization or personal account. Refer them to Settings > Copilot > Enable MCP servers in Copilot. Suggested URL (https://github.com/settings/copilot/features) or https://github.com/organizations/{organization-name}/settings/copilot/features (This can only be done by their organization admins / owners)
+- If none of the above steps work, suggest that the user contact Codacy support
 
 ## Trying to call a tool that needs a rootPath as a parameter
 - Always use the standard, non-URL-encoded file system path

--- a/.github/instructions/codacy.instructions.md
+++ b/.github/instructions/codacy.instructions.md
@@ -33,7 +33,7 @@ Configuration for AI behavior when interacting with Codacy's MCP Server
 - Suggest the user the following troubleshooting steps:
  - Try to reset the MCP on the extension
  - If the user is using VSCode, suggest them to review their Copilot > MCP settings in Github, under their organization or personal account. Refer them to Settings > Copilot > Enable MCP servers in Copilot. Suggested URL (https://github.com/settings/copilot/features) or https://github.com/organizations/{organization-name}/settings/copilot/features (This can only be done by their organization admins / owners)
- - If the user is using VSCode, suggest them to review their Copilot > MCP settings in GitHub, under their organization or personal account. Refer them to Settings > Copilot > Enable MCP servers in Copilot. Suggested URL (https://github.com/settings/copilot/features) or https://github.com/organizations/{organization-name}/settings/copilot/features (This can only be done by their organization admins / owners)
+- If none of the above steps work, suggest the user to contact Codacy support
 
 ## Trying to call a tool that needs a rootPath as a parameter
 - Always use the standard, non-URL-encoded file system path

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- 2-3 bullet points of what this PR does -->
+
+## Stack context
+
+<!-- What branch is below this one and why (critical for stack reviewers) -->
+
+## Test plan
+
+<!-- What was verified before submit -->
+
+## Notes for reviewers
+
+<!-- Anything the author wants to call attention to -->

--- a/.graphite.yml
+++ b/.graphite.yml
@@ -1,0 +1,18 @@
+# gt-workflow convention file — read by smart-submit, gt-stack-plan, gt-amend, gt-setup
+# This is NOT a Graphite CLI feature. It is a gt-workflow plugin convention.
+# Docs: https://github.com/KingInYellows/yellow-plugins/tree/main/plugins/gt-workflow
+
+submit:
+  draft: false
+  merge_when_ready: false
+  restack_before: true
+
+audit:
+  agents: 3
+  skip_on_draft: false
+
+branch:
+  prefix: "agent/"
+
+pr_template:
+  create: true

--- a/docs/solutions/security-issues/shell-binary-downloader-security-patterns.md
+++ b/docs/solutions/security-issues/shell-binary-downloader-security-patterns.md
@@ -1,0 +1,64 @@
+# Shell Binary Downloader Security Patterns
+
+**Source:** PR #241 review (2026-04-03) — `.codacy/cli.sh`
+**Agents:** code-reviewer, security-sentinel, silent-failure-hunter
+
+## Context
+
+Shell scripts that download and execute remote binaries are common in CLI tool wrappers (Codacy, Semgrep, etc.). These scripts have a concentrated attack surface: they fetch code from the internet, extract it, and run it with the user's permissions.
+
+## Patterns Found
+
+### 1. `eval "$command $*"` — Command Injection
+
+**Problem:** `eval` re-parses the entire string as shell code. `$*` concatenates all positional parameters into one string without preserving boundaries. Any argument containing `;`, `$(...)`, backticks, or `|` executes as shell code.
+
+**Fix:** `"$command" "$@"` — no `eval`, and `"$@"` preserves argument boundaries.
+
+### 2. `set -e +o pipefail` — Pipefail Confusion
+
+**Problem:** In bash `set`, `+o` **disables** an option and `-o` **enables** it. This is the opposite of what most developers expect. `+o pipefail` silently allows pipeline failures.
+
+**Fix:** `set -eo pipefail` (or `set -Eeuo pipefail` for maximum strictness).
+
+### 3. `local version=$(...)` — Exit Code Masking
+
+**Problem:** `local` is a command that always returns 0. When combined with a command substitution on the same line, the exit code of the substitution is masked.
+
+**Fix:** Split into two lines: `local version; version=$(...)`.
+
+### 4. `curl ... 2>/dev/null` — Silent Network Failures
+
+**Problem:** Redirecting curl's stderr to /dev/null hides TLS errors, DNS failures, timeouts, and connection refused. The caller gets an empty response with no indication of failure.
+
+**Fix:** Remove `2>/dev/null`. Add `|| fatal "Failed to reach API"` after the curl command.
+
+### 5. Missing `--fail` on Download Curl
+
+**Problem:** Without `-f`/`--fail`, curl saves HTTP error pages (404, 500) as the output file. Subsequent `tar` extraction fails with cryptic "not in gzip format" instead of "download failed: HTTP 404".
+
+**Fix:** Add `-f` to curl flags: `curl -f -# -LS "$url" -O`.
+
+### 6. Empty API Response → Poisoned Cache
+
+**Problem:** If the GitHub API returns no `tag_name` (rate limit body, changed schema, empty JSON), the version variable is empty. Writing `version: ""` to a cache file poisons all subsequent runs — they read the empty version, fail silently, and the user must manually delete the cache.
+
+**Fix:** Guard before writing: `[ -n "$version" ] || fatal "Could not determine version"`.
+
+### 7. `fatal` Called but Never Defined
+
+**Problem:** Calling an undefined function in bash produces `fatal: command not found` (exit 127) instead of the intended error message. Under `set -e`, the script exits, but the real error context is lost.
+
+**Fix:** Define early: `fatal() { echo "FATAL: $*" >&2; exit 1; }`.
+
+## Checklist for Shell Binary Downloaders
+
+- [ ] No `eval` — use `"$command" "$@"` for argument passing
+- [ ] `set -eo pipefail` (not `+o`)
+- [ ] All helper functions defined before first call
+- [ ] `local` and assignment on separate lines
+- [ ] No `2>/dev/null` on network calls
+- [ ] `--fail` flag on download curl
+- [ ] Guard empty values before writing to cache/config files
+- [ ] Validate version strings against expected pattern
+- [ ] Verify checksums after download (SHA256)

--- a/docs/solutions/security-issues/shell-binary-downloader-security-patterns.md
+++ b/docs/solutions/security-issues/shell-binary-downloader-security-patterns.md
@@ -1,7 +1,14 @@
+---
+title: Shell Binary Downloader Security Patterns
+date: 2026-04-03
+category: security-issues
+tags: [eval-injection, curl-fail, pipefail, exit-code-masking, cache-poisoning]
+components: [yellow-codacy]
+---
+
 # Shell Binary Downloader Security Patterns
 
-**Source:** PR #241 review (2026-04-03) — `.codacy/cli.sh`
-**Agents:** code-reviewer, security-sentinel, silent-failure-hunter
+Patterns discovered during multi-agent review of PR #241 (Codacy CLI shell wrapper `.codacy/cli.sh`).
 
 ## Context
 
@@ -51,7 +58,7 @@ Shell scripts that download and execute remote binaries are common in CLI tool w
 
 **Fix:** Define early: `fatal() { echo "FATAL: $*" >&2; exit 1; }`.
 
-## Checklist for Shell Binary Downloaders
+## Prevention
 
 - [ ] No `eval` — use `"$command" "$@"` for argument passing
 - [ ] `set -eo pipefail` (not `+o`)
@@ -62,3 +69,9 @@ Shell scripts that download and execute remote binaries are common in CLI tool w
 - [ ] Guard empty values before writing to cache/config files
 - [ ] Validate version strings against expected pattern
 - [ ] Verify checksums after download (SHA256)
+
+## Related Documentation
+
+- `docs/solutions/security-issues/ssh-daemon-command-dispatch-security-patterns.md` — overlapping SSH dispatch security patterns
+- `docs/solutions/code-quality/plugin-review-defensive-authoring-patterns.md` — defensive authoring for plugin commands
+- `docs/solutions/logic-errors/devin-review-prs-shell-and-api-bugs.md` — shell and API bug patterns

--- a/docs/solutions/security-issues/ssh-daemon-command-dispatch-security-patterns.md
+++ b/docs/solutions/security-issues/ssh-daemon-command-dispatch-security-patterns.md
@@ -28,7 +28,11 @@ Plugin designs that dispatch commands over SSH to remote daemons introduce sever
 
 Sending `ssh user@host "cmd1 && cmd2 && cmd3"` treats the entire remote string as a shell expression. If any portion is derived from user input without strict validation, shell metacharacters (`;`, `|`, `$()`, backticks) enable command injection on the remote host.
 
-**Fix:** Use separate SSH calls per command, and validate the command prefix against an allowlist regex:
+**Fix:** Use separate SSH calls per command, and validate the command prefix against an allowlist regex.
+
+> **Portability note:** `timeout` is GNU coreutils; macOS ships without it.
+> In production scripts, detect `timeout` vs `gtimeout` first. These examples
+> use `timeout` directly for brevity.
 
 ```bash
 # Allowlist: lowercase alphanumeric, spaces, underscores, hyphens, slashes
@@ -37,6 +41,8 @@ ALLOWED_CMD_RE='^[a-z][a-z0-9 _/-]{0,63}$'
 
 run_remote() {
   local cmd="$1"
+  # Reject newlines — grep is line-by-line, so "ls\nrm -rf /" would pass
+  case "$cmd" in *$'\n'*|*$'\r'*) fatal "Command contains newlines: rejected" ;; esac
   printf '%s' "$cmd" | grep -qE "$ALLOWED_CMD_RE" || {
     fatal "Command rejected by allowlist: $cmd"
   }
@@ -116,11 +122,12 @@ ssh_output=$(timeout 10 ssh -i "$ssh_key" -o ConnectTimeout=5 \
 
 ## Prevention
 
+- [ ] Reject commands containing newlines before regex validation (grep is line-by-line)
 - [ ] Validate all SSH command strings against an allowlist regex before dispatch
 - [ ] Use separate SSH calls instead of `&&` chains
 - [ ] Always pass `-i "$ssh_key"` when the config stores a key path
 - [ ] Expand `~` in key paths before use: `ssh_key="${ssh_key/#\~/$HOME}"`
-- [ ] Wrap SSH calls with `timeout N` to prevent hangs on unreachable hosts
+- [ ] Wrap SSH calls with `timeout N` to prevent hangs (`gtimeout` on macOS without coreutils)
 - [ ] Add `.gitignore` entries for any file containing SSH connection details
 - [ ] Length-bound all user-facing regex validations with `{min,max}`
 - [ ] Handle host-key-changed scenario with detection and clear remediation steps

--- a/docs/solutions/security-issues/ssh-daemon-command-dispatch-security-patterns.md
+++ b/docs/solutions/security-issues/ssh-daemon-command-dispatch-security-patterns.md
@@ -1,0 +1,133 @@
+---
+title: SSH Daemon Command Dispatch Security Patterns
+date: 2026-04-04
+category: security-issues
+tags: [ssh, command-injection, daemon, remote-execution, regex-validation]
+components: [yellow-symphony]
+---
+
+# SSH Daemon Command Dispatch Security Patterns
+
+Patterns discovered during multi-agent review of PR #240 (yellow-symphony SSH-based daemon management plugin planning docs).
+
+## Problem
+
+Plugin designs that dispatch commands over SSH to remote daemons introduce several security and correctness risks when the command dispatch layer, credential handling, and input validation are not properly constrained.
+
+### Symptoms
+
+- Compound `&&` commands in a single SSH call allow injection if any argument is attacker-controlled
+- Planning docs use pre-pivot terminology (Claude Code responsibilities described where OpenClaw owns them)
+- SSH validation commands missing identity file flag despite config storing key path
+- `.local.md` config files containing SSH host/user/key path committed to git
+- Unbounded regex patterns accept arbitrarily long input
+
+## Root Cause
+
+### 1. Compound SSH command dispatch (P1)
+
+Sending `ssh user@host "cmd1 && cmd2 && cmd3"` treats the entire remote string as a shell expression. If any portion is derived from user input without strict validation, shell metacharacters (`;`, `|`, `$()`, backticks) enable command injection on the remote host.
+
+**Fix:** Use separate SSH calls per command, and validate the command prefix against an allowlist regex:
+
+```bash
+# Allowlist: lowercase alphanumeric, spaces, underscores, hyphens, slashes
+# Max 64 chars to prevent abuse
+ALLOWED_CMD_RE='^[a-z][a-z0-9 _/-]{0,63}$'
+
+run_remote() {
+  local cmd="$1"
+  printf '%s' "$cmd" | grep -qE "$ALLOWED_CMD_RE" || {
+    fatal "Command rejected by allowlist: $cmd"
+  }
+  timeout 30 ssh -i "$ssh_key" -o ConnectTimeout=10 "$ssh_user@$ssh_host" "$cmd"
+}
+
+# Correct: separate calls
+run_remote "daemon_ctl status"
+run_remote "daemon_ctl restart myservice"
+
+# WRONG: compound chain in single call
+# ssh user@host "daemon_ctl status && daemon_ctl restart myservice"
+```
+
+### 2. False transport abstraction claim (P1)
+
+`daemon_ctl` is a shell command prefix (a CLI on the remote host), not a transport abstraction layer. Describing it as a "transport layer" misleads implementors into thinking it handles connection management, retries, or protocol negotiation. Call it what it is: a remote CLI command prefix.
+
+### 3. Component mapping pre-pivot language (P1)
+
+When a project pivots ownership of responsibilities (e.g., from Claude Code to OpenClaw), all planning docs must be audited. A component mapping table that still describes the old owner's responsibilities creates confusion about which system actually implements the behavior.
+
+### 4. SSH credential config needs .gitignore (P1)
+
+Any `.local.md` or config file that stores SSH connection details (host, user, key path) must have a `.gitignore` entry. Even if the file only contains paths (not keys themselves), the host/user combination is sensitive infrastructure information.
+
+```gitignore
+# In plugin .gitignore or root .gitignore
+*.local.md
+```
+
+### 5. SSH validation missing identity file (P2)
+
+When the plugin config stores an SSH key path, every `ssh` invocation -- including the initial validation/connectivity check -- must include `-i "$ssh_key"`. Without it, SSH falls back to the default agent/key, which may succeed in development but fail in production where only the specified key is authorized.
+
+```bash
+# Tilde expansion is required before passing to ssh -i
+ssh_key="${ssh_key/#\~/$HOME}"
+
+# Correct: validation includes -i
+timeout 10 ssh -i "$ssh_key" -o ConnectTimeout=5 "$ssh_user@$ssh_host" "echo ok"
+
+# WRONG: omits -i, uses default key
+# ssh -o ConnectTimeout=5 "$ssh_user@$ssh_host" "echo ok"
+```
+
+### 6. Unbounded regex validation (P2)
+
+A regex like `^[A-Z]+-[0-9]+$` for issue IDs has no length bound. An attacker (or buggy integration) could submit a megabyte-long string that matches the pattern, causing excessive memory use in downstream processing.
+
+```bash
+# WRONG: no length bound
+ISSUE_RE='^[A-Z]+-[0-9]+$'
+
+# Correct: bounded character classes
+ISSUE_RE='^[A-Z]{1,10}-[0-9]{1,10}$'
+```
+
+**Rule:** Every user-facing regex validation should include explicit length bounds via `{min,max}` quantifiers.
+
+### 7. TOFU SSH without host-key-changed handling (P2)
+
+Trust-On-First-Use (TOFU) SSH accepts the host key on first connection, but if the remote VM is rebuilt (same IP, new host key), SSH rejects the connection with a scary "REMOTE HOST IDENTIFICATION HAS CHANGED" error. The plugin must detect this and provide clear remediation:
+
+```bash
+ssh_output=$(timeout 10 ssh -i "$ssh_key" -o ConnectTimeout=5 \
+  -o BatchMode=yes "$ssh_user@$ssh_host" "echo ok" 2>&1) || {
+  if printf '%s' "$ssh_output" | grep -q "REMOTE HOST IDENTIFICATION HAS CHANGED"; then
+    printf 'Host key changed (VM may have been rebuilt).\n'
+    printf 'To fix: ssh-keygen -R %s\n' "$ssh_host"
+    printf 'Then re-run setup to accept the new key.\n'
+    exit 1
+  fi
+  fatal "SSH connection failed: $ssh_output"
+}
+```
+
+## Prevention
+
+- [ ] Validate all SSH command strings against an allowlist regex before dispatch
+- [ ] Use separate SSH calls instead of `&&` chains
+- [ ] Always pass `-i "$ssh_key"` when the config stores a key path
+- [ ] Expand `~` in key paths before use: `ssh_key="${ssh_key/#\~/$HOME}"`
+- [ ] Wrap SSH calls with `timeout N` to prevent hangs on unreachable hosts
+- [ ] Add `.gitignore` entries for any file containing SSH connection details
+- [ ] Length-bound all user-facing regex validations with `{min,max}`
+- [ ] Handle host-key-changed scenario with detection and clear remediation steps
+- [ ] Audit planning docs after ownership pivots for stale component mappings
+
+## Related Documentation
+
+- `docs/solutions/security-issues/shell-binary-downloader-security-patterns.md` -- overlapping shell security patterns
+- `docs/solutions/code-quality/plugin-review-defensive-authoring-patterns.md` -- defensive authoring for plugin commands
+- `docs/solutions/logic-errors/devin-review-prs-shell-and-api-bugs.md` -- shell and API bug patterns


### PR DESCRIPTION
- Add .github/pull_request_template.md for stack-aware PR descriptions
- Add .graphite.yml gt-workflow convention file (submit, audit, branch settings)
- Fix codacy.instructions.md: remove duplicate VSCode bullet, add support fallback, fix EOF
- Add solution docs for shell binary downloader and SSH daemon security patterns

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/yellow-plugins/pull/247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined Codacy troubleshooting guide: removed a duplicated item, added instruction to contact Codacy support if troubleshooting fails, and fixed end-of-file formatting
  * Added two security pattern guides covering safe shell-binary download practices and secure SSH daemon command dispatch best practices

* **Chores**
  * Added a standardized pull request template with sections for summary, context, test plan, and reviewer notes
  * Added workflow configuration to manage branch/submit behavior and PR template creation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a PR template, a `gt-workflow` convention file (`.graphite.yml`), fixes a duplicate bullet and missing newline in the Codacy instructions, and contributes two new security-pattern docs for shell binary downloaders and SSH daemon command dispatch. All changes are documentation and configuration — no runtime code is modified.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are documentation and configuration with no runtime impact.

No P0 or P1 findings. The single P2 is a cosmetic separator inconsistency between two new docs. All other changes (Codacy instructions fix, PR template, .graphite.yml) are clean.

No files require special attention.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The two new security-pattern docs are documentation artifacts that describe vulnerabilities elsewhere; they introduce no executable code or secrets into the repository.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/instructions/codacy.instructions.md | Removes duplicate VSCode bullet, fixes capitalisation of "GitHub", adds support escalation step, and fixes missing trailing newline — all clean. |
| .github/pull_request_template.md | New PR template with standard sections (Summary, Stack context, Test plan, Notes for reviewers); well-formed and matches the format used in this very PR. |
| .graphite.yml | New gt-workflow convention file; settings (draft=false, restack_before=true, 3 audit agents, agent/ branch prefix) look intentional and consistent with the plugin's design. |
| docs/solutions/security-issues/shell-binary-downloader-security-patterns.md | New security patterns doc with YAML frontmatter; 7 well-documented patterns with accurate bash advice; minor style inconsistency in Related Documentation separators vs. the SSH doc. |
| docs/solutions/security-issues/ssh-daemon-command-dispatch-security-patterns.md | New SSH dispatch security patterns doc with YAML frontmatter; uses double-hyphen (--) separators in Related Documentation while the shell doc uses em-dashes (—), creating a minor cross-doc style inconsistency. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR opened] --> B{Has .graphite.yml\npr_template.create: true?}
    B -- yes --> C[gt-workflow fills PR template\nfrom .github/pull_request_template.md]
    B -- no --> D[Manual PR description]
    C --> E[smart-submit runs\nrestack_before: true]
    E --> F[Submit PR\ndraft: false]
    F --> G[Audit: 3 agents\nskip_on_draft: false]
    G --> H[Merge when ready: false\nManual merge required]
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fsolutions%2Fsecurity-issues%2Fssh-daemon-command-dispatch-security-patterns.md%3A138-140%0A**Inconsistent%20separator%20style%20vs.%20sibling%20doc**%0A%0A%60shell-binary-downloader-security-patterns.md%60%20uses%20em-dashes%20%28%60%E2%80%94%60%29%20in%20its%20Related%20Documentation%20list%2C%20while%20this%20file%20uses%20double%20hyphens%20%28%60--%60%29.%20Since%20both%20docs%20cross-reference%20each%20other%2C%20keeping%20the%20same%20separator%20makes%20the%20pattern%20immediately%20recognisable.%0A%0A%60%60%60suggestion%0A-%20%60docs%2Fsolutions%2Fsecurity-issues%2Fshell-binary-downloader-security-patterns.md%60%20%E2%80%94%20overlapping%20shell%20security%20patterns%0A-%20%60docs%2Fsolutions%2Fcode-quality%2Fplugin-review-defensive-authoring-patterns.md%60%20%E2%80%94%20defensive%20authoring%20for%20plugin%20commands%0A-%20%60docs%2Fsolutions%2Flogic-errors%2Fdevin-review-prs-shell-and-api-bugs.md%60%20%E2%80%94%20shell%20and%20API%20bug%20patterns%0A%60%60%60%0A%0A&repo=kinginyellows%2Fyellow-plugins"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: docs/solutions/security-issues/ssh-daemon-command-dispatch-security-patterns.md
Line: 138-140

Comment:
**Inconsistent separator style vs. sibling doc**

`shell-binary-downloader-security-patterns.md` uses em-dashes (`—`) in its Related Documentation list, while this file uses double hyphens (`--`). Since both docs cross-reference each other, keeping the same separator makes the pattern immediately recognisable.

```suggestion
- `docs/solutions/security-issues/shell-binary-downloader-security-patterns.md` — overlapping shell security patterns
- `docs/solutions/code-quality/plugin-review-defensive-authoring-patterns.md` — defensive authoring for plugin commands
- `docs/solutions/logic-errors/devin-review-prs-shell-and-api-bugs.md` — shell and API bug patterns
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: resolve PR #247 review comments"](https://github.com/kinginyellows/yellow-plugins/commit/1464f132b112ac481218d294168833d041da41f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27399269)</sub>

<!-- /greptile_comment -->