### PR TITLE
feat(lint): emit GitHub Actions ::warning:: / ::error:: annotations

### DIFF
--- a/scripts/lint-plugins.sh
+++ b/scripts/lint-plugins.sh
@@ -28,12 +28,43 @@ cd "$ROOT" || exit 1
 errors=0
 warnings=0
 
+# When run inside GitHub Actions, also emit native ::warning::/::error::
+# annotations so findings surface in the PR UI instead of being buried in raw
+# job logs. Annotations go to stdout (where GitHub parses them); the human-
+# readable [lint-plugins] line continues to go to stderr unchanged.
+#
+# GitHub's workflow-command parser requires %, CR, and LF in the message
+# body to be URL-encoded, otherwise the annotation is truncated or malformed.
+# File paths get the same treatment for safety.
+ga_escape() {
+  printf '%s' "$1" | sed -e 's/%/%25/g' -e 's/\r/%0D/g' | awk 'BEGIN{ORS=""} {if(NR>1) printf "%%0A"; print}'
+}
+
+emit_annotation() {
+  # $1=level (warning|error), $2=message
+  local level="$1" msg="$2" file escaped_file escaped_msg
+  [ "${GITHUB_ACTIONS:-}" = "true" ] || return 0
+  # grep -o returns 1 with no match; under set -e that would abort the script.
+  # Tolerate misses and let $file stay empty so we fall through to the
+  # unanchored annotation form below.
+  file=$(printf '%s' "$msg" | grep -oE 'plugins/[A-Za-z0-9._/-]+\.md' | head -1 || true)
+  escaped_msg=$(ga_escape "$msg")
+  if [ -n "$file" ]; then
+    escaped_file=$(ga_escape "$file")
+    printf '::%s file=%s::%s\n' "$level" "$escaped_file" "$escaped_msg"
+  else
+    printf '::%s::%s\n' "$level" "$escaped_msg"
+  fi
+}
+
 err() {
   printf '[lint-plugins] ERROR: %s\n' "$*" >&2
+  emit_annotation error "$*"
   errors=$((errors + 1))
 }
 warn() {
   printf '[lint-plugins] WARN:  %s\n' "$*" >&2
+  emit_annotation warning "$*"
   warnings=$((warnings + 1))
 }
 

--- a/tests/lint-plugins.bats
+++ b/tests/lint-plugins.bats
@@ -48,7 +48,7 @@ run_lint_in_fixture() {
   # bats-core >= 1.5.0 captures only stdout in $output; lint-plugins.sh writes
   # findings to stderr via err()/warn(). Merge streams so $output assertions
   # see the actual error/warning text.
-  run bash "$LINT_SCRIPT" 2>&1
+  run env -u GITHUB_ACTIONS bash "$LINT_SCRIPT" 2>&1
   cd "$ROOT"
 }
 
@@ -136,7 +136,7 @@ run_lint_in_fixture() {
       && git commit -q -m init >/dev/null )
   cd "$TEST_TMP/clean"
   # Merge stderr into $output (see run_lint_in_fixture for rationale).
-  run bash "$LINT_SCRIPT" 2>&1
+  run env -u GITHUB_ACTIONS bash "$LINT_SCRIPT" 2>&1
   cd "$ROOT"
   [ "$status" -eq 0 ]
   [[ "$output" != *"ERROR"* ]]

--- a/tests/lint-plugins.bats
+++ b/tests/lint-plugins.bats
@@ -142,3 +142,58 @@ run_lint_in_fixture() {
   [[ "$output" != *"ERROR"* ]]
   [[ "$output" != *"WARN"* ]]
 }
