### PR TITLE
chore: unbundle context7 MCP from yellow-core; repoint yellow-research to user-level

### DIFF
--- a/.changeset/unbundle-context7-mcp.md
+++ b/.changeset/unbundle-context7-mcp.md
@@ -1,6 +1,6 @@
 ---
-"yellow-core": minor
-"yellow-research": minor
+"yellow-core": patch
+"yellow-research": patch
 ---
 
 Unbundle context7 MCP from yellow-core; repoint yellow-research callers to user-level

--- a/.changeset/unbundle-context7-mcp.md
+++ b/.changeset/unbundle-context7-mcp.md
@@ -1,0 +1,15 @@
+---
+"yellow-core": patch
+"yellow-research": patch
+---
+
+Unbundle context7 MCP from yellow-core; repoint yellow-research callers to user-level
+
+Remove the bundled `mcpServers.context7` entry from `plugins/yellow-core/.claude-plugin/plugin.json` to avoid the dual-OAuth-pop-up issue when users have context7 installed both at user level and bundled inside yellow-core (the namespace collision pattern documented in `docs/solutions/integration-issues/duplicate-mcp-url-double-oauth.md`). Per CE PR #486 (compound-engineering v2.62.0, 2026-04-03) parity.
+
+- **yellow-core:** `mcpServers` block removed from `plugin.json`; `best-practices-researcher` agent's tool list updated to user-level `mcp__context7__*` names; CLAUDE.md/README.md updated to recommend user-level install; statusline/setup.md no longer lists yellow-core as having an MCP.
+- **yellow-research:** `code-researcher` agent, `/research:code` command, `/research:setup` command, `research-patterns` skill, CLAUDE.md, and README.md all repointed from `mcp__plugin_yellow-core_context7__*` to user-level `mcp__context7__*`. ToolSearch availability check + EXA fallback preserved (existing prose).
+
+**User action:** install context7 at user level via `/plugin install context7@upstash` (or via Claude Code MCP settings UI). The user-level context7 server registers tools as `mcp__context7__resolve-library-id` and `mcp__context7__query-docs`. yellow-research's `code-researcher` falls back to EXA `get_code_context_exa` if user-level context7 is not detected by ToolSearch — no behavior change for users without context7.
+
+Roll back by re-adding the `mcpServers.context7` block to `plugins/yellow-core/.claude-plugin/plugin.json` and reverting the tool-name repoints in yellow-research.

--- a/.changeset/unbundle-context7-mcp.md
+++ b/.changeset/unbundle-context7-mcp.md
@@ -1,6 +1,6 @@
 ---
-"yellow-core": patch
-"yellow-research": patch
+"yellow-core": minor
+"yellow-research": minor
 ---
 
 Unbundle context7 MCP from yellow-core; repoint yellow-research callers to user-level

--- a/docs/mcp-tool-naming-verification.md
+++ b/docs/mcp-tool-naming-verification.md
@@ -144,3 +144,11 @@ Fix tool names in Phase 2 or as a follow-up PR:
    in yellow-devin
 5. Replace `mcp__plugin_linear_linear__` with
    `mcp__plugin_yellow-linear_linear__` in yellow-chatprd (cross-plugin refs)
+
+---
+
+## Update 2026-04-29
+
+**yellow-core no longer bundles context7 as a plugin MCP.** Per CE PR #486 parity (and to avoid the dual-OAuth-pop-up issue when users have context7 installed both at user level and bundled in yellow-core), the `mcpServers.context7` block was removed from `plugins/yellow-core/.claude-plugin/plugin.json`. References under `mcp__plugin_yellow-core_context7__*` no longer exist; live yellow-research callers (`code-researcher`, `/research:code`, `/research:setup`, `best-practices-researcher`) now reference user-level `mcp__context7__*` tool names with ToolSearch availability checks and EXA fallback. Install user-level context7 via `/plugin install context7@upstash` to retain library-doc lookup capability.
+
+This change supersedes the "Expected prefix: `mcp__plugin_yellow-core_context7__`" line above. Other MCPs in this verification document remain at their bundled prefixes.

--- a/plans/everyinc-merge.md
+++ b/plans/everyinc-merge.md
@@ -184,29 +184,45 @@ Before each wave's implementation session begins:
 
 **Tasks:**
 
