### PR TITLE
chore: fix codacy config node version typo and bump opengrep

### DIFF
--- a/.codacy/codacy.yaml
+++ b/.codacy/codacy.yaml
@@ -1,6 +1,6 @@
 runtimes:
     - java@17.0.10
-    - node@22.2.0
+    - node@22.22.0
     - python@3.11.11
 tools:
     - eslint@8.57.0

--- a/.codacy/codacy.yaml
+++ b/.codacy/codacy.yaml
@@ -1,10 +1,10 @@
 runtimes:
     - java@17.0.10
-    - node@22.22.0
+    - node@22.2.0
     - python@3.11.11
 tools:
     - eslint@8.57.0
     - lizard@1.17.31
-    - opengrep@1.16.4
+    - opengrep@1.17.0
     - pmd@6.55.0
     - trivy@0.69.3


### PR DESCRIPTION
- node@22.22.0 → node@22.2.0 (22.22.0 does not exist)
- opengrep@1.16.4 → opengrep@1.17.0

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/yellow-plugins/pull/249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling and runtime configurations for improved code quality analysis and enhanced stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `opengrep` from `1.16.4` to `1.17.0` (released April 3, 2026) in the Codacy config. The PR description also claims to downgrade `node` from `22.22.0` to `22.2.0`, but that change is **not present in the diff** — `node@22.22.0` remains unchanged in the file, likely removed after the prior review thread flagged it as a downgrade.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only code change is a valid opengrep version bump.

The actual diff contains a single, straightforward tool version bump (opengrep 1.16.4 → 1.17.0) with no logic changes. The PR description mentions a node version change that was removed from the diff. No P0/P1 issues.

No files require special attention.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .codacy/codacy.yaml | Bumps opengrep from 1.16.4 to 1.17.0 (valid release from April 3, 2026); the node version change described in the PR description is not present in the diff — node remains at 22.22.0. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[.codacy/codacy.yaml] --> B[runtimes section]
    A --> C[tools section]
    B --> D[java 17.0.10]
    B --> E[node 22.22.0 - unchanged]
    B --> F[python 3.11.11]
    C --> G[eslint 8.57.0]
    C --> H[lizard 1.17.31]
    C --> I[opengrep 1.16.4 to 1.17.0 - updated]
    C --> J[pmd 6.55.0]
    C --> K[trivy 0.69.3]
```

<sub>Reviews (2): Last reviewed commit: ["fix: revert node version downgrade, keep..."](https://github.com/kinginyellows/yellow-plugins/commit/9f0f78a079710567e35da2e3397403c34ce52c60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27660198)</sub>

<!-- /greptile_comment -->