### PR TITLE
fix(yellow-core,yellow-review): tighten learnings-researcher empty-result contract

### DIFF
--- a/.changeset/learnings-researcher-sentinel-fix.md
+++ b/.changeset/learnings-researcher-sentinel-fix.md
@@ -1,0 +1,47 @@
+---
+"yellow-core": patch
+"yellow-review": patch
+---
+
+Fix `learnings-researcher` empty-result sentinel violation +
+defense-in-depth on the keystone check
+
+The `learnings-researcher` agent's empty-result protocol requires
+`NO_PRIOR_LEARNINGS` to be the **first non-whitespace line** of the
+response. In practice the agent was emitting a "thinking out loud"
+scan-summary paragraph before the sentinel — flipping the keystone's
+Step 3d.4 strict-equality check from "empty → skip injection" to
+"non-empty → inject as learnings", which delivered useless prose to
+all 4–9 dispatched reviewers per `/review:pr` invocation.
+
+Two-sided fix:
+
+1. **`plugins/yellow-core/agents/research/learnings-researcher.md`** —
+   tighten the empty-result protocol with explicit anti-pattern
+   guidance (forbidden prose-before-token, no thinking-out-loud, no
+   closing remarks) and a self-check checklist before emission. The
+   agent-side contract is unchanged (token must still be first
+   non-whitespace line); the spec just makes the LLM-compliance bar
+   harder to miss.
+
+2. **`plugins/yellow-review/commands/review/review-pr.md`** Step 3d.4
+   — replace the strict "first non-whitespace line equals literal
+   token" check with two-condition empty-result detection:
+   - **(a)** the token appears on its own line anywhere in the
+     response (regex `(?m)^\s*NO_PRIOR_LEARNINGS\s*$`), AND
+   - **(b)** the response does NOT contain a `## Past Learnings`
+     heading (regex `(?m)^##\s+Past\s+Learnings\s*$`).
+
+   When both hold → skip injection (the original fix intent —
+   tolerate LLM thinking-out-loud preamble before the sentinel).
+   When only (a) holds (token + findings heading both present) →
+   contract violation; log a warning, strip the sentinel line, and
+   treat the response as non-empty so findings are not silently
+   dropped. The `## Past Learnings` heading dominance ensures the
+   relaxation never masks the "combined sentinel with findings"
+   anti-pattern the agent body forbids.
+
+Together the two changes mean Wave 3 PR reviews will get clean
+empty-result handling immediately, with a robust safety net that
+preserves findings even when an agent-side regression combines the
+sentinel with real findings.

--- a/plugins/yellow-core/agents/research/learnings-researcher.md
+++ b/plugins/yellow-core/agents/research/learnings-researcher.md
@@ -199,7 +199,8 @@ current code. List `<file:line> — <claim> — <observed reality>`.)
 returned: `Additional candidates not surfaced: N. Highest skipped: <title>`.)
 ```
 
-When **no** relevant learnings are found:
+When **no** relevant learnings are found, return EXACTLY this — nothing
+before, nothing else:
 
 ```
 NO_PRIOR_LEARNINGS