-- [ ] **W1.1 — Remove context7 MCP and clean up references.** (`patch`
+- [ ] **W1.1 — Unbundle context7 MCP, repoint yellow-research callers to user-level.** (`patch`
   yellow-core, `patch` yellow-research)
-  - [ ] Remove `mcpServers` block from
-    `plugins/yellow-core/.claude-plugin/plugin.json` (lines 20–25).
-  - [ ] Remove context7 tools from `tools:` in
-    `plugins/yellow-core/agents/research/best-practices-researcher.md`
-    (lines 13–14: `mcp__plugin_yellow-core_context7__resolve-library-id`,
-    `mcp__plugin_yellow-core_context7__query-docs`).
-  - [ ] Remove context7 references from
-    `plugins/yellow-core/commands/statusline/setup.md` (lines 107, 371).
-  - [ ] Remove context7 description from
-    `plugins/yellow-core/CLAUDE.md` (lines 90–92) and
-    `plugins/yellow-core/README.md` (line 71).
-  - [ ] Remove context7 from `plugins/yellow-research/agents/research/code-researcher.md`
-    `tools:` (lines 15–16) and body routing (lines 34, 44). **Note: this file
-    lives in yellow-research, not yellow-core as the brainstorm states.**
-  - [ ] Remove context7 from `plugins/yellow-research/commands/research/code.md`
-    `allowed-tools:` (lines 15–16) and from
-    `plugins/yellow-research/commands/research/setup.md` (lines 12, 320–321).
-  - [ ] Remove context7 from `plugins/yellow-research/CLAUDE.md` optional-deps
-    section (lines 156–157).
-  - [ ] Verify `code-researcher` body still routes coherently to remaining
-    sources (Exa, Perplexity, ast-grep, etc.) without context7.
+  - [ ] **Decision (2026-04-29):** Option chosen is *unbundle but keep callers wired to user-level context7*.
+    Rationale: context7 itself is valuable for library docs; the dual-install OAuth/namespace problem
+    (CE PR #486) only requires unbundling. Users who want context7 install it once at user level
+    (standard `/plugin install context7@upstash` flow) and `mcp__context7__*` tool names register globally.
+  - [ ] Remove `mcpServers` block from `plugins/yellow-core/.claude-plugin/plugin.json` (yellow-core no
+    longer claims context7 as a bundled MCP).
+  - [ ] In `plugins/yellow-core/agents/research/best-practices-researcher.md`: drop bundled tool refs
+    (`mcp__plugin_yellow-core_context7__*`); the body's Phase 1 should fall back to ToolSearch-detection
+    of user-level `mcp__context7__resolve-library-id` and `mcp__context7__query-docs`, with WebSearch as
+    final fallback. Skills-first parity (W1.3) takes priority for full body rewrite; this PR is the
+    minimal tool-list edit.
+  - [ ] Update `plugins/yellow-core/commands/statusline/setup.md`: remove yellow-core from the
+    `DETECTED_PLUGINS` example and from the preview output table — yellow-core no longer ships an MCP.
+  - [ ] Update `plugins/yellow-core/CLAUDE.md`: change `MCP Servers (1)` → `MCP Servers (0)`; replace the
+    context7 entry with a note recommending user-level context7 install.
+  - [ ] Update `plugins/yellow-core/README.md`: remove the bundled context7 row from MCP Servers table;
+    reference user-level install instead.
+  - [ ] In `plugins/yellow-research/agents/research/code-researcher.md`: repoint context7 tool refs from
+    `mcp__plugin_yellow-core_context7__*` to user-level `mcp__context7__*` (lines 15-16, body lines
+    34/42-46). Add a ToolSearch availability check at routing time — if user-level context7 not found,
+    fall through to EXA `get_code_context_exa` (existing behavior preserved by the `If ToolSearch cannot
+    find ... skip directly to EXA` prose).
+  - [ ] In `plugins/yellow-research/commands/research/code.md`: repoint `allowed-tools:` (lines 15-16) to
+    user-level names.
+  - [ ] In `plugins/yellow-research/commands/research/setup.md`: repoint `allowed-tools` (line 12),
+    update the Context7 probe block (lines 316-322) to detect user-level form, update the example
+    output and preview text (lines 429, 457, 509) to reflect that context7 is a user-level
+    optional MCP rather than a yellow-core bundled one.
+  - [ ] In `plugins/yellow-research/CLAUDE.md` (lines 156-157) and `plugins/yellow-research/README.md`
+    (line 18): update the yellow-core optional-dep entry — context7 is now installed at user level
+    (`/plugin install context7@upstash`), not bundled inside yellow-core.
+  - [ ] In `plugins/yellow-research/skills/research-patterns/SKILL.md` (line 62): the source-routing
+    table entry for "Library / framework docs → Context7" stays — but add a parenthetical noting
+    "(user-level MCP, install separately)".
+  - [ ] Verify `code-researcher` body still routes coherently after the repoint; the `ToolSearch cannot
+    find ... skip directly to EXA` prose now applies to user-level context7 unavailability rather than
+    bundled.
 
 - [ ] **W1.2 — Strip Bash from all 14 reviewer agents.** (`minor` for each
   affected plugin: yellow-core, yellow-review, yellow-codex)
@@ -1729,5 +1745,15 @@ The work is structured as **7 linear backbone PRs (Phase 0 prep + Wave 1 + Wave 
 - **Tasks:** W2.1, W2.2, W2.3, W2.4, W2.5, W2.6, W2.7, W2.8, W2.9
 - **Depends on:** #6
 - **Notes:** Keystone PR. Bumps yellow-review MAJOR (rename); yellow-core minor. Includes graceful-degradation guard so future agent additions are atomic.
+
+## Stack Progress
+<!-- Updated by workflows:work. Do not edit manually. -->
+- [x] 1. docs/everyinc-merge-plan (completed 2026-04-29; PR https://app.graphite.com/github/pr/KingInYellows/yellow-plugins/273)
+- [ ] 2. chore/remove-context7-mcp
+- [ ] 3. chore/strip-bash-from-reviewers
+- [ ] 4. refactor/repair-drifted-agents
+- [ ] 5. fix/pr-comment-fence-verify-and-validation
+- [ ] 6. feat/knowledge-compounder-track-schema
+- [ ] 7. feat/review-pr-keystone-rewrite
 
 

--- a/plugins/yellow-core/.claude-plugin/plugin.json
+++ b/plugins/yellow-core/.claude-plugin/plugin.json
@@ -16,11 +16,5 @@
     "python",
     "rust",
     "go"
-  ],
-  "mcpServers": {
-    "context7": {
-      "type": "http",
-      "url": "https://mcp.context7.com/mcp"
-    }
-  }
+  ]
 }

--- a/plugins/yellow-core/CLAUDE.md
+++ b/plugins/yellow-core/CLAUDE.md
@@ -85,11 +85,19 @@ Comprehensive dev toolkit for TypeScript, Python, Rust, and Go projects.
   duplicating the Ceramic MCP registration across plugins (single OAuth
   session).
 
-### MCP Servers (1)
+### MCP Servers (0)
 
-- `context7` — up-to-date library documentation via
-  [context7.com](https://context7.com). Third-party HTTP service; all agents
-  work without it (used only for fetching live docs). No credentials are sent.
+yellow-core no longer bundles any MCP servers. Previously it shipped
+`context7` as a bundled HTTP MCP, but that caused dual-registration issues
+when users also had context7 at user level. Per CE PR #486 (2026-04-03)
+parity, the bundled entry has been removed.
+
+**Recommended user-level MCP:** `context7` — up-to-date library documentation
+via [context7.com](https://context7.com). Install once at user level
+(`/plugin install context7@upstash` or via Claude Code MCP settings); all
+yellow-core and yellow-research agents that benefit from it (e.g.,
+`best-practices-researcher`, `code-researcher`) detect availability via
+ToolSearch and gracefully fall through to WebSearch / EXA when absent.
 
 ### MCP Tool Integration
 

--- a/plugins/yellow-core/README.md
+++ b/plugins/yellow-core/README.md
@@ -66,9 +66,16 @@ TypeScript, Python, Rust, and Go.
 
 ## MCP Servers
 
-| Server   | URL                            | Auth          |
-| -------- | ------------------------------ | ------------- |
-| Context7 | `https://mcp.context7.com/mcp` | None (public) |
+yellow-core does not bundle any MCP servers. Agents that benefit from
+external library documentation (`best-practices-researcher`) detect
+user-level Context7 (`mcp__context7__*`) at runtime via ToolSearch and fall
+back to `WebSearch` when it is absent. Install Context7 at user level if
+you want richer library docs:
+
+```sh
+# At user level (recommended) — single OAuth, no plugin-namespace conflict:
+/plugin install context7@upstash
+```
 
 ## License
 

--- a/plugins/yellow-core/agents/research/best-practices-researcher.md
+++ b/plugins/yellow-core/agents/research/best-practices-researcher.md
@@ -10,8 +10,8 @@ tools:
   - Glob
   - Grep
   - ToolSearch
-  - mcp__plugin_yellow-core_context7__resolve-library-id
-  - mcp__plugin_yellow-core_context7__query-docs
+  - mcp__context7__resolve-library-id
+  - mcp__context7__query-docs
   - mcp__plugin_yellow-research_ceramic__ceramic_search
 ---
 
@@ -29,8 +29,12 @@ sources and organize findings by importance.
 
 ### Phase 1: Curated Knowledge Check
 
-1. **Check Available Skills:** Use Context7 MCP to search for official
-   documentation and curated knowledge
+1. **Check Available Skills:** First, use ToolSearch to detect whether
+   user-level Context7 is installed (`mcp__context7__resolve-library-id`). If
+   present, prefer it for official documentation lookup; if absent, fall
+   through to WebSearch / WebFetch on authoritative domains. Context7 is a
+   user-level optional MCP since 2026-04 — yellow-core no longer bundles it
+   to avoid the dual-install OAuth pop-up problem.
 2. **Query Format:** Use specific library/framework names and version
    information
 3. **Priority Sources:** Official docs, API references, migration guides

--- a/plugins/yellow-core/commands/statusline/setup.md
+++ b/plugins/yellow-core/commands/statusline/setup.md
@@ -104,11 +104,13 @@ From the Step 1 output, build two Python dicts:
 
 ```python
 DETECTED_PLUGINS = {
-    "yellow-core": ["context7"],
-    "yellow-research": ["perplexity", "tavily", "exa", "parallel"],
+    "yellow-research": ["perplexity", "tavily", "exa", "parallel", "ceramic"],
     # ... only what was actually detected in Step 1
 }
 ```
+
+Note: yellow-core no longer bundles any MCP servers (previously context7 was
+bundled; removed 2026-04-29 per CE PR #486 parity).
 
 **ENV_REQUIREMENTS** — Only for command-type servers that have env var
 dependencies. Map server name to the full list of required env vars:
@@ -368,7 +370,6 @@ Yellow Plugins Statusline — Preview
 Detected plugins:
   Plugin            MCP Servers                    Status
   ----------------  ----------------------------   ------
-  yellow-core       context7 (HTTP)                OK
   yellow-research   perplexity, tavily, exa, ...   3/4 keys set
   ...
 

--- a/plugins/yellow-research/CLAUDE.md
+++ b/plugins/yellow-research/CLAUDE.md
@@ -152,13 +152,16 @@ automatically (no API key needed). You'll be prompted to authorize on first use.
 
 These external tools improve research quality but are not required:
 
-- **yellow-core plugin** — provides Context7
-  (`mcp__plugin_yellow-core_context7__resolve-library-id`,
-  `mcp__plugin_yellow-core_context7__query-docs`) for official library docs.
-  Used by `/research:code` for library queries. Also provides
-  `repo-research-analyst` agent used by `/workflows:deepen-plan` for codebase
-  validation. Falls back to EXA (for Context7) or skips codebase research (for
-  deepen-plan) if not installed. Install:
+- **Context7 MCP (user-level)** — provides `mcp__context7__resolve-library-id`
+  and `mcp__context7__query-docs` for official library docs. Used by
+  `/research:code` for library queries; falls back to EXA when absent. Install
+  at user level: `/plugin install context7@upstash` (or via Claude Code MCP
+  settings UI). yellow-core no longer bundles context7 (removed 2026-04-29 to
+  avoid the dual-OAuth pop-up issue when users had context7 at user level
+  too).
+- **yellow-core plugin** — provides the `repo-research-analyst` agent used by
+  `/workflows:deepen-plan` for codebase validation. Skips codebase research if
+  not installed. Install:
   `/plugin marketplace add KingInYellows/yellow-plugins` (select yellow-core)
 - **grep MCP** — provides `mcp__grep__searchGitHub` for GitHub code search via
   grep.app (web-based GitHub search). This is distinct from the bundled ast-grep

--- a/plugins/yellow-research/README.md
+++ b/plugins/yellow-research/README.md
@@ -15,8 +15,10 @@ EXA, Parallel Task, and ast-grep MCP servers with three workflows:
 
 Then enable `yellow-research` from the plugin list.
 
-**Optional:** Install the `yellow-core` plugin for Context7 library docs
-support in `/research:code`. If absent, the code-researcher falls back to EXA.
+**Optional:** Install the user-level `context7` MCP for library-docs support
+in `/research:code` (`/plugin install context7@upstash`). If absent, the
+code-researcher falls back to EXA. Install the `yellow-core` plugin for the
+`repo-research-analyst` agent.
 
 **ast-grep:** The ast-grep MCP server requires the `ast-grep` binary. Run
 `/research:setup` which offers to install it automatically via npm. Or install

--- a/plugins/yellow-research/agents/research/code-researcher.md
+++ b/plugins/yellow-research/agents/research/code-researcher.md
@@ -12,8 +12,8 @@ tools:
   - mcp__plugin_yellow-research_ceramic__ceramic_search
   - mcp__plugin_yellow-research_exa__get_code_context_exa
   - mcp__plugin_yellow-research_exa__web_search_exa
-  - mcp__plugin_yellow-core_context7__resolve-library-id
-  - mcp__plugin_yellow-core_context7__query-docs
+  - mcp__context7__resolve-library-id
+  - mcp__context7__query-docs
   - mcp__grep__searchGitHub
   - mcp__plugin_yellow-research_perplexity__perplexity_search
   - mcp__plugin_yellow-research_ast-grep__find_code
@@ -31,7 +31,7 @@ Choose the best source based on query type:
 
 | Query Type                      | Primary Tool                                                                                                             |
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| Library/framework docs          | `mcp__plugin_yellow-core_context7__resolve-library-id` → `mcp__plugin_yellow-core_context7__query-docs` (Context7)       |
+| Library/framework docs          | `mcp__context7__resolve-library-id` → `mcp__context7__query-docs` (Context7 — user-level MCP, install separately)       |
 | Code examples, patterns, GitHub | `mcp__plugin_yellow-research_exa__get_code_context_exa`                                                                  |
 | AST/structural code patterns    | `mcp__plugin_yellow-research_ast-grep__find_code` / `mcp__plugin_yellow-research_ast-grep__find_code_by_rule` (ast-grep) |
 | GitHub code search              | `mcp__grep__searchGitHub`                                                                                                |
@@ -40,8 +40,10 @@ Choose the best source based on query type:
 | General web (neural fallback)   | `mcp__plugin_yellow-research_exa__web_search_exa`                                                                        |
 
 **Start with Context7** for any named library when the tool is available — it
-has official, up-to-date docs. If ToolSearch cannot find
-`mcp__plugin_yellow-core_context7__resolve-library-id`, skip directly to
+has official, up-to-date docs. **Context7 is a user-level optional MCP** since
+2026-04 (yellow-core no longer bundles it; install once at user level via
+`/plugin install context7@upstash` to enable). If ToolSearch cannot find
+`mcp__context7__resolve-library-id`, skip directly to
 `mcp__plugin_yellow-research_exa__get_code_context_exa`. If Context7 is
 available but returns no match, use
 `mcp__plugin_yellow-research_exa__get_code_context_exa` as the content fallback.

--- a/plugins/yellow-research/commands/research/code.md
+++ b/plugins/yellow-research/commands/research/code.md
@@ -12,8 +12,8 @@ allowed-tools:
   - mcp__plugin_yellow-research_ceramic__ceramic_search
   - mcp__plugin_yellow-research_exa__get_code_context_exa
   - mcp__plugin_yellow-research_exa__web_search_exa
-  - mcp__plugin_yellow-core_context7__resolve-library-id
-  - mcp__plugin_yellow-core_context7__query-docs
+  - mcp__context7__resolve-library-id
+  - mcp__context7__query-docs
   - mcp__grep__searchGitHub
   - mcp__plugin_yellow-research_perplexity__perplexity_search
   - mcp__plugin_yellow-research_ast-grep__find_code
@@ -24,8 +24,9 @@ allowed-tools:
 
 # Code Research
 
-Research code topics inline using Ceramic, EXA, Context7, GitHub, Perplexity,
-and ast-grep. Results are returned in-context — no file is saved.
+Research code topics inline using Ceramic, EXA, GitHub, Perplexity, ast-grep,
+and Context7 (user-level optional MCP — install via `/plugin install context7@upstash`).
+Results are returned in-context — no file is saved.
 
 ## Workflow
 

--- a/plugins/yellow-research/commands/research/setup.md
+++ b/plugins/yellow-research/commands/research/setup.md
@@ -9,7 +9,7 @@ allowed-tools:
   - Bash
   - AskUserQuestion
   - ToolSearch
-  - mcp__plugin_yellow-core_context7__resolve-library-id
+  - mcp__context7__resolve-library-id
   - mcp__grep__searchGitHub
   - mcp__plugin_yellow-morph_morph__warpgrep_codebase_search
   - mcp__filesystem-with-morph__warpgrep_codebase_search
@@ -313,13 +313,18 @@ For each source below, follow this pattern:
 4. If the call throws an exception, returns an explicit error object, `null`, or
    a non-structured response, record status as `FAIL`.
 
-**Context7** (yellow-core plugin — library docs and code examples):
+**Context7** (user-level optional MCP — library docs and code examples):
 
 ```text
 ToolSearch keyword: "resolve-library-id"
-Tool name: mcp__plugin_yellow-core_context7__resolve-library-id
-Test call: mcp__plugin_yellow-core_context7__resolve-library-id with libraryName: "react"
+Tool name: mcp__context7__resolve-library-id
+Test call: mcp__context7__resolve-library-id with libraryName: "react"
 ```
+
+If the user-level Context7 MCP is not installed, the probe records `INACTIVE` and
+the install hint is `/plugin install context7@upstash` (or per Claude Code MCP
+settings UI). yellow-core no longer bundles context7 (removed 2026-04-29 to avoid
+the dual-OAuth pop-up issue).
 
 **Grep MCP** (global — GitHub code pattern search):
 
@@ -423,16 +428,16 @@ OAuth-authenticated MCP servers (no API key needed)
   Ceramic MCP    — Claude Code browser OAuth, prompted on first ceramic_search use.
   (CERAMIC_API_KEY is for the REST live-probe above — the MCP uses OAuth.)
 
-MCP Sources (no API key required — always available if plugin installed)
-  Source         Plugin             Status
-  -----------    ---------------    --------
-  Context7       yellow-core        ACTIVE
-  Grep MCP       (global)           ACTIVE
-  WarpGrep       (global)           UNAVAILABLE
-  DeepWiki       yellow-devin       ACTIVE
-  ast-grep       (bundled)          ACTIVE
-  Parallel Task  (bundled)          ACTIVE (ToolSearch only — server reachability not verified)
-  Ceramic        (bundled)          ACTIVE (ToolSearch only — server reachability and OAuth state not verified)
+MCP Sources (no API key required — always available if plugin/MCP installed)
+  Source         Plugin / source       Status
+  -----------    -------------------   --------
+  Context7       (user-level MCP)      ACTIVE
+  Grep MCP       (global)              ACTIVE
+  WarpGrep       (global)              UNAVAILABLE
+  DeepWiki       yellow-devin          ACTIVE
+  ast-grep       (bundled)             ACTIVE
+  Parallel Task  (bundled)             ACTIVE (ToolSearch only — server reachability not verified)
+  Ceramic        (bundled)             ACTIVE (ToolSearch only — server reachability and OAuth state not verified)
 
 Capability summary:
   /research:deep    PARTIAL (2/3 API sources — Perplexity inactive)
@@ -506,7 +511,7 @@ If any MCP sources are `UNAVAILABLE` or `FAIL`, show this block:
 ```text
 To enable missing MCP sources:
 
-  Context7:   Install yellow-core — /plugin marketplace add KingInYellows/yellow-plugins (select yellow-core)
+  Context7:   Install at user level — /plugin install context7@upstash (no plugin namespace; gives mcp__context7__*)
   Grep MCP:   Configure grep MCP globally in Claude Code MCP settings
   WarpGrep:   Install yellow-morph — /plugin marketplace add KingInYellows/yellow-plugins (select yellow-morph)
               Or configure filesystem-with-morph MCP globally in Claude Code MCP settings

--- a/plugins/yellow-research/commands/research/setup.md
+++ b/plugins/yellow-research/commands/research/setup.md
@@ -321,10 +321,10 @@ Tool name: mcp__context7__resolve-library-id
 Test call: mcp__context7__resolve-library-id with libraryName: "react"
 ```
 
-If the user-level Context7 MCP is not installed, the probe records `INACTIVE` and
-the install hint is `/plugin install context7@upstash` (or per Claude Code MCP
-settings UI). yellow-core no longer bundles context7 (removed 2026-04-29 to avoid
-the dual-OAuth pop-up issue).
+If the user-level Context7 MCP is not installed, the probe records
+`UNAVAILABLE` and the install hint is `/plugin install context7@upstash`
+(or per Claude Code MCP settings UI). yellow-core no longer bundles
+context7 (removed 2026-04-29 to avoid the dual-OAuth pop-up issue).
 
 **Grep MCP** (global — GitHub code pattern search):
 

--- a/plugins/yellow-research/skills/research-patterns/SKILL.md
+++ b/plugins/yellow-research/skills/research-patterns/SKILL.md
@@ -59,7 +59,7 @@ mkdir -p docs/research
 
 | Query Type                     | Primary Source                   | Secondary                    |
 | ------------------------------ | -------------------------------- | ---------------------------- |
-| Library / framework docs       | Context7                         | EXA `get_code_context_exa`   |
+| Library / framework docs       | Context7 (user-level MCP)        | EXA `get_code_context_exa`   |
 | Code examples, GitHub patterns | EXA `get_code_context_exa`       | GitHub grep                  |
 | Keyword-tight general web      | Ceramic `ceramic_search`         | EXA `web_search_exa`         |
 | Recent news, current events    | Perplexity `perplexity_search`   | Tavily `tavily_search`       |


### PR DESCRIPTION
- Remove mcpServers.context7 from yellow-core/.claude-plugin/plugin.json
- Repoint mcp__plugin_yellow-core_context7__* -> mcp__context7__* in yellow-research:
  code-researcher.md, commands/research/code.md, commands/research/setup.md, skills/research-patterns/SKILL.md
- Update best-practices-researcher Phase 1 to ToolSearch-detect user-level context7
- Update yellow-core CLAUDE.md, README.md, statusline/setup.md to reflect zero bundled MCPs
- Update yellow-research CLAUDE.md, README.md to recommend /plugin install context7@upstash
- Append 2026-04-29 update to docs/mcp-tool-naming-verification.md
- Stack Progress: item #1 (docs/everyinc-merge-plan) marked complete
- Plan W1.1 task definition updated to reflect "unbundle + repoint" decision
- Changeset: yellow-core patch, yellow-research patch

Per CE PR #486 (compound-engineering v2.62.0, 2026-04-03) parity: bundled
context7 caused dual-OAuth pop-ups and namespace collisions when users had
context7 also installed at user level. Users keep library-doc capability by
installing context7 once at user level; ToolSearch detects availability and
yellow-research code-researcher falls back to EXA when absent.

Entire-Checkpoint: a1321d0ad7b9

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR unbundles the `context7` MCP from `yellow-core` (removing the `mcpServers.context7` block from `plugin.json`) and repoints all 5 live callers across `yellow-research` and `yellow-core` from the old plugin-namespaced `mcp__plugin_yellow-core_context7__*` tool names to user-level `mcp__context7__*`, with ToolSearch availability detection and EXA fallback preserved throughout. Supporting docs, README files, and the `statusline/setup.md` example output are all consistently updated.

<h3>Confidence Score: 5/5</h3>

Safe to merge — mechanical find-and-replace of tool names across operational files with no logic changes and correct fallback handling preserved throughout.

All live operational files (agent frontmatter, command allowed-tools, setup probe blocks, SKILL routing table) have been consistently updated. No old plugin-namespaced `mcp__plugin_yellow-core_context7__*` references remain in the `plugins/` tree. Remaining references in `plans/`, `RESEARCH/`, and `docs/brainstorms/` are either archival/historical docs untouched by this PR or explicitly superseded by the `docs/mcp-tool-naming-verification.md` update. The changeset bump is `patch`, matching the PR description. No P0 or P1 issues found.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/yellow-core/.claude-plugin/plugin.json | Removes the `mcpServers.context7` block; no other fields touched. Clean, minimal change. |
| plugins/yellow-core/agents/research/best-practices-researcher.md | Tool names repointed to user-level `mcp__context7__*`; Phase 1 updated to use ToolSearch detection before calling Context7. |
| plugins/yellow-research/agents/research/code-researcher.md | Both frontmatter tool list and routing table updated; fallback-to-EXA prose preserved correctly. |
| plugins/yellow-research/commands/research/setup.md | Probe block and MCP Sources status table both updated; install hint and UNAVAILABLE handling added for user-level Context7. |
| plugins/yellow-research/commands/research/code.md | Frontmatter allowed-tools updated; description prose notes Context7 as optional user-level MCP. |
| plugins/yellow-core/commands/statusline/setup.md | DETECTED_PLUGINS example removes `yellow-core: [context7]`; example output drops the `context7 (HTTP) OK` row. Also adds `ceramic` to the yellow-research MCP list, which is a correct correction since ceramic is a bundled yellow-research server. |
| .changeset/unbundle-context7-mcp.md | Bump type is `patch` for both packages, consistent with PR description and `plans/everyinc-merge.md` W1.1 spec. |
| docs/mcp-tool-naming-verification.md | Appends a dated update explicitly superseding the old `mcp__plugin_yellow-core_context7__*` prefix entry. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent invoked\ne.g. code-researcher / best-practices-researcher] --> B[ToolSearch\nlookup mcp__context7__resolve-library-id]
    B --> C{Context7 found\nat user level?}
    C -- Yes --> D[mcp__context7__resolve-library-id\n→ mcp__context7__query-docs]
    C -- No --> E[Skip to EXA\nmcp__plugin_yellow-research_exa__get_code_context_exa]
    D --> F{Match found?}
    F -- Yes --> G[Return library docs]
    F -- No --> E
    E --> H[Return EXA results]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `plans/research-setup-mcp-and-deepen-plan.md`, line 54 ([link](https://github.com/kinginyellows/yellow-plugins/blob/8670424ac4ea6def0993959049a2e375ff8e9524/plans/research-setup-mcp-and-deepen-plan.md#L54)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale tool name in example YAML block**

   This planning doc still shows `mcp__plugin_yellow-core_context7__resolve-library-id` in the `allowed-tools` example YAML (line 54) and in the tool-name reference table (line 363). While this file is not a live command, a developer following this plan to configure `research:setup` would see a now-invalid tool name. The update to `docs/mcp-tool-naming-verification.md` covers the supersession at the registry level, but this plan doc doesn't point back to it.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: plans/research-setup-mcp-and-deepen-plan.md
   Line: 54

   Comment:
   **Stale tool name in example YAML block**

   This planning doc still shows `mcp__plugin_yellow-core_context7__resolve-library-id` in the `allowed-tools` example YAML (line 54) and in the tool-name reference table (line 363). While this file is not a live command, a developer following this plan to configure `research:setup` would see a now-invalid tool name. The update to `docs/mcp-tool-naming-verification.md` covers the supersession at the registry level, but this plan doc doesn't point back to it.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Fchore%2Fremove-context7-mcp%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Fchore%2Fremove-context7-mcp%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plans%2Fresearch-setup-mcp-and-deepen-plan.md%0ALine%3A%2054%0A%0AComment%3A%0A**Stale%20tool%20name%20in%20example%20YAML%20block**%0A%0AThis%20planning%20doc%20still%20shows%20%60mcp__plugin_yellow-core_context7__resolve-library-id%60%20in%20the%20%60allowed-tools%60%20example%20YAML%20%28line%2054%29%20and%20in%20the%20tool-name%20reference%20table%20%28line%20363%29.%20While%20this%20file%20is%20not%20a%20live%20command%2C%20a%20developer%20following%20this%20plan%20to%20configure%20%60research%3Asetup%60%20would%20see%20a%20now-invalid%20tool%20name.%20The%20update%20to%20%60docs%2Fmcp-tool-naming-verification.md%60%20covers%20the%20supersession%20at%20the%20registry%20level%2C%20but%20this%20plan%20doc%20doesn't%20point%20back%20to%20it.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (7): Last reviewed commit: ["revert: PR #274 changeset back to patch ..."](https://github.com/kinginyellows/yellow-plugins/commit/987183d779ba3f52880f73bc34756f5651dfe18f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30207248)</sub>

<!-- /greptile_comment -->