### PR TITLE
test(lint): add fixture-based test harness for lint-plugins.sh

### DIFF
--- a/.github/workflows/lint-plugins.yml
+++ b/.github/workflows/lint-plugins.yml
@@ -7,6 +7,8 @@ on:
       - 'scripts/lint-plugins.sh'
       - 'scripts/validate-plugin.js'
       - 'schemas/plugin.schema.json'
+      - 'tests/lint-plugins.bats'
+      - 'fixtures/lint/**'
       - '.github/workflows/lint-plugins.yml'
   push:
     branches: [main]
@@ -15,6 +17,8 @@ on:
       - 'scripts/lint-plugins.sh'
       - 'scripts/validate-plugin.js'
       - 'schemas/plugin.schema.json'
+      - 'tests/lint-plugins.bats'
+      - 'fixtures/lint/**'
       - '.github/workflows/lint-plugins.yml'
 
 permissions:
@@ -31,6 +35,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Bats
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq bats
+
+      - name: Self-test lint script (fixture-based, Bats)
+        run: bats tests/lint-plugins.bats
 
       - name: Run plugin frontmatter and convention lint
         run: bash scripts/lint-plugins.sh

--- a/fixtures/lint/plugins/sample-plugin/.claude-plugin/plugin.json
+++ b/fixtures/lint/plugins/sample-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "sample-plugin",
+  "version": "0.1.0",
+  "description": "Synthetic plugin used by scripts/test-lint-plugins.sh — not a real plugin.",
+  "author": "lint-fixture"
+}

--- a/fixtures/lint/plugins/sample-plugin/.claude-plugin/plugin.json
+++ b/fixtures/lint/plugins/sample-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sample-plugin",
   "version": "0.1.0",
-  "description": "Synthetic plugin used by scripts/test-lint-plugins.sh — not a real plugin.",
+  "description": "Synthetic plugin used by tests/lint-plugins.bats — not a real plugin.",
   "author": "lint-fixture"
 }

--- a/fixtures/lint/plugins/sample-plugin/agents/good-agent.md
+++ b/fixtures/lint/plugins/sample-plugin/agents/good-agent.md
@@ -1,0 +1,11 @@
+---
+name: good-agent
+description: A clean agent fixture — has name, description, and tools. Should produce no findings.
+model: inherit
+tools:
+  - Read
+---
+
+# Good Agent
+
+This agent is a fixture; it does not run.

--- a/fixtures/lint/plugins/sample-plugin/agents/memory-project.md
+++ b/fixtures/lint/plugins/sample-plugin/agents/memory-project.md
@@ -1,0 +1,12 @@
+---
+name: memory-project
+description: Fixture with the correct memory scope. Lint should not warn.
+model: inherit
+memory: project
+tools:
+  - Read
+---
+
+# Memory Project
+
+Fixture body.

--- a/fixtures/lint/plugins/sample-plugin/agents/memory-true.md
+++ b/fixtures/lint/plugins/sample-plugin/agents/memory-true.md
@@ -1,0 +1,12 @@
+---
+name: memory-true
+description: Fixture with the wrong memory form. Lint should emit a WARN.
+model: inherit
+memory: true
+tools:
+  - Read
+---
+
+# Memory True
+
+Fixture body.

--- a/fixtures/lint/plugins/sample-plugin/agents/missing-description.md
+++ b/fixtures/lint/plugins/sample-plugin/agents/missing-description.md
@@ -1,0 +1,10 @@
+---
+name: missing-description
+model: inherit
+tools:
+  - Read
+---
+
+# Missing Description
+
+Fixture body.

--- a/fixtures/lint/plugins/sample-plugin/agents/missing-name.md
+++ b/fixtures/lint/plugins/sample-plugin/agents/missing-name.md
@@ -1,0 +1,10 @@
+---
+description: Fixture missing the name field. Lint should emit an ERROR.
+model: inherit
+tools:
+  - Read
+---
+
+# Missing Name
+
+Fixture body.

