### PR TITLE
chore(docs): clear validator INFO + document non-interactive cache refresh

### DIFF
--- a/.changeset/changelog-3-segment-and-cache-refresh-doc.md
+++ b/.changeset/changelog-3-segment-and-cache-refresh-doc.md
@@ -1,0 +1,27 @@
+---
+"yellow-core": patch
+"yellow-review": patch
+---
+
+Update CHANGELOG migration text to runtime-current 3-segment subagent_type
+form + document non-interactive cache-refresh workaround
+
+Two small docs/maintenance fixes:
+
+1. **CHANGELOG migration text:** `plugins/yellow-core/CHANGELOG.md` and
+   `plugins/yellow-review/CHANGELOG.md` had migration notes citing the
+   legacy 2-segment `subagent_type: "yellow-review:code-reviewer"` form.
+   The repo's runtime expects 3-segment as of PRs #288/#290. The
+   validator's INFO note flagged these for future hard-fail. Updated both
+   migration snippets to the 3-segment form
+   (`yellow-review:review:code-reviewer`) so the migration text stays
+   accurate and the INFO warnings clear.
+
+2. **CONTRIBUTING.md cache-refresh note:** added a "Manual cache refresh
+   for non-interactive sessions" subsection covering the rsync workaround
+   when `/plugin marketplace update` (TUI-only) isn't available — e.g.,
+   background agents or Remote Control sessions verifying a freshly-merged
+   `chore: version packages` release. Includes the loop script + a note
+   to run `/reload-plugins` after.
+
+No code changes; documentation-only patches.

--- a/.changeset/changelog-3-segment-and-cache-refresh-doc.md
+++ b/.changeset/changelog-3-segment-and-cache-refresh-doc.md
@@ -21,7 +21,11 @@ Two small docs/maintenance fixes:
    for non-interactive sessions" subsection covering the rsync workaround
    when `/plugin marketplace update` (TUI-only) isn't available — e.g.,
    background agents or Remote Control sessions verifying a freshly-merged
-   `chore: version packages` release. Includes the loop script + a note
-   to run `/reload-plugins` after.
+   `chore: version packages` release. The loop hardens against
+   path-traversal via plugin name and version (allowlist regex), uses
+   `sort -V` instead of lexicographic `ls | tail -1` so `1.10.x` is
+   correctly preferred over `1.9.x`, requires `set -euo pipefail` plus
+   `command -v` prereq checks, and surfaces `cp` failures rather than
+   silently skipping rsync.
 
 No code changes; documentation-only patches.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,11 @@ work. All agent and command markdown must comply before merging.
 5. **Agent frontmatter tools key:** Use `tools:` in agent frontmatter. Do not
    use `allowed-tools:`.
 6. **Subagent references must resolve:** Any `subagent_type` reference to a
-   plugin agent must match a declared `plugin-name:agent-name` pair.
+   plugin agent must use the 3-segment form
+   `plugin-name:subdir:agent-name` (e.g., `yellow-review:review:correctness-reviewer`)
+   matching the agent file's `name:` frontmatter field. The validator at
+   `scripts/validate-agent-authoring.js` registers both forms but warns on
+   2-segment usage; the runtime only resolves 3-segment.
 7. **Command file path resolution:** Markdown commands must not source plugin
    files through `BASH_SOURCE`; use `${CLAUDE_PLUGIN_ROOT}` or a concrete script
    path instead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -262,6 +262,10 @@ CACHE=~/.claude/plugins/cache/yellow-plugins
 }
 
 for plugin_dir in "$MARKETPLACE"/*/; do
+  # Skip non-plugin dirs (e.g., `.DS_Store`, partial clones) before any
+  # jq invocation — `set -euo pipefail` would otherwise abort the loop on
+  # the first non-plugin directory.
+  [ -f "$plugin_dir/.claude-plugin/plugin.json" ] || continue
   plugin=$(basename "$plugin_dir")
   # Allowlist plugin name (kebab-case [a-z0-9-]) so a directory named
   # `..` or `foo$(rm)` cannot reach path construction below.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -289,8 +289,13 @@ for plugin_dir in "$MARKETPLACE"/*/; do
     # No version dir yet for this plugin (brand-new install or post
     # `chore: version packages` bump). Seed from the highest existing
     # semver dir's structure — `sort -V` handles 1.10 > 1.9 correctly,
