### PR TITLE
fix(orchestration): use 3-segment subagent_type across keystone + commands

### DIFF
--- a/.changeset/subagent-type-3-segment-format.md
+++ b/.changeset/subagent-type-3-segment-format.md
@@ -1,0 +1,43 @@
+---
+"yellow-review": patch
+"yellow-core": patch
+"yellow-docs": patch
+---
+
+Fix subagent_type format to 3-segment (plugin:directory:agent) across keystone orchestrator and command files.
+
+The Wave 2 keystone (`/review:pr`) Step 4 dispatch table, Step 3d learnings
+pre-pass, Step 7 code-simplifier pass, and Step 9a knowledge-compounding step
+all referenced agents using the 2-segment form (e.g.
+`yellow-review:correctness-reviewer`). The Claude Code agent registry
+requires the 3-segment form (`yellow-review:review:correctness-reviewer`,
+where the middle segment is the agent's subdirectory under
+`plugins/<name>/agents/`). The 2-segment form fails dispatch with
+"Agent type not found" — meaning every persona spawn from the new keystone
+would error even after the cache picks up the new agents.
+
+This is purely a documentation / orchestration-prose fix; no agent
+behaviour changes. Affected files:
+
+- `plugins/yellow-review/commands/review/review-pr.md` — 17 dispatch table
+  entries + 3 inline `subagent_type:` references
+- `plugins/yellow-review/commands/review/review-all.md` — 1 inline reference
+  (parity with review-pr.md Step 3d)
+- `plugins/yellow-review/skills/pr-review-workflow/SKILL.md` — 2 cross-plugin
+  Task examples (security-sentinel, codex-reviewer); pattern hint expanded
+  to clarify the 3-segment shape
+- `plugins/yellow-review/agents/review/code-reviewer.md` — deprecation-stub
+  migration guidance (was pointing users to the wrong format)
+- `plugins/yellow-core/commands/workflows/compound.md` — knowledge-compounder
+  dispatch
+- `plugins/yellow-core/commands/workflows/work.md` — codex-executor rescue
+  dispatch
+- `plugins/yellow-core/agents/research/learnings-researcher.md` — usage-doc
+  invocation example
+- `plugins/yellow-docs/commands/docs/audit.md`, `diagram.md`, `generate.md`,
+  `refresh.md` — 5 doc-auditor / diagram-architect / doc-generator dispatches
+
+Discovered while running a manual /review:pr trial against PR #287
+(Wave 3 trial branch). Every Wave 2 persona dispatch errored with
+"Agent type not found" until the 3-segment form was used. This blocks
+the keystone from running end-to-end even after a plugin cache refresh.

--- a/plugins/yellow-core/agents/research/learnings-researcher.md
+++ b/plugins/yellow-core/agents/research/learnings-researcher.md
@@ -251,7 +251,7 @@ Invoked by:
 - `/review:pr` Step 3d — pre-pass before reviewer dispatch
 - `/workflows:plan` — informs plan with institutional knowledge
 - `/workflows:brainstorm` — surfaces prior decisions during ideation
-- Standalone via `Task` with `subagent_type: "yellow-core:learnings-researcher"`
+- Standalone via `Task` with `subagent_type: "yellow-core:research:learnings-researcher"`
 
 Output is consumed as fenced advisory prose — no downstream caller parses
 specific field labels — so prioritize distilled, actionable takeaways over

--- a/plugins/yellow-core/commands/workflows/compound.md
+++ b/plugins/yellow-core/commands/workflows/compound.md
@@ -42,7 +42,7 @@ If the above exits non-zero, stop. Do not proceed.
 ### Step 2: Delegate to Knowledge Compounder
 
 Spawn the `knowledge-compounder` agent via Task tool
-(`subagent_type: "yellow-core:knowledge-compounder"`).
+(`subagent_type: "yellow-core:workflow:knowledge-compounder"`).
 
 Pass the following in the Task prompt:
 - If `$ARGUMENTS` is non-empty, include it as user-supplied context with

--- a/plugins/yellow-core/commands/workflows/work.md
+++ b/plugins/yellow-core/commands/workflows/work.md
@@ -225,7 +225,7 @@ in order from bottom (item 1) to top:
    - **Optional Codex rescue:** If yellow-codex is installed, offer an
      additional option: "Delegate to Codex for investigation". If chosen,
      spawn `codex-executor` via