--- a/fixtures/lint/plugins/sample-plugin/agents/missing-tools.md
+++ b/fixtures/lint/plugins/sample-plugin/agents/missing-tools.md
@@ -1,0 +1,9 @@
+---
+name: missing-tools
+description: Fixture without the tools field. Lint should emit an ERROR (escalated from WARN in PR #261).
+model: inherit
+---
+
+# Missing Tools
+
+Fixture body.

--- a/fixtures/lint/plugins/sample-plugin/agents/skill-body-ref.md
+++ b/fixtures/lint/plugins/sample-plugin/agents/skill-body-ref.md
@@ -1,0 +1,16 @@
+---
+name: skill-body-ref
+description: Fixture referencing a string that only appears in SKILL.md body prose. Lint MUST error with "unknown skill" — proves the pre-PR-261 body-parsing regression stays fixed.
+model: inherit
+skills:
+  - should-not-be-collected
+tools:
+  - Read
+---
+
+# Skill Body Regression Fixture
+
+If the lint script collects `name:` lines from SKILL.md body prose, this
+agent's reference to `should-not-be-collected` would silently resolve. The
+fix in PR #261 scopes name extraction to frontmatter, so this reference
+must surface as "unknown skill: should-not-be-collected".

--- a/fixtures/lint/plugins/sample-plugin/agents/unknown-skill.md
+++ b/fixtures/lint/plugins/sample-plugin/agents/unknown-skill.md
@@ -1,0 +1,13 @@
+---
+name: unknown-skill-ref
+description: Fixture referencing a skill that does not exist. Lint should emit an ERROR.
+model: inherit
+skills:
+  - this-skill-does-not-exist
+tools:
+  - Read
+---
+
+# Unknown Skill
+
+Fixture body.

--- a/fixtures/lint/plugins/sample-plugin/agents/valid-skill.md
+++ b/fixtures/lint/plugins/sample-plugin/agents/valid-skill.md
@@ -1,0 +1,13 @@
+---
+name: valid-skill-ref
+description: Fixture referencing a real skill in this fixture plugin. Lint should not error.
+model: inherit
+skills:
+  - test-skill
+tools:
+  - Read
+---
+
+# Valid Skill
+
+Fixture body.

--- a/fixtures/lint/plugins/sample-plugin/skills/test-skill/SKILL.md
+++ b/fixtures/lint/plugins/sample-plugin/skills/test-skill/SKILL.md
@@ -10,5 +10,10 @@ Body content. The body intentionally contains a stray `name:` line below to
 regression-test the P1 fix from PR #261, which scoped name extraction to
 frontmatter so body prose can no longer corrupt the known-skills set.
 
-> Example documentation snippet that mentions `name: should-not-be-collected`
-> in body prose. The lint script must NOT treat this string as a skill name.
+The next line deliberately starts at column 1 with no blockquote or code
+fence prefix, so an awk extractor running on the whole file (the pre-fix
+bug) would match `^name:` against it. The lint script must NOT treat this
+body-prose `name:` as a skill — only the frontmatter `name: test-skill`
+should index.
+
+name: should-not-be-collected

--- a/fixtures/lint/plugins/sample-plugin/skills/test-skill/SKILL.md
+++ b/fixtures/lint/plugins/sample-plugin/skills/test-skill/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: test-skill
+description: Skill fixture used to validate the skill-reference resolver in lint-plugins.sh.
+user-invokable: false
+---
+
+# Test Skill
+
+Body content. The body intentionally contains a stray `name:` line below to
+regression-test the P1 fix from PR #261, which scoped name extraction to
+frontmatter so body prose can no longer corrupt the known-skills set.
+
+> Example documentation snippet that mentions `name: should-not-be-collected`
+> in body prose. The lint script must NOT treat this string as a skill name.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "validate:marketplace": "node scripts/validate-marketplace.js",
     "validate:plugins": "node scripts/validate-plugin.js",
     "validate:setup-all": "node scripts/validate-setup-all.js",
+    "test:lint-plugins": "bats tests/lint-plugins.bats",
+    "lint:plugins": "bash scripts/lint-plugins.sh",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md,yml,yaml}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md,yml,yaml}\"",
     "release:check": "pnpm run validate:schemas && pnpm run validate:versions && pnpm run typecheck",