@@ -210,9 +211,35 @@ capturing with /workflows:compound after it lands — the absence is itself
 useful signal.
 ```
 
-The literal `NO_PRIOR_LEARNINGS` token on its own line at the top is the
-contract: orchestrators check for this token and skip the injection block.
-Never combine the token with prose findings.
+The literal `NO_PRIOR_LEARNINGS` token must be the **first non-whitespace
+line of your entire response**. Orchestrators may tolerate leading prose
+as a recovery safety net, but the agent contract requires token-first.
+Never combine the sentinel with a `## Past Learnings` findings heading —
+the two output formats are mutually exclusive.
+
+**Forbidden in the empty-result response — these all violate the
+contract:**
+
+- ❌ Scan-summary prose before the token (e.g., "I scanned the catalog.
+  No entry matched..."). The contract requires token-first; do not
+  emit preamble.
+- ❌ "Thinking out loud" or methodology recap (e.g., "The closest
+  candidates are X and Y, but neither rises to a strong match..."). The
+  advisory after the token is the only place for that — and it must be
+  brief.
+- ❌ Closing remarks or hedging (e.g., "Hope this helps", "Let me know
+  if you'd like a deeper search"). The orchestrator is the consumer,
+  not a human.
+- ❌ Combining the empty-result token with any non-zero findings list
+  (i.e., a `## Past Learnings` heading + numbered finding entries
+  alongside the sentinel). The two output formats are mutually
+  exclusive.
+- ❌ Paraphrases (`No prior learnings`, `none found`, `NO PRIOR
+  LEARNINGS` with underscores replaced by spaces) — the token is a
+  literal string match.
+
+When in doubt, prefer the literal token + a single short advisory
+sentence over any longer explanation.
 
 ## Efficiency rules
 
@@ -241,9 +268,27 @@ Never combine the token with prose findings.
 When grep returns zero candidates, when ranking surfaces no strong or
 moderate matches, or when every candidate fails the conflict check (claims
 contradict current code without resolution), return the `NO_PRIOR_LEARNINGS`
-sentinel exactly as shown above. The orchestrator depends on the literal
-token — do not paraphrase it (`No prior learnings`, `none found`, etc. all
-break the contract).
+sentinel exactly as shown in the **Output Format** section above. The
+agent contract requires the token as the **first non-whitespace line** —
+do not paraphrase it (`No prior learnings`, `none found`, etc.) and do
+not put any prose, scan summary, or methodology recap before it.
+Orchestrators may tolerate leading prose as a recovery safety net, but
+relying on that tolerance violates the contract.
+
+**Self-check before emitting an empty-result response:**
+
+1. Is the first non-whitespace line of my response *exactly*
+   `NO_PRIOR_LEARNINGS`? If not, revise the response so it is — do
+   not emit a response with prose before this line.
+2. Is the response a single token line followed by one brief advisory
+   paragraph? If longer, trim the advisory to one sentence about what
+   was scanned.
+3. Did I include any "I scanned the catalog. No entry matched..."
+   prose as a separate paragraph? That belongs in the advisory's
+   `<keyword list>` slot, not as preamble before the token.
+4. Does my response contain BOTH `NO_PRIOR_LEARNINGS` AND a `## Past
+   Learnings` heading? That is a contract violation — pick one
+   format only.
 
 ## Integration
 

--- a/plugins/yellow-review/commands/review/review-all.md
+++ b/plugins/yellow-review/commands/review/review-all.md
@@ -127,8 +127,15 @@ aggregation rules change there, propagate the same change here.
    `learnings-researcher` (via
    `Task(subagent_type: "yellow-core:research:learnings-researcher", ...)`) with a
    `<work-context>` block built from PR title, files, body, and inferred
-   domains. If the agent returns the literal `NO_PRIOR_LEARNINGS` token,
-   skip injection. Otherwise build the
+   domains. Apply the two-condition detection from review-pr.md Step 3d.4:
+   **(a)** response contains `NO_PRIOR_LEARNINGS` as a complete line
+   (regex `(?m)^\s*NO_PRIOR_LEARNINGS\s*$`) AND **(b)** response does NOT
+   contain a `## Past Learnings` heading (regex
+   `(?m)^##\s+Past\s+Learnings\s*$`) → both hold, skip injection. Only
+   (a) holds → contract violation: log warning, strip sentinel line(s)
+   AND any immediately-following advisory paragraph, treat as non-empty.
+   No sentinel token → non-empty. (See review-pr.md Step 3d.4 for full
+   algorithm.) Otherwise build the
    `--- begin learnings-context (reference only) ---` fenced block and
    prepend to **every** reviewer's Task prompt for this PR — **only when
    `review_pipeline` is not `legacy`**. The legacy path is the pre-Wave-2

--- a/plugins/yellow-review/commands/review/review-pr.md
+++ b/plugins/yellow-review/commands/review/review-pr.md
@@ -188,13 +188,52 @@ relevant to this PR.
 
 3. Wait for the agent's return.
 
-4. **Empty-result handling.** If the **first non-whitespace line** of the
-   response equals the literal token `NO_PRIOR_LEARNINGS` (the agent's
-   empty-result sentinel), skip injection entirely and proceed to Step 4.
-   Note the absence in the final report's Coverage section: "Past
-   learnings: none found in docs/solutions/". Strict equality on the
-   first non-whitespace line is the contract — do not match on substring,
-   prefix-after-whitespace, or paraphrase.
+4. **Empty-result handling.** Empty-result detection is two-condition,
+   to tolerate LLM thinking-out-loud preamble without silently dropping
+   findings when the agent violates the "don't combine sentinel with
+   findings" anti-pattern:
+
+   - **Condition (a):** the response contains the literal token
+     `NO_PRIOR_LEARNINGS` as a complete line on its own anywhere in the
+     output (regex `(?m)^\s*NO_PRIOR_LEARNINGS\s*$`).
+   - **Condition (b):** the response does NOT contain a `## Past
+     Learnings` heading (regex `(?m)^##\s+Past\s+Learnings\s*$`).
+     This heading is the agent's non-empty-result format marker and
+     dominates: when present, the response is non-empty regardless of
+     whether the sentinel token also appears.
+
+   **Both conditions hold → skip injection.** Note the absence in the
+   final report's Coverage section: "Past learnings: none found in
+   docs/solutions/".
+
+   **Only (a) holds (token present AND findings heading present) →
+   contract violation.** The agent body forbids combining the
+   sentinel with findings; if it happens anyway, log
+   `[review:pr] Warning: learnings-researcher response combined
+   NO_PRIOR_LEARNINGS sentinel with findings — contract violation;
+   treating as non-empty (preserving findings)` to stderr, strip the
+   sentinel line(s) AND any immediately-following empty-result
+   advisory paragraph (the `(advisory) docs/solutions/ scanned for:
+   ...` block, if present) from the response, and proceed to Step 5
+   with the stripped response as non-empty. Never silently drop
+   findings on a contract violation.
+
+   **No sentinel token found ((a) is false, regardless of (b)) →
+   non-empty.** Treat as non-empty per Step 5 below. This branch
+   covers both the normal non-empty return (heading present, no token)
+   and the malformed/empty response edge case (no token, no heading) —
+   both route identically since absence of the sentinel means the
+   response is not the empty-result format.
+
+   Substring matches inside prose (`...is this NO_PRIOR_LEARNINGS?...`)
+   and paraphrases (`No prior learnings`, `none found`) still do NOT
+   count for condition (a) — only a literal line-aligned match.
+
+   This orchestrator-side check is more forgiving than the agent's
+   strict-first-line contract by design (tolerates thinking-out-loud
+   preamble), but the dominance of the `## Past Learnings` heading
+   prevents the relaxation from masking the "combined sentinel with
+   findings" anti-pattern.
 
 5. **Non-empty handling.** When `learnings-researcher` returns findings,
    build a fenced advisory block:


### PR DESCRIPTION
The learnings-researcher's empty-result protocol requires
NO_PRIOR_LEARNINGS to be the first non-whitespace line. In practice the
agent was emitting a "thinking out loud" scan-summary paragraph before
the sentinel — flipping the keystone's Step 3d.4 check from "empty →
skip injection" to "non-empty → inject as learnings", which delivered
useless prose to all 4–9 dispatched reviewers per /review:pr run.

Two-sided fix:

1. learnings-researcher.md — tighten the empty-result protocol with
   explicit anti-pattern guidance (no prose-before-token, no thinking-
   out-loud, no closing remarks) and a self-check checklist before
   emission. The contract is unchanged; the spec just makes the
   LLM-compliance bar harder to miss.

2. review-pr.md Step 3d.4 — relax the orchestrator's check from "first
   non-whitespace line" to "literal token on its own line anywhere in
   the output" (regex (?m)^\s*NO_PRIOR_LEARNINGS\s*$). Defense-in-depth.

Surfaced during keystone verification on PR #263 — every dispatched
reviewer received 1.1KB of "I scanned and found nothing" wrapped as a
learnings advisory.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/yellow-plugins/pull/294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed empty-result detection to properly handle edge cases where sentinel tokens and findings coexist.
  * Enhanced validation to prevent accidental data loss when protocol violations occur.
  * Improved detection logic to distinguish between truly empty results and contract violations.

* **Documentation**
  * Updated response protocol guidance with stricter constraints and validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the `learnings-researcher` empty-result sentinel bug that was causing \"thinking out loud\" prose to be injected as learnings into all dispatched reviewers. The fix is two-sided: the agent spec gains explicit anti-pattern guidance and a self-check checklist, while the orchestrator's Step 3d.4 is relaxed to a two-condition regex check (sentinel-on-any-line + `## Past Learnings` heading dominance) with a contract-violation recovery path that preserves findings.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 suggestions on spec precision with no functional regressions

All three inline comments are P2: one on regex strictness for the heading dominance guard, one on advisory-paragraph stripping ambiguity with blank lines, and one on a log-prefix mismatch in review-all.md. None represent present functional defects; the core algorithm is correct and an improvement over the original single-line equality check.

review-pr.md Step 3d.4 — heading regex and advisory stripping spec clarity

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/yellow-review/commands/review/review-pr.md | Step 3d.4 replaced with two-condition detection (sentinel regex + heading dominance); logic is sound but condition (b) regex is too strict for heading variants and "immediately-following" stripping is ambiguous with blank-line separator in canonical format |
| plugins/yellow-core/agents/research/learnings-researcher.md | Empty-result protocol tightened with explicit anti-pattern list, forbidden patterns, and self-check checklist; well-structured and clear |
| plugins/yellow-review/commands/review/review-all.md | Mirrors the two-condition detection from review-pr.md Step 3d.4; defers to review-pr.md for full algorithm but the hardcoded [review:pr] log prefix would be misleading in review:all traces |
| .changeset/learnings-researcher-sentinel-fix.md | Changeset accurately documents the two-sided fix and conditions; no issues found |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[learnings-researcher returns response] --> B{Step 7: agent failed?\ntimeout / not-found / malformed}
    B -- Yes --> C[Log warning\nSkip injection\nProceed to Step 4]
    B -- No --> D{Condition a:\nNO_PRIOR_LEARNINGS\non its own line?}
    D -- No --> G[Non-empty path\nProceed to Step 5]
    D -- Yes --> E{Condition b:\nNO ## Past Learnings\nheading present?}
    E -- Both hold --> F[Skip injection\nNote absence in Coverage section]
    E -- Only a holds\nheading also present --> H[CONTRACT VIOLATION\nLog warning to stderr\nStrip sentinel + advisory paragraph\nTreat as non-empty]
    H --> G
    G --> I[Step 5: Build fenced advisory block\nPrepend to all reviewer Task prompts]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffix%2Flearnings-researcher-sentinel%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffix%2Flearnings-researcher-sentinel%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aplugins%2Fyellow-review%2Fcommands%2Freview%2Freview-pr.md%3A199-203%0A**Condition%20%28b%29%20regex%20too%20strict%20%E2%80%94%20heading%20variant%20can%20silently%20drop%20findings**%0A%0AThe%20heading%20check%20%60%28%3Fm%29%5E%23%23%5Cs%2BPast%5Cs%2BLearnings%5Cs*%24%60%20requires%20an%20exact%20match.%20If%20an%20LLM%20ever%20outputs%20%60%23%23%20Past%20Learnings%3A%60%20%28trailing%20colon%29%2C%20%60%23%23Past%20Learnings%60%20%28no%20space%20after%20%60%23%23%60%29%2C%20or%20%60%23%23%23%20Past%20Learnings%60%20%28H3%29%2C%20condition%20%28b%29%20evaluates%20to%20%60true%60%20%28heading%20*not*%20present%29.%20Combined%20with%20%60%28a%29%3Dtrue%60%2C%20that%20routes%20to%20%22skip%20injection%22%20%E2%80%94%20silently%20dropping%20real%20findings.%20Given%20that%20this%20path%20is%20defense-in-depth%20intended%20to%20*preserve*%20findings%20on%20contract%20violation%2C%20a%20slightly%20malformed%20heading%20defeats%20the%20safety%20net%20entirely.%0A%0AConsider%20a%20more%20tolerant%20regex%2C%20e.g.%3A%0A%0A%60%60%60%0A%28%3Fm%29%5E%23%7B1%2C3%7D%5Cs*Past%5Cs%2BLearnings%5Cs*%3A%3F%5Cs*%24%0A%60%60%60%0A%0AThis%20covers%20missing%20space%20after%20%60%23%60%2C%20optional%20trailing%20colon%2C%20and%20H3%20variants%20without%20opening%20up%20false%20positives.%0A%0A%23%23%23%20Issue%202%20of%203%0Aplugins%2Fyellow-review%2Fcommands%2Freview%2Freview-pr.md%3A214-219%0A**%22Immediately-following%22%20advisory%20stripping%20is%20ambiguous%20with%20canonical%20blank-line%20separator**%0A%0AThe%20contract%20violation%20path%20strips%20%22the%20sentinel%20line%28s%29%20AND%20any%20immediately-following%20empty-result%20advisory%20paragraph.%22%20However%2C%20the%20canonical%20empty-result%20format%20in%20%60learnings-researcher.md%60%20%28lines%20205%E2%80%93212%29%20shows%20a%20**blank%20line**%20between%20the%20sentinel%20and%20the%20advisory%3A%0A%0A%60%60%60%0ANO_PRIOR_LEARNINGS%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%86%90%20blank%20line%20here%0A%28advisory%29%20docs%2Fsolutions%2F%20scanned%20for%3A%20...%0A%60%60%60%0A%0AA%20literal%20reading%20of%20%22immediately-following%22%20could%20mean%20%22no%20blank%20line%20allowed%22%20%E2%80%94%20causing%20the%20advisory%20paragraph%20to%20be%20left%20in%20the%20stripped%20response%20and%20subsequently%20injected%20into%20reviewers%20as%20spurious%20findings%20prose.%20Clarify%20whether%20intervening%20blank%20lines%20are%20consumed%20during%20stripping%20%28e.g.%2C%20%22strip%20the%20sentinel%20line%28s%29%2C%20any%20immediately-following%20blank%20lines%2C%20and%20the%20first%20following%20%60%28advisory%29%20%E2%80%A6%60%20paragraph%2C%20if%20present%22%29.%0A%0A%23%23%23%20Issue%203%20of%203%0Aplugins%2Fyellow-review%2Fcommands%2Freview%2Freview-all.md%3A135-136%0A**Log-prefix%20mismatch%20when%20algorithm%20is%20reused%20by%20%60%2Freview%3Aall%60**%0A%0AThe%20full%20algorithm%20in%20%60review-pr.md%60%20Step%203d.4%20hardcodes%20the%20warning%20prefix%20%60%5Breview%3Apr%5D%60%20in%20the%20log%20line.%20%60review-all.md%60%20defers%20to%20that%20spec%20via%20%22%28See%20review-pr.md%20Step%203d.4%20for%20full%20algorithm%29%22%2C%20which%20means%20an%20LLM%20running%20%60%2Freview%3Aall%60%20would%20emit%20a%20%60%5Breview%3Apr%5D%60%20tag%20in%20its%20stderr%20log%20%E2%80%94%20making%20the%20contract-violation%20warning%20misleading%20in%20traces%20for%20the%20%60%2Freview%3Aall%60%20code%20path.%20Consider%20either%20specifying%20a%20distinct%20prefix%20in%20%60review-all.md%60%20%28e.g.%2C%20%60%5Breview%3Aall%5D%60%29%20or%20parameterising%20the%20log%20message%20in%20the%20shared%20algorithm%20description.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
plugins/yellow-review/commands/review/review-pr.md:199-203
**Condition (b) regex too strict — heading variant can silently drop findings**

The heading check `(?m)^##\s+Past\s+Learnings\s*$` requires an exact match. If an LLM ever outputs `## Past Learnings:` (trailing colon), `##Past Learnings` (no space after `##`), or `### Past Learnings` (H3), condition (b) evaluates to `true` (heading *not* present). Combined with `(a)=true`, that routes to "skip injection" — silently dropping real findings. Given that this path is defense-in-depth intended to *preserve* findings on contract violation, a slightly malformed heading defeats the safety net entirely.

Consider a more tolerant regex, e.g.:

```
(?m)^#{1,3}\s*Past\s+Learnings\s*:?\s*$
```

This covers missing space after `#`, optional trailing colon, and H3 variants without opening up false positives.

### Issue 2 of 3
plugins/yellow-review/commands/review/review-pr.md:214-219
**"Immediately-following" advisory stripping is ambiguous with canonical blank-line separator**

The contract violation path strips "the sentinel line(s) AND any immediately-following empty-result advisory paragraph." However, the canonical empty-result format in `learnings-researcher.md` (lines 205–212) shows a **blank line** between the sentinel and the advisory:

```
NO_PRIOR_LEARNINGS
                    ← blank line here
(advisory) docs/solutions/ scanned for: ...
```

A literal reading of "immediately-following" could mean "no blank line allowed" — causing the advisory paragraph to be left in the stripped response and subsequently injected into reviewers as spurious findings prose. Clarify whether intervening blank lines are consumed during stripping (e.g., "strip the sentinel line(s), any immediately-following blank lines, and the first following `(advisory) …` paragraph, if present").

### Issue 3 of 3
plugins/yellow-review/commands/review/review-all.md:135-136
**Log-prefix mismatch when algorithm is reused by `/review:all`**

The full algorithm in `review-pr.md` Step 3d.4 hardcodes the warning prefix `[review:pr]` in the log line. `review-all.md` defers to that spec via "(See review-pr.md Step 3d.4 for full algorithm)", which means an LLM running `/review:all` would emit a `[review:pr]` tag in its stderr log — making the contract-violation warning misleading in traces for the `/review:all` code path. Consider either specifying a distinct prefix in `review-all.md` (e.g., `[review:all]`) or parameterising the log message in the shared algorithm description.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: address review findings from correc..."](https://github.com/kinginyellows/yellow-plugins/commit/95955f129b5eea42bd3907979af456e4689bb58f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30282953)</sub>

<!-- /greptile_comment -->