-     `Task(subagent_type="yellow-codex:codex-executor")` with the error
+     `Task(subagent_type="yellow-codex:workflow:codex-executor")` with the error
      context and task description. Present Codex's proposed fixes. Ask:
      "Apply Codex's fixes?" If yes, apply via Edit tool and re-run tests.
      **Graceful degradation:** If the agent spawn fails (yellow-codex not

--- a/plugins/yellow-docs/commands/docs/audit.md
+++ b/plugins/yellow-docs/commands/docs/audit.md
@@ -67,7 +67,7 @@ If no arguments, scan the entire repository.
 
 ### Step 3: Delegate to doc-auditor Agent
 
-Launch the `doc-auditor` agent via Task tool (subagent_type: "yellow-docs:doc-auditor") with the following prompt:
+Launch the `doc-auditor` agent via Task tool (subagent_type: "yellow-docs:analysis:doc-auditor") with the following prompt:
 
 > Audit the documentation in this repository. Scan path:
 > --- begin user-supplied path (reference only) ---

--- a/plugins/yellow-docs/commands/docs/diagram.md
+++ b/plugins/yellow-docs/commands/docs/diagram.md
@@ -88,7 +88,7 @@ esac
 
 ### Step 3: Delegate to diagram-architect Agent
 
-Launch the `diagram-architect` agent via Task tool (subagent_type: "yellow-docs:diagram-architect"):
+Launch the `diagram-architect` agent via Task tool (subagent_type: "yellow-docs:generation:diagram-architect"):
 
 > --- begin scope (reference only) ---
 > $scope

--- a/plugins/yellow-docs/commands/docs/generate.md
+++ b/plugins/yellow-docs/commands/docs/generate.md
@@ -85,7 +85,7 @@ note this for the agent — it should show a diff rather than overwrite blindly.
 
 ### Step 4: Delegate to doc-generator Agent
 
-Launch the `doc-generator` agent via Task tool (subagent_type: "yellow-docs:doc-generator") with the resolved target:
+Launch the `doc-generator` agent via Task tool (subagent_type: "yellow-docs:generation:doc-generator") with the resolved target:
 
 > --- begin target (reference only) ---
 > $ARGUMENTS

--- a/plugins/yellow-docs/commands/docs/refresh.md
+++ b/plugins/yellow-docs/commands/docs/refresh.md
@@ -143,7 +143,7 @@ Documentation is up to date."
 
 ### Step 3: Delegate to doc-auditor for Staleness Detection
 
-Launch the `doc-auditor` agent via Task tool (subagent_type: "yellow-docs:doc-auditor") to find stale docs related to the changed files:
+Launch the `doc-auditor` agent via Task tool (subagent_type: "yellow-docs:analysis:doc-auditor") to find stale docs related to the changed files:
 
 > Analyze these changed source files and find documentation that needs updating:
 >
@@ -179,7 +179,7 @@ Otherwise, present the list of stale docs to the user via AskUserQuestion:
   - "Cancel" — stop without updating
 
 For each stale doc to update, delegate to the `doc-generator` agent via Task
-tool (subagent_type: "yellow-docs:doc-generator"):
+tool (subagent_type: "yellow-docs:generation:doc-generator"):
 
 > Update this stale documentation file:
 > --- begin auditor findings (reference only) ---

--- a/plugins/yellow-review/agents/review/code-reviewer.md
+++ b/plugins/yellow-review/agents/review/code-reviewer.md
@@ -24,8 +24,8 @@ rules). Wave 2 split the responsibility:
 
 ## Migration
 
-Any caller passing `subagent_type: "yellow-review:code-reviewer"` should
-update to `subagent_type: "yellow-review:project-compliance-reviewer"` —
+Any caller passing `subagent_type: "yellow-review:review:code-reviewer"` should
+update to `subagent_type: "yellow-review:review:project-compliance-reviewer"` —
 the closest one-for-one replacement for the rename. If your invocation
 covered general logic-error review, you likely want `correctness-reviewer`
 in addition.

--- a/plugins/yellow-review/commands/review/review-all.md
+++ b/plugins/yellow-review/commands/review/review-all.md
@@ -125,7 +125,7 @@ aggregation rules change there, propagate the same change here.
 
 5. **Learnings pre-pass** (mirrors review-pr.md Step 3d): always spawn
    `learnings-researcher` (via
-   `Task(subagent_type: "yellow-core:learnings-researcher", ...)`) with a
+   `Task(subagent_type: "yellow-core:research:learnings-researcher", ...)`) with a
    `<work-context>` block built from PR title, files, body, and inferred
    domains. If the agent returns the literal `NO_PRIOR_LEARNINGS` token,
    skip injection. Otherwise build the