+
+# ============================================================================
+# Test 3: GitHub Actions annotation emission. When GITHUB_ACTIONS=true,
+# the script must emit ::warning::/::error:: lines to stdout (where the
+# Actions runner parses them). Runs without the env var must NOT emit them.
+# The "local" invocation explicitly unsets GITHUB_ACTIONS so this assertion
+# holds even when the test harness itself runs inside CI (where
+# GITHUB_ACTIONS is already exported as "true" for every step).
+# ============================================================================
+
+setup_annotations_fixture() {
+  mkdir "$TEST_TMP/actions"
+  cp -r "$FIXTURE_SRC/plugins" "$TEST_TMP/actions/plugins"
+  ( cd "$TEST_TMP/actions" \
+      && git init -q \
+      && git config user.email lint@example.invalid \
+      && git config user.name lint \
+      && git add . \
+      && git commit -q -m init >/dev/null )
+}
+
+@test "annotations: local run (GITHUB_ACTIONS unset) emits 0 annotations to stdout" {
+  setup_annotations_fixture
+  cd "$TEST_TMP/actions"
+  local_stdout=$(env -u GITHUB_ACTIONS bash "$LINT_SCRIPT" 2>/dev/null || true)
+  cd "$ROOT"
+  count=$(printf '%s' "$local_stdout" | grep -c '^::' || true)
+  [ "$count" -eq 0 ]
+}
+
+@test "annotations: GITHUB_ACTIONS=true emits ::warning:: lines to stdout" {
+  setup_annotations_fixture
+  cd "$TEST_TMP/actions"
+  ga_stdout=$(GITHUB_ACTIONS=true bash "$LINT_SCRIPT" 2>/dev/null || true)
+  cd "$ROOT"
+  count=$(printf '%s' "$ga_stdout" | grep -c '^::warning' || true)
+  [ "$count" -ge 1 ]
+}
+
+@test "annotations: GITHUB_ACTIONS=true emits ::error:: lines to stdout" {
+  setup_annotations_fixture
+  cd "$TEST_TMP/actions"
+  ga_stdout=$(GITHUB_ACTIONS=true bash "$LINT_SCRIPT" 2>/dev/null || true)
+  cd "$ROOT"
+  count=$(printf '%s' "$ga_stdout" | grep -c '^::error' || true)
+  [ "$count" -ge 1 ]
+}
+
+@test "annotations: GITHUB_ACTIONS=true emits file-anchored annotations" {
+  setup_annotations_fixture
+  cd "$TEST_TMP/actions"
+  ga_stdout=$(GITHUB_ACTIONS=true bash "$LINT_SCRIPT" 2>/dev/null || true)
+  cd "$ROOT"
+  [[ "$ga_stdout" == *"file=plugins/"* ]]
+}


### PR DESCRIPTION
## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds GitHub Actions annotation support to `scripts/lint-plugins.sh` so that lint findings surface directly in the PR diff UI (`::warning::` / `::error::`) instead of being buried in raw job logs. It also introduces a fixture-based Bats test suite and the corresponding CI step to self-test the lint script on every relevant path change.

- `ga_escape()` / `emit_annotation()` are added to `lint-plugins.sh`; annotations are guarded behind `GITHUB_ACTIONS=true`, preserving the existing stderr output for local runs unchanged.
- `tests/lint-plugins.bats` provides three test groups: full-fixture (errors + warnings), clean-fixture (exit 0), and annotation-emission. All tests use `env -u GITHUB_ACTIONS` to prevent CI environment contamination.
- `fixtures/lint/plugins/sample-plugin/` supplies deterministic agent and skill fixtures, including a SKILL.md with a deliberate body-prose `name:` line to regression-test the PR #261 frontmatter-scoping fix.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the annotation logic is additive and gate-guarded, leaving existing lint behaviour unchanged for local runs.

