### PR TITLE
chore(gt-workflow): rename 'gt repo sync' references to 'gt sync'

### DIFF
--- a/plugins/gt-workflow/CLAUDE.md
+++ b/plugins/gt-workflow/CLAUDE.md
@@ -31,7 +31,7 @@ Graphite-native workflow commands for stacked PR development.
 | `gt commit create -m "msg"`  | Add a commit (deprecated, use `gt modify --commit`) |
 | `gt commit amend -m "msg"`   | Amend the current branch commit         |
 | `gt submit --no-interactive` | Push stack and create/update PRs        |
-| `gt repo sync`               | Fetch trunk, detect merged branches     |
+| `gt sync`                    | Fetch trunk, detect merged branches     |
 | `gt stack restack`           | Rebase stack on latest trunk            |
 | `gt log` / `gt log short`    | Visualize the stack                     |
 | `gt up` / `gt down`          | Navigate up/down the stack              |

--- a/plugins/gt-workflow/README.md
+++ b/plugins/gt-workflow/README.md
@@ -95,7 +95,7 @@ orphaned, closed-PR, stale, and diverged branches.
 
 One-command repo sync, restack, and cleanup.
 
-- Syncs trunk via `gt repo sync`
+- Syncs trunk via `gt sync`
 - Restacks branches if needed
 - Reports conflicts clearly with resolution instructions
 - Cleans up merged branches

--- a/plugins/gt-workflow/commands/gt-sync.md
+++ b/plugins/gt-workflow/commands/gt-sync.md
@@ -16,7 +16,7 @@ up merged PRs.
 Optional arguments:
 
 - `--no-delete` — Skip deleting merged branches by passing `--no-delete` through
-  to `gt repo sync` so it does not prompt for deletions
+  to `gt sync` so it does not prompt for deletions
 - `--force` — Restack even if the stack appears clean (still stopping at
   conflicts for manual resolution) instead of skipping Phase 2 when there are no
   divergence markers
@@ -51,16 +51,16 @@ Run Graphite repo sync to pull the latest trunk and identify merged branches.
 If `--no-delete` was passed:
 
 ```bash
-gt repo sync --no-delete
+gt sync --no-delete
 ```
 
 Otherwise:
 
 ```bash
-gt repo sync
+gt sync
 ```
 
-If `gt repo sync` fails (network error, authentication issue, etc.), report the
+If `gt sync` fails (network error, authentication issue, etc.), report the
 error to the user and stop. Do not proceed to restacking with stale state.
 
 This will:

--- a/plugins/yellow-core/commands/workflows/work.md
+++ b/plugins/yellow-core/commands/workflows/work.md
@@ -651,7 +651,7 @@ step 5. Phase 4 becomes a summary phase:
   after each item. This enables resume across sessions if context is exhausted.
 - **Checkpoints are safe stops:** At each checkpoint, all previous items are
   already submitted. Stopping mid-stack leaves the codebase in a clean state.
-- **Do not sync mid-stack:** Avoid `gt repo sync` or `gt stack restack` between
+- **Do not sync mid-stack:** Avoid `gt sync` or `gt stack restack` between
   items unless explicitly requested. Stacked PRs should be based on each other.
 - **Changeset strategy:** One changeset in the bottom branch covers the whole
   feature. Subsequent branches inherit it.
@@ -669,7 +669,7 @@ gt modify -m "feat: message"
 gt log short
 
 # Sync with trunk
-gt repo sync
+gt sync
 
 # Rebase stack
 gt upstack restack
@@ -681,5 +681,5 @@ gt submit --no-interactive
 gt commit amend -m "new message"
 
 # Continue after fixing conflicts
-gt repo sync --continue
+gt continue
 ```


### PR DESCRIPTION
## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/yellow-plugins/pull/264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated command docs to reference `gt sync` (and `gt continue` where applicable) instead of `gt repo sync`.
  * Revised example commands and workflow steps to use the new command names for repository synchronization.
  * Clarified argument text to show `--no-delete` is passed through to `gt sync` and updated related failure/continuation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the rename of `gt repo sync` to `gt sync` across the plugin documentation, addressing the stale references flagged in the previous review thread. All four changed files are updated correctly, including the `gt repo sync --continue` → `gt continue` change in `work.md`, which aligns with the documented `gt continue` command in `CLAUDE.md` and `gt-sync.md`. No executable command files retain `gt repo sync` references.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only rename with no logic changes and no remaining stale references in executable files.

All changes are documentation updates renaming `gt repo sync` to `gt sync`. The `gt continue` substitution is confirmed correct against existing authoritative references in the repo. No P1 or P0 findings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/gt-workflow/CLAUDE.md | Reference table updated: `gt repo sync` → `gt sync`. Consistent with the rest of the rename. |
| plugins/gt-workflow/README.md | Prose description updated: `gt repo sync` → `gt sync`. Straightforward single-line change. |
| plugins/gt-workflow/commands/gt-sync.md | All four `gt repo sync` occurrences (bash blocks and prose) correctly renamed to `gt sync`. |
| plugins/yellow-core/commands/workflows/work.md | Three references updated: two prose/inline `gt repo sync` → `gt sync`, and `gt repo sync --continue` → `gt continue` (confirmed correct per CLAUDE.md and gt-sync.md). |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["gt sync"] --> B{"--no-delete?"}
    B -- yes --> C["gt sync --no-delete"]
    B -- no --> D["gt sync"]
    C --> E["Check stack state\ngt log short"]
    D --> E
    E --> F{"Needs restack?"}
    F -- no --> G["Phase 3: Report"]
    F -- yes --> H["gt stack restack"]
    H --> I{"Conflicts?"}
    I -- yes --> J["Resolve conflicts manually\ngit add ...\ngt continue"]
    I -- no --> G
    J --> G
```

<sub>Reviews (2): Last reviewed commit: ["fix: complete gt repo sync rename in wor..."](https://github.com/kinginyellows/yellow-plugins/commit/cdce3ddf34a6c414867dd6a07d2bea8689c7c160) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29788031)</sub>

<!-- /greptile_comment -->