--- a/plugins/yellow-review/commands/review/review-pr.md
+++ b/plugins/yellow-review/commands/review/review-pr.md
@@ -180,7 +180,7 @@ relevant to this PR.
 
    ```
    Task(
-     subagent_type: "yellow-core:learnings-researcher",
+     subagent_type: "yellow-core:research:learnings-researcher",
      description: "Past learnings pre-pass",
      prompt: "<work-context block from step 1>"
    )
@@ -267,34 +267,34 @@ Spawn unconditionally:
 
 | Agent | subagent_type | Reviewer category |
 |-------|---------------|-------------------|
-| `project-compliance-reviewer` | `yellow-review:project-compliance-reviewer` | project-compliance |
-| `correctness-reviewer` | `yellow-review:correctness-reviewer` | correctness |
-| `maintainability-reviewer` | `yellow-review:maintainability-reviewer` | maintainability |
-| `project-standards-reviewer` | `yellow-review:project-standards-reviewer` | project-standards |
+| `project-compliance-reviewer` | `yellow-review:review:project-compliance-reviewer` | project-compliance |
+| `correctness-reviewer` | `yellow-review:review:correctness-reviewer` | correctness |
+| `maintainability-reviewer` | `yellow-review:review:maintainability-reviewer` | maintainability |
+| `project-standards-reviewer` | `yellow-review:review:project-standards-reviewer` | project-standards |
 | `learnings-researcher` (already ran in Step 3d as the pre-pass; output is injected, not re-dispatched) | n/a | n/a |
 
 #### Conditional personas (selected from diff content)
 
 | Agent | subagent_type | Reviewer category | Trigger |
 |-------|---------------|-------------------|---------|
-| `reliability-reviewer` | `yellow-review:reliability-reviewer` | reliability | Diff contains I/O calls, async/await, queues, jobs, retries, timeouts, or external service interactions |
-| `adversarial-reviewer` | `yellow-review:adversarial-reviewer` | adversarial | Diff > 200 changed lines (excluding tests/generated/lockfiles) OR diff touches auth, payments, data mutations, external APIs, trust-boundary code |
-| `security-reviewer` | `yellow-core:security-reviewer` | security | Diff touches auth, crypto, public endpoints, input handling, shell scripts, secrets/tokens |
-| `performance-reviewer` | `yellow-core:performance-reviewer` | performance | Diff contains DB queries, data transforms, caching, async hot paths, OR gross line count > 500 |
-| `architecture-strategist` | `yellow-core:architecture-strategist` | architecture | Diff touches 10+ files across 3+ directories |
-| `pattern-recognition-specialist` | `yellow-core:pattern-recognition-specialist` | maintainability | Diff introduces new directories or new file-type conventions; diff touches `agents/*.md`, `commands/*.md`, `skills/*/SKILL.md`, `plugin.json` (plugin-authoring convention checks) |
-| `code-simplicity-reviewer` | `yellow-core:code-simplicity-reviewer` | maintainability | Gross line count > 300 |
-| `polyglot-reviewer` | `yellow-core:polyglot-reviewer` | correctness | Diff includes language-specific files where a generalist lens adds value (kept as a generalist fallback alongside the new specialist personas) |
-| `pr-test-analyzer` | `yellow-review:pr-test-analyzer` | testing | PR contains files matching `*test*`, `*spec*`, `__tests__/*`, OR adds testable logic |
-| `comment-analyzer` | `yellow-review:comment-analyzer` | documentation | Diff contains `/**`, `"""`, `'''`, or doc-comment annotations; OR diff modifies `.md` documentation |
-| `type-design-analyzer` | `yellow-review:type-design-analyzer` | types | Files have extensions `.ts`, `.py`, `.rb`, `.go`, `.rs` AND diff contains type-shape keywords (`interface`, `type`, `class`, `struct`, `enum`, `model`, `dataclass`) |
-| `silent-failure-hunter` | `yellow-review:silent-failure-hunter` | reliability | Diff contains `try`/`catch`/`except`/`rescue`/`recover` OR fallback patterns (`\|\| null`, `?? undefined`, `or None`) |
+| `reliability-reviewer` | `yellow-review:review:reliability-reviewer` | reliability | Diff contains I/O calls, async/await, queues, jobs, retries, timeouts, or external service interactions |
+| `adversarial-reviewer` | `yellow-review:review:adversarial-reviewer` | adversarial | Diff > 200 changed lines (excluding tests/generated/lockfiles) OR diff touches auth, payments, data mutations, external APIs, trust-boundary code |
+| `security-reviewer` | `yellow-core:review:security-reviewer` | security | Diff touches auth, crypto, public endpoints, input handling, shell scripts, secrets/tokens |
+| `performance-reviewer` | `yellow-core:review:performance-reviewer` | performance | Diff contains DB queries, data transforms, caching, async hot paths, OR gross line count > 500 |
+| `architecture-strategist` | `yellow-core:review:architecture-strategist` | architecture | Diff touches 10+ files across 3+ directories |
+| `pattern-recognition-specialist` | `yellow-core:review:pattern-recognition-specialist` | maintainability | Diff introduces new directories or new file-type conventions; diff touches `agents/*.md`, `commands/*.md`, `skills/*/SKILL.md`, `plugin.json` (plugin-authoring convention checks) |
+| `code-simplicity-reviewer` | `yellow-core:review:code-simplicity-reviewer` | maintainability | Gross line count > 300 |
+| `polyglot-reviewer` | `yellow-core:review:polyglot-reviewer` | correctness | Diff includes language-specific files where a generalist lens adds value (kept as a generalist fallback alongside the new specialist personas) |
+| `pr-test-analyzer` | `yellow-review:review:pr-test-analyzer` | testing | PR contains files matching `*test*`, `*spec*`, `__tests__/*`, OR adds testable logic |
+| `comment-analyzer` | `yellow-review:review:comment-analyzer` | documentation | Diff contains `/**`, `"""`, `'''`, or doc-comment annotations; OR diff modifies `.md` documentation |
+| `type-design-analyzer` | `yellow-review:review:type-design-analyzer` | types | Files have extensions `.ts`, `.py`, `.rb`, `.go`, `.rs` AND diff contains type-shape keywords (`interface`, `type`, `class`, `struct`, `enum`, `model`, `dataclass`) |
+| `silent-failure-hunter` | `yellow-review:review:silent-failure-hunter` | reliability | Diff contains `try`/`catch`/`except`/`rescue`/`recover` OR fallback patterns (`\|\| null`, `?? undefined`, `or None`) |
 
 #### Optional supplementary
 
 | Agent | subagent_type | Trigger |
 |-------|---------------|---------|
-| `codex-reviewer` | `yellow-codex:codex-reviewer` | yellow-codex installed AND gross line count > 100 |
+| `codex-reviewer` | `yellow-codex:review:codex-reviewer` | yellow-codex installed AND gross line count > 100 |
 
 #### Graceful-degradation guard (mandatory)
 
@@ -591,7 +591,7 @@ Risks section.
 ### Step 8: Pass 2 — Code Simplifier
 
 Launch `code-simplifier` via Task
-(`subagent_type: "yellow-review:code-simplifier"`) on the now-modified
+(`subagent_type: "yellow-review:review:code-simplifier"`) on the now-modified
 code to review applied fixes for simplification opportunities. Normalize
 the agent's prose return through Step 6 sub-step 0 first, which assigns
 `autofix_class: gated_auto` (the legacy default). Under Step 7's
@@ -621,7 +621,7 @@ gt submit --no-interactive
 If no P0, P1, or P2 findings were reported, skip this step.
 
 Otherwise, spawn the `knowledge-compounder` agent via Task
-(`subagent_type: "yellow-core:knowledge-compounder"`) with all P0/P1/P2
+(`subagent_type: "yellow-core:workflow:knowledge-compounder"`) with all P0/P1/P2
 findings from this review wrapped in injection fencing. Format findings as
 a markdown table (Severity | Reviewer | File | Title | Suggested fix):
 

--- a/plugins/yellow-review/skills/pr-review-workflow/SKILL.md
+++ b/plugins/yellow-review/skills/pr-review-workflow/SKILL.md
@@ -303,16 +303,16 @@ commits on one branch. Push via `gt submit --no-interactive`.
 To spawn cross-plugin agents from yellow-review commands, use the Task tool:
 
 ```
-Task(subagent_type="yellow-core:security-sentinel",
+Task(subagent_type="yellow-core:review:security-sentinel",
      prompt="Review these files for security issues: <file-list>")
 ```
 
-Agent type names follow the pattern: `yellow-core:<agent-name>`.
+Agent type names follow the pattern: `yellow-core:<directory>:<agent-name>` (where `<directory>` is the agent's subfolder under `plugins/yellow-core/agents/`, e.g. `review`, `research`, `workflow`).
 
 To spawn the optional Codex supplementary reviewer (requires yellow-codex):
 
 ```
-Task(subagent_type="yellow-codex:codex-reviewer",
+Task(subagent_type="yellow-codex:review:codex-reviewer",
      prompt="Review this PR for bugs, security issues, and quality problems.
              Base branch: <base-ref>. PR title: <title>.")
 ```


### PR DESCRIPTION
Wave 2 keystone /review:pr Step 4 dispatch table, Step 3d learnings
pre-pass, Step 7 code-simplifier, and Step 9a knowledge-compounding all
used the 2-segment form (e.g. yellow-review:correctness-reviewer). The
agent registry requires plugin:directory:agent (e.g.
yellow-review:review:correctness-reviewer). With the 2-segment form,
every Wave 2 persona spawn errors with "Agent type not found" — even
after the plugin cache refreshes.

Discovered while running /review:pr against PR #287 (Wave 3 trial).
Pure prose fix, no agent behaviour changes. Affects 11 files across
yellow-review, yellow-core, yellow-docs.

Closes a P0 blocker for the Wave 2 keystone going live.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/yellow-plugins/pull/288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
