### PR TITLE
ci: switch version-packages.yml to ubuntu-latest

### DIFF
--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -41,7 +41,11 @@ jobs:
   # ==========================================================================
   version-or-publish:
     name: Version or Publish
-    runs-on: [self-hosted, pool:ares]
+    # Release pipeline exception: this workflow runs on GitHub-hosted runners
+    # rather than the self-hosted pool:ares default. Release workflows benefit
+    # from the higher availability + cleaner credential isolation of
+    # GitHub-hosted runners, and this matches the notify job below.
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     outputs:
@@ -188,7 +192,8 @@ jobs:
   # ==========================================================================
   build-and-release:
     name: Build and Release
-    runs-on: [self-hosted, pool:ares]
+    # Release pipeline exception — see version-or-publish for rationale.
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [version-or-publish]
     environment: production


### PR DESCRIPTION
## Summary

- Move both Version Packages jobs (`version-or-publish` and `build-and-release`) from `runs-on: [self-hosted, pool:ares]` to `runs-on: ubuntu-latest`.
- Five consecutive runs (4 push-triggered, 1 workflow_dispatch) sat in pending/queued for 4+ minutes each with zero job allocation before being cancelled. The user confirmed pool:ares works in other repos, so the problem is specific to this workflow's label routing for this repo.
- Notify job already runs on ubuntu-latest — this aligns the whole file.
- Scope is release pipeline only; other workflows continue to use pool:ares.

## Why GitHub-hosted is appropriate here

Release workflows benefit from GitHub-hosted runners' availability and credential isolation. The version-packages workflow doesn't need any pool:ares-specific tooling — it runs `pnpm install`, `changesets/action`, `softprops/action-gh-release`, and standard tar/sha256sum commands. The notify job already uses `ubuntu-latest`.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, push triggers a Version Packages run that actually allocates runners (reaches `in_progress`, not stuck `pending`)
- [ ] The run produces the expected "chore: version packages" PR with the 4 minor bumps queued from the prior session (yellow-review, yellow-core, yellow-docs, yellow-research)
- [ ] Merging that Version PR triggers Phase 2 publish (per-plugin tags + GitHub Release)

If pool:ares routing is fixed later, this commit can be reverted.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/yellow-plugins/pull/291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR switches the `version-or-publish` and `build-and-release` jobs in `.github/workflows/version-packages.yml` from `runs-on: [self-hosted, pool:ares]` to `runs-on: ubuntu-latest`, aligning them with the pre-existing `notify` job. The change is motivated by repeated runner-allocation failures specific to this repo's label routing, and the workflow only requires standard tooling (`pnpm`, `changesets/action`, `softprops/action-gh-release`, `tar`, `sha256sum`) that is fully available on GitHub-hosted runners.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, well-motivated runner label swap with no logic modifications.

Only two `runs-on` lines are changed. All tooling invoked (`pnpm`, `changesets/action`, `softprops/action-gh-release`, `tar`, `sha256sum`) is available on `ubuntu-latest`. Credential handling (`persist-credentials: false`, explicit cleanup steps) is runner-agnostic. No logic, secrets, or permissions are altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/version-packages.yml | Runner label changed from `[self-hosted, pool:ares]` to `ubuntu-latest` for two jobs; explanatory comments added; all tooling used is compatible with GitHub-hosted runners. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    trigger["push: main\nworkflow_dispatch"]

    subgraph "version-or-publish [ubuntu-latest ← was pool:ares]"
        detect["Detect phase\n(changesets / force_publish)"]
        changeset_action["changesets/action\n(create Version PR or tag)"]
        read_version["Read catalog version"]
    end

    subgraph "build-and-release [ubuntu-latest ← was pool:ares]"
        build["Build packages"]
        sbom["Generate SBOM"]
        checksums["Compute SHA256SUMS"]
        gh_release["Create GitHub Release\nsoftprops/action-gh-release"]
        npm_publish["Publish to NPM\n(optional)"]
    end

    subgraph "notify [ubuntu-latest — unchanged]"
        status["Log release status\nfail on build error"]
    end

    trigger --> detect
    detect -->|"run_changesets=true"| changeset_action
    changeset_action --> read_version
    read_version -->|"should_publish=true"| build
    build --> sbom --> checksums --> gh_release --> npm_publish
    gh_release --> status
    npm_publish --> status
```

<sub>Reviews (1): Last reviewed commit: ["ci: switch version-packages.yml to ubunt..."](https://github.com/kinginyellows/yellow-plugins/commit/624553113a4f21888bccf8f1804bcdcf94afeec6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30279182)</sub>

<!-- /greptile_comment -->