emit_annotation is a strict no-op unless GITHUB_ACTIONS=true, so it cannot affect existing stderr output or exit codes. ga_escape correctly handles the three characters GitHub's workflow-command parser requires URL-encoding. The Bats tests explicitly unset GITHUB_ACTIONS in all non-annotation paths, preventing CI contamination. Fixture coverage is thorough and the regression guard for the PR #261 body-prose bug is preserved.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/lint-plugins.sh | Adds ga_escape() and emit_annotation() to emit ::warning::/::error:: annotations to stdout when GITHUB_ACTIONS=true; human-readable stderr output unchanged. |
| tests/lint-plugins.bats | New Bats test file covering fixture-based regression checks and annotation emission; Test 1 runs the full fixture 9 times independently. |
| .github/workflows/lint-plugins.yml | Installs Bats and adds a self-test step before the production lint step; extends path triggers to cover fixtures and tests. |
| fixtures/lint/plugins/sample-plugin/skills/test-skill/SKILL.md | Deliberately contains a body-prose 'name: should-not-be-collected' line to regression-test the frontmatter-scoped name extractor from PR #261. |
| fixtures/lint/plugins/sample-plugin/agents/missing-tools.md | Fixture verifying that a missing tools: field escalates to ERROR; name and description present to isolate the check. |

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22feat%2Flint-plugins-actions-annotations%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Flint-plugins-actions-annotations%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atests%2Flint-plugins.bats%3A60-116%0AEach%20of%20the%209%20assertions%20in%20Test%201%20independently%20calls%20%60run_lint_in_fixture%20full%60%2C%20performing%20a%20full%20%60git%20init%60%20%2B%20%60git%20commit%60%20%2B%20lint%20invocation%20per%20test.%20Since%20%60setup%28%29%60%20gives%20every%20test%20its%20own%20%60%24TEST_TMP%60%20there%20is%20no%20correctness%20issue%2C%20but%20the%20wall-clock%20cost%20is%20significant%3A%209%20separate%20git%20repositories%20are%20created%20and%20linted%20for%20identical%20fixture%20state.%20Bats%20supports%20%60setup_file%60%2F%60teardown_file%60%20%28stable%20since%20bats-core%201.3%29%20which%20would%20let%20you%20run%20the%20fixture%20once%20per%20file%20and%20expose%20captured%20output%2Fstatus%20to%20all%20tests%20via%20a%20temp%20file.%0A%0A%60%60%60suggestion%0Asetup_file%28%29%20%7B%0A%20%20ROOT%3D%22%24%28cd%20%22%24BATS_TEST_DIRNAME%2F..%22%20%26%26%20pwd%29%22%0A%20%20LINT_SCRIPT%3D%22%24ROOT%2Fscripts%2Flint-plugins.sh%22%0A%20%20FIXTURE_SRC%3D%22%24ROOT%2Ffixtures%2Flint%22%0A%20%20FULL_TMP%3D%24%28mktemp%20-d%20-t%20lint-full-XXXXXX%29%0A%20%20FULL_OUTPUT_FILE%3D%24%28mktemp%20-t%20lint-full-out-XXXXXX%29%0A%20%20FULL_STATUS_FILE%3D%24%28mktemp%20-t%20lint-full-status-XXXXXX%29%0A%20%20cp%20-r%20%22%24FIXTURE_SRC%2Fplugins%22%20%22%24FULL_TMP%2Fplugins%22%0A%20%20%28%20cd%20%22%24FULL_TMP%22%20%5C%0A%20%20%20%20%20%20%26%26%20git%20init%20-q%20%5C%0A%20%20%20%20%20%20%26%26%20git%20config%20user.email%20lint%40example.invalid%20%5C%0A%20%20%20%20%20%20%26%26%20git%20config%20user.name%20lint%20%5C%0A%20%20%20%20%20%20%26%26%20git%20add%20.%20%5C%0A%20%20%20%20%20%20%26%26%20git%20commit%20-q%20-m%20init%20%3E%2Fdev%2Fnull%20%29%0A%20%20env%20-u%20GITHUB_ACTIONS%20bash%20%22%24LINT_SCRIPT%22%20%3E%22%24FULL_OUTPUT_FILE%22%202%3E%261%0A%20%20echo%20%24%3F%20%3E%22%24FULL_STATUS_FILE%22%0A%20%20export%20FULL_TMP%20FULL_OUTPUT_FILE%20FULL_STATUS_FILE%0A%7D%0A%0Ateardown_file%28%29%20%7B%0A%20%20rm%20-rf%20%22%24%7BFULL_TMP%3A-%7D%22%0A%20%20rm%20-f%20%22%24%7BFULL_OUTPUT_FILE%3A-%7D%22%20%22%24%7BFULL_STATUS_FILE%3A-%7D%22%0A%7D%0A%0A%40test%20%22full%20fixture%3A%20exit%20code%20is%201%20%28errors%20present%29%22%20%7B%0A%20%20%5B%20%22%24%28cat%20%22%24FULL_STATUS_FILE%22%29%22%20-eq%201%20%5D%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Flint-plugins.sh%3A50%0A**File%20regex%20is%20intentionally%20%60.md%60-only%20%E2%80%94%20worth%20documenting**%0A%0AThe%20regex%20%60plugins%2F%5BA-Za-z0-9._%2F-%5D%2B%5C.md%60%20only%20matches%20paths%20ending%20in%20%60.md%60.%20Findings%20that%20reference%20non-%60.md%60%20artifacts%20%28e.g.%20%60plugin.json%60%29%20will%20silently%20fall%20through%20to%20the%20unanchored%20annotation%20form.%20A%20short%20comment%20noting%20the%20intentional%20scope%20would%20make%20this%20easier%20to%20extend%20safely%20when%20future%20checks%20cover%20non-%60.md%60%20files.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
tests/lint-plugins.bats:60-116
Each of the 9 assertions in Test 1 independently calls `run_lint_in_fixture full`, performing a full `git init` + `git commit` + lint invocation per test. Since `setup()` gives every test its own `$TEST_TMP` there is no correctness issue, but the wall-clock cost is significant: 9 separate git repositories are created and linted for identical fixture state. Bats supports `setup_file`/`teardown_file` (stable since bats-core 1.3) which would let you run the fixture once per file and expose captured output/status to all tests via a temp file.