-    # which `ls | tail -1` would not.
-    existing=$(ls -d "$CACHE/$plugin"/*/ 2>/dev/null | sort -V | tail -1)
+    # which `ls | tail -1` would not. The trailing `|| true` is required
+    # under `set -euo pipefail`: when no version dirs exist yet, `ls`
+    # exits non-zero, `pipefail` propagates that through the pipeline,
+    # and `set -e` would abort the entire script. With `|| true`,
+    # `existing` becomes empty and the `[ -n "$existing" ]` guard below
+    # skips the seed-copy as intended.
+    existing=$(ls -d "$CACHE/$plugin"/*/ 2>/dev/null | sort -V | tail -1) || true
     if [ -n "$existing" ]; then
       cp -r -- "$existing" "$target" || {
         printf '[cache-refresh] Error: failed to seed %s from %s\n' "$target" "$existing" >&2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,20 +243,58 @@ background agent verifying a freshly-merged `chore: version packages`
 release), rsync the marketplace clone over the cache:
 
 ```bash
+set -euo pipefail
+
+command -v rsync >/dev/null 2>&1 || {
+  printf '[cache-refresh] Error: rsync required\n' >&2
+  exit 1
+}
+command -v jq >/dev/null 2>&1 || {
+  printf '[cache-refresh] Error: jq required\n' >&2
+  exit 1
+}
+
 MARKETPLACE=~/.claude/plugins/marketplaces/yellow-plugins/plugins
 CACHE=~/.claude/plugins/cache/yellow-plugins
+[ -d "$MARKETPLACE" ] || {
+  printf '[cache-refresh] Error: MARKETPLACE not found: %s\n' "$MARKETPLACE" >&2
+  exit 1
+}
+
 for plugin_dir in "$MARKETPLACE"/*/; do
   plugin=$(basename "$plugin_dir")
+  # Allowlist plugin name (kebab-case [a-z0-9-]) so a directory named
+  # `..` or `foo$(rm)` cannot reach path construction below.
+  case "$plugin" in
+    *[!a-z0-9-]* | '' | -* | *-)
+      printf '[cache-refresh] Skipping unsafe plugin name: %s\n' "$plugin" >&2
+      continue
+      ;;
+  esac
   mp_ver=$(jq -r '.version // ""' "$plugin_dir/.claude-plugin/plugin.json")
-  [ -z "$mp_ver" ] && continue
+  # Allowlist version: reject empty, traversal sequences, hidden-file
+  # leading dot, or hyphen-prefixed values that rsync/cp could read as flags.
+  case "$mp_ver" in
+    '' | */* | *..* | .* | -*)
+      printf '[cache-refresh] Skipping invalid version %s for %s\n' "$mp_ver" "$plugin" >&2
+      continue
+      ;;
+  esac
   target="$CACHE/$plugin/$mp_ver"
   if [ ! -d "$target" ]; then
-    # New version dir for a fresh chore: version packages bump —
-    # seed from the most recent existing version dir's structure.
-    existing=$(ls -d "$CACHE/$plugin"/*/ 2>/dev/null | tail -1)
-    [ -n "$existing" ] && cp -r "$existing" "$target"
+    # No version dir yet for this plugin (brand-new install or post
+    # `chore: version packages` bump). Seed from the highest existing
+    # semver dir's structure — `sort -V` handles 1.10 > 1.9 correctly,
+    # which `ls | tail -1` would not.
+    existing=$(ls -d "$CACHE/$plugin"/*/ 2>/dev/null | sort -V | tail -1)
+    if [ -n "$existing" ]; then
+      cp -r -- "$existing" "$target" || {
+        printf '[cache-refresh] Error: failed to seed %s from %s\n' "$target" "$existing" >&2
+        continue
+      }
+    fi
   fi
-  [ -d "$target" ] && rsync -a --delete "$plugin_dir/" "$target/"
+  [ -d "$target" ] && rsync -a --delete -- "$plugin_dir/" "$target/"
 done
 ```
 