--- a/tests/lint-plugins.bats
+++ b/tests/lint-plugins.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+# Tests for scripts/lint-plugins.sh — fixture-based regression coverage.
+#
+# Catches regressions in:
+#   - frontmatter completeness checks (Check 1, including missing-tools as ERROR)
+#   - memory: true detection (Check 2 — must be scoped to frontmatter only)
+#   - skill-reference resolution (Check 3) — including the regression where
+#     SKILL.md body prose containing "name:" lines was corrupting the
+#     known-skills set (P1 fix shipped in PR #261)
+#   - exit code aggregation (errors → 1, warnings-only → 0)
+
+setup() {
+  ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  LINT_SCRIPT="$ROOT/scripts/lint-plugins.sh"
+  FIXTURE_SRC="$ROOT/fixtures/lint"
+
+  [ -f "$LINT_SCRIPT" ] || skip "lint script not found at $LINT_SCRIPT"
+  [ -d "$FIXTURE_SRC/plugins" ] || skip "fixture not found at $FIXTURE_SRC"
+
+  TEST_TMP=$(mktemp -d -t lint-tests-XXXXXX)
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+}
+
+# Helper: build a git-initialized fixture tree under $TEST_TMP/<subdir>
+# and run the lint script. Sets $output and $status (Bats run conventions).
+run_lint_in_fixture() {
+  local subdir="$1"
+  local fixture_path="$2"
+  cp -r "$fixture_path" "$TEST_TMP/$subdir/plugins"
+  ( cd "$TEST_TMP/$subdir" \
+      && git init -q \
+      && git config user.email lint@example.invalid \
+      && git config user.name lint \
+      && git add . \
+      && git commit -q -m init >/dev/null )
+  cd "$TEST_TMP/$subdir"
+  run bash "$LINT_SCRIPT"
+  cd "$ROOT"
+}
+
+# ============================================================================
+# Test 1: full fixture (intentional errors and warnings)
+# Exit code should be 1 (errors present). All expected findings must appear.
+# ============================================================================
+
+@test "full fixture: exit code is 1 (errors present)" {
+  mkdir "$TEST_TMP/full"
+  run_lint_in_fixture full "$FIXTURE_SRC/plugins"
+  [ "$status" -eq 1 ]
+}
+
+@test "full fixture: missing-name agent fires ERROR" {
+  mkdir "$TEST_TMP/full"
+  run_lint_in_fixture full "$FIXTURE_SRC/plugins"
+  [[ "$output" == *"missing 'name:' frontmatter: plugins/sample-plugin/agents/missing-name.md"* ]]
+}
+
+@test "full fixture: missing-description agent fires ERROR" {
+  mkdir "$TEST_TMP/full"
+  run_lint_in_fixture full "$FIXTURE_SRC/plugins"
+  [[ "$output" == *"missing 'description:' frontmatter: plugins/sample-plugin/agents/missing-description.md"* ]]
+}
+
+@test "full fixture: missing-tools agent fires ERROR (escalated from warn in PR #261)" {
+  mkdir "$TEST_TMP/full"
+  run_lint_in_fixture full "$FIXTURE_SRC/plugins"
+  [[ "$output" == *"missing required 'tools:' allowlist"* ]]
+}
+
+@test "full fixture: unknown-skill reference fires ERROR" {
+  mkdir "$TEST_TMP/full"
+  run_lint_in_fixture full "$FIXTURE_SRC/plugins"
+  [[ "$output" == *"unknown skill: this-skill-does-not-exist"* ]]
+}
+
+@test "full fixture: body-prose 'name:' does NOT index as a skill (regression for PR #261)" {
+  # skill-body-ref.md (fixture) references `should-not-be-collected`, a string
+  # that only appears in SKILL.md body prose. Under the pre-PR-261 bug, the
+  # extractor collected it as a known skill and the reference silently
+  # resolved. Under the fix, it must surface as an unknown skill error.
+  mkdir "$TEST_TMP/full"
+  run_lint_in_fixture full "$FIXTURE_SRC/plugins"
+  [[ "$output" == *"unknown skill: should-not-be-collected"* ]]
+}
+
+@test "full fixture: memory: true fires WARN" {
+  mkdir "$TEST_TMP/full"
+  run_lint_in_fixture full "$FIXTURE_SRC/plugins"
+  [[ "$output" == *"'memory: true' is likely a no-op"* ]]
+}
+
+@test "full fixture: memory: project does NOT trigger the memory check" {
+  mkdir "$TEST_TMP/full"
+  run_lint_in_fixture full "$FIXTURE_SRC/plugins"
+  [[ "$output" != *"memory-project.md"* ]]
+}
+
+@test "full fixture: valid skill reference does NOT error" {
+  mkdir "$TEST_TMP/full"
+  run_lint_in_fixture full "$FIXTURE_SRC/plugins"
+  [[ "$output" != *"unknown skill: test-skill"* ]]
+}
+
+# ============================================================================
+# Test 2: clean fixture (only good agents) — exit 0, no ERRORs.
+# ============================================================================
+
+@test "clean subset: exits 0 (no errors)" {
+  mkdir -p "$TEST_TMP/clean/plugins/sample-plugin/agents" \
+           "$TEST_TMP/clean/plugins/sample-plugin/skills/test-skill"
+  cp "$FIXTURE_SRC/plugins/sample-plugin/agents/good-agent.md" \
+     "$TEST_TMP/clean/plugins/sample-plugin/agents/"
+  cp "$FIXTURE_SRC/plugins/sample-plugin/agents/valid-skill.md" \
+     "$TEST_TMP/clean/plugins/sample-plugin/agents/"
+  cp "$FIXTURE_SRC/plugins/sample-plugin/skills/test-skill/SKILL.md" \
+     "$TEST_TMP/clean/plugins/sample-plugin/skills/test-skill/"
+  ( cd "$TEST_TMP/clean" \
+      && git init -q \
+      && git config user.email lint@example.invalid \
+      && git config user.name lint \
+      && git add . \
+      && git commit -q -m init >/dev/null )
+  cd "$TEST_TMP/clean"
+  run bash "$LINT_SCRIPT"
+  cd "$ROOT"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"ERROR"* ]]
+}

