### PR TITLE
docs(solutions): add bash-block subshell isolation pattern

### DIFF
--- a/docs/solutions/code-quality/bash-block-subshell-isolation-in-command-files.md
+++ b/docs/solutions/code-quality/bash-block-subshell-isolation-in-command-files.md
@@ -1,0 +1,193 @@
+---
+title: "Bash Block Subshell Isolation in Command Files"
+category: code-quality
+track: knowledge
+problem: "Shell functions and variables defined in one bash block are invisible to subsequent bash blocks in Claude Code command .md files — produces silent fail-open bugs"
+tags:
+  - bash
+  - subshell
+  - command-authoring
+  - plugin-authoring
+  - silent-failure
+  - shell-functions
+date: "2026-04-28"
+pr: "#259"
+components:
+  - plugins/yellow-semgrep/commands/semgrep/setup.md
+  - plugins/yellow-research/commands/research/setup.md
+  - plugins/yellow-devin/commands/devin/setup.md
+  - plugins/yellow-core/commands/setup/all.md
+---
+
+# Bash Block Subshell Isolation in Command Files
+
+## Problem
+
+In Claude Code command `.md` files, each fenced bash block is executed as a
+fresh subprocess. This is already documented for variables (PR #74, section 15
+of `claude-code-command-authoring-anti-patterns.md`). PR #259 revealed a
+second, distinct failure mode that the PR #74 entry missed: **shell functions
+defined in one bash block are equally invisible to subsequent bash blocks.**
+
+This produced three P1 bugs in the same PR:
+
+1. `has_userconfig()` was defined and called within setup preamble blocks, then
+   called again in later workflow steps — where it was undefined. Every call
+   silently fell through to `command not found` (exit code 127); any non-zero
+   exit causes the surrounding `if` to take the `else` branch, so the call site
+   read it as "key not present."
+
+2. `SKIP_CURL_PROBE` was set in one block and read in the next:
+
+   ```bash
+   # Block 1
+   SKIP_CURL_PROBE=1
+   ```
+
+   ```bash
+   # Block 2 — fresh subprocess; SKIP_CURL_PROBE is always unset here
+   if [ "$SKIP_CURL_PROBE" = "1" ]; then
+     ...
+   fi
+   ```
+
+3. Asymmetric defaults compounded the invisible scope: `[ "$X" = 0 ]` is a
+   fail-open guard (false when `$X` is unset, so the body runs on every
+   subshell). Meanwhile `${X:-0}` as a boolean-flag default looks defensive but
+   is also fail-open (defaults to 0 = disabled). Both patterns produce the same
+   surface behavior — the step always executes — but they fail silently in
+   opposite directions depending on the intended semantics.
+
+## Root Cause
+
+Claude Code command files are LLM-directed workflows. When the LLM executes a
+bash code block via the Bash tool, it runs in a new subprocess. That subprocess
+inherits the baseline environment (e.g., `CLAUDE_*` variables, `PATH`, and the
+user's shell environment), but any shell state set inside a prior bash block —
+variables, functions, aliases, exports defined by that block — does not survive
+into the next invocation.
+
+This is intuitive for variables (`$VAR`) but easy to miss for functions:
+authors naturally write helper functions once at the top of a long command file,
+expecting them to be available throughout the workflow. In an actual shell
+script that assumption holds; in a command `.md` file it does not.
+
+The failure is always silent: `command not found` in a subshell does not surface
+as a visible error unless the surrounding code explicitly checks the exit code.
+An `if has_userconfig ...; then` block where `has_userconfig` is undefined just
+evaluates the `else` branch every time.
+
+## Fix
+
+### For functions: re-define inline
+
+Re-define any helper function inside every bash block that calls it. This is
+verbose but the only safe option:
+
+```bash
+# Every block that calls has_userconfig must define it first
+# Pseudocode pattern — the jq path and config file below are illustrative.
+# Adapt the path and key to match your runtime config storage layout;
+# Claude Code's project settings.json uses extraKnownMarketplaces/enabledPlugins,
+# not a .plugins[].userConfig path.
+has_userconfig() {
+  local plugin="$1" key="$2"
+  jq -e --arg p "$plugin" --arg k "$key" \
+    '.plugins[$p].userConfig[$k] // empty' \
+    "${CLAUDE_PROJECT_DIR:-$PWD}/.claude/settings.json" >/dev/null 2>&1
+}
+
+if has_userconfig yellow-devin devin_api_key; then
+  TOKEN_SRC=userconfig
+fi
+```
+
+Alternatively, move the function to a sourced library file and source it at the
+top of each block:
+
+```bash
+# shellcheck source=/dev/null
+. "${CLAUDE_PLUGIN_ROOT}/lib/userconfig.sh"
+```
+
+### For variables: hoist or re-derive at the point of use
+
+Variables that feed into a later block must be defined in that block. Never
+rely on a value set in a previous Bash tool call. Two patterns apply depending
+on the variable type:
+
+**Constants and settings-derived values** — define (or re-derive) the variable
+at the top of every block that uses it:
+
+```bash
+# Block 2 — define SEMGREP_API inline; do NOT rely on any value set in a
+# previous Bash tool call.
+SEMGREP_API="https://semgrep.dev/api/v1"
+response=$(curl -s -H "Authorization: Bearer $SEMGREP_APP_TOKEN" \
+  "${SEMGREP_API}/deployments")
+```
+
+This is the structural pattern PR #259 applied to yellow-semgrep/setup.md:
+`SEMGREP_API` was hoisted out of the skip-detection block and re-stated in
+each block where it is used.
+
+**Runtime-detection flags** like `SKIP_CURL_PROBE` (a Block 1 decision, not a
+constant) require a different structural fix: hoist the dependent step *into*
+Block 1 with the flag, or re-run the detection logic at the top of Block 2.
+Never assume a flag set by a prior block survives.
+
+### For boolean flags: pick defaults that match the intended posture
+
+`${FLAG:-0}` looks defensive but defaults to 0 (disabled = skip). Authors
+sometimes label this "fail-closed" — but the standard security-engineering
+meaning of *fail-closed* is "deny by default," which is only correct here if
+the unset state should disable the flagged step. For a security probe whose
+absence would silently reduce coverage, the safer default is the opposite —
+the probe should run unless explicitly suppressed:
+
+```bash
+# Default-enabled: probe runs unless explicitly disabled (1=run, 0=skip).
+# Skipping the probe is the privileged action; an unset flag means run.
+RUN_CURL_PROBE="${RUN_CURL_PROBE:-1}"
+if [ "$RUN_CURL_PROBE" = "1" ]; then
+  ...
+fi
+```
+
+The principle is independent of the "fail-closed / fail-open" labels: pick
+the default such that an unset flag produces the safer outcome for the
+specific step. Destructive actions default to skip (`:-0`); detection /
+probe / coverage actions default to run (`:-1`). Document the semantics
+inline (`# 1=run, 0=skip`) so reviewers can audit each default at a glance.
+
+## Detection
+
+When reviewing a command `.md` file, run:
+
+```bash
+# Find all function definitions
+rg -g 'plugins/*/commands/**/*.md' '^\s*\w+\(\)\s*\{'
+
+# Find all calls to those functions and check which bash blocks they appear in
+# (manual: confirm each call site re-defines the function in that block)
+```
+
+Checklist question: "Is every function called in a bash block also defined in
+that same bash block (or sourced from a file)?"
+
+## Prevention
+
+Add to command file review checklist:
+
+- [ ] Every helper function called in a bash block is defined in that same block
+      or sourced at the top of that block — never assumed from a prior block
+- [ ] Boolean flag defaults match the intended posture: destructive actions
+      default to skip (`:-0`), security probes / coverage steps default to run (`:-1`)
+- [ ] `has_userconfig` calls use keys declared in `plugin.json.userConfig`
+      (undeclared keys will never be present in settings — dead code)
+
+## Related Documentation
+
+- `docs/solutions/code-quality/claude-code-command-authoring-anti-patterns.md` — Section 15
+  covers the variable-survival angle of this same root cause (PR #74)
+- MEMORY.md: "**$VAR in bash code blocks (from PR #74)**" entry in Command File Anti-Patterns


### PR DESCRIPTION
Captures a recurring P1 silent-failure pattern surfaced during PR #259's
multi-agent review: each ```bash``` block in a command file runs in a fresh
subprocess, so functions and variables defined in one block don't survive
into the next.

Symptoms:
- has_userconfig() defined in Step 1 was undefined in Step 3 → empty bearer
  token sent to provider APIs (yellow-research/setup.md)
- SKIP_CURL_PROBE=1 set in Step 2 was unset in Step 3 → asymmetric default
  behavior between blocks (yellow-semgrep/setup.md)
- TOKEN_SRC=userconfig set in Step 1 defaulted to 'shell' in Step 2 →
  false 'format invalid' error for userConfig-only users
  (yellow-devin/setup.md)

Fixes (re-define inline / fail-closed defaults / sentinel-and-re-detect)
applied in PR #259 commit 5295832. This doc captures the pattern for
future plugin authors.

Source: review:pr findings on PR #259 (silent-failure-hunter,
code-reviewer, code-simplicity-reviewer).

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a code-quality guide describing bash fenced-blocks running in isolated subprocesses and resulting function/variable loss across blocks
  * Describes observed failure modes and their user-visible effects
  * Provides prescriptive fixes: redefine or source helpers per block, re-derive needed variables, and restructure flag detection
  * Includes detection commands and links to related guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new knowledge-track solution document capturing the bash-block subshell isolation pattern discovered in PR #259, covering three P1 silent-failure bugs caused by functions and variables not surviving across bash fenced blocks in Claude Code command files. The doc is well-structured with problem description, root cause, fixes for each case, a detection snippet, and a prevention checklist.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the single P2 finding is a frontmatter accuracy gap that does not affect runtime behavior

Only P2 findings present; all addressed previous-thread concerns (yellow-devin/yellow-morph swap, fail-closed terminology, SEMGREP_API example) appear to have been actioned or are in prior threads. No blocking issues in the new content.

No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/solutions/code-quality/bash-block-subshell-isolation-in-command-files.md | New knowledge-track solution doc capturing the bash subshell isolation pattern; one P2: `yellow-core/commands/setup/all.md` is listed in frontmatter `components` without any corresponding bug description in the document body |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Command .md file loaded by Claude Code"] --> B["LLM encounters bash fenced block"]
    B --> C["Bash tool spawns fresh subprocess"]
    C --> D["Subprocess inherits baseline env\n(CLAUDE_*, PATH, user shell env)"]
    D --> E["Block executes: defines functions,\nsets variables, exports"]
    E --> F["Subprocess exits — all\nlocal state lost"]
    F --> G["LLM encounters next bash block"]
    G --> H["New fresh subprocess spawned\n(same baseline, no prior state)"]
    H --> I{Is function/variable\nre-defined in this block?}
    I -- "Yes (safe)" --> J["Block executes correctly"]
    I -- "No (bug)" --> K["command not found (exit 127)\nor unset variable\nsilent fallback to else-branch"]
    K --> L["Silent fail-open behavior\ne.g. empty bearer token,\nskip-flag ignored"]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Fchore%2Fbash-block-subshell-doc-pr259%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Fchore%2Fbash-block-subshell-doc-pr259%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fsolutions%2Fcode-quality%2Fbash-block-subshell-isolation-in-command-files.md%3A19%0A**%60yellow-core%60%20in%20components%20with%20no%20corresponding%20bug%20description**%0A%0A%60plugins%2Fyellow-core%2Fcommands%2Fsetup%2Fall.md%60%20is%20the%20only%20entry%20in%20the%20frontmatter%20%60components%60%20list%20that%20does%20not%20map%20to%20any%20of%20the%20three%20numbered%20bugs%20described%20in%20the%20document%20body%20or%20in%20the%20PR%20description.%20The%20other%20three%20paths%20each%20anchor%20to%20a%20specific%20symptom%20%28bearer-token%2C%20SKIP_CURL_PROBE%2C%20TOKEN_SRC%29.%20Without%20a%20corresponding%20entry%20in%20the%20Problem%20section%20%E2%80%94%20or%20at%20minimum%20a%20brief%20inline%20note%20%E2%80%94%20it%20is%20unclear%20whether%20%60plugins%2Fyellow-core%2Fcommands%2Fsetup%2Fall.md%60%20was%20a%20fourth%20affected%20file%2C%20an%20orchestrator%20that%20triggered%20one%20of%20the%20listed%20bugs%2C%20or%20an%20accidental%20leftover.%20Either%20document%20the%20connection%20in%20the%20body%20or%20remove%20it%20from%20the%20frontmatter.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
docs/solutions/code-quality/bash-block-subshell-isolation-in-command-files.md:19
**`yellow-core` in components with no corresponding bug description**

`plugins/yellow-core/commands/setup/all.md` is the only entry in the frontmatter `components` list that does not map to any of the three numbered bugs described in the document body or in the PR description. The other three paths each anchor to a specific symptom (bearer-token, SKIP_CURL_PROBE, TOKEN_SRC). Without a corresponding entry in the Problem section — or at minimum a brief inline note — it is unclear whether `plugins/yellow-core/commands/setup/all.md` was a fourth affected file, an orchestrator that triggered one of the listed bugs, or an accidental leftover. Either document the connection in the body or remove it from the frontmatter.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: resolve PR #272 review comments"](https://github.com/kinginyellows/yellow-plugins/commit/c215ad50abf98f3cef12e14e0eda683eec290ddb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30207202)</sub>

<!-- /greptile_comment -->