@@ -264,13 +302,14 @@ After the rsync, run `/reload-plugins` in your session so the runtime
 re-reads the registry.
 
 The rsync uses `--delete`, which removes any cache-only files not present
-in the marketplace clone. For a fresh post-`chore: version packages`
-state where the cache has no existing version dir to seed from (e.g.,
-brand-new plugin install), the loop has nothing to copy structure from;
-in that case an interactive `/plugin marketplace update` is still
-required to initialize the versioned directory. The rsync shortcut is
-for the common case where the directory already exists but its contents
-are stale.
+in the marketplace clone. The seed-copy fallback only fires when no prior
+version directory exists under `$CACHE/$plugin/` (brand-new install or
+wiped cache); when no prior version is available to seed from, the loop
+skips that plugin and an interactive `/plugin marketplace update` is
+still required to initialize the versioned directory. The shortcut
+covers the common case where a prior version directory already exists
+(from a previous install or seed copy) but its contents are stale after
+a version bump.
 
 ## Coding Standards
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,6 +234,44 @@ fixed, users can run `/plugin marketplace update` to fetch the latest. Version
 bumps are still worth doing — they will be retroactively effective once the bug
 is fixed.
 
+### Manual cache refresh for non-interactive sessions
+
+`/plugin marketplace update` requires the Claude Code TUI and is not
+available over Remote Control / non-interactive sessions. If you need to
+refresh the locally-cached plugin content without a TUI (e.g., a
+background agent verifying a freshly-merged `chore: version packages`
+release), rsync the marketplace clone over the cache:
+
+```bash
+MARKETPLACE=~/.claude/plugins/marketplaces/yellow-plugins/plugins
+CACHE=~/.claude/plugins/cache/yellow-plugins
+for plugin_dir in "$MARKETPLACE"/*/; do
+  plugin=$(basename "$plugin_dir")
+  mp_ver=$(jq -r '.version // ""' "$plugin_dir/.claude-plugin/plugin.json")
+  [ -z "$mp_ver" ] && continue
+  target="$CACHE/$plugin/$mp_ver"
+  if [ ! -d "$target" ]; then
+    # New version dir for a fresh chore: version packages bump —
+    # seed from the most recent existing version dir's structure.
+    existing=$(ls -d "$CACHE/$plugin"/*/ 2>/dev/null | tail -1)
+    [ -n "$existing" ] && cp -r "$existing" "$target"
+  fi
+  [ -d "$target" ] && rsync -a --delete "$plugin_dir/" "$target/"
+done
+```
+
+After the rsync, run `/reload-plugins` in your session so the runtime
+re-reads the registry.
+
+The rsync uses `--delete`, which removes any cache-only files not present
+in the marketplace clone. For a fresh post-`chore: version packages`
+state where the cache has no existing version dir to seed from (e.g.,
+brand-new plugin install), the loop has nothing to copy structure from;
+in that case an interactive `/plugin marketplace update` is still
+required to initialize the versioned directory. The rsync shortcut is
+for the common case where the directory already exists but its contents
+are stale.
+
 ## Coding Standards
 
 ### TypeScript