--- a/tests/lint-plugins.bats
+++ b/tests/lint-plugins.bats
@@ -21,7 +21,9 @@ setup() {
 }
 
 teardown() {
-  rm -rf "$TEST_TMP"
+  # TEST_TMP may be unset if `setup` skipped before mktemp; guard the rm so
+  # it does not silently expand to `rm -rf ""`.
+  [ -n "${TEST_TMP:-}" ] && rm -rf "$TEST_TMP"
 }
 
 # Helper: build a git-initialized fixture tree under $TEST_TMP/<subdir>
@@ -37,7 +39,10 @@ run_lint_in_fixture() {
       && git add . \
       && git commit -q -m init >/dev/null )
   cd "$TEST_TMP/$subdir"
-  run bash "$LINT_SCRIPT"
+  # bats-core >= 1.5.0 captures only stdout in $output; lint-plugins.sh writes
+  # findings to stderr via err()/warn(). Merge streams so $output assertions
+  # see the actual error/warning text.
+  run bash "$LINT_SCRIPT" 2>&1
   cd "$ROOT"
 }
 
@@ -124,7 +129,8 @@ run_lint_in_fixture() {
       && git add . \
       && git commit -q -m init >/dev/null )
   cd "$TEST_TMP/clean"
-  run bash "$LINT_SCRIPT"
+  # Merge stderr into $output (see run_lint_in_fixture for rationale).
+  run bash "$LINT_SCRIPT" 2>&1
   cd "$ROOT"
   [ "$status" -eq 0 ]
   [[ "$output" != *"ERROR"* ]]

