### PR TITLE
feat(yellow-morph): migrate to userConfig, fix ENABLED_TOOLS bug, correct tool name

### DIFF
--- a/.changeset/yellow-morph-install-hardening.md
+++ b/.changeset/yellow-morph-install-hardening.md
@@ -1,0 +1,9 @@
+---
+"yellow-morph": patch
+---
+
+Hardening of the @morphllm/morphmcp install path:
+
+- Extract shared install primitives into `plugins/yellow-morph/lib/install-morphmcp.sh` (path validation, mkdir-lock, npm ci wrapper, cleanup). `bin/start-morph.sh`, `hooks/scripts/prewarm-morph.sh`, and `/morph:setup` Step 3 now source the lib instead of each carrying its own copy of the install protocol — single source of truth for the install contract.
+- Add stale-lock recovery to the mkdir install lock: each holder writes its PID into `$LOCK_DIR/pid` on acquisition. Subsequent acquirers detect a dead owner via `kill -0` and clear the lock once before retrying. Recovers automatically from SIGKILL / OOM of a prior holder instead of forcing 20s of timeout-then-manual-cleanup on every later install.
+- Tighten the npm ci environment from `unset MORPH_API_KEY` to `env -i` with an explicit allowlist (HOME, PATH, NPM_CONFIG_USERCONFIG, NPM_CONFIG_GLOBALCONFIG, NPM_CONFIG_PREFIX). Postinstall scripts in transitive deps no longer inherit any session secrets — not just MORPH_API_KEY but also ANTHROPIC_API_KEY, GITHUB_TOKEN, and anything else exported into Claude Code's process environment.

--- a/.changeset/yellow-morph-userconfig.md
+++ b/.changeset/yellow-morph-userconfig.md
@@ -1,0 +1,24 @@
+---
+"yellow-morph": minor
+"yellow-core": patch
+"yellow-research": patch
+---
+
+yellow-morph: migrate Morph API key from shell `MORPH_API_KEY` to plugin
+`userConfig` (Claude Code prompts at plugin-enable time and stores in the
+system keychain). Shell `MORPH_API_KEY` remains supported as a power-user
+fallback. Ship `bin/start-morph.sh` wrapper and a SessionStart prewarm hook
+that install `@morphllm/morphmcp@0.8.165` into `${CLAUDE_PLUGIN_DATA}` —
+serialized via an atomic `mkdir`-lock so wrapper and hook cannot run
+concurrent `npm ci`. Fix `ENABLED_TOOLS` no-op (morphmcp ignores it; switch
+to `DISABLED_TOOLS=github_codebase_search`). Correct WarpGrep tool name
+from the non-existent `warpgrep_codebase_search` to `codebase_search`.
+
+yellow-core: update `setup:all` classification probe so yellow-morph is
+detected via the renamed `codebase_search` tool, and refresh the
+mcp-integration-patterns skill to reference the new tool name.
+
+yellow-research: rename the `filesystem-with-morph` global MCP probe in
+`/research:setup` to `codebase_search` (current name), with
+`warpgrep_codebase_search` retained in `allowed-tools` as a backward-
+compatibility hedge for users still on an older global MCP version.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -134,7 +134,7 @@
     {
       "name": "yellow-morph",
       "description": "Intelligent code editing and search via Morph Fast Apply and WarpGrep",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "KingInYellows"
       },

--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -603,7 +603,13 @@ jobs:
             echo "::endgroup::"
 
             echo "::group::Scanning for secrets in manifests"
-            SENSITIVE=$(grep -rE '(api[_-]?key|password|token|secret)' .claude-plugin/ plugins/ --include="*.json" | grep -v '"permissionScopes"' || true)
+            # Exclusions: "permissionScopes" literal; JSON userConfig field
+            # declarations (lines ending in `: {` are object-typed field
+            # openings, not secret values); ${user_config.*} template
+            # references (substituted at runtime, not literal secrets).
+            SENSITIVE=$(grep -rE '(api[_-]?key|password|token|secret)' .claude-plugin/ plugins/ --include="*.json" \
+              | grep -vE '"permissionScopes"|:[[:space:]]*\{[[:space:]]*$|\$\{user_config\.' \
+              || true)
             if [ -n "$SENSITIVE" ]; then
               echo "$SENSITIVE"
               echo "::error::Potential sensitive data found in manifest files"

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ node_modules/
 **/node_modules/
 package-lock.json
 yarn.lock
+# Exception: plugins that install external MCP binaries at runtime commit
+# their lockfile so `npm ci` pins the full transitive dependency tree
+# (supply-chain guarantee). Add new plugins here as they adopt the pattern.
+!plugins/yellow-morph/package-lock.json
 
 # Build outputs (Task I1.T1: pnpm workspace)
 dist/
@@ -95,3 +99,6 @@ temp/
 
 # Entire AI tool per-developer config (telemetry, settings, logs)
 .entire/
+
+# RuVector intelligence data
+.claude/statusline.sh

--- a/docs/upstream-pins.md
+++ b/docs/upstream-pins.md
@@ -1,0 +1,56 @@
+# Upstream Package Pins
+
+Every MCP server or external binary that yellow-plugins invokes via `npx`, `uvx`,
+or a bundled path is listed here with its current pinned version. Review on a
+monthly cadence (or before cutting a release) to decide whether to bump.
+
+Drift is checked automatically by `scripts/check-upstream-pins.js`, which queries
+the npm registry and prints any pin that lags the `latest` tag. Run it manually
+or hook it into CI as a non-blocking advisory.
+
+## Policy
+
+- **Pin exact versions** (`@scope/pkg@X.Y.Z`, not `^X.Y.Z`) so every session
+  resolves the same artifact. Version floats reintroduce the cold-start race
+  the plugin system works hard to avoid.
+- **Pin git MCPs by commit SHA** (via `uvx --from git+<url>@<sha>`). Moving
+  tags are not acceptable.
+- **Bump requires a verification step**: install the new version locally and
+  probe the MCP's `tools/list` (and any critical env vars) before updating.
+  See the 0.8.110 → 0.8.165 bump for an example (`ENABLED_TOOLS` turned out
+  to be non-functional; the pin bump surfaced the bug).
+
+## Current Pins
+
+| Plugin           | Package                          | Pinned   | Registry | Notes                                                                   |
+| ---------------- | -------------------------------- | -------- | -------- | ----------------------------------------------------------------------- |
+| yellow-morph     | `@morphllm/morphmcp`             | `0.8.165`| npm      | Bumped 2026-04-17 from 0.8.110. No public changelog; verify empirically. |
+| yellow-research  | `@perplexity-ai/mcp-server`      | `0.8.2`  | npm      | Perplexity MCP. Requires `PERPLEXITY_API_KEY`.                          |
+| yellow-research  | `tavily-mcp`                     | `0.2.17` | npm      | Tavily research MCP. Requires `TAVILY_API_KEY`.                         |
+| yellow-research  | `exa-mcp-server`                 | `3.1.8`  | npm      | Exa MCP. Requires `EXA_API_KEY`. Tool whitelist passed as positional arg.|
+| yellow-research  | `ast-grep-mcp`                   | `674272f`| git SHA  | Installed via `uvx` from `github.com/ast-grep/ast-grep-mcp`. No npm release. |
+| yellow-ruvector  | `ruvector`                       | _latest_ | npm      | No version pin — ruvector handles its own DB migration. Consider pinning after v1.0 cut. |
+
+## Bump Checklist
+
+When bumping a pin:
+
+1. Read the upstream changelog. If none exists (e.g., `@morphllm/morphmcp`),
+   install the new version in a disposable workspace and compare
+   `tools/list` + env-var surface vs the prior pin.
+2. Update the pin in the plugin's `.claude-plugin/plugin.json` `args` array.
+3. Update the matching row in this file.
+4. Bump the plugin's `version` (minor for behavior-preserving bumps, major
+   for breaking changes in the MCP's tool surface).
+5. Update the plugin's `CHANGELOG.md` with "Changed" or "Breaking" entries.
+6. Run `node scripts/check-upstream-pins.js` — it should report zero drift
+   for the bumped package.
+
+## Why exact pins?
+
+Cold-start reliability: a floating version (`latest`) means each fresh install
+resolves whatever was published most recently, possibly seconds before the
+user's session. That's a supply-chain attack surface AND a reliability
+problem — an upstream regression lands the moment a user boots Claude Code,
+with no warning. Exact pins decouple plugin behavior from upstream publishing
+cadence and give us a deterministic upgrade path.

--- a/docs/upstream-pins.md
+++ b/docs/upstream-pins.md
@@ -24,7 +24,7 @@ or hook it into CI as a non-blocking advisory.
 
 | Plugin           | Package                          | Pinned   | Registry | Notes                                                                   |
 | ---------------- | -------------------------------- | -------- | -------- | ----------------------------------------------------------------------- |
-| yellow-morph     | `@morphllm/morphmcp`             | `0.8.165`| npm      | Bumped 2026-04-17 from 0.8.110. No public changelog; verify empirically. |
+| yellow-morph     | `@morphllm/morphmcp`             | `0.8.165`| npm      | Bumped 2026-04-17 from 0.8.110. No public changelog; verify empirically. **Pin tracked in `plugins/yellow-morph/package.json` deps (wrapper-based); NOT in `plugin.json` args.** |
 | yellow-research  | `@perplexity-ai/mcp-server`      | `0.8.2`  | npm      | Perplexity MCP. Requires `PERPLEXITY_API_KEY`.                          |
 | yellow-research  | `tavily-mcp`                     | `0.2.17` | npm      | Tavily research MCP. Requires `TAVILY_API_KEY`.                         |
 | yellow-research  | `exa-mcp-server`                 | `3.1.8`  | npm      | Exa MCP. Requires `EXA_API_KEY`. Tool whitelist passed as positional arg.|
@@ -39,6 +39,11 @@ When bumping a pin:
    install the new version in a disposable workspace and compare
    `tools/list` + env-var surface vs the prior pin.
 2. Update the pin in the plugin's `.claude-plugin/plugin.json` `args` array.
+   **Exception — wrapper-based plugins (e.g., yellow-morph):** the version pin
+   lives in `plugins/<name>/package.json` (under `dependencies`) and
+   `plugins/<name>/package-lock.json`. Run `npm install @scope/pkg@X.Y.Z` inside
+   the plugin directory to update both files. The `plugin.json` `args` array
+   invokes the wrapper script and does NOT contain the package version.
 3. Update the matching row in this file.
 4. Bump the plugin's `version` (minor for behavior-preserving bumps, major
    for breaking changes in the MCP's tool surface).

--- a/plugins/yellow-core/commands/setup/all.md
+++ b/plugins/yellow-core/commands/setup/all.md
@@ -78,10 +78,10 @@ fi
 printf '\n=== Environment Variables ===\n'
 if [ -n "${MORPH_API_KEY:-}" ]; then
   printf 'MORPH_API_KEY:             set (shell env)\n'
-elif grep -qE '"morph_api_key"[[:space:]]*:' "${HOME}/.claude/settings.json" 2>/dev/null; then
+elif grep -qE '"morph_api_key"[[:space:]]*:' "${HOME}/.claude/.credentials.json" 2>/dev/null; then
   printf 'MORPH_API_KEY:             set (userConfig)\n'
 else
-  printf 'MORPH_API_KEY:             NOT SET\n'
+  printf 'MORPH_API_KEY:             NOT SET (run /morph:setup if you configured via keychain)\n'
 fi
 [ -n "${DEVIN_SERVICE_USER_TOKEN:-}" ] && printf 'DEVIN_SERVICE_USER_TOKEN:  set\n' || printf 'DEVIN_SERVICE_USER_TOKEN:  NOT SET\n'
 [ -n "${DEVIN_ORG_ID:-}" ] && printf 'DEVIN_ORG_ID:              set\n' || printf 'DEVIN_ORG_ID:              NOT SET\n'

--- a/plugins/yellow-core/commands/setup/all.md
+++ b/plugins/yellow-core/commands/setup/all.md
@@ -76,7 +76,13 @@ else
 fi
 
 printf '\n=== Environment Variables ===\n'
-[ -n "${MORPH_API_KEY:-}" ] && printf 'MORPH_API_KEY:             set\n' || printf 'MORPH_API_KEY:             NOT SET\n'
+if [ -n "${MORPH_API_KEY:-}" ]; then
+  printf 'MORPH_API_KEY:             set (shell env)\n'
+elif grep -q '"morph_api_key"' "${HOME}/.claude/settings.json" 2>/dev/null; then
+  printf 'MORPH_API_KEY:             set (userConfig)\n'
+else
+  printf 'MORPH_API_KEY:             NOT SET\n'
+fi
 [ -n "${DEVIN_SERVICE_USER_TOKEN:-}" ] && printf 'DEVIN_SERVICE_USER_TOKEN:  set\n' || printf 'DEVIN_SERVICE_USER_TOKEN:  NOT SET\n'
 [ -n "${DEVIN_ORG_ID:-}" ] && printf 'DEVIN_ORG_ID:              set\n' || printf 'DEVIN_ORG_ID:              NOT SET\n'
 [ -n "${SEMGREP_APP_TOKEN:-}" ] && printf 'SEMGREP_APP_TOKEN:         set\n' || printf 'SEMGREP_APP_TOKEN:         NOT SET\n'
@@ -238,9 +244,23 @@ as **NOT INSTALLED** and skip all other checks for that plugin.
 
 **yellow-morph:**
 
-- READY: `node18_check` ok AND `npx` OK AND `rg` OK AND `MORPH_API_KEY` set
-- PARTIAL: local prerequisites are satisfied but `MORPH_API_KEY` is NOT SET
-- NEEDS SETUP: any local prerequisite missing (`node18_check`, `npx`, or `rg`)
+The Morph API key can be supplied via either the plugin's `userConfig`
+prompt (stored in the system keychain, preferred) or a shell
+`MORPH_API_KEY` export (power-user fallback). Neither is visible to
+shell checks directly, so treat READY as "key is configured via *some*
+path" and rely on `/morph:status` for authoritative OFFLINE detection.
+
+- READY: `node18_check` ok AND `npx` OK AND `rg` OK AND either of:
+  (a) shell `MORPH_API_KEY` set, OR
+  (b) `pluginConfigs.yellow-morph.options.morph_api_key` present in
+      `~/.claude/settings.json` (userConfig was answered). Detection:
+      `grep -q '"morph_api_key"' ~/.claude/settings.json 2>/dev/null`.
+- PARTIAL: local prerequisites are satisfied but neither the shell env
+  var nor the userConfig option is detectable — the plugin will install
+  but the MCP server will not start. Recommend running `/morph:setup`
+  or answering the userConfig prompt at next plugin-enable.
+- NEEDS SETUP: any local prerequisite missing (`node18_check`, `npx`, or
+  `rg`).
 
 **yellow-devin:**
 

--- a/plugins/yellow-core/commands/setup/all.md
+++ b/plugins/yellow-core/commands/setup/all.md
@@ -78,7 +78,7 @@ fi
 printf '\n=== Environment Variables ===\n'
 if [ -n "${MORPH_API_KEY:-}" ]; then
   printf 'MORPH_API_KEY:             set (shell env)\n'
-elif grep -q '"morph_api_key"' "${HOME}/.claude/settings.json" 2>/dev/null; then
+elif grep -qE '"morph_api_key"[[:space:]]*:' "${HOME}/.claude/settings.json" 2>/dev/null; then
   printf 'MORPH_API_KEY:             set (userConfig)\n'
 else
   printf 'MORPH_API_KEY:             NOT SET\n'
@@ -250,16 +250,16 @@ prompt (stored in the system keychain, preferred) or a shell
 shell checks directly, so treat READY as "key is configured via *some*
 path" and rely on `/morph:status` for authoritative OFFLINE detection.
 
-- READY: `node18_check` ok AND `npx` OK AND `rg` OK AND either of:
+- READY: `node18_check` ok AND `npm` OK AND `rg` OK AND either of:
   (a) shell `MORPH_API_KEY` set, OR
   (b) `pluginConfigs.yellow-morph.options.morph_api_key` present in
       `~/.claude/settings.json` (userConfig was answered). Detection:
-      `grep -q '"morph_api_key"' ~/.claude/settings.json 2>/dev/null`.
+      `grep -qE '"morph_api_key"[[:space:]]*:' ~/.claude/settings.json 2>/dev/null`.
 - PARTIAL: local prerequisites are satisfied but neither the shell env
   var nor the userConfig option is detectable — the plugin will install
   but the MCP server will not start. Recommend running `/morph:setup`
   or answering the userConfig prompt at next plugin-enable.
-- NEEDS SETUP: any local prerequisite missing (`node18_check`, `npx`, or
+- NEEDS SETUP: any local prerequisite missing (`node18_check`, `npm`, or
   `rg`).
 
 **yellow-devin:**
@@ -375,7 +375,7 @@ Marketplace Setup Dashboard
   -------------------  -----------     ------------------------------------------
   gt-workflow          READY           Graphite auth detected, repo initialized
   yellow-ruvector      NEEDS SETUP     Global ruvector binary missing from PATH
-  yellow-morph         PARTIAL         Local tools ready, MORPH_API_KEY missing
+  yellow-morph         PARTIAL         Local tools ready, Morph API key not configured
   yellow-devin         NEEDS SETUP     DEVIN_SERVICE_USER_TOKEN not set
   yellow-semgrep       PARTIAL         Token set, semgrep CLI missing
   yellow-research      PARTIAL         2/6 bundled sources available
@@ -519,7 +519,7 @@ If any plugins still need attention, list them with their final detail:
 
 ```text
 Still need attention:
-  yellow-morph — PARTIAL (MORPH_API_KEY not set)
+  yellow-morph — PARTIAL (Morph API key not configured)
   yellow-review — PARTIAL (yellow-core not installed)
 ```
 

--- a/plugins/yellow-core/commands/setup/all.md
+++ b/plugins/yellow-core/commands/setup/all.md
@@ -253,8 +253,8 @@ path" and rely on `/morph:status` for authoritative OFFLINE detection.
 - READY: `node18_check` ok AND `npm` OK AND `rg` OK AND either of:
   (a) shell `MORPH_API_KEY` set, OR
   (b) `pluginConfigs.yellow-morph.options.morph_api_key` present in
-      `~/.claude/settings.json` (userConfig was answered). Detection:
-      `grep -qE '"morph_api_key"[[:space:]]*:' ~/.claude/settings.json 2>/dev/null`.
+      `~/.claude/.credentials.json` (userConfig was answered). Detection:
+      `grep -qE '"morph_api_key"[[:space:]]*:' ~/.claude/.credentials.json 2>/dev/null`.
 - PARTIAL: local prerequisites are satisfied but neither the shell env
   var nor the userConfig option is detectable — the plugin will install
   but the MCP server will not start. Recommend running `/morph:setup`

--- a/plugins/yellow-core/skills/mcp-integration-patterns/SKILL.md
+++ b/plugins/yellow-core/skills/mcp-integration-patterns/SKILL.md
@@ -252,7 +252,7 @@ tools silently when morph is not installed.
 1. Call ToolSearch("morph warpgrep")
 2. If found AND query is intent-based ("what calls this function?",
    "find similar patterns", "blast radius of this change"):
-   prefer morph warpgrep_codebase_search
+   prefer morph codebase_search (aka WarpGrep)
 3. If not found OR query is exact-match (specific string, regex):
    use built-in Grep
 4. No warning on fallback. No degradation message.
@@ -266,6 +266,15 @@ tools silently when morph is not installed.
   fast (sub-100ms), avoids coupling to morph package names.
 - **No hard dependency** — morph tools are never listed in command
   `allowed-tools`. Discovery happens at runtime.
+
+### Common Failure Mode
+
+If `ToolSearch("morph edit")` returns no results, the most common cause is
+that the yellow-morph plugin's `userConfig.morph_api_key` was not provided
+at plugin-enable time — the MCP server fails to start and no tools are
+registered. Suggest `/morph:setup` to the user, but do not block: fall back
+to built-in tools silently per the pattern above. This is an enhancement,
+not a dependency.
 
 ### Anti-Patterns
 

--- a/plugins/yellow-morph/.claude-plugin/plugin.json
+++ b/plugins/yellow-morph/.claude-plugin/plugin.json
@@ -22,6 +22,7 @@
       "args": [],
       "env": {
         "MORPH_API_KEY_USERCONFIG": "${user_config.morph_api_key}",
+        "MORPH_API_KEY": "${MORPH_API_KEY:-}",
         "DISABLED_TOOLS": "github_codebase_search",
         "WORKSPACE_MODE": "true"
       }

--- a/plugins/yellow-morph/.claude-plugin/plugin.json
+++ b/plugins/yellow-morph/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yellow-morph",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Intelligent code editing and search via Morph Fast Apply and WarpGrep",
   "author": {
     "name": "KingInYellows",
@@ -10,13 +10,19 @@
   "repository": "https://github.com/KingInYellows/yellow-plugins",
   "license": "MIT",
   "keywords": ["code-editing", "code-search", "fast-apply", "warpgrep", "morph"],
+  "userConfig": {
+    "morph_api_key": {
+      "description": "Morph API key (get one at https://morphllm.com — free tier 250K credits/month). Stored in system keychain or ~/.claude/.credentials.json.",
+      "sensitive": true
+    }
+  },
   "mcpServers": {
     "morph": {
       "command": "npx",
-      "args": ["-y", "@morphllm/morphmcp@0.8.110"],
+      "args": ["-y", "@morphllm/morphmcp@0.8.165"],
       "env": {
-        "MORPH_API_KEY": "${MORPH_API_KEY}",
-        "ENABLED_TOOLS": "edit_file,warpgrep_codebase_search",
+        "MORPH_API_KEY": "${user_config.morph_api_key}",
+        "DISABLED_TOOLS": "github_codebase_search",
         "WORKSPACE_MODE": "true"
       }
     }

--- a/plugins/yellow-morph/.claude-plugin/plugin.json
+++ b/plugins/yellow-morph/.claude-plugin/plugin.json
@@ -26,5 +26,19 @@
         "WORKSPACE_MODE": "true"
       }
     }
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prewarm-morph.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
   }
 }