--- a/docs/solutions/security-issues/docs-snippet-path-traversal-and-lex-sort.md
+++ b/docs/solutions/security-issues/docs-snippet-path-traversal-and-lex-sort.md
@@ -1,0 +1,96 @@
+# Documentation Snippet Path Traversal and Lex-Sort Bugs (PR #295)
+
+**Category:** security-issues  
+**PR:** #295 — chore(docs): clear validator INFO + document non-interactive cache refresh  
+**Date:** 2026-04-30
+
+## Summary
+
+A "documentation-only" PR introduced a copy-paste shell snippet in `CONTRIBUTING.md` with two P1
+findings surfaced by 4-way cross-reviewer agreement:
+
+1. **Path traversal via jq-controlled shell values** — `mp_ver` and `plugin` (basename) flowed
+   directly into `rsync --delete` target paths without allowlist validation. A malicious
+   `plugin.json` with `version: "../../../"` or a directory named `../evil` could reach arbitrary
+   filesystem paths.
+
+2. **Lexicographic sort failure on semver** — `ls -d "$CACHE/$plugin"/*/ | tail -1` selects
+   highest directory by locale-dependent byte order, not semantic version. `1.9.0` sorts after
+   `1.10.0` lexicographically, so the seed-copy fallback would incorrectly prefer `1.9.x` over
+   `1.10.x`.
+
+## Root Cause
+
+Both bugs are invisible to quick review because the snippet was presented as documentation rather
+than checked-in code, and neither introduced functional regressions in the happy path. The lex-sort
+bug only manifests on double-digit minor/patch versions; the path traversal requires a crafted
+marketplace clone.
+
+## Fix Applied
+
+**Path traversal:** Added `case` allowlist guards on both values before any path construction:
+
+```bash
+# plugin name: reject anything not matching [a-z0-9-], empty, or hyphen-anchored
+case "$plugin" in
+  *[!a-z0-9-]* | '' | -* | *-)
+    printf '[cache-refresh] Skipping unsafe plugin name: %s\n' "$plugin" >&2
+    continue
+    ;;
+esac
+
+# version: reject empty, path separators, double-dots, leading dot or hyphen
+case "$mp_ver" in
+  '' | */* | *..* | .* | -*)
+    printf '[cache-refresh] Skipping invalid version %s for %s\n' "$mp_ver" "$plugin" >&2
+    continue
+    ;;
+esac
+```
+
+**Lex-sort:** Replace `ls | tail -1` with `sort -V | tail -1`:
+
+```bash
+# Before (wrong — locale-dependent lex sort)
+existing=$(ls -d "$CACHE/$plugin"/*/ 2>/dev/null | tail -1)
+
+# After (correct — semantic version sort)
+existing=$(ls -d "$CACHE/$plugin"/*/ 2>/dev/null | sort -V | tail -1)
+```
+
+**Additional hardening in same pass:**
+- Added `set -euo pipefail` + `command -v rsync/jq` prereq checks
+- Added `--` separator before all positional args to rsync and cp
+- Added explicit `cp` failure handler (`|| { printf '...\n' >&2; continue; }`)
+- Added `[ -d "$MARKETPLACE" ]` guard
+
+## Lessons
+
+1. **Documentation snippets are a real attack surface.** A `CONTRIBUTING.md` code block that users
+   run verbatim has identical security requirements to a checked-in script. Apply the same
+   path-traversal / lex-sort / error-handling review to prose shell examples.
+
+2. **`ls | tail -1` is always wrong for "highest version."** Use `sort -V | tail -1`. The lex-sort
+   bug is silent in CI (test fixtures rarely span `x.9.y` → `x.10.y`) and only manifests in
+   production environments with enough version history.
+
+3. **4-way cross-reviewer agreement (anchor 100) is a reliable P1 signal.** The lex-sort finding
+   was flagged independently by maintainability-reviewer, correctness-reviewer, security-reviewer,
+   and comment-analyzer — cross-reviewer agreement promotion elevated it from P2 → P1 before
+   human review. Treat 3+ independent reviewers citing the same fingerprint as a hard finding.
+
+4. **`jq -r '.version // ""'` does not sanitize.** The `// ""` guard only handles `null` — it does
+   not prevent `../traversal`, `/abs/path`, or hyphen-prefixed flag strings from entering path
+   construction. Always apply a separate allowlist after jq extraction.
+
+## Detection Checklist
+
+When reviewing any shell snippet (docs or code) that:
+- Reads a field from external JSON (jq) and uses it in a path
+- Selects a "latest" directory with `ls | tail` or `ls | sort | tail`
+
+Apply:
+- [ ] Allowlist the jq-extracted value with `case` before path construction
+- [ ] Replace `ls | tail` with `ls | sort -V | tail` for semver directories
+- [ ] Add `--` before positional args that follow `cp`, `rsync`, `mv`
+- [ ] Verify `sort -V` availability (`man sort | grep version-sort` or `sort --help | grep -V`)