--- a/tests/lint-plugins.bats
+++ b/tests/lint-plugins.bats
@@ -31,13 +31,19 @@ teardown() {
 run_lint_in_fixture() {
   local subdir="$1"
   local fixture_path="$2"
-  cp -r "$fixture_path" "$TEST_TMP/$subdir/plugins"
+  cp -r "$fixture_path" "$TEST_TMP/$subdir/plugins" || {
+    echo "fixture setup failed: cp -r '$fixture_path' '$TEST_TMP/$subdir/plugins'" >&2
+    return 1
+  }
   ( cd "$TEST_TMP/$subdir" \
       && git init -q \
       && git config user.email lint@example.invalid \
       && git config user.name lint \
       && git add . \
-      && git commit -q -m init >/dev/null )
+      && git commit -q -m init >/dev/null ) || {
+    echo "fixture setup failed: git init/commit in '$TEST_TMP/$subdir'" >&2
+    return 1
+  }
   cd "$TEST_TMP/$subdir"
   # bats-core >= 1.5.0 captures only stdout in $output; lint-plugins.sh writes
   # findings to stderr via err()/warn(). Merge streams so $output assertions
@@ -134,4 +140,5 @@ run_lint_in_fixture() {
   cd "$ROOT"
   [ "$status" -eq 0 ]
   [[ "$output" != *"ERROR"* ]]
+  [[ "$output" != *"WARN"* ]]
 }


### PR DESCRIPTION
## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a fixture-based Bats test harness for `scripts/lint-plugins.sh`, replacing an older ad-hoc test script. It adds a `fixtures/lint/` directory with a synthetic plugin containing curated agent and skill files designed to trigger (or not trigger) each lint check, adds `tests/lint-plugins.bats` with 10 tests covering exit-code aggregation, frontmatter completeness, the `memory: true` false-positive guard, and the PR #261 skill-body-prose regression.

- A `run_lint_in_fixture` helper sets up a fresh git-initialized copy of the fixture and runs the lint script, merging stderr into `$output` so Bats assertions see lint findings.
- The CI workflow gains two new path triggers (`tests/lint-plugins.bats`, `fixtures/lint/**`), a Bats install step, and a self-test step that runs before the production lint step.
- `package.json` adds a `test:lint-plugins` script pointing directly to the Bats entry point.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are purely additive test infrastructure and do not touch production code paths.

The lint script itself is unchanged. The new Bats tests, fixtures, workflow additions, and npm scripts are all self-contained. The only concern is a test-quality gap in the negative-assertion tests, which does not affect the correctness of the lint script or CI production runs.

tests/lint-plugins.bats — the three negative-assertion tests in the "full fixture" group should also assert `$status -eq 1` to prevent vacuous passes.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tests/lint-plugins.bats | New Bats test file; logic is sound but negative-assertion tests each re-run the lint script independently without also verifying the script ran to completion, creating a silent pass risk on total script failure. |
| .github/workflows/lint-plugins.yml | Adds Bats install + self-test step and expands path filters to include the new test and fixture paths; no issues found. |
| package.json | Adds `test:lint-plugins` (bats) and `lint:plugins` (bash) npm scripts; both point to correct paths. |
| fixtures/lint/plugins/sample-plugin/skills/test-skill/SKILL.md | Intentionally places a bare `name: should-not-be-collected` line in the body to regression-test the frontmatter-scoping fix; well-documented. |
| fixtures/lint/plugins/sample-plugin/agents/missing-tools.md | Fixture for the escalated `tools:` error; correctly omits the tools field to trigger the lint check. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[bats tests/lint-plugins.bats] --> B[setup: mktemp TEST_TMP]
    B --> C[run_lint_in_fixture helper]
    C --> D[cp fixture to TEST_TMP/subdir/plugins]
    D --> E[git init + commit in TEST_TMP/subdir]
    E --> F[run bash lint-plugins.sh 2>&1]
    F --> G{assertions on output / status}
    G -->|positive ==| H[Pass: expected finding present]
    G -->|negative !=| I[Pass: unwanted finding absent]
    G -->|exit code| J[Pass: errors=1, clean=0]
    B --> K[teardown: rm -rf TEST_TMP]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/lint-plugins.yml`, line 5-14 ([link](https://github.com/kinginyellows/yellow-plugins/blob/d7327925ceaf7526639d90c8a5457664d7d7272b/.github/workflows/lint-plugins.yml#L5-L14)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Workflow won't trigger on test-harness or fixture changes**

   Both the `pull_request` and `push` path filters are missing `scripts/test-lint-plugins.sh` and `fixtures/**`. A PR that only modifies those files (e.g., adding a new fixture, fixing an assertion) will not trigger this workflow, meaning CI gives no signal on whether the self-test still passes.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/lint-plugins.yml
   Line: 5-14

   Comment:
   **Workflow won't trigger on test-harness or fixture changes**

   Both the `pull_request` and `push` path filters are missing `scripts/test-lint-plugins.sh` and `fixtures/**`. A PR that only modifies those files (e.g., adding a new fixture, fixing an assertion) will not trigger this workflow, meaning CI gives no signal on whether the self-test still passes.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22test%2Flint-plugins-test-harness%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22test%2Flint-plugins-test-harness%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Flint-plugins.yml%0ALine%3A%205-14%0A%0AComment%3A%0A**Workflow%20won't%20trigger%20on%20test-harness%20or%20fixture%20changes**%0A%0ABoth%20the%20%60pull_request%60%20and%20%60push%60%20path%20filters%20are%20missing%20%60scripts%2Ftest-lint-plugins.sh%60%20and%20%60fixtures%2F**%60.%20A%20PR%20that%20only%20modifies%20those%20files%20%28e.g.%2C%20adding%20a%20new%20fixture%2C%20fixing%20an%20assertion%29%20will%20not%20trigger%20this%20workflow%2C%20meaning%20CI%20gives%20no%20signal%20on%20whether%20the%20self-test%20still%20passes.%0A%0A%60%60%60suggestion%0Aon%3A%0A%20%20pull_request%3A%0A%20%20%20%20paths%3A%0A%20%20%20%20%20%20-%20'plugins%2F**'%0A%20%20%20%20%20%20-%20'scripts%2Flint-plugins.sh'%0A%20%20%20%20%20%20-%20'scripts%2Ftest-lint-plugins.sh'%0A%20%20%20%20%20%20-%20'fixtures%2F**'%0A%20%20%20%20%20%20-%20'.github%2Fworkflows%2Flint-plugins.yml'%0A%20%20push%3A%0A%20%20%20%20branches%3A%20%5Bmain%5D%0A%20%20%20%20paths%3A%0A%20%20%20%20%20%20-%20'plugins%2F**'%0A%20%20%20%20%20%20-%20'scripts%2Flint-plugins.sh'%0A%20%20%20%20%20%20-%20'scripts%2Ftest-lint-plugins.sh'%0A%20%20%20%20%20%20-%20'fixtures%2F**'%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22test%2Flint-plugins-test-harness%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22test%2Flint-plugins-test-harness%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Flint-plugins.bats%3A113-125%0A**Negative-assertion%20tests%20don't%20guard%20against%20silent%20script%20failure**%0A%0AThe%20three%20tests%20that%20assert%20what%20is%20*not*%20in%20%60%24output%60%20%E2%80%94%20%22memory%3A%20project%20does%20NOT%20trigger%22%2C%20%22valid%20skill%20reference%20does%20NOT%20error%22%2C%20and%20the%20body-prose%20regression%20test's%20positive-result%20check%20%E2%80%94%20each%20run%20the%20lint%20script%20independently%20but%20never%20verify%20the%20script%20actually%20ran%20to%20completion.%20If%20%60run_lint_in_fixture%60%20sets%20up%20correctly%20but%20the%20lint%20script%20crashes%20before%20emitting%20any%20diagnostics%20%28e.g.%2C%20a%20bash%20syntax%20error%29%2C%20%60%24output%60%20will%20be%20empty%20and%20every%20%60!%3D%60%20assertion%20passes%20vacuously.%20Since%20the%20full%20fixture%20always%20contains%20intentional%20errors%20the%20script%20must%20find%2C%20adding%20%60%5B%20%22%24status%22%20-eq%201%20%5D%60%20at%20the%20top%20of%20each%20of%20these%20tests%20%28mirroring%20the%20first%20test%20in%20the%20group%29%20would%20ensure%20the%20run%20was%20healthy%20before%20trusting%20the%20absence%20of%20a%20finding.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/lint-plugins.bats:113-125
**Negative-assertion tests don't guard against silent script failure**

The three tests that assert what is *not* in `$output` — "memory: project does NOT trigger", "valid skill reference does NOT error", and the body-prose regression test's positive-result check — each run the lint script independently but never verify the script actually ran to completion. If `run_lint_in_fixture` sets up correctly but the lint script crashes before emitting any diagnostics (e.g., a bash syntax error), `$output` will be empty and every `!=` assertion passes vacuously. Since the full fixture always contains intentional errors the script must find, adding `[ "$status" -eq 1 ]` at the top of each of these tests (mirroring the first test in the group) would ensure the run was healthy before trusting the absence of a finding.


`````

</details>

<sub>Reviews (13): Last reviewed commit: ["test(lint-plugins): address copilot revi..."](https://github.com/kinginyellows/yellow-plugins/commit/ea1a10d7473aa27d9ebeac8e77e05c15ce07933d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28766760)</sub>

<!-- /greptile_comment -->