--- a/plugins/yellow-morph/.claude-plugin/plugin.json
+++ b/plugins/yellow-morph/.claude-plugin/plugin.json
@@ -18,10 +18,10 @@
   },
   "mcpServers": {
     "morph": {
-      "command": "npx",
-      "args": ["-y", "@morphllm/morphmcp@0.8.165"],
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/start-morph.sh",
+      "args": [],
       "env": {
-        "MORPH_API_KEY": "${user_config.morph_api_key}",
+        "MORPH_API_KEY_USERCONFIG": "${user_config.morph_api_key}",
         "DISABLED_TOOLS": "github_codebase_search",
         "WORKSPACE_MODE": "true"
       }

--- a/plugins/yellow-morph/CHANGELOG.md
+++ b/plugins/yellow-morph/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   system keychain (or `~/.claude/.credentials.json` on minimal Linux). Fresh
   installs no longer require a `MORPH_API_KEY` export before launching
   Claude Code, and no longer require a Claude Code restart after setup.
-  Power-user fallback via shell env var lands in 1.2.0 once the wrapper
-  script is in place; for 1.1.0, answer the userConfig prompt on first
-  enable.
+  Power-user fallback via a shell `MORPH_API_KEY` export is also supported
+  in 1.1.0 — `bin/start-morph.sh` resolves the userConfig value first, then
+  falls through to the shell env var when userConfig is empty.
 - **MCP pin bumped from `@morphllm/morphmcp@0.8.110` to `0.8.165`** (55
   versions of upstream fixes).
 

--- a/plugins/yellow-morph/CHANGELOG.md
+++ b/plugins/yellow-morph/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.1.0] - 2026-04-17
+
+### Changed (breaking)
+
+- **Config surface: `MORPH_API_KEY` now read from `userConfig`, not shell env.**
+  Claude Code prompts for the key at plugin-enable time and stores it in the
+  system keychain (or `~/.claude/.credentials.json` on minimal Linux). Fresh
+  installs no longer require a `MORPH_API_KEY` export before launching
+  Claude Code, and no longer require a Claude Code restart after setup.
+  Power-user fallback via shell env var lands in 1.2.0 once the wrapper
+  script is in place; for 1.1.0, answer the userConfig prompt on first
+  enable.
+- **MCP pin bumped from `@morphllm/morphmcp@0.8.110` to `0.8.165`** (55
+  versions of upstream fixes).
+
+### Fixed
+
+- **`edit_file` tool was silently disabled.** morphmcp disables `edit_file`
+  by default; the plugin had been setting the (non-existent)
+  `ENABLED_TOOLS` env var, which is silently ignored. Switched to
+  `DISABLED_TOOLS=github_codebase_search` so both `edit_file` and
+  `codebase_search` (the two tools the plugin advertises) are now actually
+  exposed.
+- **Tool name corrected: `warpgrep_codebase_search` → `codebase_search`.**
+  The `warpgrep_` prefix does not exist in morphmcp 0.8.165. References
+  updated across CLAUDE.md, README, `/morph:status`, and the
+  `mcp-integration-patterns` skill. The `MCP__plugin_yellow-morph_morph__edit_file`
+  and `mcp__plugin_yellow-morph_morph__codebase_search` names are what
+  agents should call going forward.
+
+### Migration
+
+- Existing users: run `claude plugin update yellow-morph@yellow-plugins`.
+  Claude Code detects the new `userConfig` field and prompts for the key on
+  next plugin enable. Answer the prompt to migrate.
+- If your prior setup relied on `mcp__plugin_yellow-morph_morph__warpgrep_codebase_search`,
+  agents invoking the old name will fail — update the call site to
+  `mcp__plugin_yellow-morph_morph__codebase_search`.
+
+---
+
 ## [1.0.0] - 2026-03-03
 
 ### Added

--- a/plugins/yellow-morph/CHANGELOG.md
+++ b/plugins/yellow-morph/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Tool name corrected: `warpgrep_codebase_search` → `codebase_search`.**
   The `warpgrep_` prefix does not exist in morphmcp 0.8.165. References
   updated across CLAUDE.md, README, `/morph:status`, and the
-  `mcp-integration-patterns` skill. The `MCP__plugin_yellow-morph_morph__edit_file`
+  `mcp-integration-patterns` skill. The `mcp__plugin_yellow-morph_morph__edit_file`
   and `mcp__plugin_yellow-morph_morph__codebase_search` names are what
   agents should call going forward.
 

--- a/plugins/yellow-morph/CLAUDE.md
+++ b/plugins/yellow-morph/CLAUDE.md
@@ -4,7 +4,9 @@ Intelligent code editing and search via Morph Fast Apply and WarpGrep.
 
 ## MCP Server
 
-- **morph** — Stdio transport via `npx @morphllm/morphmcp@0.8.165`
+- **morph** — Stdio transport via `bin/start-morph.sh`, which runs
+  `node @morphllm/morphmcp@0.8.165` from a per-user install in
+  `${CLAUDE_PLUGIN_DATA}/node_modules/`.
 - Requires a Morph API key configured via plugin `userConfig` (Claude Code
   prompts for it at plugin-enable time and stores it in the system keychain
   or `~/.claude/.credentials.json`). No shell `export MORPH_API_KEY` required,
@@ -12,8 +14,11 @@ Intelligent code editing and search via Morph Fast Apply and WarpGrep.
 - Tools: `mcp__plugin_yellow-morph_morph__edit_file`,
   `mcp__plugin_yellow-morph_morph__codebase_search`
 - Lifecycle: starts on first MCP tool call, shuts down on session end
-- First call may be slow (20-40s cold start on first npx download; subsequent
-  sessions use npm cache and start in seconds)
+- First-ever call may be slow (20-40s cold start: `npm ci` runs once to
+  install morphmcp into the plugin data dir). A SessionStart hook
+  (`hooks/scripts/prewarm-morph.sh`) runs the same install in parallel so
+  the wait usually happens at session start instead of on first MCP call.
+  Subsequent sessions reuse the cached install and start in seconds.
 
 ## Tool Preference Rules
 

--- a/plugins/yellow-morph/CLAUDE.md
+++ b/plugins/yellow-morph/CLAUDE.md
@@ -126,5 +126,7 @@ do not apply.
 - WarpGrep timeout: 30s default (configurable via MORPH_WARP_GREP_TIMEOUT env
   var)
 - edit_file is not suitable for non-code files (configs, markdown, YAML)
-- First npx download may take 20-40s; subsequent sessions use npm cache
+- First install may take 20-40s (`npm ci` installs `@morphllm/morphmcp` into
+  `${CLAUDE_PLUGIN_DATA}/node_modules/`); subsequent sessions reuse the cached
+  install
 - Code is sent to Morph's API — not suitable for air-gapped environments

--- a/plugins/yellow-morph/CLAUDE.md
+++ b/plugins/yellow-morph/CLAUDE.md
@@ -4,10 +4,13 @@ Intelligent code editing and search via Morph Fast Apply and WarpGrep.
 
 ## MCP Server
 
-- **morph** — Stdio transport via `npx @morphllm/morphmcp@0.8.110`
-- Requires `MORPH_API_KEY` environment variable (will not start without it)
+- **morph** — Stdio transport via `npx @morphllm/morphmcp@0.8.165`
+- Requires a Morph API key configured via plugin `userConfig` (Claude Code
+  prompts for it at plugin-enable time and stores it in the system keychain
+  or `~/.claude/.credentials.json`). No shell `export MORPH_API_KEY` required,
+  and no Claude Code restart needed after setup.
 - Tools: `mcp__plugin_yellow-morph_morph__edit_file`,
-  `mcp__plugin_yellow-morph_morph__warpgrep_codebase_search`
+  `mcp__plugin_yellow-morph_morph__codebase_search`
 - Lifecycle: starts on first MCP tool call, shuts down on session end
 - First call may be slow (20-40s cold start on first npx download; subsequent
   sessions use npm cache and start in seconds)
@@ -27,9 +30,9 @@ Intelligent code editing and search via Morph Fast Apply and WarpGrep.
   markers — the AI specifies what changes, morph handles the merge
 - Scales to 1,500-line files at 99.2% accuracy
 
-### warpgrep_codebase_search (WarpGrep) vs built-in Grep
+### codebase_search (WarpGrep) vs built-in Grep
 
-- Prefer `mcp__plugin_yellow-morph_morph__warpgrep_codebase_search` for
+- Prefer `mcp__plugin_yellow-morph_morph__codebase_search` for
   intent-based queries ("how does authentication work?", "find error handling
   for payment failures", "what calls this function?")
 - Continue using built-in Grep for exact pattern matching (regex, literal
@@ -52,7 +55,7 @@ When both yellow-morph and yellow-ruvector are installed:
 Routing rules:
 
 - Discovery query about unseen code →
-  `mcp__plugin_yellow-morph_morph__warpgrep_codebase_search`
+  `mcp__plugin_yellow-morph_morph__codebase_search`
 - Recall query about past learning or similar pattern → ruvector tools
 - If ruvector is not installed → WarpGrep handles all code search
 
@@ -61,17 +64,18 @@ Routing rules:
 - If `mcp__plugin_yellow-morph_morph__edit_file` fails (API error, timeout,
   credits exhausted): fall back to built-in Edit tool. Note the fallback
   briefly.
-- If `mcp__plugin_yellow-morph_morph__warpgrep_codebase_search` fails: fall back
+- If `mcp__plugin_yellow-morph_morph__codebase_search` fails: fall back
   to built-in Grep. Note the fallback briefly.
-- If `MORPH_API_KEY` is not set: MCP server does not start. All workflows
-  continue with built-in tools. No error.
+- If no Morph API key is configured (userConfig not answered and no shell
+  `MORPH_API_KEY` fallback): MCP server does not start. All workflows continue
+  with built-in tools. No error. `/morph:status` reports `OFFLINE`.
 - Morph is an enhancement, never a dependency. No workflow should block on morph
   tool availability.
 
 ## Security and Privacy
 
 - **Data transmission:** Both `mcp__plugin_yellow-morph_morph__edit_file` and
-  `mcp__plugin_yellow-morph_morph__warpgrep_codebase_search` send code to
+  `mcp__plugin_yellow-morph_morph__codebase_search` send code to
   Morph's API servers (api.morphllm.com)
 - **Data retention:** Free/Starter tiers retain data for 90 days. Enterprise
   offers zero-data-retention (ZDR) mode.
@@ -97,7 +101,9 @@ do not apply.
 
 - ripgrep (`rg`) installed — required by WarpGrep for local search
 - Node.js 22.22.0 or later — required for MCP server via npx
-- `MORPH_API_KEY` environment variable — obtain from https://morphllm.com
+- Morph API key — answer the `userConfig` prompt at plugin-enable time
+  (obtain a key from https://morphllm.com). A shell `MORPH_API_KEY` export
+  remains supported as a fallback for power users.
 - Network egress to api.morphllm.com (port 443)
 
 ## Cost Considerations

--- a/plugins/yellow-morph/README.md
+++ b/plugins/yellow-morph/README.md
@@ -23,7 +23,7 @@ Intelligent code editing and search via
 
 Once configured, morph tools are available automatically — no explicit
 invocation needed. Claude will prefer `edit_file` for large edits and
-`warpgrep_codebase_search` for intent-based code discovery.
+`codebase_search` for intent-based code discovery.
 
 ## Commands
 
@@ -36,7 +36,7 @@ invocation needed. Claude will prefer `edit_file` for large edits and
 
 - **Fast Apply** (`edit_file`) — high-accuracy code merging for complex,
   multi-line edits. 98%+ accuracy at 10,500+ tok/s, scaling to 1,500-line files.
-- **WarpGrep** (`warpgrep_codebase_search`) — intent-based code discovery that
+- **WarpGrep** (`codebase_search`) — intent-based code discovery that
   answers "how does X work?" queries without indexing. Sub-6 second average.
 
 See [CLAUDE.md](CLAUDE.md) for detailed tool preference rules, domain separation
@@ -46,8 +46,9 @@ with ruvector, cost/credit details, and privacy notes.
 
 - **ripgrep** (`rg`) — required by WarpGrep for local search
 - **Node.js 22.22.0 or later** — required for MCP server via npx
-- **MORPH_API_KEY** — obtain from https://morphllm.com (free tier: 250K
-  credits/month)
+- **Morph API key** — obtain from https://morphllm.com (free tier: 250K
+  credits/month). Answer the `userConfig` prompt at plugin-enable time; a
+  shell `MORPH_API_KEY` export is accepted as a fallback.
 - **Network access** to api.morphllm.com (port 443)
 
 ## Privacy

--- a/plugins/yellow-morph/bin/start-morph.sh
+++ b/plugins/yellow-morph/bin/start-morph.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# yellow-morph MCP server wrapper.
+#
+# Responsibilities (correctness gate — do NOT rely on the SessionStart hook
+# for install; it races MCP startup per community precedent):
+#   1. Resolve MORPH_API_KEY from userConfig (preferred) or shell env.
+#   2. Ensure @morphllm/morphmcp is installed in ${CLAUDE_PLUGIN_DATA};
+#      install synchronously if missing.
+#   3. Exec morphmcp.
+#
+# Required env from plugin.json:
+#   CLAUDE_PLUGIN_ROOT         — plugin install dir (read-only at runtime).
+#   CLAUDE_PLUGIN_DATA         — plugin persistent data dir (writable).
+#   MORPH_API_KEY_USERCONFIG   — userConfig-substituted value (may be empty).
+#
+# Optional inherited env:
+#   MORPH_API_KEY              — shell fallback for power users.
+#
+set -eu
+
+# --- 1. Resolve the API key. userConfig wins; shell env is fallback.
+if [ -n "${MORPH_API_KEY_USERCONFIG:-}" ]; then
+  export MORPH_API_KEY="$MORPH_API_KEY_USERCONFIG"
+fi
+unset MORPH_API_KEY_USERCONFIG
+# If neither userConfig nor shell MORPH_API_KEY is set, morphmcp will emit
+# its own warning and exit — we don't duplicate that error path here.
+
+# --- 2. Ensure morphmcp is installed in the persistent data directory.
+: "${CLAUDE_PLUGIN_ROOT:?yellow-morph wrapper: CLAUDE_PLUGIN_ROOT is unset}"
+: "${CLAUDE_PLUGIN_DATA:?yellow-morph wrapper: CLAUDE_PLUGIN_DATA is unset}"
+
+MORPH_ENTRY="${CLAUDE_PLUGIN_DATA}/node_modules/@morphllm/morphmcp/dist/index.js"
+
+if [ ! -f "$MORPH_ENTRY" ]; then
+  mkdir -p "$CLAUDE_PLUGIN_DATA"
+  # Copy the plugin's package.json so `npm install` has a manifest to act on.
+  cp "${CLAUDE_PLUGIN_ROOT}/package.json" "${CLAUDE_PLUGIN_DATA}/package.json"
+  # Install. Emit progress to stderr so Claude Code shows it during the
+  # first-session delay instead of hanging the tool call silently.
+  printf 'yellow-morph: first-run install of @morphllm/morphmcp into %s...\n' \
+    "$CLAUDE_PLUGIN_DATA" >&2
+  if ! (cd "$CLAUDE_PLUGIN_DATA" && npm install --no-audit --no-fund --loglevel=error) >&2; then
+    printf 'yellow-morph: npm install failed. Run /morph:setup to diagnose.\n' >&2
+    # Remove the copied manifest so the next session retries instead of
+    # seeing an out-of-sync state.
+    rm -f "${CLAUDE_PLUGIN_DATA}/package.json"
+    exit 1
+  fi
+fi
+
+# --- 3. Exec morphmcp. The SessionStart hook may have done the same install
+# in parallel; that's OK — npm install is idempotent, and by the time we
+# reach this line the entry file exists.
+exec node "$MORPH_ENTRY" "$@"

--- a/plugins/yellow-morph/bin/start-morph.sh
+++ b/plugins/yellow-morph/bin/start-morph.sh
@@ -114,6 +114,13 @@ if needs_install; then
   fi
 fi
 
-# --- 3. Exec morphmcp. By this point the install lock (if we held one) is
-# released by the EXIT trap before exec runs.
+# --- 3. Release the install lock explicitly before exec. Bash's EXIT trap
+# does NOT fire when `exec` replaces the shell with another program — the
+# shell never "exits" in the sense that triggers EXIT. Without this manual
+# cleanup, an exec into a long-running morphmcp would leave $LOCK_DIR
+# behind for the entire session, blocking future upgrades.
+if [ "${LOCK_ACQUIRED:-0}" -eq 1 ]; then
+  rmdir "$LOCK_DIR" 2>/dev/null || true
+  trap - EXIT INT TERM
+fi
 exec node "$MORPH_ENTRY" "$@"

--- a/plugins/yellow-morph/bin/start-morph.sh
+++ b/plugins/yellow-morph/bin/start-morph.sh
@@ -30,21 +30,40 @@ unset MORPH_API_KEY_USERCONFIG
 : "${CLAUDE_PLUGIN_ROOT:?yellow-morph wrapper: CLAUDE_PLUGIN_ROOT is unset}"
 : "${CLAUDE_PLUGIN_DATA:?yellow-morph wrapper: CLAUDE_PLUGIN_DATA is unset}"
 
+# Defense in depth: Claude Code sets CLAUDE_PLUGIN_DATA to a path under the
+# user's home directory. If something else populated these vars with an
+# unexpected path (misconfiguration or compromised env), refuse to install —
+# we do not want `cp` / `npm ci` to write to e.g. /etc or /var.
+case "$CLAUDE_PLUGIN_DATA" in
+  "$HOME"/*|/tmp/*) ;;
+  *) printf 'yellow-morph: refusing install — CLAUDE_PLUGIN_DATA is not under $HOME or /tmp: %s\n' "$CLAUDE_PLUGIN_DATA" >&2; exit 1 ;;
+esac
+case "$CLAUDE_PLUGIN_ROOT" in
+  "$HOME"/*|/tmp/*|/usr/*|/opt/*) ;;
+  *) printf 'yellow-morph: refusing install — CLAUDE_PLUGIN_ROOT has unexpected prefix: %s\n' "$CLAUDE_PLUGIN_ROOT" >&2; exit 1 ;;
+esac
+
 MORPH_ENTRY="${CLAUDE_PLUGIN_DATA}/node_modules/@morphllm/morphmcp/dist/index.js"
 
 if [ ! -f "$MORPH_ENTRY" ]; then
   mkdir -p "$CLAUDE_PLUGIN_DATA"
-  # Copy the plugin's package.json so `npm install` has a manifest to act on.
+  # Copy both the manifest AND the committed lockfile so `npm ci` can do a
+  # deterministic, transitive-pinned install. Without the lockfile, npm
+  # falls back to lockfile-less resolution and silently installs whatever
+  # transitive versions the registry currently advertises — a supply-chain
+  # risk that defeats the point of pinning @morphllm/morphmcp.
   cp "${CLAUDE_PLUGIN_ROOT}/package.json" "${CLAUDE_PLUGIN_DATA}/package.json"
-  # Install. Emit progress to stderr so Claude Code shows it during the
-  # first-session delay instead of hanging the tool call silently.
+  cp "${CLAUDE_PLUGIN_ROOT}/package-lock.json" "${CLAUDE_PLUGIN_DATA}/package-lock.json"
+  # Install in a subshell that does NOT inherit MORPH_API_KEY — a malicious
+  # postinstall script in any transitive dep could otherwise exfiltrate the
+  # key before the real MCP server ever starts.
   printf 'yellow-morph: first-run install of @morphllm/morphmcp into %s...\n' \
     "$CLAUDE_PLUGIN_DATA" >&2
-  if ! (cd "$CLAUDE_PLUGIN_DATA" && npm install --no-audit --no-fund --loglevel=error) >&2; then
-    printf 'yellow-morph: npm install failed. Run /morph:setup to diagnose.\n' >&2
-    # Remove the copied manifest so the next session retries instead of
-    # seeing an out-of-sync state.
-    rm -f "${CLAUDE_PLUGIN_DATA}/package.json"
+  if ! (unset MORPH_API_KEY; cd "$CLAUDE_PLUGIN_DATA" && npm ci --no-audit --no-fund --loglevel=error) >&2; then
+    printf 'yellow-morph: npm ci failed. Run /morph:setup to diagnose.\n' >&2
+    # Remove the copied manifest+lockfile so the next session retries
+    # instead of seeing an out-of-sync state.
+    rm -f "${CLAUDE_PLUGIN_DATA}/package.json" "${CLAUDE_PLUGIN_DATA}/package-lock.json"
     exit 1
   fi
 fi

--- a/plugins/yellow-morph/bin/start-morph.sh
+++ b/plugins/yellow-morph/bin/start-morph.sh
@@ -29,98 +29,54 @@ unset MORPH_API_KEY_USERCONFIG
 # If neither userConfig nor shell MORPH_API_KEY is set, morphmcp will emit
 # its own warning and exit — we don't duplicate that error path here.
 
-# --- 2. Ensure morphmcp is installed in the persistent data directory.
+# --- 2. Source install primitives and ensure morphmcp is installed.
 : "${CLAUDE_PLUGIN_ROOT:?yellow-morph wrapper: CLAUDE_PLUGIN_ROOT is unset}"
-: "${CLAUDE_PLUGIN_DATA:?yellow-morph wrapper: CLAUDE_PLUGIN_DATA is unset}"
+# shellcheck source=../lib/install-morphmcp.sh
+. "${CLAUDE_PLUGIN_ROOT}/lib/install-morphmcp.sh"
 
-# Defense in depth: Claude Code sets CLAUDE_PLUGIN_DATA to a path under the
-# user's home directory. If something else populated these vars with an
-# unexpected path (misconfiguration or compromised env), refuse to install —
-# we do not want `cp` / `npm ci` to write to e.g. /etc or /var.
-#
-# `${HOME:-/__unset__}` sentinel — an unset HOME would otherwise expand to
-# `/*`, matching ANY absolute path and bypassing the check entirely. The
-# sentinel is a path that cannot match any real CLAUDE_PLUGIN_DATA value.
-case "$CLAUDE_PLUGIN_DATA" in
-  "${HOME:-/__unset__}"/*|/tmp/*) ;;
-  *) printf 'yellow-morph: refusing install — CLAUDE_PLUGIN_DATA is not under $HOME or /tmp: %s\n' "$CLAUDE_PLUGIN_DATA" >&2; exit 1 ;;
-esac
-case "$CLAUDE_PLUGIN_ROOT" in
-  "${HOME:-/__unset__}"/*|/tmp/*|/usr/*|/opt/*) ;;
-  *) printf 'yellow-morph: refusing install — CLAUDE_PLUGIN_ROOT has unexpected prefix: %s\n' "$CLAUDE_PLUGIN_ROOT" >&2; exit 1 ;;
-esac
+yellow_morph_validate_paths || exit 1
 
-MORPH_ENTRY="${CLAUDE_PLUGIN_DATA}/node_modules/@morphllm/morphmcp/dist/index.js"
-LOCK_DIR="${CLAUDE_PLUGIN_DATA}/.install.lock"
-
-# Reinstall when the entry file is missing OR the persistent install
-# diverges from CLAUDE_PLUGIN_ROOT (e.g., after a plugin version bump).
-# Without the lockfile check, an upgraded morphmcp pin would run only on
-# next session unless the SessionStart prewarm hook caught it — and a
-# failed prewarm (network blip, timeout) would silently leave the user
-# on the stale install.
-needs_install() {
-  [ ! -f "$MORPH_ENTRY" ] && return 0
-  ! diff -q "${CLAUDE_PLUGIN_ROOT}/package-lock.json" \
-            "${CLAUDE_PLUGIN_DATA}/package-lock.json" >/dev/null 2>&1
-}
-
-if needs_install; then
+LOCK_ACQUIRED=0
+if yellow_morph_needs_install; then
   mkdir -p "$CLAUDE_PLUGIN_DATA"
 
-  # Acquire an atomic mkdir-lock to serialize against the SessionStart
-  # prewarm hook. `npm ci` deletes node_modules before installing, so two
-  # concurrent runs against the same target would corrupt the install.
-  # mkdir is atomic across POSIX systems (no flock dependency).
-  LOCK_ACQUIRED=0
-  for _i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
-    if mkdir "$LOCK_DIR" 2>/dev/null; then
-      LOCK_ACQUIRED=1
-      trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT INT TERM
-      break
-    fi
-    sleep 1
-  done
-
-  if [ "$LOCK_ACQUIRED" -eq 0 ]; then
-    printf 'yellow-morph: timed out (20s) waiting for install lock at %s\n' "$LOCK_DIR" >&2
-    printf 'yellow-morph: another install may be running, or a stale lock\n' >&2
-    printf 'yellow-morph: needs manual cleanup: rmdir %s\n' "$LOCK_DIR" >&2
+  # 20s budget — synchronous correctness gate. If we can't acquire after
+  # 20s the prior holder is either still installing or stuck; the lib's
+  # stale-PID recovery covers crashed holders. A live holder finishing
+  # within ~20s is the common case.
+  if ! yellow_morph_acquire_install_lock 20; then
+    printf 'yellow-morph: timed out (20s) waiting for install lock at %s\n' \
+      "${CLAUDE_PLUGIN_DATA}/.install.lock" >&2
+    printf 'yellow-morph: another install may be running, or the lock is\n' >&2
+    printf 'yellow-morph: held by an unkillable process — manual cleanup:\n' >&2
+    printf 'yellow-morph:   rmdir %s\n' "${CLAUDE_PLUGIN_DATA}/.install.lock" >&2
     exit 1
   fi
+  LOCK_ACQUIRED=1
+  trap 'yellow_morph_release_install_lock' EXIT INT TERM
 
   # Re-check under the lock — the prewarm hook may have completed the
-  # install while we were waiting, in which case we have nothing to do.
-  if needs_install; then
-    # Copy both the manifest AND the committed lockfile so `npm ci` can do a
-    # deterministic, transitive-pinned install. Without the lockfile, npm
-    # falls back to lockfile-less resolution and silently installs whatever
-    # transitive versions the registry currently advertises — a supply-chain
-    # risk that defeats the point of pinning @morphllm/morphmcp.
-    cp "${CLAUDE_PLUGIN_ROOT}/package.json" "${CLAUDE_PLUGIN_DATA}/package.json"
-    cp "${CLAUDE_PLUGIN_ROOT}/package-lock.json" "${CLAUDE_PLUGIN_DATA}/package-lock.json"
-    # Install in a subshell that does NOT inherit MORPH_API_KEY — a malicious
-    # postinstall script in any transitive dep could otherwise exfiltrate the
-    # key before the real MCP server ever starts.
+  # install while we were waiting, in which case there is nothing to do.
+  if yellow_morph_needs_install; then
     printf 'yellow-morph: installing @morphllm/morphmcp into %s...\n' \
       "$CLAUDE_PLUGIN_DATA" >&2
-    if ! (unset MORPH_API_KEY; cd "$CLAUDE_PLUGIN_DATA" && npm ci --no-audit --no-fund --loglevel=error) >&2; then
+    if ! yellow_morph_do_install >&2; then
       printf 'yellow-morph: npm ci failed. Run /morph:setup to diagnose.\n' >&2
-      # Remove the copied manifest+lockfile so the next session retries
-      # instead of seeing an out-of-sync state.
-      rm -f "${CLAUDE_PLUGIN_DATA}/package.json" "${CLAUDE_PLUGIN_DATA}/package-lock.json"
+      yellow_morph_cleanup_failed_install
       exit 1
     fi
   fi
 fi
 
-# --- 3. Release the install lock explicitly before exec. Bash's EXIT trap
-# does NOT fire when `exec` replaces the shell with another program — the
-# shell never "exits" in the sense that triggers EXIT. Without this manual
-# cleanup, an exec into a long-running morphmcp would leave $LOCK_DIR
-# behind for the entire session, blocking future upgrades.
-if [ "${LOCK_ACQUIRED:-0}" -eq 1 ]; then
-  rmdir "$LOCK_DIR" 2>/dev/null || true
+# --- 3. Release the install lock explicitly before exec. Bash's EXIT
+# trap does NOT fire when `exec` replaces the shell with another program —
+# the shell never "exits" in the sense that triggers EXIT. Without this
+# manual cleanup, an exec into a long-running morphmcp would leave the
+# lock dir behind for the entire session, blocking future upgrades.
+if [ "$LOCK_ACQUIRED" -eq 1 ]; then
+  yellow_morph_release_install_lock
   trap - EXIT INT TERM
 fi
+
+MORPH_ENTRY="${CLAUDE_PLUGIN_DATA}/node_modules/@morphllm/morphmcp/dist/index.js"
 exec node "$MORPH_ENTRY" "$@"

--- a/plugins/yellow-morph/bin/start-morph.sh
+++ b/plugins/yellow-morph/bin/start-morph.sh
@@ -5,7 +5,10 @@
 # for install; it races MCP startup per community precedent):
 #   1. Resolve MORPH_API_KEY from userConfig (preferred) or shell env.
 #   2. Ensure @morphllm/morphmcp is installed in ${CLAUDE_PLUGIN_DATA};
-#      install synchronously if missing.
+#      install synchronously if missing or out of sync with the plugin
+#      install. Reinstall is serialized against the SessionStart prewarm
+#      hook via an atomic mkdir-lock so concurrent `npm ci` cannot corrupt
+#      node_modules.
 #   3. Exec morphmcp.
 #
 # Required env from plugin.json:
@@ -16,7 +19,7 @@
 # Optional inherited env:
 #   MORPH_API_KEY              — shell fallback for power users.
 #
-set -eu
+set -euo pipefail
 
 # --- 1. Resolve the API key. userConfig wins; shell env is fallback.
 if [ -n "${MORPH_API_KEY_USERCONFIG:-}" ]; then
@@ -34,41 +37,83 @@ unset MORPH_API_KEY_USERCONFIG
 # user's home directory. If something else populated these vars with an
 # unexpected path (misconfiguration or compromised env), refuse to install —
 # we do not want `cp` / `npm ci` to write to e.g. /etc or /var.
+#
+# `${HOME:-/__unset__}` sentinel — an unset HOME would otherwise expand to
+# `/*`, matching ANY absolute path and bypassing the check entirely. The
+# sentinel is a path that cannot match any real CLAUDE_PLUGIN_DATA value.
 case "$CLAUDE_PLUGIN_DATA" in
-  "$HOME"/*|/tmp/*) ;;
+  "${HOME:-/__unset__}"/*|/tmp/*) ;;
   *) printf 'yellow-morph: refusing install — CLAUDE_PLUGIN_DATA is not under $HOME or /tmp: %s\n' "$CLAUDE_PLUGIN_DATA" >&2; exit 1 ;;
 esac
 case "$CLAUDE_PLUGIN_ROOT" in
-  "$HOME"/*|/tmp/*|/usr/*|/opt/*) ;;
+  "${HOME:-/__unset__}"/*|/tmp/*|/usr/*|/opt/*) ;;
   *) printf 'yellow-morph: refusing install — CLAUDE_PLUGIN_ROOT has unexpected prefix: %s\n' "$CLAUDE_PLUGIN_ROOT" >&2; exit 1 ;;
 esac
 
 MORPH_ENTRY="${CLAUDE_PLUGIN_DATA}/node_modules/@morphllm/morphmcp/dist/index.js"
+LOCK_DIR="${CLAUDE_PLUGIN_DATA}/.install.lock"
 
-if [ ! -f "$MORPH_ENTRY" ]; then
+# Reinstall when the entry file is missing OR the persistent install
+# diverges from CLAUDE_PLUGIN_ROOT (e.g., after a plugin version bump).
+# Without the lockfile check, an upgraded morphmcp pin would run only on
+# next session unless the SessionStart prewarm hook caught it — and a
+# failed prewarm (network blip, timeout) would silently leave the user
+# on the stale install.
+needs_install() {
+  [ ! -f "$MORPH_ENTRY" ] && return 0
+  ! diff -q "${CLAUDE_PLUGIN_ROOT}/package-lock.json" \
+            "${CLAUDE_PLUGIN_DATA}/package-lock.json" >/dev/null 2>&1
+}
+
+if needs_install; then
   mkdir -p "$CLAUDE_PLUGIN_DATA"
-  # Copy both the manifest AND the committed lockfile so `npm ci` can do a
-  # deterministic, transitive-pinned install. Without the lockfile, npm
-  # falls back to lockfile-less resolution and silently installs whatever
-  # transitive versions the registry currently advertises — a supply-chain
-  # risk that defeats the point of pinning @morphllm/morphmcp.
-  cp "${CLAUDE_PLUGIN_ROOT}/package.json" "${CLAUDE_PLUGIN_DATA}/package.json"
-  cp "${CLAUDE_PLUGIN_ROOT}/package-lock.json" "${CLAUDE_PLUGIN_DATA}/package-lock.json"
-  # Install in a subshell that does NOT inherit MORPH_API_KEY — a malicious
-  # postinstall script in any transitive dep could otherwise exfiltrate the
-  # key before the real MCP server ever starts.
-  printf 'yellow-morph: first-run install of @morphllm/morphmcp into %s...\n' \
-    "$CLAUDE_PLUGIN_DATA" >&2
-  if ! (unset MORPH_API_KEY; cd "$CLAUDE_PLUGIN_DATA" && npm ci --no-audit --no-fund --loglevel=error) >&2; then
-    printf 'yellow-morph: npm ci failed. Run /morph:setup to diagnose.\n' >&2
-    # Remove the copied manifest+lockfile so the next session retries
-    # instead of seeing an out-of-sync state.
-    rm -f "${CLAUDE_PLUGIN_DATA}/package.json" "${CLAUDE_PLUGIN_DATA}/package-lock.json"
+
+  # Acquire an atomic mkdir-lock to serialize against the SessionStart
+  # prewarm hook. `npm ci` deletes node_modules before installing, so two
+  # concurrent runs against the same target would corrupt the install.
+  # mkdir is atomic across POSIX systems (no flock dependency).
+  LOCK_ACQUIRED=0
+  for _i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+      LOCK_ACQUIRED=1
+      trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT INT TERM
+      break
+    fi
+    sleep 1
+  done
+
+  if [ "$LOCK_ACQUIRED" -eq 0 ]; then
+    printf 'yellow-morph: timed out (20s) waiting for install lock at %s\n' "$LOCK_DIR" >&2
+    printf 'yellow-morph: another install may be running, or a stale lock\n' >&2
+    printf 'yellow-morph: needs manual cleanup: rmdir %s\n' "$LOCK_DIR" >&2
     exit 1
+  fi
+
+  # Re-check under the lock — the prewarm hook may have completed the
+  # install while we were waiting, in which case we have nothing to do.
+  if needs_install; then
+    # Copy both the manifest AND the committed lockfile so `npm ci` can do a
+    # deterministic, transitive-pinned install. Without the lockfile, npm
+    # falls back to lockfile-less resolution and silently installs whatever
+    # transitive versions the registry currently advertises — a supply-chain
+    # risk that defeats the point of pinning @morphllm/morphmcp.
+    cp "${CLAUDE_PLUGIN_ROOT}/package.json" "${CLAUDE_PLUGIN_DATA}/package.json"
+    cp "${CLAUDE_PLUGIN_ROOT}/package-lock.json" "${CLAUDE_PLUGIN_DATA}/package-lock.json"
+    # Install in a subshell that does NOT inherit MORPH_API_KEY — a malicious
+    # postinstall script in any transitive dep could otherwise exfiltrate the
+    # key before the real MCP server ever starts.
+    printf 'yellow-morph: installing @morphllm/morphmcp into %s...\n' \
+      "$CLAUDE_PLUGIN_DATA" >&2
+    if ! (unset MORPH_API_KEY; cd "$CLAUDE_PLUGIN_DATA" && npm ci --no-audit --no-fund --loglevel=error) >&2; then
+      printf 'yellow-morph: npm ci failed. Run /morph:setup to diagnose.\n' >&2
+      # Remove the copied manifest+lockfile so the next session retries
+      # instead of seeing an out-of-sync state.
+      rm -f "${CLAUDE_PLUGIN_DATA}/package.json" "${CLAUDE_PLUGIN_DATA}/package-lock.json"
+      exit 1
+    fi
   fi
 fi
 
-# --- 3. Exec morphmcp. The SessionStart hook may have done the same install
-# in parallel; that's OK — npm install is idempotent, and by the time we
-# reach this line the entry file exists.
+# --- 3. Exec morphmcp. By this point the install lock (if we held one) is
+# released by the EXIT trap before exec runs.
 exec node "$MORPH_ENTRY" "$@"

--- a/plugins/yellow-morph/commands/morph/setup.md
+++ b/plugins/yellow-morph/commands/morph/setup.md
@@ -86,47 +86,43 @@ visible progress indicator and surfaces install errors immediately rather
 than hanging the first tool call.
 
 ```bash
-DATA_DIR="${CLAUDE_PLUGIN_DATA:-$HOME/.claude/plugins/data/yellow-morph}"
-ROOT_DIR="${CLAUDE_PLUGIN_ROOT:?CLAUDE_PLUGIN_ROOT must be set}"
-LOCK_DIR="${DATA_DIR}/.install.lock"
+export CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:?CLAUDE_PLUGIN_ROOT must be set}"
+export CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA:-$HOME/.claude/plugins/data/yellow-morph}"
 
-mkdir -p "$DATA_DIR"
+# Source the shared install primitives used by bin/start-morph.sh and the
+# SessionStart prewarm hook. Single source of truth for path validation,
+# the mkdir lock (with PID-file staleness recovery), and the env-isolated
+# npm ci.
+. "${CLAUDE_PLUGIN_ROOT}/lib/install-morphmcp.sh"
 
-# Acquire the same atomic mkdir-lock used by bin/start-morph.sh and the
-# SessionStart prewarm hook. `npm ci` deletes node_modules before installing,
-# so two concurrent runs against the same DATA_DIR corrupt the install.
-# 20 retries × 1s = 20s budget, matching start-morph.sh.
-LOCK_ACQUIRED=0
-for _i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
-  if mkdir "$LOCK_DIR" 2>/dev/null; then
-    LOCK_ACQUIRED=1
-    trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT INT TERM
-    break
+yellow_morph_validate_paths || exit 1
+
+if yellow_morph_needs_install; then
+  mkdir -p "$CLAUDE_PLUGIN_DATA"
+
+  # 20s budget matches start-morph.sh. Stale-PID recovery in the lib
+  # auto-clears locks held by crashed prior holders.
+  if ! yellow_morph_acquire_install_lock 20; then
+    printf 'yellow-morph: timed out (20s) waiting for install lock at %s\n' \
+      "${CLAUDE_PLUGIN_DATA}/.install.lock"
+    printf 'yellow-morph: another install may be running. Manual cleanup if stuck:\n'
+    printf 'yellow-morph:   rmdir %s\n' "${CLAUDE_PLUGIN_DATA}/.install.lock"
+    exit 1
   fi
-  sleep 1
-done
+  trap 'yellow_morph_release_install_lock' EXIT INT TERM
 
-if [ "$LOCK_ACQUIRED" -eq 0 ]; then
-  printf 'yellow-morph: timed out (20s) waiting for install lock at %s\n' "$LOCK_DIR"
-  printf 'yellow-morph: another install may be running, or a stale lock — cleanup: rmdir %s\n' "$LOCK_DIR"
-  exit 1
+  if yellow_morph_needs_install; then
+    if ! yellow_morph_do_install 2>&1; then
+      yellow_morph_cleanup_failed_install
+      yellow_morph_release_install_lock
+      trap - EXIT INT TERM
+      exit 1
+    fi
+  fi
+
+  yellow_morph_release_install_lock
+  trap - EXIT INT TERM
 fi
-
-# Re-check under the lock — the wrapper or prewarm hook may have already
-# completed the install while we were waiting for the lock.
-MORPH_ENTRY="${DATA_DIR}/node_modules/@morphllm/morphmcp/dist/index.js"
-if ! diff -q "${ROOT_DIR}/package-lock.json" "${DATA_DIR}/package-lock.json" >/dev/null 2>&1 \
-   || [ ! -f "$MORPH_ENTRY" ]; then
-  cp "${ROOT_DIR}/package.json" "${DATA_DIR}/package.json"
-  cp "${ROOT_DIR}/package-lock.json" "${DATA_DIR}/package-lock.json"
-  # Use `npm ci` (not `npm install`) to enforce the committed lockfile so the
-  # same transitive deps land here as in SessionStart and the wrapper.
-  # Unset MORPH_API_KEY in the subshell — postinstall scripts must not see it.
-  (cd "$DATA_DIR" && env -u MORPH_API_KEY npm ci --no-audit --no-fund --loglevel=error) 2>&1
-fi
-
-rmdir "$LOCK_DIR" 2>/dev/null || true
-trap - EXIT INT TERM
 ```
 
 On success: "morphmcp installed to ${DATA_DIR}/node_modules. First tool

--- a/plugins/yellow-morph/commands/morph/setup.md
+++ b/plugins/yellow-morph/commands/morph/setup.md
@@ -8,6 +8,7 @@ allowed-tools:
   - Bash
   - Read
   - AskUserQuestion
+  - ToolSearch
 ---
 
 # Set Up yellow-morph

--- a/plugins/yellow-morph/commands/morph/setup.md
+++ b/plugins/yellow-morph/commands/morph/setup.md
@@ -88,14 +88,45 @@ than hanging the first tool call.
 ```bash
 DATA_DIR="${CLAUDE_PLUGIN_DATA:-$HOME/.claude/plugins/data/yellow-morph}"
 ROOT_DIR="${CLAUDE_PLUGIN_ROOT:?CLAUDE_PLUGIN_ROOT must be set}"
+LOCK_DIR="${DATA_DIR}/.install.lock"
 
 mkdir -p "$DATA_DIR"
-cp "${ROOT_DIR}/package.json" "${DATA_DIR}/package.json"
-cp "${ROOT_DIR}/package-lock.json" "${DATA_DIR}/package-lock.json"
-# Use `npm ci` (not `npm install`) to match the wrapper and hook — this
-# enforces the committed lockfile so the same transitive deps land here,
-# in SessionStart, and on first tool invocation.
-(cd "$DATA_DIR" && env -u MORPH_API_KEY npm ci --no-audit --no-fund --loglevel=error) 2>&1
+
+# Acquire the same atomic mkdir-lock used by bin/start-morph.sh and the
+# SessionStart prewarm hook. `npm ci` deletes node_modules before installing,
+# so two concurrent runs against the same DATA_DIR corrupt the install.
+# 20 retries × 1s = 20s budget, matching start-morph.sh.
+LOCK_ACQUIRED=0
+for _i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    LOCK_ACQUIRED=1
+    trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT INT TERM
+    break
+  fi
+  sleep 1
+done
+
+if [ "$LOCK_ACQUIRED" -eq 0 ]; then
+  printf 'yellow-morph: timed out (20s) waiting for install lock at %s\n' "$LOCK_DIR"
+  printf 'yellow-morph: another install may be running, or a stale lock — cleanup: rmdir %s\n' "$LOCK_DIR"
+  exit 1
+fi
+
+# Re-check under the lock — the wrapper or prewarm hook may have already
+# completed the install while we were waiting for the lock.
+MORPH_ENTRY="${DATA_DIR}/node_modules/@morphllm/morphmcp/dist/index.js"
+if ! diff -q "${ROOT_DIR}/package-lock.json" "${DATA_DIR}/package-lock.json" >/dev/null 2>&1 \
+   || [ ! -f "$MORPH_ENTRY" ]; then
+  cp "${ROOT_DIR}/package.json" "${DATA_DIR}/package.json"
+  cp "${ROOT_DIR}/package-lock.json" "${DATA_DIR}/package-lock.json"
+  # Use `npm ci` (not `npm install`) to enforce the committed lockfile so the
+  # same transitive deps land here as in SessionStart and the wrapper.
+  # Unset MORPH_API_KEY in the subshell — postinstall scripts must not see it.
+  (cd "$DATA_DIR" && env -u MORPH_API_KEY npm ci --no-audit --no-fund --loglevel=error) 2>&1
+fi
+
+rmdir "$LOCK_DIR" 2>/dev/null || true
+trap - EXIT INT TERM
 ```
 
 On success: "morphmcp installed to ${DATA_DIR}/node_modules. First tool

--- a/plugins/yellow-morph/commands/morph/setup.md
+++ b/plugins/yellow-morph/commands/morph/setup.md
@@ -92,7 +92,11 @@ ROOT_DIR="${CLAUDE_PLUGIN_ROOT:?CLAUDE_PLUGIN_ROOT must be set}"
 
 mkdir -p "$DATA_DIR"
 cp "${ROOT_DIR}/package.json" "${DATA_DIR}/package.json"
-(cd "$DATA_DIR" && npm install --no-audit --no-fund --loglevel=error) 2>&1
+cp "${ROOT_DIR}/package-lock.json" "${DATA_DIR}/package-lock.json"
+# Use `npm ci` (not `npm install`) to match the wrapper and hook — this
+# enforces the committed lockfile so the same transitive deps land here,
+# in SessionStart, and on first tool invocation.
+(cd "$DATA_DIR" && env -u MORPH_API_KEY npm ci --no-audit --no-fund --loglevel=error) 2>&1
 ```
 
 On success: "morphmcp installed to ${DATA_DIR}/node_modules. First tool

--- a/plugins/yellow-morph/commands/morph/setup.md
+++ b/plugins/yellow-morph/commands/morph/setup.md
@@ -1,8 +1,6 @@
 ---
 name: morph:setup
-description:
-  'Check prerequisites and configure Morph API key. Use when first installing
-  the plugin, when morph tools fail, or to verify API connectivity.'
+description: "Check prerequisites and configure Morph API key. Use when first installing the plugin, when morph tools fail, or to verify API connectivity."
 argument-hint: ''
 allowed-tools:
   - Bash
@@ -30,7 +28,7 @@ command -v rg   >/dev/null 2>&1 && printf 'ripgrep (rg):  OK\n' || printf 'ripgr
 command -v node >/dev/null 2>&1 && printf 'node:          OK (%s)\n' "$(node --version 2>/dev/null)" || printf 'node:          NOT FOUND\n'
 command -v npm  >/dev/null 2>&1 && printf 'npm:           OK (%s)\n' "$(npm --version 2>/dev/null)" || printf 'npm:           NOT FOUND\n'
 printf '\n=== Environment ===\n'
-[ -n "${MORPH_API_KEY:-}" ] && printf '%-28s set (%s...) — fallback path\n' 'MORPH_API_KEY (shell):' "$(printf '%s' "$MORPH_API_KEY" | head -c 4)" || printf '%-28s not set\n' 'MORPH_API_KEY (shell):'
+[ -n "${MORPH_API_KEY:-}" ] && printf '%-28s set — fallback path\n' 'MORPH_API_KEY (shell):' || printf '%-28s not set\n' 'MORPH_API_KEY (shell):'
 ```
 
 Collect **all** failures before stopping — report them together.

--- a/plugins/yellow-morph/commands/morph/setup.md
+++ b/plugins/yellow-morph/commands/morph/setup.md
@@ -12,8 +12,10 @@ allowed-tools:
 
 # Set Up yellow-morph
 
-Verify prerequisites, configure MORPH_API_KEY, and verify MCP server
-connectivity.
+Verify prerequisites, confirm a Morph API key is configured (via plugin
+`userConfig` — the recommended path — or shell `MORPH_API_KEY` as fallback),
+pre-install `@morphllm/morphmcp` into the plugin data directory so the first
+tool call is instant, and verify API connectivity.
 
 ## Workflow
 
@@ -25,9 +27,9 @@ Run all prerequisite checks in a single Bash call:
 printf '=== Prerequisites ===\n'
 command -v rg   >/dev/null 2>&1 && printf 'ripgrep (rg):  OK\n' || printf 'ripgrep (rg):  NOT FOUND\n'
 command -v node >/dev/null 2>&1 && printf 'node:          OK (%s)\n' "$(node --version 2>/dev/null)" || printf 'node:          NOT FOUND\n'
-command -v npx  >/dev/null 2>&1 && printf 'npx:           OK\n' || printf 'npx:           NOT FOUND\n'
+command -v npm  >/dev/null 2>&1 && printf 'npm:           OK (%s)\n' "$(npm --version 2>/dev/null)" || printf 'npm:           NOT FOUND\n'
 printf '\n=== Environment ===\n'
-[ -n "${MORPH_API_KEY:-}" ] && printf '%-20s set (%s...)\n' 'MORPH_API_KEY:' "$(printf '%s' "$MORPH_API_KEY" | head -c 4)" || printf '%-20s NOT SET\n' 'MORPH_API_KEY:'
+[ -n "${MORPH_API_KEY:-}" ] && printf '%-28s set (%s...) — fallback path\n' 'MORPH_API_KEY (shell):' "$(printf '%s' "$MORPH_API_KEY" | head -c 4)" || printf '%-28s not set\n' 'MORPH_API_KEY (shell):'
 ```
 
 Collect **all** failures before stopping — report them together.
@@ -38,46 +40,79 @@ Stop conditions (after reporting all):
   https://github.com/BurntSushi/ripgrep#installation"
 - `node` not found: "Node.js 22.22.0 or later is required. Install from
   https://nodejs.org/"
-- `npx` not found: "npx is required (bundled with Node.js). Verify Node.js
+- `npm` not found: "npm is required (bundled with Node.js). Verify Node.js
   installation."
 - Node <22.22.0: "Node.js 22.22.0 or later is required. Current: vX.Y.Z. Please
   upgrade."
 
-Node version check: If node version is below 22.22.0, stop with: "Node.js
-22.22.0 or later is required. Current: vX.Y.Z. Please upgrade Node.js from
-https://nodejs.org/, then re-run /morph:setup."
+Shell `MORPH_API_KEY` not set is **not** a failure — the `userConfig` path
+(recommended) stores the key in the system keychain instead.
 
-`MORPH_API_KEY` not set is a warning, not a stop — continue to Step 2.
+### Step 2: Verify Morph API Key is Configured
 
-### Step 2: API Key Configuration
+The yellow-morph plugin reads its API key from `userConfig.morph_api_key`
+(prompted at plugin-enable time) with shell `MORPH_API_KEY` as a power-user
+fallback.
 
-If `MORPH_API_KEY` is not set:
+Use `ToolSearch` with query `"+morph edit_file"` to check whether the MCP
+server has started. If `mcp__plugin_yellow-morph_morph__edit_file` is
+visible, the key is configured and accepted — skip to Step 3.
 
-Ask via AskUserQuestion: "MORPH_API_KEY is not set. Do you have a Morph API
-key?"
+If the tool is NOT visible, the MCP server did not start. Ask via
+AskUserQuestion: "No Morph API key is configured. How would you like to
+provide one?"
 
-- **Yes, I have one** → "Please set it in your shell profile and restart Claude
-  Code:
+- **Answer the userConfig prompt (recommended)** → "Run
+  `/plugin disable yellow-morph` then `/plugin enable yellow-morph`.
+  Claude Code will prompt you for the key; it is stored in the system
+  keychain (or `~/.claude/.credentials.json` at 0600 perms on Linux). No
+  shell export and no Claude Code restart are required — the MCP server
+  picks up the new key when it starts on the next tool invocation. Get a
+  key at https://morphllm.com (free tier: 250K credits/month)."
+- **Export as shell env var (fallback, power users)** → "Add
+  `export MORPH_API_KEY=your-key-here` to `~/.zshrc` or `~/.bashrc`, then
+  **restart Claude Code**. This path is less ergonomic because it requires
+  the restart, but it continues to work for users who prefer shell-level
+  secrets management."
+- **Skip (I just want to check prereqs)** → Stop here. Privacy note
+  applies regardless: "Note: Morph tools send code to Morph's API servers.
+  Free/Starter tiers retain data for 90 days. See
+  https://morphllm.com/privacy"
 
-  ```bash
-  echo 'export MORPH_API_KEY=your-key-here' >> ~/.zshrc  # or ~/.bashrc
-  source ~/.zshrc
-  ```
+### Step 3: Pre-install morphmcp into the plugin data directory
 
-  Then re-run `/morph:setup` to verify." Show info: "Get a key at
-  https://morphllm.com — free tier includes 250K credits/month." Stop here
-  (cannot verify without key).
+The plugin ships a wrapper script that installs `@morphllm/morphmcp` on
+first invocation, but running the install during setup gives the user a
+visible progress indicator and surfaces install errors immediately rather
+than hanging the first tool call.
 
-- **No, I need one** → "Sign up at https://morphllm.com to get an API key. Free
-  tier includes 250K credits/month (200 requests/month)." Show privacy note:
-  "Note: Morph tools send code to Morph's API servers. Free/Starter tiers retain
-  data for 90 days. See https://morphllm.com/privacy" Stop here.
+```bash
+DATA_DIR="${CLAUDE_PLUGIN_DATA:-$HOME/.claude/plugins/data/yellow-morph}"
+ROOT_DIR="${CLAUDE_PLUGIN_ROOT:?CLAUDE_PLUGIN_ROOT must be set}"
 
-If `MORPH_API_KEY` is set: continue to Step 3.
+mkdir -p "$DATA_DIR"
+cp "${ROOT_DIR}/package.json" "${DATA_DIR}/package.json"
+(cd "$DATA_DIR" && npm install --no-audit --no-fund --loglevel=error) 2>&1
+```
 
-### Step 3: Verify API Connectivity
+On success: "morphmcp installed to ${DATA_DIR}/node_modules. First tool
+call will be instant."
 
-Test API key with a minimal completion call:
+Handle install failures with actionable messages:
+
+- **Permission error writing ${DATA_DIR}**: "Cannot write to plugin data
+  directory. Check permissions: `ls -ld ${DATA_DIR}`."
+- **npm ENOSPC (disk full)**: "Disk full. Free space under ${DATA_DIR} and
+  retry."
+- **npm ECONNREFUSED / 403**: "Cannot reach the npm registry. Check
+  network / proxy settings (HTTP_PROXY, HTTPS_PROXY)."
+- **Other npm errors**: print the tail of npm output, suggest re-running
+  `/morph:setup` after fixing, and continue — the SessionStart hook and
+  wrapper script will retry on next session.
+
+### Step 4: Verify API Connectivity (optional — skipped without shell env)
+
+If shell `MORPH_API_KEY` is set, test connectivity:
 
 ```bash
 HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
@@ -94,25 +129,18 @@ else
 fi
 ```
 
-- **200**: API key valid. Continue to Step 4.
+- **200**: API key valid.
 - **401**: "API key is invalid. Check your MORPH_API_KEY value." Stop.
 - **403**: "API key is forbidden. Your account may be suspended." Stop.
 - **000 or empty**: "Cannot reach Morph API. Check network connectivity to
   api.morphllm.com." Stop.
-- **429**: "Rate limit exceeded. You may have exhausted your free tier credits."
-  Warn, continue.
+- **429**: "Rate limit exceeded. You may have exhausted your free tier
+  credits." Warn, continue.
 
-### Step 4: Verify MCP Package
-
-Check that the MCP package is accessible from the npm registry:
-
-```bash
-npm view @morphllm/morphmcp@0.8.110 version 2>/dev/null || echo "NPM_LOOKUP_FAILED"
-```
-
-- Version output (e.g., `0.8.110`): Package accessible. Continue to Step 5.
-- `NPM_LOOKUP_FAILED`: "Cannot query npm registry for @morphllm/morphmcp. Check
-  npm access." Warn, continue.
+If shell `MORPH_API_KEY` is not set but the MCP tool was visible in Step 2,
+skip this step — the userConfig key is not readable from the shell.
+Connectivity is implicitly verified by the MCP server having started with
+tools exposed.
 
 ### Step 5: Report
 

--- a/plugins/yellow-morph/commands/morph/status.md
+++ b/plugins/yellow-morph/commands/morph/status.md
@@ -12,69 +12,117 @@ allowed-tools:
 
 # Morph Status
 
-Show API health and MCP tool availability.
+Show API health and MCP tool availability, classified as one of three states:
+
+- **OFFLINE** — morph MCP tools are not visible to Claude Code. The server
+  never started (no key configured, or it crashed at boot). Built-in
+  Edit/Grep handle everything.
+- **DEGRADED** — MCP tools are loaded, but the API health probe returns a
+  non-200 status. Tools are callable but will fail at invocation time.
+- **HEALTHY** — MCP tools loaded AND API responds 200.
 
 ## Workflow
 
-### Step 1: Check Environment
+### Step 1: Check MCP tool visibility (authoritative OFFLINE detection)
+
+Call `ToolSearch` with query `"+morph edit_file"`. If
+`mcp__plugin_yellow-morph_morph__edit_file` is NOT returned, the MCP server
+did not start — the plugin is **OFFLINE**. Skip the API probe and report:
+
+```text
+yellow-morph Status: OFFLINE
+
+MCP Tools
+  mcp__plugin_yellow-morph_morph__edit_file       not loaded
+  mcp__plugin_yellow-morph_morph__codebase_search not loaded
+
+What to do:
+  1. Confirm the plugin is enabled: `/plugin list`
+  2. If enabled: the MCP server failed to start. Most likely cause is that
+     the `userConfig.morph_api_key` prompt was never answered, or the stored
+     value was cleared. Run `/morph:setup` to re-prompt.
+  3. If the prompt does not fire on setup, disable and re-enable the plugin
+     (`/plugin disable yellow-morph` then `/plugin enable yellow-morph`) —
+     known Claude Code quirk (GitHub issue #39827).
+  4. If userConfig is already set, check keychain/credentials permissions:
+     `ls -l ~/.claude/.credentials.json` (should be 0600, owned by you).
+```
+
+If the tool IS visible, continue to Step 2.
+
+### Step 2: Read the configured key source
 
 ```bash
 printf '=== Environment ===\n'
-[ -n "${MORPH_API_KEY:-}" ] && printf 'MORPH_API_KEY:  set\n' || printf 'MORPH_API_KEY:  NOT SET\n'
+[ -n "${MORPH_API_KEY:-}" ] && printf 'MORPH_API_KEY (shell):  set (fallback)\n' || printf 'MORPH_API_KEY (shell):  not set\n'
 [ -n "${MORPH_WARP_GREP_TIMEOUT:-}" ] && printf 'MORPH_WARP_GREP_TIMEOUT: %s ms\n' "$MORPH_WARP_GREP_TIMEOUT" || printf 'MORPH_WARP_GREP_TIMEOUT: 30000 ms (default)\n'
 ```
 
-If `MORPH_API_KEY` is not set: report "MORPH_API_KEY not set. Run `/morph:setup`
-to configure." and stop.
+The `userConfig.morph_api_key` value is stored in the system keychain or
+`~/.claude/.credentials.json` and is not directly readable from shell — we
+rely on MCP tool visibility (Step 1) to confirm it is set and accepted.
 
-### Step 2: Check API Health
+### Step 3: Probe API health
+
+The shell env var may not be set even when the plugin is healthy (userConfig
+supplies the key to the MCP server directly). Use either the shell env var
+when present, or skip the API probe and rely on MCP tool-level health.
 
 ```bash
-HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
-  --connect-timeout 5 --max-time 8 \
-  -H "Authorization: Bearer ${MORPH_API_KEY}" \
-  -H "Content-Type: application/json" \
-  -d '{"model":"morph-v3-fast","messages":[{"role":"user","content":"ping"}],"max_tokens":1}' \
-  https://api.morphllm.com/v1/chat/completions 2>/dev/null)
-CURL_EXIT=$?
-if [ "$CURL_EXIT" -ne 0 ]; then
-  printf 'API status: UNREACHABLE (curl exit %d)\n' "$CURL_EXIT"
+if [ -n "${MORPH_API_KEY:-}" ]; then
+  HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+    --connect-timeout 5 --max-time 8 \
+    -H "Authorization: Bearer ${MORPH_API_KEY}" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"morph-v3-fast","messages":[{"role":"user","content":"ping"}],"max_tokens":1}' \
+    https://api.morphllm.com/v1/chat/completions 2>/dev/null)
+  CURL_EXIT=$?
+  if [ "$CURL_EXIT" -ne 0 ]; then
+    printf 'API status: UNREACHABLE (curl exit %d)\n' "$CURL_EXIT"
+  else
+    printf 'API status: %s\n' "$HTTP_CODE"
+  fi
 else
-  printf 'API status: %s\n' "$HTTP_CODE"
+  printf 'API status: skipped (no shell MORPH_API_KEY; MCP tools loaded so userConfig is set)\n'
 fi
 ```
 
-- **200**: API reachable and authenticated
-- **401**: "API key invalid"
-- **429**: "Rate limit exceeded — credits may be exhausted"
-- **Other**: "API unreachable (HTTP $HTTP_CODE)"
-
-### Step 3: Check MCP Tool Availability
-
-Use ToolSearch to check if morph MCP tools are loaded:
-
-```bash
-ToolSearch query: "+morph edit"
-```
-
-Report whether `mcp__plugin_yellow-morph_morph__edit_file` and `mcp__plugin_yellow-morph_morph__warpgrep_codebase_search` are available.
+- **200**: API reachable and authenticated — **HEALTHY**
+- **401**: API key invalid — **DEGRADED**
+- **429**: Rate limit exceeded — credits may be exhausted — **DEGRADED**
+- **UNREACHABLE / other**: **DEGRADED**
+- **Skipped (userConfig-only)**: treat as **HEALTHY** since the MCP server
+  authenticates at startup; if the key were bad, the MCP tools would be
+  absent (OFFLINE).
 
 ### Step 4: Report
 
 ```text
-yellow-morph Status
-===================
+yellow-morph Status: HEALTHY | DEGRADED | OFFLINE
+======================================
 
 Environment
-  MORPH_API_KEY         set
-  MORPH_WARP_GREP_TIMEOUT  30000 ms
+  MORPH_API_KEY (shell)     set (fallback) | not set
+  userConfig.morph_api_key  assumed set (MCP tools loaded) | unset (OFFLINE)
+  MORPH_WARP_GREP_TIMEOUT   30000 ms
 
 API
-  Status                OK (200)
+  Status                    200 (HEALTHY) | 401 (DEGRADED) | skipped (HEALTHY)
 
 MCP Tools
-  mcp__plugin_yellow-morph_morph__edit_file             available | not loaded
-  mcp__plugin_yellow-morph_morph__warpgrep_codebase_search  available | not loaded
+  mcp__plugin_yellow-morph_morph__edit_file       available | not loaded
+  mcp__plugin_yellow-morph_morph__codebase_search available | not loaded
 
 Overall: HEALTHY | DEGRADED | OFFLINE
 ```
+
+### Classification summary
+
+| MCP tools | API probe                | State      |
+| --------- | ------------------------ | ---------- |
+| not loaded| (not run)                | OFFLINE    |
+| loaded    | 200 or skipped           | HEALTHY    |
+| loaded    | 401 / 429 / unreachable  | DEGRADED   |
+
+For each state, print a "What to do" next-step block so the user has a
+concrete action to take.

--- a/plugins/yellow-morph/commands/morph/status.md
+++ b/plugins/yellow-morph/commands/morph/status.md
@@ -1,8 +1,6 @@
 ---
 name: morph:status
-description: "Show Morph API health and MCP server state. Use when morph tools
-  seem slow, to verify connectivity, or to check tool availability. Note: API
-  health check consumes one API request (counts against rate limits)."
+description: "Show Morph API health and MCP server state. Use when morph tools seem slow, to verify connectivity, or to check tool availability. Note: API health check consumes one API request (counts against rate limits)."
 argument-hint: ''
 allowed-tools:
   - Bash

--- a/plugins/yellow-morph/commands/morph/status.md
+++ b/plugins/yellow-morph/commands/morph/status.md
@@ -81,17 +81,22 @@ if [ -n "${MORPH_API_KEY:-}" ]; then
     printf 'API status: %s\n' "$HTTP_CODE"
   fi
 else
-  printf 'API status: skipped (no shell MORPH_API_KEY; MCP tools loaded so userConfig is set)\n'
+  printf 'API status: skipped (probe not possible — key is in keychain, not accessible to bash)\n'
 fi
 ```
 
 - **200**: API reachable and authenticated — **HEALTHY**
-- **401**: API key invalid — **DEGRADED**
-- **429**: Rate limit exceeded — credits may be exhausted — **DEGRADED**
-- **UNREACHABLE / other**: **DEGRADED**
-- **Skipped (userConfig-only)**: treat as **HEALTHY** since the MCP server
-  authenticates at startup; if the key were bad, the MCP tools would be
-  absent (OFFLINE).
+- **401**: API key invalid — **DEGRADED** (only reachable when `MORPH_API_KEY`
+  is exported in the shell environment)
+- **429**: Rate limit exceeded — credits may be exhausted — **DEGRADED** (only
+  reachable when `MORPH_API_KEY` is exported in the shell environment)
+- **UNREACHABLE / other**: **DEGRADED** (only reachable when `MORPH_API_KEY` is
+  exported in the shell environment)
+- **Skipped (userConfig-only)**: **HEALTHY (probe skipped — key in keychain,
+  not accessible to bash)**. The status command cannot detect invalid keys,
+  exhausted credits, or API outages for keychain-backed installs. To probe the
+  API directly, temporarily export your key in the shell:
+  `export MORPH_API_KEY=<your-key>` and re-run `/morph:status`.
 
 ### Step 4: Report
 
@@ -105,7 +110,7 @@ Environment
   MORPH_WARP_GREP_TIMEOUT   30000 ms
 
 API
-  Status                    200 (HEALTHY) | 401 (DEGRADED) | skipped (HEALTHY)
+  Status                    200 (HEALTHY) | 401 (DEGRADED) | skipped (HEALTHY — probe skipped)
 
 MCP Tools
   mcp__plugin_yellow-morph_morph__edit_file       available | not loaded
@@ -119,8 +124,9 @@ Overall: HEALTHY | DEGRADED | OFFLINE
 | MCP tools | API probe                | State      |
 | --------- | ------------------------ | ---------- |
 | not loaded| (not run)                | OFFLINE    |
-| loaded    | 200 or skipped           | HEALTHY    |
-| loaded    | 401 / 429 / unreachable  | DEGRADED   |
+| loaded    | 200                      | HEALTHY    |
+| loaded    | skipped (keychain path)  | HEALTHY (probe skipped) |
+| loaded    | 401 / 429 / unreachable  | DEGRADED (shell env path only) |
 
 For each state, print a "What to do" next-step block so the user has a
 concrete action to take.

--- a/plugins/yellow-morph/hooks/hooks.json
+++ b/plugins/yellow-morph/hooks/hooks.json
@@ -4,7 +4,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "diff -q \"${CLAUDE_PLUGIN_ROOT}/package.json\" \"${CLAUDE_PLUGIN_DATA}/package.json\" >/dev/null 2>&1 || (mkdir -p \"${CLAUDE_PLUGIN_DATA}\" && cp \"${CLAUDE_PLUGIN_ROOT}/package.json\" \"${CLAUDE_PLUGIN_DATA}/package.json\" && cd \"${CLAUDE_PLUGIN_DATA}\" && npm install --no-audit --no-fund --loglevel=error) || rm -f \"${CLAUDE_PLUGIN_DATA}/package.json\""
+          "command": "case \"${CLAUDE_PLUGIN_DATA}\" in \"${HOME}\"/*|/tmp/*) : ;; *) exit 0 ;; esac; diff -q \"${CLAUDE_PLUGIN_ROOT}/package-lock.json\" \"${CLAUDE_PLUGIN_DATA}/package-lock.json\" >/dev/null 2>&1 || (mkdir -p \"${CLAUDE_PLUGIN_DATA}\" && cp \"${CLAUDE_PLUGIN_ROOT}/package.json\" \"${CLAUDE_PLUGIN_DATA}/package.json\" && cp \"${CLAUDE_PLUGIN_ROOT}/package-lock.json\" \"${CLAUDE_PLUGIN_DATA}/package-lock.json\" && cd \"${CLAUDE_PLUGIN_DATA}\" && env -u MORPH_API_KEY npm ci --no-audit --no-fund --loglevel=error) || rm -f \"${CLAUDE_PLUGIN_DATA}/package.json\" \"${CLAUDE_PLUGIN_DATA}/package-lock.json\""
         }
       ]
     }

--- a/plugins/yellow-morph/hooks/hooks.json
+++ b/plugins/yellow-morph/hooks/hooks.json
@@ -1,0 +1,12 @@
+{
+  "SessionStart": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "diff -q \"${CLAUDE_PLUGIN_ROOT}/package.json\" \"${CLAUDE_PLUGIN_DATA}/package.json\" >/dev/null 2>&1 || (mkdir -p \"${CLAUDE_PLUGIN_DATA}\" && cp \"${CLAUDE_PLUGIN_ROOT}/package.json\" \"${CLAUDE_PLUGIN_DATA}/package.json\" && cd \"${CLAUDE_PLUGIN_DATA}\" && npm install --no-audit --no-fund --loglevel=error) || rm -f \"${CLAUDE_PLUGIN_DATA}/package.json\""
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/yellow-morph/hooks/hooks.json
+++ b/plugins/yellow-morph/hooks/hooks.json
@@ -1,10 +1,13 @@
 {
+  "_comment": "Reference only — Claude Code reads inline hooks from plugin.json. The authoritative SessionStart hook runs hooks/scripts/prewarm-morph.sh.",
   "SessionStart": [
     {
+      "matcher": "*",
       "hooks": [
         {
           "type": "command",
-          "command": "case \"${CLAUDE_PLUGIN_DATA}\" in \"${HOME}\"/*|/tmp/*) : ;; *) exit 0 ;; esac; diff -q \"${CLAUDE_PLUGIN_ROOT}/package-lock.json\" \"${CLAUDE_PLUGIN_DATA}/package-lock.json\" >/dev/null 2>&1 || (mkdir -p \"${CLAUDE_PLUGIN_DATA}\" && cp \"${CLAUDE_PLUGIN_ROOT}/package.json\" \"${CLAUDE_PLUGIN_DATA}/package.json\" && cp \"${CLAUDE_PLUGIN_ROOT}/package-lock.json\" \"${CLAUDE_PLUGIN_DATA}/package-lock.json\" && cd \"${CLAUDE_PLUGIN_DATA}\" && env -u MORPH_API_KEY npm ci --no-audit --no-fund --loglevel=error) || rm -f \"${CLAUDE_PLUGIN_DATA}/package.json\" \"${CLAUDE_PLUGIN_DATA}/package-lock.json\""
+          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prewarm-morph.sh",
+          "timeout": 30
         }
       ]
     }

--- a/plugins/yellow-morph/hooks/scripts/prewarm-morph.sh
+++ b/plugins/yellow-morph/hooks/scripts/prewarm-morph.sh
@@ -17,67 +17,40 @@ json_exit() {
   exit 0
 }
 
-# Defense in depth — refuse to write outside the user's home or /tmp.
-case "${CLAUDE_PLUGIN_DATA:-}" in
-  "${HOME:-/__unset__}"/*|/tmp/*) ;;
-  '') json_exit "CLAUDE_PLUGIN_DATA unset; skipping prewarm" ;;
-  *) json_exit "CLAUDE_PLUGIN_DATA outside HOME and /tmp; skipping prewarm" ;;
-esac
-
+# Source install primitives. The lib must be present; if it's missing the
+# plugin install is broken in a more fundamental way and we can't safely
+# do anything except yield.
 if [ -z "${CLAUDE_PLUGIN_ROOT:-}" ]; then
   json_exit "CLAUDE_PLUGIN_ROOT unset; skipping prewarm"
 fi
+LIB="${CLAUDE_PLUGIN_ROOT}/lib/install-morphmcp.sh"
+if [ ! -r "$LIB" ]; then
+  json_exit "lib/install-morphmcp.sh missing; skipping prewarm"
+fi
+# shellcheck source=../../lib/install-morphmcp.sh
+. "$LIB"
+
+yellow_morph_validate_paths || json_exit "path validation failed; skipping prewarm"
 
 # Already in sync — nothing to do.
-if diff -q "${CLAUDE_PLUGIN_ROOT}/package-lock.json" \
-           "${CLAUDE_PLUGIN_DATA}/package-lock.json" >/dev/null 2>&1; then
-  json_exit
-fi
+yellow_morph_needs_install || json_exit
 
 mkdir -p "$CLAUDE_PLUGIN_DATA" || json_exit "mkdir failed; skipping prewarm"
 
-# Acquire the same atomic mkdir-lock that bin/start-morph.sh uses so a
-# wrapper invocation that races us cannot run a second `npm ci` concurrently.
-# `npm ci` deletes node_modules before installing — concurrent runs corrupt
-# the install. Prewarm is purely an optimization, so if we cannot get the
-# lock within a few seconds we yield to the wrapper and exit.
-LOCK_DIR="${CLAUDE_PLUGIN_DATA}/.install.lock"
-LOCK_ACQUIRED=0
-for _i in 1 2 3 4 5; do
-  if mkdir "$LOCK_DIR" 2>/dev/null; then
-    LOCK_ACQUIRED=1
-    trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT INT TERM
-    break
-  fi
-  sleep 1
-done
-
-if [ "$LOCK_ACQUIRED" -eq 0 ]; then
+# 5s budget. Prewarm is purely an optimization — if we can't acquire the
+# lock quickly, yield to whoever has it (probably the wrapper) and exit.
+if ! yellow_morph_acquire_install_lock 5; then
   json_exit "install lock held by another process; yielding to start-morph.sh"
 fi
+trap 'yellow_morph_release_install_lock' EXIT INT TERM
 
 # Re-check under the lock — the wrapper or a previous prewarm may have
 # completed the install while we were waiting.
-if diff -q "${CLAUDE_PLUGIN_ROOT}/package-lock.json" \
-           "${CLAUDE_PLUGIN_DATA}/package-lock.json" >/dev/null 2>&1; then
+yellow_morph_needs_install || json_exit
+
+if yellow_morph_do_install >&2; then
   json_exit
 fi
 
-cp "${CLAUDE_PLUGIN_ROOT}/package.json"      "${CLAUDE_PLUGIN_DATA}/package.json" \
-  || json_exit "package.json copy failed; skipping prewarm"
-cp "${CLAUDE_PLUGIN_ROOT}/package-lock.json" "${CLAUDE_PLUGIN_DATA}/package-lock.json" \
-  || json_exit "package-lock.json copy failed; skipping prewarm"
-
-# Install in a subshell that does NOT inherit MORPH_API_KEY — a malicious
-# postinstall script in any transitive dep could otherwise exfiltrate the key
-# before the real MCP server starts.
-if (cd "$CLAUDE_PLUGIN_DATA" && env -u MORPH_API_KEY \
-    npm ci --no-audit --no-fund --loglevel=error) >&2; then
-  json_exit
-fi
-
-# Install failed — remove the copied manifest+lockfile so the next session
-# retries from a clean state instead of seeing an out-of-sync install.
-rm -f "${CLAUDE_PLUGIN_DATA}/package.json" \
-      "${CLAUDE_PLUGIN_DATA}/package-lock.json"
+yellow_morph_cleanup_failed_install
 json_exit "npm ci failed; start-morph.sh will retry synchronously on first MCP call"

--- a/plugins/yellow-morph/hooks/scripts/prewarm-morph.sh
+++ b/plugins/yellow-morph/hooks/scripts/prewarm-morph.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# yellow-morph SessionStart hook — pre-warm @morphllm/morphmcp install before
+# the first MCP tool call so morph startup is fast on first use.
+#
+# Note: -e omitted intentionally — hook must output {"continue": true} on all
+# paths, even when individual commands fail. start-morph.sh handles install
+# synchronously as a correctness gate; this hook is purely an optimization.
+set -uo pipefail
+
+# Centralized JSON-output exit. Claude Code BLOCKS session startup if a
+# SessionStart hook exits without printing this line, so every code path —
+# including failures — must terminate via json_exit.
+json_exit() {
+  local msg="${1:-}"
+  [ -n "$msg" ] && printf '[yellow-morph] %s\n' "$msg" >&2
+  printf '{"continue": true}\n'
+  exit 0
+}
+
+# Defense in depth — refuse to write outside the user's home or /tmp.
+case "${CLAUDE_PLUGIN_DATA:-}" in
+  "${HOME:-/__unset__}"/*|/tmp/*) ;;
+  '') json_exit "CLAUDE_PLUGIN_DATA unset; skipping prewarm" ;;
+  *) json_exit "CLAUDE_PLUGIN_DATA outside HOME and /tmp; skipping prewarm" ;;
+esac
+
+if [ -z "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  json_exit "CLAUDE_PLUGIN_ROOT unset; skipping prewarm"
+fi
+
+# Already in sync — nothing to do.
+if diff -q "${CLAUDE_PLUGIN_ROOT}/package-lock.json" \
+           "${CLAUDE_PLUGIN_DATA}/package-lock.json" >/dev/null 2>&1; then
+  json_exit
+fi
+
+mkdir -p "$CLAUDE_PLUGIN_DATA" || json_exit "mkdir failed; skipping prewarm"
+cp "${CLAUDE_PLUGIN_ROOT}/package.json"      "${CLAUDE_PLUGIN_DATA}/package.json" \
+  || json_exit "package.json copy failed; skipping prewarm"
+cp "${CLAUDE_PLUGIN_ROOT}/package-lock.json" "${CLAUDE_PLUGIN_DATA}/package-lock.json" \
+  || json_exit "package-lock.json copy failed; skipping prewarm"
+
+# Install in a subshell that does NOT inherit MORPH_API_KEY — a malicious
+# postinstall script in any transitive dep could otherwise exfiltrate the key
+# before the real MCP server starts.
+if (cd "$CLAUDE_PLUGIN_DATA" && env -u MORPH_API_KEY \
+    npm ci --no-audit --no-fund --loglevel=error) >&2; then
+  json_exit
+fi
+
+# Install failed — remove the copied manifest+lockfile so the next session
+# retries from a clean state instead of seeing an out-of-sync install.
+rm -f "${CLAUDE_PLUGIN_DATA}/package.json" \
+      "${CLAUDE_PLUGIN_DATA}/package-lock.json"
+json_exit "npm ci failed; start-morph.sh will retry synchronously on first MCP call"

--- a/plugins/yellow-morph/hooks/scripts/prewarm-morph.sh
+++ b/plugins/yellow-morph/hooks/scripts/prewarm-morph.sh
@@ -35,6 +35,34 @@ if diff -q "${CLAUDE_PLUGIN_ROOT}/package-lock.json" \
 fi
 
 mkdir -p "$CLAUDE_PLUGIN_DATA" || json_exit "mkdir failed; skipping prewarm"
+
+# Acquire the same atomic mkdir-lock that bin/start-morph.sh uses so a
+# wrapper invocation that races us cannot run a second `npm ci` concurrently.
+# `npm ci` deletes node_modules before installing — concurrent runs corrupt
+# the install. Prewarm is purely an optimization, so if we cannot get the
+# lock within a few seconds we yield to the wrapper and exit.
+LOCK_DIR="${CLAUDE_PLUGIN_DATA}/.install.lock"
+LOCK_ACQUIRED=0
+for _i in 1 2 3 4 5; do
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    LOCK_ACQUIRED=1
+    trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT INT TERM
+    break
+  fi
+  sleep 1
+done
+
+if [ "$LOCK_ACQUIRED" -eq 0 ]; then
+  json_exit "install lock held by another process; yielding to start-morph.sh"
+fi
+
+# Re-check under the lock — the wrapper or a previous prewarm may have
+# completed the install while we were waiting.
+if diff -q "${CLAUDE_PLUGIN_ROOT}/package-lock.json" \
+           "${CLAUDE_PLUGIN_DATA}/package-lock.json" >/dev/null 2>&1; then
+  json_exit
+fi
+
 cp "${CLAUDE_PLUGIN_ROOT}/package.json"      "${CLAUDE_PLUGIN_DATA}/package.json" \
   || json_exit "package.json copy failed; skipping prewarm"
 cp "${CLAUDE_PLUGIN_ROOT}/package-lock.json" "${CLAUDE_PLUGIN_DATA}/package-lock.json" \

--- a/plugins/yellow-morph/lib/install-morphmcp.sh
+++ b/plugins/yellow-morph/lib/install-morphmcp.sh
@@ -1,0 +1,140 @@
+#!/bin/false
+# yellow-morph install primitives. Sourced by:
+#   - bin/start-morph.sh                 (synchronous correctness gate)
+#   - hooks/scripts/prewarm-morph.sh     (SessionStart pre-warmer)
+#   - commands/morph/setup.md            (manual /morph:setup)
+#
+# This file MUST NOT set -e or call exit — callers control termination so
+# they can choose between bare exit (wrapper, setup command) and json_exit
+# (SessionStart hook). Functions return 0 on success, non-zero on failure,
+# and print diagnostics to stderr.
+#
+# All functions are prefixed yellow_morph_ to avoid namespace collisions
+# when sourced into a long-lived shell.
+
+# Validate that CLAUDE_PLUGIN_ROOT and CLAUDE_PLUGIN_DATA are set and point
+# at expected locations. Returns 1 if either is unset or has an unexpected
+# prefix — defense in depth so cp / npm ci cannot write to /etc, /var, etc.
+yellow_morph_validate_paths() {
+  if [ -z "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+    printf 'yellow-morph: CLAUDE_PLUGIN_ROOT unset\n' >&2
+    return 1
+  fi
+  if [ -z "${CLAUDE_PLUGIN_DATA:-}" ]; then
+    printf 'yellow-morph: CLAUDE_PLUGIN_DATA unset\n' >&2
+    return 1
+  fi
+  case "$CLAUDE_PLUGIN_DATA" in
+    "${HOME:-/__unset__}"/*|/tmp/*) ;;
+    *)
+      printf 'yellow-morph: refusing — CLAUDE_PLUGIN_DATA outside HOME/tmp: %s\n' \
+        "$CLAUDE_PLUGIN_DATA" >&2
+      return 1 ;;
+  esac
+  case "$CLAUDE_PLUGIN_ROOT" in
+    "${HOME:-/__unset__}"/*|/tmp/*|/usr/*|/opt/*) ;;
+    *)
+      printf 'yellow-morph: refusing — CLAUDE_PLUGIN_ROOT unexpected prefix: %s\n' \
+        "$CLAUDE_PLUGIN_ROOT" >&2
+      return 1 ;;
+  esac
+  return 0
+}
+
+# Returns 0 if morphmcp needs to be (re)installed, 1 if the cached install
+# is in sync with the plugin's committed lockfile. Treats any diff failure
+# (missing files, permission errors) as "needs install" — fail-open and
+# safe.
+yellow_morph_needs_install() {
+  local entry="${CLAUDE_PLUGIN_DATA}/node_modules/@morphllm/morphmcp/dist/index.js"
+  [ ! -f "$entry" ] && return 0
+  ! diff -q "${CLAUDE_PLUGIN_ROOT}/package-lock.json" \
+            "${CLAUDE_PLUGIN_DATA}/package-lock.json" >/dev/null 2>&1
+}
+
+# Try to acquire the atomic mkdir-based install lock. $1 = max retry count
+# (1s sleep between attempts). Returns 0 on success, 1 on timeout.
+#
+# Stale-lock recovery: when mkdir fails with EEXIST, read the recorded
+# owner PID from $LOCK_DIR/pid. If the owner is no longer alive (kill -0
+# fails), clear the lock and retry once. This recovers from SIGKILL / OOM
+# of a prior holder without requiring 20s of timeout-then-manual-cleanup
+# on every subsequent install.
+#
+# Stale recovery happens at most once per call to bound the worst-case
+# behavior: a directory that mkdir cannot create for unrelated reasons
+# (permission denied, ENOSPC) does not loop forever.
+yellow_morph_acquire_install_lock() {
+  local max_attempts="${1:-20}"
+  local lock_dir="${CLAUDE_PLUGIN_DATA}/.install.lock"
+  local stale_recovered=0
+  local i
+
+  for ((i=1; i<=max_attempts; i++)); do
+    if mkdir "$lock_dir" 2>/dev/null; then
+      # Record owner PID — best-effort. Failure to write the PID file does
+      # not invalidate the lock (we still hold the directory).
+      printf '%s' "$$" > "${lock_dir}/pid" 2>/dev/null || true
+      return 0
+    fi
+
+    if [ "$stale_recovered" -eq 0 ] && [ -f "${lock_dir}/pid" ]; then
+      local owner_pid
+      owner_pid=$(cat "${lock_dir}/pid" 2>/dev/null)
+      if [ -n "$owner_pid" ] && ! kill -0 "$owner_pid" 2>/dev/null; then
+        printf 'yellow-morph: stale lock owner PID %s no longer running; clearing\n' \
+          "$owner_pid" >&2
+        rm -f "${lock_dir}/pid" 2>/dev/null
+        rmdir "$lock_dir" 2>/dev/null
+        stale_recovered=1
+        continue
+      fi
+    fi
+
+    sleep 1
+  done
+  return 1
+}
+
+# Release the install lock. Idempotent — safe to call from EXIT/INT/TERM
+# traps and again before exec.
+yellow_morph_release_install_lock() {
+  local lock_dir="${CLAUDE_PLUGIN_DATA}/.install.lock"
+  rm -f "${lock_dir}/pid" 2>/dev/null
+  rmdir "$lock_dir" 2>/dev/null || true
+}
+
+# Copy the manifest+lockfile from the plugin install into the data dir,
+# then run `npm ci` with a sanitized environment. env -i denies ANY
+# inherited secret (ANTHROPIC_API_KEY, GITHUB_TOKEN, etc.) to npm
+# postinstall scripts — a tighter boundary than `unset MORPH_API_KEY`,
+# which only blocks the one variable.
+#
+# HOME and PATH are required for npm to function. NPM_CONFIG_* are passed
+# through when present so user-level npm config (registry, proxy, prefix)
+# still applies. Caller is responsible for holding the install lock.
+yellow_morph_do_install() {
+  cp "${CLAUDE_PLUGIN_ROOT}/package.json" \
+     "${CLAUDE_PLUGIN_DATA}/package.json"      || return 1
+  cp "${CLAUDE_PLUGIN_ROOT}/package-lock.json" \
+     "${CLAUDE_PLUGIN_DATA}/package-lock.json" || return 1
+
+  local -a env_args=(
+    "HOME=${HOME:-/}"
+    "PATH=${PATH:-/usr/local/bin:/usr/bin:/bin}"
+  )
+  [ -n "${NPM_CONFIG_USERCONFIG:-}" ]   && env_args+=("NPM_CONFIG_USERCONFIG=$NPM_CONFIG_USERCONFIG")
+  [ -n "${NPM_CONFIG_GLOBALCONFIG:-}" ] && env_args+=("NPM_CONFIG_GLOBALCONFIG=$NPM_CONFIG_GLOBALCONFIG")
+  [ -n "${NPM_CONFIG_PREFIX:-}" ]       && env_args+=("NPM_CONFIG_PREFIX=$NPM_CONFIG_PREFIX")
+
+  ( cd "$CLAUDE_PLUGIN_DATA" \
+    && env -i "${env_args[@]}" \
+       npm ci --no-audit --no-fund --loglevel=error )
+}
+
+# Remove copied manifest+lockfile after a failed install so the next run
+# retries from a clean state instead of seeing an out-of-sync install.
+yellow_morph_cleanup_failed_install() {
+  rm -f "${CLAUDE_PLUGIN_DATA}/package.json" \
+        "${CLAUDE_PLUGIN_DATA}/package-lock.json" 2>/dev/null
+}

--- a/plugins/yellow-morph/package-lock.json
+++ b/plugins/yellow-morph/package-lock.json
@@ -1,0 +1,2711 @@
+{
+  "name": "yellow-morph",
+  "version": "1.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "yellow-morph",
+      "version": "1.1.0",
+      "dependencies": {
+        "@morphllm/morphmcp": "0.8.165"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.104",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.104.tgz",
+      "integrity": "sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.21.0.tgz",
+      "integrity": "sha512-7XhUbtnlkSEZK15kN3t+tzIMxsbKm/dSkKBFalj+20NvPKe1kBY7mR2P7vuijEn+f06z5+A8bVGKO0v39cr6Wg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@morphllm/morphmcp": {
+      "version": "0.8.165",
+      "resolved": "https://registry.npmjs.org/@morphllm/morphmcp/-/morphmcp-0.8.165.tgz",
+      "integrity": "sha512-Hn6kiSTJSbzDYw9bzyF0k/F7FlTsYeFj5NUkCl3nqPtFkV4HB6LBmhjN3GKMpaqsmw7F1Rb3i8cIfvE9MImG4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@google/generative-ai": "^0.21.0",
+        "@modelcontextprotocol/sdk": "^1.12.3",
+        "@morphllm/morphsdk": "0.2.164",
+        "@vscode/ripgrep": "^1.15.14",
+        "axios": "^1.6.0",
+        "chalk": "^5.3.0",
+        "diff": "^5.1.0",
+        "glob": "^10.3.10",
+        "minimatch": "^10.0.1",
+        "openai": "^4.52.7",
+        "p-defer": "^4.0.0",
+        "semver": "^7.6.3",
+        "string-argv": "^0.3.2",
+        "zod": "^3.23.5",
+        "zod-to-json-schema": "^3.23.5"
+      },
+      "bin": {
+        "morph-mcp": "dist/index.js"
+      }
+    },
+    "node_modules/@morphllm/morphsdk": {
+      "version": "0.2.164",
+      "resolved": "https://registry.npmjs.org/@morphllm/morphsdk/-/morphsdk-0.2.164.tgz",
+      "integrity": "sha512-Fg+i6CKq6A8nB5KSOVu32hVg35OtVH0O9M9FlKOoQMpFmtFMFvKvk7etcLR9iCfFQcWfe+0eThYyEAMiVyp/xg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/ripgrep": "^1.17.0",
+        "ai": ">=5.0.0",
+        "diff": "^7.0.0",
+        "isomorphic-git": "^1.25.10",
+        "openai": "^4.52.7",
+        "zod": ">=3.23.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.25.0",
+        "@google/generative-ai": ">=0.21.0",
+        "ai": ">=5.0.0",
+        "zod": ">=3.23.0"
+      },
+      "peerDependenciesMeta": {
+        "@anthropic-ai/sdk": {
+          "optional": true
+        },
+        "@google/generative-ai": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@morphllm/morphsdk/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vscode/ripgrep": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.17.1.tgz",
+      "integrity": "sha512-xTs7DGyAO3IsJYOCTBP8LnTvPiYVKEuyv8s0xyJDBXfs8rhBfqnZPvb6xDT+RnwWzcXqW27xLS/aGrkjX7lNWw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "https-proxy-agent": "^7.0.2",
+        "proxy-from-env": "^1.1.0",
+        "yauzl": "^2.9.2"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.168",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.168.tgz",
+      "integrity": "sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.104",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/clean-git-ref": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
+      "integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff3": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+      "integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
+      "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/isomorphic-git": {
+      "version": "1.37.5",
+      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.37.5.tgz",
+      "integrity": "sha512-wek54c5uFvd3WsxewLWt6h0GXKWQh0P8rRXns9bN1rHNjcgCb3+0lmyAsP594NeTtQFeCJQVS9b0kjbkD1l5qg==",
+      "license": "MIT",
+      "dependencies": {
+        "async-lock": "^1.4.1",
+        "clean-git-ref": "^2.0.1",
+        "crc-32": "^1.2.0",
+        "diff3": "0.0.3",
+        "ignore": "^5.1.4",
+        "minimisted": "^2.0.0",
+        "pako": "^1.0.10",
+        "pify": "^4.0.1",
+        "readable-stream": "^4.0.0",
+        "sha.js": "^2.4.12",
+        "simple-get": "^4.0.1"
+      },
+      "bin": {
+        "isogit": "cli.cjs"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minimisted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
+      "integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.1.tgz",
+      "integrity": "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/plugins/yellow-morph/package.json
+++ b/plugins/yellow-morph/package.json
@@ -1,6 +1,9 @@
 {
   "name": "yellow-morph",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
-  "description": "Intelligent code editing and search via Morph Fast Apply and WarpGrep"
+  "description": "Intelligent code editing and search via Morph Fast Apply and WarpGrep",
+  "dependencies": {
+    "@morphllm/morphmcp": "0.8.165"
+  }
 }

--- a/plugins/yellow-research/CLAUDE.md
+++ b/plugins/yellow-research/CLAUDE.md
@@ -169,12 +169,12 @@ These external tools improve research quality but are not required:
   `/research:deep`. No API key required. Configure globally in Claude Code MCP
   settings.
 - **yellow-morph plugin** (preferred) — provides WarpGrep
-  (`mcp__plugin_yellow-morph_morph__warpgrep_codebase_search`) for agentic
+  (`mcp__plugin_yellow-morph_morph__codebase_search`) for agentic
   codebase search. Replaces the global `filesystem-with-morph` MCP. When both
   are installed, yellow-morph's plugin-namespaced tool is preferred. Install:
   `/plugin marketplace add KingInYellows/yellow-plugins` (select yellow-morph)
 - **filesystem-with-morph MCP** (legacy) — provides WarpGrep
-  (`mcp__filesystem-with-morph__warpgrep_codebase_search`) for agentic codebase
+  (`mcp__filesystem-with-morph__codebase_search`) for agentic codebase
   and GitHub search. No API key required. Configure globally in Claude Code MCP
   settings. When yellow-morph is installed, prefer the plugin-namespaced tool
   instead.

--- a/plugins/yellow-research/commands/research/setup.md
+++ b/plugins/yellow-research/commands/research/setup.md
@@ -11,8 +11,8 @@ allowed-tools:
   - ToolSearch
   - mcp__context7__resolve-library-id
   - mcp__grep__searchGitHub
-  - mcp__plugin_yellow-morph_morph__warpgrep_codebase_search
-  - mcp__filesystem-with-morph__warpgrep_codebase_search
+  - mcp__plugin_yellow-morph_morph__codebase_search
+  - mcp__filesystem-with-morph__codebase_search
   - mcp__plugin_yellow-devin_deepwiki__read_wiki_structure
   - mcp__plugin_yellow-research_ast-grep__find_code
 ---
@@ -337,10 +337,13 @@ Test call: mcp__grep__searchGitHub with query: "test", maxResults: 1
 **WarpGrep** (yellow-morph plugin preferred, global MCP fallback):
 
 ```text
-ToolSearch keyword: "warpgrep_codebase_search"
-Preferred tool name: mcp__plugin_yellow-morph_morph__warpgrep_codebase_search
-Fallback tool name: mcp__filesystem-with-morph__warpgrep_codebase_search
+ToolSearch keyword: "codebase_search" (or "morph warpgrep" — same tool)
+Preferred tool name: mcp__plugin_yellow-morph_morph__codebase_search
+Fallback tool name: mcp__filesystem-with-morph__codebase_search
 Test call: <matched tool> with query: "README"
+Note: In morphmcp 0.8.165 the tool is named `codebase_search`. Older
+versions exposed it as `warpgrep_codebase_search`; that name no longer
+exists.
 ```
 
 Check for the plugin-namespaced tool first. If not found, fall back to the

--- a/plugins/yellow-research/commands/research/setup.md
+++ b/plugins/yellow-research/commands/research/setup.md
@@ -1,9 +1,6 @@
 ---
 name: research:setup
-description:
-  'Check which research API keys and MCP sources are configured and active. Use
-  when first installing the plugin, after adding API keys, or to understand why
-  a research command degraded to fewer sources.'
+description: "Check which research API keys and MCP sources are configured and active. Use when first installing the plugin, after adding API keys, or to understand why a research command degraded to fewer sources."
 argument-hint: ''
 allowed-tools:
   - Bash

--- a/plugins/yellow-research/commands/research/setup.md
+++ b/plugins/yellow-research/commands/research/setup.md
@@ -13,6 +13,7 @@ allowed-tools:
   - mcp__grep__searchGitHub
   - mcp__plugin_yellow-morph_morph__codebase_search
   - mcp__filesystem-with-morph__codebase_search
+  - mcp__filesystem-with-morph__warpgrep_codebase_search
   - mcp__plugin_yellow-devin_deepwiki__read_wiki_structure
   - mcp__plugin_yellow-research_ast-grep__find_code
 ---
@@ -339,15 +340,19 @@ Test call: mcp__grep__searchGitHub with query: "test", maxResults: 1
 ```text
 ToolSearch keyword: "codebase_search" (or "morph warpgrep" — same tool)
 Preferred tool name: mcp__plugin_yellow-morph_morph__codebase_search
-Fallback tool name: mcp__filesystem-with-morph__codebase_search
+Fallback tool name (current):  mcp__filesystem-with-morph__codebase_search
+Fallback tool name (legacy):   mcp__filesystem-with-morph__warpgrep_codebase_search
 Test call: <matched tool> with query: "README"
-Note: In morphmcp 0.8.165 the tool is named `codebase_search`. Older
-versions exposed it as `warpgrep_codebase_search`; that name no longer
-exists.
+Note: morphmcp 0.8.165 (and the yellow-morph plugin) name the tool
+`codebase_search`. A user's global `filesystem-with-morph` MCP may still
+be running an older morphmcp that exposes `warpgrep_codebase_search` —
+that legacy name is therefore listed as a final fallback so the command
+remains authorized to call it.
 ```
 
-Check for the plugin-namespaced tool first. If not found, fall back to the
-global MCP tool name. Report which variant is active.
+Check tools in this order: plugin-namespaced first, then the global MCP
+current name, then the global MCP legacy name. Report which variant is
+active.
 
 **DeepWiki** (yellow-devin plugin — AI-powered repo documentation):
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,15 +118,25 @@ importers:
 
   plugins/yellow-ci: {}
 
+  plugins/yellow-codex: {}
+
+  plugins/yellow-composio: {}
+
   plugins/yellow-core: {}
 
   plugins/yellow-debt: {}
 
   plugins/yellow-devin: {}
 
+  plugins/yellow-docs: {}
+
   plugins/yellow-linear: {}
 
-  plugins/yellow-morph: {}
+  plugins/yellow-morph:
+    dependencies:
+      '@morphllm/morphmcp':
+        specifier: 0.8.165
+        version: 0.8.165
 
   plugins/yellow-research: {}
 
@@ -831,6 +841,20 @@ packages:
       '@shikijs/vscode-textmate': 10.0.2
     dev: true
 
+  /@google/generative-ai@0.21.0:
+    resolution: {integrity: sha512-7XhUbtnlkSEZK15kN3t+tzIMxsbKm/dSkKBFalj+20NvPKe1kBY7mR2P7vuijEn+f06z5+A8bVGKO0v39cr6Wg==}
+    engines: {node: '>=18.0.0'}
+    dev: false
+
+  /@hono/node-server@1.19.14(hono@4.12.16):
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+    dependencies:
+      hono: 4.12.16
+    dev: false
+
   /@humanwhocodes/config-array@0.13.0:
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -877,7 +901,6 @@ packages:
       strip-ansi-cjs: /strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: /wrap-ansi@7.0.0
-    dev: true
 
   /@jest/schemas@29.6.3:
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
@@ -910,6 +933,96 @@ packages:
       read-yaml-file: 1.1.0
     dev: true
 
+  /@modelcontextprotocol/sdk@1.29.0(zod@3.25.76):
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.16)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.5.0(express@5.2.1)
+      hono: 4.12.16
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@morphllm/morphmcp@0.8.165:
+    resolution: {integrity: sha512-Hn6kiSTJSbzDYw9bzyF0k/F7FlTsYeFj5NUkCl3nqPtFkV4HB6LBmhjN3GKMpaqsmw7F1Rb3i8cIfvE9MImG4g==}
+    hasBin: true
+    dependencies:
+      '@google/generative-ai': 0.21.0
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      '@morphllm/morphsdk': 0.2.164(@google/generative-ai@0.21.0)(zod@3.25.76)
+      '@vscode/ripgrep': 1.17.1
+      axios: 1.16.0
+      chalk: 5.6.2
+      diff: 5.2.2
+      glob: 10.3.16
+      minimatch: 10.2.5
+      openai: 4.104.0(zod@3.25.76)
+      p-defer: 4.0.1
+      semver: 7.7.3
+      string-argv: 0.3.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@anthropic-ai/sdk'
+      - '@cfworker/json-schema'
+      - ai
+      - debug
+      - encoding
+      - supports-color
+      - ws
+    dev: false
+
+  /@morphllm/morphsdk@0.2.164(@google/generative-ai@0.21.0)(zod@3.25.76):
+    resolution: {integrity: sha512-Fg+i6CKq6A8nB5KSOVu32hVg35OtVH0O9M9FlKOoQMpFmtFMFvKvk7etcLR9iCfFQcWfe+0eThYyEAMiVyp/xg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@anthropic-ai/sdk': '>=0.25.0'
+      '@google/generative-ai': '>=0.21.0'
+      ai: '>=5.0.0'
+      zod: '>=3.23.0'
+    peerDependenciesMeta:
+      '@anthropic-ai/sdk':
+        optional: true
+      '@google/generative-ai':
+        optional: true
+      ai:
+        optional: true
+      zod:
+        optional: true
+    dependencies:
+      '@google/generative-ai': 0.21.0
+      '@vscode/ripgrep': 1.17.1
+      diff: 7.0.0
+      isomorphic-git: 1.37.6
+      openai: 4.104.0(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+      - ws
+    dev: false
+
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -935,7 +1048,6 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-android-arm-eabi@4.55.1:
@@ -1220,15 +1332,27 @@ packages:
       '@types/unist': 2.0.11
     dev: true
 
+  /@types/node-fetch@2.6.13:
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+    dependencies:
+      '@types/node': 22.19.15
+      form-data: 4.0.5
+    dev: false
+
   /@types/node@12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
+
+  /@types/node@18.19.130:
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+    dependencies:
+      undici-types: 5.26.5
+    dev: false
 
   /@types/node@22.19.15:
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
     dependencies:
       undici-types: 6.21.0
-    dev: true
 
   /@types/semver@7.7.1:
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
@@ -1413,6 +1537,32 @@ packages:
       pretty-format: 29.7.0
     dev: true
 
+  /@vscode/ripgrep@1.17.1:
+    resolution: {integrity: sha512-xTs7DGyAO3IsJYOCTBP8LnTvPiYVKEuyv8s0xyJDBXfs8rhBfqnZPvb6xDT+RnwWzcXqW27xLS/aGrkjX7lNWw==}
+    requiresBuild: true
+    dependencies:
+      https-proxy-agent: 7.0.6
+      proxy-from-env: 1.1.0
+      yauzl: 2.10.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+    dependencies:
+      event-target-shim: 5.0.1
+    dev: false
+
+  /accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+    dev: false
+
   /acorn-jsx@5.3.2(acorn@8.15.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1434,6 +1584,18 @@ packages:
     hasBin: true
     dev: true
 
+  /agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+    dev: false
+
+  /agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
+    dependencies:
+      humanize-ms: 1.2.1
+    dev: false
+
   /ajv-formats@2.1.1(ajv@8.17.1):
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -1443,6 +1605,17 @@ packages:
         optional: true
     dependencies:
       ajv: 8.17.1
+
+  /ajv-formats@3.0.1(ajv@8.17.1):
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+    dependencies:
+      ajv: 8.17.1
+    dev: false
 
   /ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -1475,19 +1648,16 @@ packages:
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
-    dev: true
 
   /ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
-    dev: true
 
   /ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
@@ -1497,7 +1667,6 @@ packages:
   /ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
-    dev: true
 
   /argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -1591,12 +1760,29 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
+  /async-lock@1.4.1:
+    resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
+    dev: false
+
+  /asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    dev: false
+
   /available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       possible-typed-array-names: 1.1.0
-    dev: true
+
+  /axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
 
   /bail@1.0.5:
     resolution: {integrity: sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==}
@@ -1604,7 +1790,15 @@ packages:
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-    dev: true
+
+  /balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+    dev: false
+
+  /base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    dev: false
 
   /better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -1612,6 +1806,23 @@ packages:
     dependencies:
       is-windows: 1.0.2
     dev: true
+
+  /body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -1624,7 +1835,13 @@ packages:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
     dependencies:
       balanced-match: 1.0.2
-    dev: true
+
+  /brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
+    dependencies:
+      balanced-match: 4.0.4
+    dev: false
 
   /braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1632,6 +1849,22 @@ packages:
     dependencies:
       fill-range: 7.1.1
     dev: true
+
+  /buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+    dev: false
+
+  /buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    dev: false
+
+  /bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+    dev: false
 
   /cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -1644,7 +1877,6 @@ packages:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
-    dev: true
 
   /call-bind@1.0.8:
     resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
@@ -1654,7 +1886,6 @@ packages:
       es-define-property: 1.0.1
       get-intrinsic: 1.3.0
       set-function-length: 1.2.2
-    dev: true
 
   /call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
@@ -1662,7 +1893,6 @@ packages:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
-    dev: true
 
   /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -1694,6 +1924,11 @@ packages:
       supports-color: 7.2.0
     dev: true
 
+  /chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: false
+
   /character-entities-legacy@1.1.4:
     resolution: {integrity: sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==}
     dev: true
@@ -1721,16 +1956,25 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /clean-git-ref@2.0.1:
+    resolution: {integrity: sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==}
+    dev: false
+
   /color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
-    dev: true
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-    dev: true
+
+  /combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      delayed-stream: 1.0.0
+    dev: false
 
   /commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
@@ -1745,6 +1989,40 @@ packages:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
     dev: true
 
+  /content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+    dev: false
+
+  /content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+    dev: false
+
+  /cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+    dev: false
+
+  /crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+    dev: false
+
   /cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1752,7 +2030,6 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-    dev: true
 
   /data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -1806,7 +2083,13 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
-    dev: true
+
+  /decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      mimic-response: 3.1.0
+    dev: false
 
   /deep-eql@4.1.4:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
@@ -1831,7 +2114,6 @@ packages:
       es-define-property: 1.0.1
       es-errors: 1.3.0
       gopd: 1.2.0
-    dev: true
 
   /define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
@@ -1842,6 +2124,16 @@ packages:
       object-keys: 1.1.1
     dev: true
 
+  /delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+    dev: false
+
+  /depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
   /detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -1851,6 +2143,20 @@ packages:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
+
+  /diff3@0.0.3:
+    resolution: {integrity: sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==}
+    dev: false
+
+  /diff@5.2.2:
+    resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
+    engines: {node: '>=0.3.1'}
+    dev: false
+
+  /diff@7.0.0:
+    resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
+    engines: {node: '>=0.3.1'}
+    dev: false
 
   /dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -1926,11 +2232,13 @@ packages:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
-    dev: true
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-    dev: true
+
+  /ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    dev: false
 
   /emoji-regex@10.1.0:
     resolution: {integrity: sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg==}
@@ -1938,11 +2246,14 @@ packages:
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-    dev: true
 
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-    dev: true
+
+  /encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+    dev: false
 
   /enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
@@ -2029,19 +2340,16 @@ packages:
   /es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
     dependencies:
       es-errors: 1.3.0
-    dev: true
 
   /es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
@@ -2051,7 +2359,6 @@ packages:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
-    dev: true
 
   /es-shim-unscopables@1.1.0:
     resolution: {integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==}
@@ -2133,6 +2440,10 @@ packages:
       '@esbuild/win32-ia32': 0.27.2
       '@esbuild/win32-x64': 0.27.2
     dev: true
+
+  /escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+    dev: false
 
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -2330,6 +2641,33 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+    dev: false
+
+  /eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+    dev: false
+
+  /eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      eventsource-parser: 3.0.8
+    dev: false
+
   /execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
@@ -2344,6 +2682,52 @@ packages:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
     dev: true
+
+  /express-rate-limit@8.5.0(express@5.2.1):
+    resolution: {integrity: sha512-XKhFohWaSBdVJNTi5TaHziqnPkv04I9UQV6q1Wy7Ui6GGQZVW12ojDFwqer14EvCXxjvPG0CyWXx7cAXpALB4Q==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+    dev: false
+
+  /express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -2390,6 +2774,12 @@ packages:
       format: 0.2.2
     dev: true
 
+  /fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+    dependencies:
+      pend: 1.2.0
+    dev: false
+
   /file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -2403,6 +2793,20 @@ packages:
     dependencies:
       to-regex-range: 5.0.1
     dev: true
+
+  /finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -2433,12 +2837,21 @@ packages:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
     dev: true
 
+  /follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
+
   /for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
     dependencies:
       is-callable: 1.2.7
-    dev: true
 
   /foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -2446,12 +2859,44 @@ packages:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
-    dev: true
+
+  /form-data-encoder@1.7.2:
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+    dev: false
+
+  /form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+    dev: false
 
   /format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
     dev: true
+
+  /formdata-node@4.4.1:
+    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
+    engines: {node: '>= 12.20'}
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 4.0.0-beta.3
+    dev: false
+
+  /forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+    dev: false
 
   /fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -2485,7 +2930,6 @@ packages:
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-    dev: true
 
   /function.prototype.name@1.1.8:
     resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
@@ -2526,7 +2970,6 @@ packages:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
-    dev: true
 
   /get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -2534,7 +2977,6 @@ packages:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
-    dev: true
 
   /get-stdin@9.0.0:
     resolution: {integrity: sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==}
@@ -2578,18 +3020,18 @@ packages:
   /glob@10.3.16:
     resolution: {integrity: sha512-JDKXl1DiuuHJ6fVS2FXjownaavciiHNUU4mOvV/B793RLh05vZL1rcPnCSaOgv1hDT6RDlY7AB7ZUvFYAtPgAw==}
     engines: {node: '>=16 || 14 >=14.18'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.3
+      minimatch: 9.0.5
       minipass: 7.1.2
       path-scurry: 1.11.1
-    dev: true
 
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -2629,7 +3071,6 @@ packages:
   /gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -2653,7 +3094,6 @@ packages:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
     dependencies:
       es-define-property: 1.0.1
-    dev: true
 
   /has-proto@1.2.0:
     resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
@@ -2665,21 +3105,23 @@ packages:
   /has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.1.0
-    dev: true
 
   /hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2
-    dev: true
+
+  /hono@4.12.16:
+    resolution: {integrity: sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==}
+    engines: {node: '>=16.9.0'}
+    dev: false
 
   /htmlparser2@7.2.0:
     resolution: {integrity: sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==}
@@ -2689,6 +3131,27 @@ packages:
       domutils: 2.8.0
       entities: 3.0.1
     dev: true
+
+  /http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+    dev: false
+
+  /https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
@@ -2700,17 +3163,25 @@ packages:
     engines: {node: '>=16.17.0'}
     dev: true
 
+  /humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+    dependencies:
+      ms: 2.1.3
+    dev: false
+
   /iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
-    dev: true
+
+  /ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+    dev: false
 
   /ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
-    dev: true
 
   /import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -2735,7 +3206,6 @@ packages:
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-    dev: true
 
   /ini@4.1.3:
     resolution: {integrity: sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==}
@@ -2750,6 +3220,16 @@ packages:
       hasown: 2.0.2
       side-channel: 1.1.0
     dev: true
+
+  /ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+    dev: false
+
+  /ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+    dev: false
 
   /is-alphabetical@1.0.4:
     resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
@@ -2805,7 +3285,6 @@ packages:
   /is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -2850,7 +3329,6 @@ packages:
   /is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
-    dev: true
 
   /is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
@@ -2906,6 +3384,10 @@ packages:
     resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
     engines: {node: '>=8'}
     dev: true
+
+  /is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+    dev: false
 
   /is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -2963,7 +3445,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       which-typed-array: 1.1.19
-    dev: true
 
   /is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -2992,11 +3473,27 @@ packages:
 
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
-    dev: true
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-    dev: true
+
+  /isomorphic-git@1.37.6:
+    resolution: {integrity: sha512-qr1NFCPsVTZ6YGqTXw0CzamnsHyH9QQ1OTEfeXIweSljRUMzuHFCJdUn0wc6OcjtTDns6knxjPb7N6LmJeftOA==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dependencies:
+      async-lock: 1.4.1
+      clean-git-ref: 2.0.1
+      crc-32: 1.2.2
+      diff3: 0.0.3
+      ignore: 5.3.2
+      minimisted: 2.0.1
+      pako: 1.0.11
+      pify: 4.0.1
+      readable-stream: 4.7.0
+      sha.js: 2.4.12
+      simple-get: 4.0.1
+    dev: false
 
   /jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
@@ -3004,7 +3501,10 @@ packages:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
-    dev: true
+
+  /jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+    dev: false
 
   /js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
@@ -3035,6 +3535,10 @@ packages:
 
   /json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  /json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+    dev: false
 
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -3119,7 +3623,6 @@ packages:
 
   /lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-    dev: true
 
   /lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
@@ -3193,7 +3696,6 @@ packages:
   /math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /mdast-util-find-and-replace@1.1.1:
     resolution: {integrity: sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA==}
@@ -3290,6 +3792,16 @@ packages:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
     dev: true
 
+  /media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+    dev: false
+
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
     dev: true
@@ -3379,10 +3891,46 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.52.0
+    dev: false
+
+  /mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+    dependencies:
+      mime-db: 1.54.0
+    dev: false
+
   /mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
     dev: true
+
+  /mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+    dev: false
+
+  /minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+    dependencies:
+      brace-expansion: 5.0.5
+    dev: false
 
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -3402,16 +3950,19 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.2
-    dev: true
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-    dev: true
+
+  /minimisted@2.0.1:
+    resolution: {integrity: sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==}
+    dependencies:
+      minimist: 1.2.8
+    dev: false
 
   /minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
-    dev: true
 
   /mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
@@ -3429,7 +3980,6 @@ packages:
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-    dev: true
 
   /nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -3441,6 +3991,17 @@ packages:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
+  /negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+    dev: false
+
   /node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -3451,7 +4012,6 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
-    dev: true
 
   /npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
@@ -3460,10 +4020,14 @@ packages:
       path-key: 4.0.0
     dev: true
 
+  /object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
@@ -3511,11 +4075,17 @@ packages:
       es-object-atoms: 1.1.1
     dev: true
 
+  /on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      ee-first: 1.1.1
+    dev: false
+
   /once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
-    dev: true
 
   /onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
@@ -3523,6 +4093,30 @@ packages:
     dependencies:
       mimic-fn: 4.0.0
     dev: true
+
+  /openai@4.104.0(zod@3.25.76):
+    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - encoding
+    dev: false
 
   /optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -3548,6 +4142,11 @@ packages:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
     dev: true
+
+  /p-defer@4.0.1:
+    resolution: {integrity: sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==}
+    engines: {node: '>=12'}
+    dev: false
 
   /p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
@@ -3607,6 +4206,10 @@ packages:
       quansync: 0.2.11
     dev: true
 
+  /pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+    dev: false
+
   /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -3625,6 +4228,11 @@ packages:
       is-hexadecimal: 1.0.4
     dev: true
 
+  /parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3638,7 +4246,6 @@ packages:
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-    dev: true
 
   /path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
@@ -3655,7 +4262,10 @@ packages:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
-    dev: true
+
+  /path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+    dev: false
 
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -3674,6 +4284,10 @@ packages:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
     dev: true
 
+  /pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+    dev: false
+
   /picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
     dev: true
@@ -3686,7 +4300,11 @@ packages:
   /pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
-    dev: true
+
+  /pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+    dev: false
 
   /pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -3699,7 +4317,6 @@ packages:
   /possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -3736,6 +4353,28 @@ packages:
       react-is: 18.3.1
     dev: true
 
+  /process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+    dev: false
+
+  /proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+    dev: false
+
+  /proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+    dev: false
+
+  /proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+    dev: false
+
   /punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
@@ -3746,6 +4385,13 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      side-channel: 1.1.0
+    dev: false
+
   /quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
     dev: true
@@ -3753,6 +4399,21 @@ packages:
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
+
+  /range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+    dev: false
 
   /react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -3767,6 +4428,17 @@ packages:
       pify: 4.0.1
       strip-bom: 3.0.0
     dev: true
+
+  /readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+    dev: false
 
   /reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -3908,6 +4580,19 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /run-con@1.3.2:
     resolution: {integrity: sha512-CcfE+mYiTcKEzg0IqS08+efdnH0oJ3zV0wSUFBNrMHMuxCtXvBCLzCJHatwuXDcu/RlhjTziTo/a1ruQik6/Yg==}
     hasBin: true
@@ -3935,6 +4620,10 @@ packages:
       isarray: 2.0.5
     dev: true
 
+  /safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: false
+
   /safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -3954,7 +4643,6 @@ packages:
 
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-    dev: true
 
   /semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -3966,6 +4654,37 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  /send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -3976,7 +4695,6 @@ packages:
       get-intrinsic: 1.3.0
       gopd: 1.2.0
       has-property-descriptors: 1.0.2
-    dev: true
 
   /set-function-name@2.0.2:
     resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
@@ -3997,17 +4715,29 @@ packages:
       es-object-atoms: 1.1.1
     dev: true
 
+  /setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+    dev: false
+
+  /sha.js@2.4.12:
+    resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
+    engines: {node: '>= 0.10'}
+    hasBin: true
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+      to-buffer: 1.2.2
+    dev: false
+
   /shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
     dependencies:
       shebang-regex: 3.0.0
-    dev: true
 
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-    dev: true
 
   /side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -4015,7 +4745,6 @@ packages:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
-    dev: true
 
   /side-channel-map@1.0.1:
     resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
@@ -4025,7 +4754,6 @@ packages:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       object-inspect: 1.13.4
-    dev: true
 
   /side-channel-weakmap@1.0.2:
     resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
@@ -4036,7 +4764,6 @@ packages:
       get-intrinsic: 1.3.0
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
-    dev: true
 
   /side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
@@ -4047,7 +4774,6 @@ packages:
       side-channel-list: 1.0.0
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
-    dev: true
 
   /siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -4056,7 +4782,18 @@ packages:
   /signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
-    dev: true
+
+  /simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+    dev: false
+
+  /simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+    dev: false
 
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -4083,6 +4820,11 @@ packages:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
 
+  /statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
   /std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
     dev: true
@@ -4095,6 +4837,11 @@ packages:
       internal-slot: 1.1.0
     dev: true
 
+  /string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+    dev: false
+
   /string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -4102,7 +4849,6 @@ packages:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-    dev: true
 
   /string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
@@ -4111,7 +4857,6 @@ packages:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.2
-    dev: true
 
   /string.prototype.trim@1.2.10:
     resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
@@ -4145,19 +4890,23 @@ packages:
       es-object-atoms: 1.1.1
     dev: true
 
+  /string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: false
+
   /strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
     dependencies:
       ansi-regex: 5.0.1
-    dev: true
 
   /strip-ansi@7.1.2:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
     dependencies:
       ansi-regex: 6.2.2
-    dev: true
 
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -4215,6 +4964,15 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: true
 
+  /to-buffer@1.2.2:
+    resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      isarray: 2.0.5
+      safe-buffer: 5.2.1
+      typed-array-buffer: 1.0.3
+    dev: false
+
   /to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -4222,9 +4980,13 @@ packages:
       is-number: 7.0.0
     dev: true
 
+  /toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+    dev: false
+
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-    dev: true
 
   /traverse@0.6.11:
     resolution: {integrity: sha512-vxXDZg8/+p3gblxB6BhhG5yWVn1kGRlaL8O78UDXc3wRnPizB5g83dcvWV1jpDMIPnjZjOFuxlMmE82XJ4407w==}
@@ -4285,6 +5047,15 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+    dev: false
+
   /typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -4292,7 +5063,6 @@ packages:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-typed-array: 1.1.15
-    dev: true
 
   /typed-array-byte-length@1.0.3:
     resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
@@ -4387,9 +5157,12 @@ packages:
     resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
     dev: true
 
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+    dev: false
+
   /undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-    dev: true
 
   /unified@9.2.2:
     resolution: {integrity: sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==}
@@ -4425,6 +5198,11 @@ packages:
     engines: {node: '>= 4.0.0'}
     dev: true
 
+  /unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
   /update-section@0.3.3:
     resolution: {integrity: sha512-BpRZMZpgXLuTiKeiu7kK0nIPwGdyrqrs6EDSaXtjD/aQ2T+qVo9a5hRC3HN3iJjCMxNT/VxoLGQ7E/OzE5ucnw==}
     dev: true
@@ -4434,6 +5212,11 @@ packages:
     dependencies:
       punycode: 2.3.1
     dev: true
+
+  /vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+    dev: false
 
   /vfile-message@2.0.4:
     resolution: {integrity: sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==}
@@ -4569,16 +5352,19 @@ packages:
       - terser
     dev: true
 
+  /web-streams-polyfill@4.0.0-beta.3:
+    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
+    engines: {node: '>= 14'}
+    dev: false
+
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-    dev: true
 
   /whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-    dev: true
 
   /which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -4631,7 +5417,6 @@ packages:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-    dev: true
 
   /which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -4639,7 +5424,6 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
-    dev: true
 
   /why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -4662,7 +5446,6 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    dev: true
 
   /wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
@@ -4671,17 +5454,22 @@ packages:
       ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.1.2
-    dev: true
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-    dev: true
 
   /yaml@2.8.2:
     resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
     engines: {node: '>= 14.6'}
     hasBin: true
     dev: true
+
+  /yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
+    dev: false
 
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -4692,6 +5480,18 @@ packages:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
     dev: true
+
+  /zod-to-json-schema@3.25.2(zod@3.25.76):
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+    dependencies:
+      zod: 3.25.76
+    dev: false
+
+  /zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+    dev: false
 
   /zwitch@1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}

--- a/schemas/plugin.schema.json
+++ b/schemas/plugin.schema.json
@@ -103,6 +103,10 @@
       "type": "object",
       "description": "MCP server configurations keyed by server name."
     },
+    "userConfig": {
+      "type": "object",
+      "description": "Claude Code userConfig field declarations keyed by config name. Each value is an object describing the field (description, type, sensitive, default, etc.); Claude Code prompts the user at plugin-enable time and stores values in the system keychain (if sensitive) or ~/.claude/settings.json."
+    },
     "hooks": {
       "oneOf": [
         {

--- a/scripts/check-upstream-pins.js
+++ b/scripts/check-upstream-pins.js
@@ -21,7 +21,11 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { execSync } = require('node:child_process');
+const { execFileSync } = require('node:child_process');
+
+// Allowlist for npm package names: scope + name chars per npm-name-validator,
+// length capped at the registry's documented 214-char limit.
+const NPM_NAME_OK = /^(?:@[a-z0-9][a-z0-9._~-]{0,213}\/)?[a-z0-9][a-z0-9._~-]{0,213}$/i;
 
 const ROOT = path.resolve(__dirname, '..');
 const PLUGINS_DIR = path.join(ROOT, 'plugins');
@@ -77,10 +81,16 @@ function walkMcpServers(pluginJson, fn) {
 }
 
 function getNpmLatest(pkg) {
+  // Reject names that do not match the npm allowlist — prevents the name
+  // becoming a shell-injection vector if a plugin.json or package.json is
+  // ever crafted maliciously. execFileSync below avoids shell parsing, but
+  // belt-and-suspenders is cheap here.
+  if (typeof pkg !== 'string' || !NPM_NAME_OK.test(pkg)) return null;
   try {
-    const out = execSync(`npm view ${pkg} version --silent 2>/dev/null`, {
+    const out = execFileSync('npm', ['view', pkg, 'version', '--silent'], {
       encoding: 'utf8',
       timeout: 10000,
+      stdio: ['ignore', 'pipe', 'ignore'],
     }).trim();
     return out || null;
   } catch {
@@ -137,6 +147,7 @@ function main() {
           if (typeof rawVersion !== 'string') continue;
           // Skip ^X.Y.Z / ~X.Y.Z / workspace: / file: / git+ — we want exact only
           if (!/^\d+\.\d+\.\d+[A-Za-z0-9.+-]*$/.test(rawVersion)) continue;
+          if (!NPM_NAME_OK.test(name)) continue;
           report.npm.push({ plugin, serverName: '(package.json)', name, version: rawVersion });
         }
       } catch {

--- a/scripts/check-upstream-pins.js
+++ b/scripts/check-upstream-pins.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * check-upstream-pins.js
+ *
+ * Scans all plugins/*.claude-plugin/plugin.json files for pinned external
+ * packages (npx -y <pkg>@<version>) and compares each pin against the
+ * `latest` tag on the npm registry. Prints a drift report; exits 0 if no
+ * drift exceeds the threshold, exits 1 otherwise.
+ *
+ * Usage:
+ *   node scripts/check-upstream-pins.js                   # advisory (all drift reported, exit 0 unless --strict)
+ *   node scripts/check-upstream-pins.js --strict          # exit 1 on any drift
+ *   node scripts/check-upstream-pins.js --threshold 10    # exit 1 only when major+minor drift >= 10 versions
+ *
+ * The git-SHA-pinned entries (uvx --from git+...@<sha>) are listed but not
+ * drift-checked, since resolving latest for a git repo requires extra API
+ * calls and is out of scope for a quick check.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execSync } = require('node:child_process');
+
+const ROOT = path.resolve(__dirname, '..');
+const PLUGINS_DIR = path.join(ROOT, 'plugins');
+
+function parseArgs(argv) {
+  const args = { strict: false, threshold: null };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--strict') args.strict = true;
+    else if (a === '--threshold') args.threshold = parseInt(argv[++i], 10);
+  }
+  return args;
+}
+
+function listPlugins() {
+  return fs
+    .readdirSync(PLUGINS_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && /^[a-zA-Z0-9_-]+$/.test(d.name))
+    .map((d) => d.name);
+}
+
+// Extract pinned npm packages from an args array like ["-y", "@scope/pkg@1.2.3"].
+function extractNpmPins(args) {
+  const pins = [];
+  if (!Array.isArray(args)) return pins;
+  for (const arg of args) {
+    if (typeof arg !== 'string') continue;
+    // Match @scope/pkg@1.2.3 or pkg@1.2.3 at start of arg (not tools= arg)
+    const m = arg.match(/^(@?[a-z0-9][a-z0-9._~/-]+)@(\d+\.\d+\.\d+[A-Za-z0-9.+-]*)$/);
+    if (m) pins.push({ name: m[1], version: m[2] });
+  }
+  return pins;
+}
+
+// Extract git-SHA pins from uvx --from git+https://...@<sha>.
+function extractGitPins(args) {
+  const pins = [];
+  if (!Array.isArray(args)) return pins;
+  for (const arg of args) {
+    if (typeof arg !== 'string') continue;
+    const m = arg.match(/^git\+([^@]+)@([0-9a-f]{7,40})$/);
+    if (m) pins.push({ url: m[1], sha: m[2] });
+  }
+  return pins;
+}
+
+function walkMcpServers(pluginJson, fn) {
+  const servers = pluginJson?.mcpServers;
+  if (!servers || typeof servers !== 'object') return;
+  for (const [name, server] of Object.entries(servers)) {
+    fn(name, server);
+  }
+}
+
+function getNpmLatest(pkg) {
+  try {
+    const out = execSync(`npm view ${pkg} version --silent 2>/dev/null`, {
+      encoding: 'utf8',
+      timeout: 10000,
+    }).trim();
+    return out || null;
+  } catch {
+    return null;
+  }
+}
+
+// Sum (major*10000 + minor*100 + patch) difference as a crude drift score.
+function driftScore(pinned, latest) {
+  const parse = (v) => v.split('.').map((s) => parseInt(s, 10) || 0);
+  const [pM, pm, pp] = parse(pinned);
+  const [lM, lm, lp] = parse(latest);
+  return lM * 10000 + lm * 100 + lp - (pM * 10000 + pm * 100 + pp);
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const plugins = listPlugins();
+  const report = { npm: [], git: [] };
+
+  for (const plugin of plugins) {
+    const manifestPath = path.join(PLUGINS_DIR, plugin, '.claude-plugin', 'plugin.json');
+    if (!fs.existsSync(manifestPath)) continue;
+
+    let json;
+    try {
+      json = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    } catch (e) {
+      console.error(`[check-upstream-pins] SKIP: cannot parse ${manifestPath}: ${e.message}`);
+      continue;
+    }
+
+    walkMcpServers(json, (serverName, server) => {
+      const npmPins = extractNpmPins(server.args);
+      const gitPins = extractGitPins(server.args);
+      for (const p of npmPins) {
+        report.npm.push({ plugin, serverName, ...p });
+      }
+      for (const p of gitPins) {
+        report.git.push({ plugin, serverName, ...p });
+      }
+    });
+
+    // Also scan plugins/<name>/package.json dependencies — the wrapper-based
+    // install pattern (yellow-morph 1.1.0+) pins versions here instead of in
+    // mcpServers.args. Only consider exact pins (no ^ or ~), mirroring the
+    // "pin exact" policy.
+    const pkgPath = path.join(PLUGINS_DIR, plugin, 'package.json');
+    if (fs.existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+        const deps = { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) };
+        for (const [name, rawVersion] of Object.entries(deps)) {
+          if (typeof rawVersion !== 'string') continue;
+          // Skip ^X.Y.Z / ~X.Y.Z / workspace: / file: / git+ — we want exact only
+          if (!/^\d+\.\d+\.\d+[A-Za-z0-9.+-]*$/.test(rawVersion)) continue;
+          report.npm.push({ plugin, serverName: '(package.json)', name, version: rawVersion });
+        }
+      } catch {
+        // Tolerate unparseable package.json — surface as a skipped note.
+        console.error(`[check-upstream-pins] NOTE: cannot parse ${pkgPath}`);
+      }
+    }
+  }
+
+  console.log('=== Upstream pin drift report ===\n');
+
+  let driftCount = 0;
+  let maxDrift = 0;
+  console.log('-- npm pins --');
+  for (const pin of report.npm) {
+    const latest = getNpmLatest(pin.name);
+    if (!latest) {
+      console.log(`  ${pin.plugin} / ${pin.serverName} :: ${pin.name}@${pin.version} -> (npm lookup failed)`);
+      continue;
+    }
+    const drift = driftScore(pin.version, latest);
+    const marker = drift > 0 ? 'DRIFT' : 'current';
+    console.log(`  ${pin.plugin} / ${pin.serverName} :: ${pin.name}@${pin.version} -> latest ${latest} [${marker}${drift ? ` +${drift}` : ''}]`);
+    if (drift > 0) {
+      driftCount++;
+      if (drift > maxDrift) maxDrift = drift;
+    }
+  }
+
+  if (report.git.length) {
+    console.log('\n-- git SHA pins (not drift-checked) --');
+    for (const pin of report.git) {
+      console.log(`  ${pin.plugin} / ${pin.serverName} :: ${pin.url}@${pin.sha}`);
+    }
+  }
+
+  console.log(`\nTotal npm pins: ${report.npm.length}, drift entries: ${driftCount}, max drift score: ${maxDrift}`);
+
+  let exitCode = 0;
+  if (args.strict && driftCount > 0) exitCode = 1;
+  else if (args.threshold !== null && maxDrift >= args.threshold) exitCode = 1;
+
+  process.exit(exitCode);
+}
+
+main();

--- a/scripts/check-upstream-pins.js
+++ b/scripts/check-upstream-pins.js
@@ -98,12 +98,17 @@ function getNpmLatest(pkg) {
   }
 }
 
-// Sum (major*10000 + minor*100 + patch) difference as a crude drift score.
+// Lexicographic semver drift score: compares major, minor, patch independently.
+// Returns positive when latest is newer, negative when pinned is ahead, 0 when equal.
+// Each component is weighted separately so large patch numbers (e.g. 165) do not
+// overflow into the minor component weight.
 function driftScore(pinned, latest) {
   const parse = (v) => v.split('.').map((s) => parseInt(s, 10) || 0);
   const [pM, pm, pp] = parse(pinned);
   const [lM, lm, lp] = parse(latest);
-  return lM * 10000 + lm * 100 + lp - (pM * 10000 + pm * 100 + pp);
+  if (lM !== pM) return (lM - pM) * 1000000;
+  if (lm !== pm) return (lm - pm) * 1000;
+  return lp - pp;
 }
 
 function main() {

--- a/scripts/check-upstream-pins.js
+++ b/scripts/check-upstream-pins.js
@@ -19,9 +19,9 @@
 
 'use strict';
 
+const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
-const { execFileSync } = require('node:child_process');
 
 // Allowlist for npm package names: scope + name chars per npm-name-validator,
 // length capped at the registry's documented 214-char limit.


### PR DESCRIPTION
## Summary

Fixes the yellow-morph fresh-install failure mode documented in `plans/yellow-morph-improvements.md`. Three problems landed in one PR:

1. **`MORPH_API_KEY` resolution at session start.** Shell env substitution in `plugin.json` resolves once at Claude Code launch — if the user hasn't exported the var before launching, morphmcp receives an empty key and the MCP never starts. No in-session fix; required restart. **Fixed:** migrated to Claude Code's native `userConfig` (sensitive, keychain-backed). No restart required after setup; shell env var preserved as power-user fallback via a wrapper script.

2. **`edit_file` was silently disabled.** The plugin passed `ENABLED_TOOLS=edit_file,warpgrep_codebase_search` — but morphmcp ignores `ENABLED_TOOLS` entirely and disables `edit_file` by default. The plugin has been serving only search tools for its entire life. Verified empirically (see `/tmp/morph-verify` probes in the Phase 1.1 task). **Fixed:** switched to `DISABLED_TOOLS=github_codebase_search`, which now correctly exposes `edit_file` + `codebase_search`.

3. **Tool name wrong.** `warpgrep_codebase_search` does not exist in morphmcp 0.8.165 — the tool is named `codebase_search`. **Fixed:** updated 7 plugin files. The client-side namespace is now `mcp__plugin_yellow-morph_morph__codebase_search`.

Pin bumped 0.8.110 → 0.8.165 (55 versions; no public changelog, verified empirically).

## Additional Improvements

- **Dual-bootstrap install** (`plugins/yellow-morph/bin/start-morph.sh` + `hooks/hooks.json`): wrapper is the correctness gate (`npm ci` if `node_modules` missing, then exec); SessionStart hook is a cache warmer. SessionStart and MCP startup race per community precedent (OpenViking memory-plugin README documents this) — wrapper ensures correctness regardless of ordering.
- **Lockfile committed** (`plugins/yellow-morph/package-lock.json`, 217 transitive pins): `npm ci` guarantees deterministic resolution, closing the supply-chain gap flagged by the security review.
- **Three-state `/morph:status`**: `OFFLINE` (no tools visible), `DEGRADED` (tools visible but API non-200), `HEALTHY` (both green). Each has an actionable "What to do" block.
- **Upstream pin tracker** (`docs/upstream-pins.md` + `scripts/check-upstream-pins.js`): drift-checks every pinned external MCP against npm latest. First run flagged three stale pins in yellow-research (perplexity +98, tavily +1, exa +92) — not bumped in this PR; tracked for follow-up.
- **`/setup:all` reclassification**: yellow-morph READY now accepts either shell env var OR userConfig presence (`grep "morph_api_key" ~/.claude/settings.json`).

## Security Review Outcomes

`security-sentinel` agent flagged 2 P1s and 2 P2s — all four fixed in commit `bbca010`:
- P1: shell injection in `check-upstream-pins.js` → `execFileSync` + argv array + npm-name allowlist.
- P1: missing lockfile → committed + switched to `npm ci`.
- P2: path traversal via `CLAUDE_PLUGIN_{ROOT,DATA}` → prefix validation in wrapper + hook.
- P2: `MORPH_API_KEY` leaking to npm-install subshell postinstall scripts → `unset` in subshell / `env -u` in hook.

## Test plan

- [x] Verified morphmcp 0.8.165 env-var behavior empirically (`/tmp/morph-verify` probes — see Phase 1.1 task).
- [x] Wrapper smoke test: first-run install (3s), cached exec (<1s); tool list matches expected (`edit_file`, `codebase_search`).
- [x] SessionStart hook smoke test: first-run install (3.8s), cached run (4ms, diff matches).
- [x] Path validation: `CLAUDE_PLUGIN_DATA=/etc` correctly causes hook to exit without side effects.
- [x] Drift checker smoke test: reports 3 yellow-research drifts, yellow-morph as `current`.
- [x] `validate-marketplace`, `validate-versions`, `validate-plugin`, `validate-setup-all` — all pass.
- [ ] Fresh-machine install on a real VM (documented in `plans/yellow-morph-improvements.md` §Testing Strategy). Not performed in this session; recommended before tag release.
- [ ] Upgrade-path test from the existing shell-env setup. Also recommended before release.

## Scope not in this PR (follow-ups)

- Phase 4 of the original plan: cross-plugin `userConfig` rollout to yellow-devin, yellow-semgrep, yellow-research. Same bug class; deliberately out of scope here.
- Shared `mcp-health-probe` skill extraction (planned Phase 4.4). Leave `/morph:status` as the prototype for now; extract once a second plugin needs the same pattern.
- Bumping yellow-research's 3 stale pins.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates yellow-morph's API key from a shell env variable to Claude Code's `userConfig` (keychain-backed), fixes the silent `edit_file` disablement caused by a non-existent `ENABLED_TOOLS` env var, corrects the tool name (`warpgrep_codebase_search` → `codebase_search`), and adds a dual-bootstrap install pattern (wrapper + SessionStart hook) with a shared `npm ci` install-lock library. The lockfile commit, `env -i` sandbox, and `execFileSync` + allowlist in the drift checker address the security findings from the prior review.

<h3>Confidence Score: 4/5</h3>

Safe to merge with the open ${MORPH_API_KEY:-} syntax thread from prior review tracked; the shell-env fallback path may silently pass a literal template string as the API key if Claude Code's template engine doesn't recognise bash's :- operator.

The ${MORPH_API_KEY:-} template substitution uncertainty (prior thread) is the only unresolved item touching the live execution path. Every other prior finding has been addressed or is an optimization concern. The new drift-checker threshold documentation is a minor labelling issue with no impact on runtime behaviour.

plugins/yellow-morph/.claude-plugin/plugin.json — the ${MORPH_API_KEY:-} env substitution syntax for the shell-env fallback path deserves a second look before release.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/yellow-morph/.claude-plugin/plugin.json | Migrates API key to userConfig (sensitive/keychain-backed), switches to wrapper-based MCP launch, fixes DISABLED_TOOLS and bumps pin; ${MORPH_API_KEY:-} bash default syntax may not be honoured by Claude Code's template engine (prior review thread). |
| plugins/yellow-morph/lib/install-morphmcp.sh | New shared install-primitive library: path validation, lockfile-diff need-check, PID-based stale-lock recovery, env-sanitised npm ci. Logic is sound; all diagnostic output goes to stderr. |
| plugins/yellow-morph/bin/start-morph.sh | Synchronous MCP correctness gate: resolves API key (userConfig wins, shell env fallback), acquires install lock, runs npm ci if lockfiles differ, releases lock before exec. Lock is correctly released manually before exec since EXIT trap does not fire after exec. |
| plugins/yellow-morph/hooks/scripts/prewarm-morph.sh | SessionStart pre-warmer that races wrapper; uses 5s lock budget and always exits via json_exit so Claude Code's continue signal is emitted on all reachable paths. |
| scripts/check-upstream-pins.js | New drift-checker: execFileSync + npm-name allowlist prevent injection; driftScore weighting fixed to use large multipliers (1M/1K/1) avoiding patch overflow; --threshold docs don't match the weighted score units. |
| plugins/yellow-core/commands/setup/all.md | READY detection now checks ~/.claude/.credentials.json for userConfig key in addition to shell env; shell-env check now labels source; example output updated. |
| plugins/yellow-morph/commands/morph/status.md | Rewrites status command to three-state OFFLINE/DEGRADED/HEALTHY; ToolSearch-based authoritative offline detection replaces env-var check; API probe now skipped when key is keychain-only. |
| plugins/yellow-morph/commands/morph/setup.md | Rewrites setup workflow for userConfig path; adds explicit npm ci pre-install step that acquires the install lock — but does not use the same mutex as start-morph.sh / prewarm-morph.sh (concurrent runs risk node_modules corruption, flagged in prior review). |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CC as Claude Code
    participant Hook as SessionStart Hook (prewarm-morph.sh)
    participant Wrapper as MCP Wrapper (start-morph.sh)
    participant Lib as lib/install-morphmcp.sh
    participant NPM as npm ci

    CC->>Hook: Session starts (parallel)
    CC->>Wrapper: First MCP tool call (parallel)

    Hook->>Lib: source install-morphmcp.sh
    Hook->>Lib: yellow_morph_validate_paths()
    Hook->>Lib: yellow_morph_needs_install()?
    alt needs install
        Hook->>Lib: yellow_morph_acquire_install_lock(5s)
        Lib-->>Hook: lock acquired
        Hook->>NPM: yellow_morph_do_install() [env -i]
        NPM-->>Hook: done
        Hook->>Lib: yellow_morph_release_install_lock()
    end
    Hook->>CC: {continue: true}

    Wrapper->>Lib: source install-morphmcp.sh
    Wrapper->>Lib: yellow_morph_validate_paths()
    Wrapper->>Lib: yellow_morph_needs_install()?
    alt needs install
        Wrapper->>Lib: yellow_morph_acquire_install_lock(20s)
        Lib-->>Wrapper: lock acquired
        Wrapper->>Lib: yellow_morph_needs_install()? (re-check under lock)
        alt still needs install
            Wrapper->>NPM: yellow_morph_do_install() [env -i]
            NPM-->>Wrapper: done
        end
        Wrapper->>Lib: yellow_morph_release_install_lock()
    end
    Wrapper->>CC: exec node morphmcp
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `plugins/yellow-morph/CHANGELOG.md`, line 222-228 ([link](https://github.com/kinginyellows/yellow-plugins/blob/80313233b1aaa69a142e51877ca95156a5a0b114/plugins/yellow-morph/CHANGELOG.md#L222-L228)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Shell env fallback already ships in 1.1.0**

   The changelog says "Power-user fallback via shell env var lands in 1.2.0 once the wrapper script is in place". But `bin/start-morph.sh` — which is part of this very PR — already implements the fallback: if `MORPH_API_KEY_USERCONFIG` is empty and `MORPH_API_KEY` is already in the shell env, morphmcp will receive it. The "1.2.0" statement is incorrect and will mislead users into thinking the fallback is not yet available.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: plugins/yellow-morph/CHANGELOG.md
   Line: 222-228

   Comment:
   **Shell env fallback already ships in 1.1.0**

   The changelog says "Power-user fallback via shell env var lands in 1.2.0 once the wrapper script is in place". But `bin/start-morph.sh` — which is part of this very PR — already implements the fallback: if `MORPH_API_KEY_USERCONFIG` is empty and `MORPH_API_KEY` is already in the shell env, morphmcp will receive it. The "1.2.0" statement is incorrect and will mislead users into thinking the fallback is not yet available.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22feat%2Fyellow-morph-userconfig-migration%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fyellow-morph-userconfig-migration%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plugins%2Fyellow-morph%2FCHANGELOG.md%0ALine%3A%20222-228%0A%0AComment%3A%0A**Shell%20env%20fallback%20already%20ships%20in%201.1.0**%0A%0AThe%20changelog%20says%20%22Power-user%20fallback%20via%20shell%20env%20var%20lands%20in%201.2.0%20once%20the%20wrapper%20script%20is%20in%20place%22.%20But%20%60bin%2Fstart-morph.sh%60%20%E2%80%94%20which%20is%20part%20of%20this%20very%20PR%20%E2%80%94%20already%20implements%20the%20fallback%3A%20if%20%60MORPH_API_KEY_USERCONFIG%60%20is%20empty%20and%20%60MORPH_API_KEY%60%20is%20already%20in%20the%20shell%20env%2C%20morphmcp%20will%20receive%20it.%20The%20%221.2.0%22%20statement%20is%20incorrect%20and%20will%20mislead%20users%20into%20thinking%20the%20fallback%20is%20not%20yet%20available.%0A%0A%60%60%60suggestion%0A-%20**Config%20surface%3A%20%60MORPH_API_KEY%60%20now%20read%20from%20%60userConfig%60%2C%20not%20shell%20env.**%0A%20%20Shell%20env%20%60MORPH_API_KEY%60%20is%20also%20accepted%20as%20a%20power-user%20fallback%20via%0A%20%20the%20wrapper%20script%20%28%60bin%2Fstart-morph.sh%60%29%3B%20userConfig%20takes%20precedence%0A%20%20when%20both%20are%20present.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

2. `plugins/yellow-morph/commands/morph/setup.md`, line 678-684 ([link](https://github.com/kinginyellows/yellow-plugins/blob/f1a7726c6b478bbbed6e0b14cfa06e46414f288f/plugins/yellow-morph/commands/morph/setup.md#L678-L684)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Step 3 pre-install bypasses the install lock**

   This block runs `npm ci` without acquiring the `.install.lock` mutex used by both `start-morph.sh` and `prewarm-morph.sh`. If a user runs `/morph:setup` during the 3–20 second window when the SessionStart prewarm hook is executing its own `npm ci`, both processes will write to `CLAUDE_PLUGIN_DATA/node_modules` concurrently. `npm ci` deletes the entire `node_modules` directory before reinstalling, so two concurrent runs corrupt the install — the same failure mode the locking scheme was specifically designed to prevent.

   Consider wrapping the pre-install block with the same `mkdir "$LOCK_DIR"` loop, or at minimum skip the install if the lockfiles already match (the "already in sync" fast-path that `prewarm-morph.sh` uses at line 32–35).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: plugins/yellow-morph/commands/morph/setup.md
   Line: 678-684

   Comment:
   **Step 3 pre-install bypasses the install lock**

   This block runs `npm ci` without acquiring the `.install.lock` mutex used by both `start-morph.sh` and `prewarm-morph.sh`. If a user runs `/morph:setup` during the 3–20 second window when the SessionStart prewarm hook is executing its own `npm ci`, both processes will write to `CLAUDE_PLUGIN_DATA/node_modules` concurrently. `npm ci` deletes the entire `node_modules` directory before reinstalling, so two concurrent runs corrupt the install — the same failure mode the locking scheme was specifically designed to prevent.

   Consider wrapping the pre-install block with the same `mkdir "$LOCK_DIR"` loop, or at minimum skip the install if the lockfiles already match (the "already in sync" fast-path that `prewarm-morph.sh` uses at line 32–35).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22feat%2Fyellow-morph-userconfig-migration%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fyellow-morph-userconfig-migration%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plugins%2Fyellow-morph%2Fcommands%2Fmorph%2Fsetup.md%0ALine%3A%20678-684%0A%0AComment%3A%0A**Step%203%20pre-install%20bypasses%20the%20install%20lock**%0A%0AThis%20block%20runs%20%60npm%20ci%60%20without%20acquiring%20the%20%60.install.lock%60%20mutex%20used%20by%20both%20%60start-morph.sh%60%20and%20%60prewarm-morph.sh%60.%20If%20a%20user%20runs%20%60%2Fmorph%3Asetup%60%20during%20the%203%E2%80%9320%20second%20window%20when%20the%20SessionStart%20prewarm%20hook%20is%20executing%20its%20own%20%60npm%20ci%60%2C%20both%20processes%20will%20write%20to%20%60CLAUDE_PLUGIN_DATA%2Fnode_modules%60%20concurrently.%20%60npm%20ci%60%20deletes%20the%20entire%20%60node_modules%60%20directory%20before%20reinstalling%2C%20so%20two%20concurrent%20runs%20corrupt%20the%20install%20%E2%80%94%20the%20same%20failure%20mode%20the%20locking%20scheme%20was%20specifically%20designed%20to%20prevent.%0A%0AConsider%20wrapping%20the%20pre-install%20block%20with%20the%20same%20%60mkdir%20%22%24LOCK_DIR%22%60%20loop%2C%20or%20at%20minimum%20skip%20the%20install%20if%20the%20lockfiles%20already%20match%20%28the%20%22already%20in%20sync%22%20fast-path%20that%20%60prewarm-morph.sh%60%20uses%20at%20line%2032%E2%80%9335%29.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

3. `plugins/yellow-morph/.claude-plugin/plugin.json`, line 258 ([link](https://github.com/kinginyellows/yellow-plugins/blob/981c975b85a069a72b1bc5b6282ff33d34530d27/plugins/yellow-morph/.claude-plugin/plugin.json#L258)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`${MORPH_API_KEY:-}` bash syntax may not be processed by Claude Code's template engine**

   Claude Code's env substitution supports `${user_config.KEY}` and `${ENV_VAR}` patterns, but it almost certainly does not implement bash's `:-` default-value operator. If `${MORPH_API_KEY:-}` is not recognized as a template token, the literal string `${MORPH_API_KEY:-}` is passed to `start-morph.sh` as the value of `MORPH_API_KEY`. Since that string is non-empty, morphmcp will use it as the API key and immediately fail authentication — silently breaking the documented shell env power-user fallback for everyone who uses it. The previous code used `${MORPH_API_KEY}` (without `:-`), which is known to work.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: plugins/yellow-morph/.claude-plugin/plugin.json
   Line: 258

   Comment:
   **`${MORPH_API_KEY:-}` bash syntax may not be processed by Claude Code's template engine**

   Claude Code's env substitution supports `${user_config.KEY}` and `${ENV_VAR}` patterns, but it almost certainly does not implement bash's `:-` default-value operator. If `${MORPH_API_KEY:-}` is not recognized as a template token, the literal string `${MORPH_API_KEY:-}` is passed to `start-morph.sh` as the value of `MORPH_API_KEY`. Since that string is non-empty, morphmcp will use it as the API key and immediately fail authentication — silently breaking the documented shell env power-user fallback for everyone who uses it. The previous code used `${MORPH_API_KEY}` (without `:-`), which is known to work.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22feat%2Fyellow-morph-userconfig-migration%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fyellow-morph-userconfig-migration%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plugins%2Fyellow-morph%2F.claude-plugin%2Fplugin.json%0ALine%3A%20258%0A%0AComment%3A%0A**%60%24%7BMORPH_API_KEY%3A-%7D%60%20bash%20syntax%20may%20not%20be%20processed%20by%20Claude%20Code's%20template%20engine**%0A%0AClaude%20Code's%20env%20substitution%20supports%20%60%24%7Buser_config.KEY%7D%60%20and%20%60%24%7BENV_VAR%7D%60%20patterns%2C%20but%20it%20almost%20certainly%20does%20not%20implement%20bash's%20%60%3A-%60%20default-value%20operator.%20If%20%60%24%7BMORPH_API_KEY%3A-%7D%60%20is%20not%20recognized%20as%20a%20template%20token%2C%20the%20literal%20string%20%60%24%7BMORPH_API_KEY%3A-%7D%60%20is%20passed%20to%20%60start-morph.sh%60%20as%20the%20value%20of%20%60MORPH_API_KEY%60.%20Since%20that%20string%20is%20non-empty%2C%20morphmcp%20will%20use%20it%20as%20the%20API%20key%20and%20immediately%20fail%20authentication%20%E2%80%94%20silently%20breaking%20the%20documented%20shell%20env%20power-user%20fallback%20for%20everyone%20who%20uses%20it.%20The%20previous%20code%20used%20%60%24%7BMORPH_API_KEY%7D%60%20%28without%20%60%3A-%60%29%2C%20which%20is%20known%20to%20work.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22feat%2Fyellow-morph-userconfig-migration%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fyellow-morph-userconfig-migration%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fcheck-upstream-pins.js%3A13%0AThe%20%60--threshold%60%20usage%20comment%20describes%20the%20argument%20in%20terms%20of%20%22major%2Bminor%20versions%22%2C%20but%20the%20actual%20comparison%20is%20against%20the%20raw%20weighted%20drift%20score%20%28major%C3%971%2C000%2C000%20%2B%20minor%C3%971%2C000%20%2B%20patch%29.%20With%20%60--threshold%2010%60%2C%20anything%20%E2%89%A5%2010%20patch%20versions%20behind%20triggers%20the%20exit%20%E2%80%94%20not%20%2210%20major%2Bminor%20versions%22%20as%20the%20comment%20implies.%20A%20user%20following%20the%20docs%20who%20wants%20to%20allow%20up%20to%20one%20minor-version%20drift%20would%20set%20%60--threshold%201%60%2C%20not%20%60--threshold%201000%60%2C%20and%20be%20surprised%20when%20it%20fires%20immediately.%0A%0A%60%60%60suggestion%0A%20*%20%20%20node%20scripts%2Fcheck-upstream-pins.js%20--threshold%2010%20%20%20%20%23%20exit%201%20when%20drift%20score%20%3E%3D%2010%20%28patch%3D1%2C%20minor%3D1000%2C%20major%3D1000000%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
scripts/check-upstream-pins.js:13
The `--threshold` usage comment describes the argument in terms of "major+minor versions", but the actual comparison is against the raw weighted drift score (major×1,000,000 + minor×1,000 + patch). With `--threshold 10`, anything ≥ 10 patch versions behind triggers the exit — not "10 major+minor versions" as the comment implies. A user following the docs who wants to allow up to one minor-version drift would set `--threshold 1`, not `--threshold 1000`, and be surprised when it fires immediately.

```suggestion
 *   node scripts/check-upstream-pins.js --threshold 10    # exit 1 when drift score >= 10 (patch=1, minor=1000, major=1000000)
```


`````

</details>

<sub>Reviews (10): Last reviewed commit: ["fix(ci): add userConfig to plugin schema..."](https://github.com/kinginyellows/yellow-plugins/commit/215833b9fc03865a382e812b66baf8810a28a0c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28766781)</sub>

<!-- /greptile_comment -->