--- a/plugins/yellow-core/CHANGELOG.md
+++ b/plugins/yellow-core/CHANGELOG.md
@@ -178,11 +178,7 @@
     `"yellow-review:review:project-compliance-reviewer"`. A deprecation stub
     is left at the old path for one minor version — third-party installs
     that reference the old name continue to function (with a deprecation
-    log line) until the stub is removed. (The original migration note
-    used the 2-segment forms `"yellow-review:code-reviewer"` and
-    `"yellow-review:project-compliance-reviewer"`, which predated the
-    runtime's 3-segment migration; both have been updated above to their
-    current 3-segment equivalents per PRs #288 / #290.)
+    log line) until the stub is removed.
   - **New persona reviewers** (all read-only, `tools: [Read, Grep, Glob]`):
     `correctness-reviewer`, `maintainability-reviewer`, `reliability-reviewer`,
     `project-standards-reviewer`, `adversarial-reviewer`. Each returns the

--- a/plugins/yellow-core/CHANGELOG.md
+++ b/plugins/yellow-core/CHANGELOG.md
@@ -174,11 +174,15 @@
     by the new `correctness-reviewer`; frontmatter / portability /
     cross-platform tool selection by the new `project-standards-reviewer`.
   - **Migration:** Callers passing
-    `subagent_type: "yellow-review:code-reviewer"` should update to
-    `"yellow-review:project-compliance-reviewer"`. A deprecation stub is left at
-    the old path for one minor version — third-party installs that reference the
-    old name continue to function (with a deprecation log line) until the stub
-    is removed.
+    `subagent_type: "yellow-review:review:code-reviewer"` should update to
+    `"yellow-review:review:project-compliance-reviewer"`. A deprecation stub
+    is left at the old path for one minor version — third-party installs
+    that reference the old name continue to function (with a deprecation
+    log line) until the stub is removed. (The original migration note
+    used the 2-segment forms `"yellow-review:code-reviewer"` and
+    `"yellow-review:project-compliance-reviewer"`, which predated the
+    runtime's 3-segment migration; both have been updated above to their
+    current 3-segment equivalents per PRs #288 / #290.)
   - **New persona reviewers** (all read-only, `tools: [Read, Grep, Glob]`):
     `correctness-reviewer`, `maintainability-reviewer`, `reliability-reviewer`,
     `project-standards-reviewer`, `adversarial-reviewer`. Each returns the

--- a/plugins/yellow-review/CHANGELOG.md
+++ b/plugins/yellow-review/CHANGELOG.md
@@ -16,11 +16,15 @@
     by the new `correctness-reviewer`; frontmatter / portability /
     cross-platform tool selection by the new `project-standards-reviewer`.
   - **Migration:** Callers passing
-    `subagent_type: "yellow-review:code-reviewer"` should update to
-    `"yellow-review:project-compliance-reviewer"`. A deprecation stub is left at
-    the old path for one minor version — third-party installs that reference the
-    old name continue to function (with a deprecation log line) until the stub
-    is removed.
+    `subagent_type: "yellow-review:review:code-reviewer"` should update to
+    `"yellow-review:review:project-compliance-reviewer"`. A deprecation stub
+    is left at the old path for one minor version — third-party installs
+    that reference the old name continue to function (with a deprecation
+    log line) until the stub is removed. (The original migration note
+    used the 2-segment forms `"yellow-review:code-reviewer"` and
+    `"yellow-review:project-compliance-reviewer"`, which predated the
+    runtime's 3-segment migration; both have been updated above to their
+    current 3-segment equivalents per PRs #288 / #290.)
   - **New persona reviewers** (all read-only, `tools: [Read, Grep, Glob]`):
     `correctness-reviewer`, `maintainability-reviewer`, `reliability-reviewer`,
     `project-standards-reviewer`, `adversarial-reviewer`. Each returns the

--- a/plugins/yellow-review/CHANGELOG.md
+++ b/plugins/yellow-review/CHANGELOG.md
@@ -20,11 +20,7 @@
     `"yellow-review:review:project-compliance-reviewer"`. A deprecation stub
     is left at the old path for one minor version — third-party installs
     that reference the old name continue to function (with a deprecation
-    log line) until the stub is removed. (The original migration note
-    used the 2-segment forms `"yellow-review:code-reviewer"` and
-    `"yellow-review:project-compliance-reviewer"`, which predated the
-    runtime's 3-segment migration; both have been updated above to their
-    current 3-segment equivalents per PRs #288 / #290.)
+    log line) until the stub is removed.
   - **New persona reviewers** (all read-only, `tools: [Read, Grep, Glob]`):
     `correctness-reviewer`, `maintainability-reviewer`, `reliability-reviewer`,
     `project-standards-reviewer`, `adversarial-reviewer`. Each returns the


### PR DESCRIPTION
Two small Wave 3 main-readiness fixes:

1. plugins/{yellow-core,yellow-review}/CHANGELOG.md — update Wave 2
   keystone migration text from legacy 2-segment subagent_type
   (yellow-review:code-reviewer) to runtime-current 3-segment form
   (yellow-review:review:code-reviewer). Validator INFO note flagged
   these for future hard-fail; CHANGELOG snapshots are now accurate
   to the runtime that actually parses subagent_type strings.

2. CONTRIBUTING.md — add "Manual cache refresh for non-interactive
   sessions" subsection. Documents the rsync workaround when
   /plugin marketplace update (TUI-only) isn't available — e.g.,
   background agents or Remote Control sessions verifying a freshly-
   merged chore: version packages release. Surfaced today during
   keystone verification.

No code changes; docs/maintenance patches only.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/yellow-plugins/pull/295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Docs-only PR with two changes: CHANGELOG migration snippets in `yellow-core` and `yellow-review` are updated from the legacy 2-segment `subagent_type` form to the runtime-current 3-segment form, and `CONTRIBUTING.md` gains a "Manual cache refresh for non-interactive sessions" subsection. The new bash snippet is well-hardened (allowlist guards on plugin name and version, `sort -V`, `set -euo pipefail`, prereq checks) and correctly addresses all four issues raised in prior review threads. `AGENTS.md` is updated to document the 3-segment requirement consistently.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all prior P1 findings are resolved and only a single P2 style inconsistency remains.

No P0 or P1 findings. The one P2 (missing $CACHE existence guard) is a UX consistency issue that causes silent no-ops on misconfigured environments but cannot corrupt data or bypass security checks. All previously flagged P1s in the snippet are addressed.

CONTRIBUTING.md — the new bash snippet is the only file with any finding (P2 only).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CONTRIBUTING.md | New 'Manual cache refresh' subsection adds a hardened rsync snippet addressing previous-thread P1s (set -euo pipefail, sort -V, allowlist guards); one P2 remains: $CACHE has no existence guard while $MARKETPLACE does, so a missing cache dir silently does nothing. |
| AGENTS.md | Updates subagent_type documentation from 2-segment to 3-segment form with a concrete example; consistent with CHANGELOG and runtime changes. |
| plugins/yellow-review/CHANGELOG.md | Migration text updated from yellow-review:code-reviewer / yellow-review:project-compliance-reviewer to the 3-segment runtime-current forms; no other changes. |
| plugins/yellow-core/CHANGELOG.md | Same 2-segment → 3-segment migration text update as yellow-review/CHANGELOG.md; straightforward and correct. |
| .changeset/changelog-3-segment-and-cache-refresh-doc.md | New changeset file correctly marks both yellow-core and yellow-review as patch bumps and accurately summarises the two documentation changes. |
| docs/solutions/security-issues/docs-snippet-path-traversal-and-lex-sort.md | New post-mortem document for the path-traversal and lex-sort bugs fixed in this PR; covers root cause, fix, and a detection checklist for future snippet reviews. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Start cache-refresh script]) --> B{rsync & jq available?}
    B -- No --> C[Exit 1 with error]
    B -- Yes --> D{MARKETPLACE dir exists?}
    D -- No --> C
    D -- Yes --> E[for each plugin_dir in MARKETPLACE]
    E --> F{plugin.json present?}
    F -- No --> E
    F -- Yes --> G[Read plugin name & version via jq]
    G --> H{Name passes allowlist regex?}
    H -- No --> I[Skip + warn] --> E
    H -- Yes --> J{Version passes allowlist case?}
    J -- No --> I
    J -- Yes --> K{target version dir already exists?}
    K -- No --> L[Find highest existing version via sort -V]
    L --> M{Prior version dir found?}
    M -- Yes --> N[cp -r seed to target]
    N --> O{cp succeeded?}
    O -- No --> I
    O -- Yes --> K2{target dir now exists?}
    M -- No --> P[Skip seed] --> K2
    K -- Yes --> K2
    K2 -- Yes --> Q[rsync --delete marketplace to cache]
    K2 -- No --> E
    Q --> E
    E --> R([Done — run /reload-plugins])
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Fchore%2Fchangelog-3-segment-and-cache-refresh-doc%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Fchore%2Fchangelog-3-segment-and-cache-refresh-doc%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACONTRIBUTING.md%3A258-262%0A**Missing%20%60%24CACHE%60%20existence%20guard**%0A%0A%60%24MARKETPLACE%60%20has%20a%20hard-fail%20guard%20%28lines%20259-262%29%2C%20but%20%60%24CACHE%60%20does%20not.%20When%20%60%24CACHE%60%20doesn't%20exist%20%28first-time%20install%2C%20wiped%20cache%2C%20or%20mis-configured%20path%29%20the%20loop%20runs%20to%20completion%20for%20every%20plugin%20%E2%80%94%20%60ls%60%20fails%20but%20%60%7C%7C%20true%60%20swallows%20it%2C%20%60existing%60%20is%20always%20empty%2C%20%60%5B%20-d%20%22%24target%22%20%5D%60%20is%20always%20false%2C%20rsync%20is%20silently%20skipped%20%E2%80%94%20and%20the%20script%20exits%20%600%60%20as%20if%20it%20succeeded.%20Adding%20a%20parallel%20guard%20makes%20the%20failure%20mode%20explicit%20and%20consistent%20with%20the%20marketplace%20check.%0A%0A%60%60%60suggestion%0ACACHE%3D~%2F.claude%2Fplugins%2Fcache%2Fyellow-plugins%0A%5B%20-d%20%22%24MARKETPLACE%22%20%5D%20%7C%7C%20%7B%0A%20%20printf%20'%5Bcache-refresh%5D%20Error%3A%20MARKETPLACE%20not%20found%3A%20%25s%5Cn'%20%22%24MARKETPLACE%22%20%3E%262%0A%20%20exit%201%0A%7D%0A%5B%20-d%20%22%24CACHE%22%20%5D%20%7C%7C%20%7B%0A%20%20printf%20'%5Bcache-refresh%5D%20Error%3A%20CACHE%20not%20found%3A%20%25s%5Cn'%20%22%24CACHE%22%20%3E%262%0A%20%20exit%201%0A%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
CONTRIBUTING.md:258-262
**Missing `$CACHE` existence guard**

`$MARKETPLACE` has a hard-fail guard (lines 259-262), but `$CACHE` does not. When `$CACHE` doesn't exist (first-time install, wiped cache, or mis-configured path) the loop runs to completion for every plugin — `ls` fails but `|| true` swallows it, `existing` is always empty, `[ -d "$target" ]` is always false, rsync is silently skipped — and the script exits `0` as if it succeeded. Adding a parallel guard makes the failure mode explicit and consistent with the marketplace check.

```suggestion
CACHE=~/.claude/plugins/cache/yellow-plugins
[ -d "$MARKETPLACE" ] || {
  printf '[cache-refresh] Error: MARKETPLACE not found: %s\n' "$MARKETPLACE" >&2
  exit 1
}
[ -d "$CACHE" ] || {
  printf '[cache-refresh] Error: CACHE not found: %s\n' "$CACHE" >&2
  exit 1
}
```

`````

</details>

<sub>Reviews (7): Last reviewed commit: ["fix: resolve PR #295 review comment (gre..."](https://github.com/kinginyellows/yellow-plugins/commit/3510d50d67b7cd11a041e2fd2656bc2d3ca72a94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30282955)</sub>

<!-- /greptile_comment -->