```suggestion
setup_file() {
  ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
  LINT_SCRIPT="$ROOT/scripts/lint-plugins.sh"
  FIXTURE_SRC="$ROOT/fixtures/lint"
  FULL_TMP=$(mktemp -d -t lint-full-XXXXXX)
  FULL_OUTPUT_FILE=$(mktemp -t lint-full-out-XXXXXX)
  FULL_STATUS_FILE=$(mktemp -t lint-full-status-XXXXXX)
  cp -r "$FIXTURE_SRC/plugins" "$FULL_TMP/plugins"
  ( cd "$FULL_TMP" \
      && git init -q \
      && git config user.email lint@example.invalid \
      && git config user.name lint \
      && git add . \
      && git commit -q -m init >/dev/null )
  env -u GITHUB_ACTIONS bash "$LINT_SCRIPT" >"$FULL_OUTPUT_FILE" 2>&1
  echo $? >"$FULL_STATUS_FILE"
  export FULL_TMP FULL_OUTPUT_FILE FULL_STATUS_FILE
}

teardown_file() {
  rm -rf "${FULL_TMP:-}"
  rm -f "${FULL_OUTPUT_FILE:-}" "${FULL_STATUS_FILE:-}"
}

@test "full fixture: exit code is 1 (errors present)" {
  [ "$(cat "$FULL_STATUS_FILE")" -eq 1 ]
}
```

### Issue 2 of 2
scripts/lint-plugins.sh:50
**File regex is intentionally `.md`-only — worth documenting**

The regex `plugins/[A-Za-z0-9._/-]+\.md` only matches paths ending in `.md`. Findings that reference non-`.md` artifacts (e.g. `plugin.json`) will silently fall through to the unanchored annotation form. A short comment noting the intentional scope would make this easier to extend safely when future checks cover non-`.md` files.

`````

</details>

<sub>Reviews (9): Last reviewed commit: ["fix(tests): unset GITHUB\_ACTIONS in bats..."](https://github.com/kinginyellows/yellow-plugins/commit/7e3a43d1332299ceaed839d4aa41389912c39a6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28766768)</sub>

<!-- /greptile_comment -->