### PR TITLE
feat(yellow-review): add /review:sweep wrapper command

### DIFF
--- a/.changeset/review-sweep-wrapper-command.md
+++ b/.changeset/review-sweep-wrapper-command.md
@@ -1,0 +1,19 @@
+---
+"yellow-review": minor
+---
+
+Add `/review:sweep` wrapper command
+
+Run `/review:pr` followed by `/review:resolve` on the same PR in one
+invocation — adaptive multi-agent code review with autonomous fixes,
+then parallel resolution of all open bot and human reviewer comment
+threads.
+
+Because the `Skill` tool surfaces no machine-readable exit status from
+invoked commands, the wrapper uses an `AskUserQuestion` between the two
+steps as the failure-boundary signal: if the user confirms `/review:pr`
+completed cleanly, the resolve step runs; otherwise it is skipped.
+
+Pure orchestration — no logic added to `/review:pr` or `/review:resolve`,
+both of which remain invokable directly when only one half of the
+sequence is needed.

--- a/docs/brainstorms/2026-04-30-review-pr-chain-resolve-brainstorm.md
+++ b/docs/brainstorms/2026-04-30-review-pr-chain-resolve-brainstorm.md
@@ -1,0 +1,132 @@
+# Brainstorm: /review:sweep — Chain /review:pr → /review:resolve
+
+## What We're Building
+
+A new wrapper command — working name `/review:sweep` — that runs `/review:pr`
+followed by `/review:resolve` sequentially on the same PR. The user invokes one
+command and gets a full pass: AI multi-agent code review with autonomous P0/P1
+fixes, then parallel resolution of all open reviewer comment threads (bot and
+human alike), leaving the PR with no unresolved threads.
+
+**Origin question (reframed):** The user initially asked whether
+`/workflows:review` could chain into `/review:resolve`. After reading the actual
+command files, the correct pairing is `/review:pr` -> `/review:resolve`:
+both operate on a single PR, both use the same `gh` / Graphite auth context,
+and both live in `plugins/yellow-review/`. `/workflows:review` is a
+session-level plan-adherence tool and was not the right target.
+
+**Critical finding — these commands do not compose as a data pipeline.**
+`/review:pr` emits its findings to the terminal (Step 10 report table) and
+applies auto-fixes to the working tree. It does NOT post findings as GitHub PR
+comment threads. `/review:resolve` consumes existing unresolved GitHub review
+threads fetched via GraphQL (`get-pr-comments` script) — threads posted by
+humans and bots, not by `/review:pr`. The chaining is a sequential UX
+convenience on a shared PR number, not a data handoff.
+
+**Confirmed: `/review:resolve` handles both bot and human threads.** The
+`get-pr-comments` GraphQL script fetches all unresolved threads with no
+author-type filter. Each thread is routed to a `pr-comment-resolver` agent
+that either submits a fix or posts an FP-response and marks the thread
+resolved. This already covers CodeAnt, Greptile, Devin, and any other
+bot-posted threads without additional work.
+
+## Why This Approach
+
+**Why a new wrapper command, not modifying either existing command:**
+
+- `/review:pr` is a general-purpose code review tool. Adding resolve
+  behavior to it would make it do two unrelated jobs and complicate its
+  failure modes.
+- `/review:resolve` is a standalone comment-resolution tool. Users invoke it
+  directly after human review cycles, independent of any prior AI review pass.
+- A wrapper is pure orchestration — no new logic enters either underlying
+  command. If users want only one step, they invoke the existing command
+  directly.
+- This follows YAGNI: the minimum change that delivers the chained workflow is
+  a thin new command file.
+
+**Recommended name: `/review:sweep`**
+
+Rationale: "sweep" communicates "clear everything" without implying a specific
+sub-operation order. It is short, tab-complete friendly, and distinct from
+`/review:pr` and `/review:resolve` so there is no ambiguity about which
+command is which.
+
+Alternatives considered:
+
+- `/review:full` — readable, but "full" is vague (full depth? full pipeline?).
+  Could conflict with a future depth-control flag on `/review:pr` itself.
+- `/review:pr-and-resolve` — accurate but verbose; not idiomatic for a slash
+  command.
+- `/review:complete` — same vagueness issue as "full."
+
+**Failure boundary: stop on review failure (user's choice B).**
+
+The resolve step only runs if `/review:pr` completes cleanly. "Clean" means:
+the command reached its Step 10 report without aborting, AND the user approved
+the Step 9 push confirmation (or there were no changes to push). If the user
+declines the Step 9 push, or if `/review:pr` errors for any reason, the
+wrapper stops and reports that the resolve step was skipped. This avoids
+resolving reviewer threads on a PR whose AI-review fixes were never committed.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Implementation shape | New wrapper command | No changes to existing commands; pure orchestration |
+| Command name | `/review:sweep` | Short, distinct, communicates "clear everything" |
+| Arg shape | Mirror `/review:pr` (PR# / URL / branch / empty=current) | User passes one arg; wrapper forwards it to both sub-commands |
+| Failure boundary | Stop if review fails or push declined | Resolve only makes sense when the review pass is committed |
+| Bot thread handling | No additional work needed | `/review:resolve` already fetches all threads with no author filter |
+| Modification to existing commands | None | YAGNI — both commands work independently and stay unchanged |
+
+**Arg shape detail:** `/review:sweep` accepts the same argument shape as
+`/review:pr`:
+
+- Numeric PR number
+- GitHub PR URL
+- Branch name
+- Empty (auto-detect from current branch)
+
+The resolved PR number is extracted once and passed explicitly to both
+sub-commands so they operate on the same PR regardless of branch state changes
+mid-run (e.g., after `/review:pr` commits fixes and `gt submit` updates the
+stack).
+
+## Open Questions
+
+These are implementation details for `/workflows:plan` to resolve:
+
+1. **How to detect Step 9 decline in `/review:pr`.** The wrapper invokes
+   `/review:pr` via the `Skill` tool (or equivalent delegation). The sub-command
+   currently reports "changes remain uncommitted for manual review" when the
+   user declines. The wrapper needs a reliable signal — either a non-zero exit
+   from the Skill invocation, or a sentinel string in the output — to know
+   whether to proceed. Plan should define the detection contract.
+
+2. **How to invoke `/review:pr` from within a command file.** Options:
+   `Skill` tool with `skill: "review:pr"`, or spawning it as a Task subagent.
+   The `Skill` tool is the idiomatic path for command-to-command delegation in
+   this codebase; confirm it surfaces exit status reliably for the failure
+   boundary check.
+
+3. **File location.** `plugins/yellow-review/commands/review/sweep.md` is the
+   natural home. Confirm the command namespace (`review:sweep`) matches what
+   Claude Code derives from that path.
+
+4. **`allowed-tools` list.** The wrapper itself needs at minimum `Skill` (or
+   `Task`) and `AskUserQuestion`. It delegates all actual work to the
+   sub-commands, so it should not need `Bash`, `Edit`, etc. directly. Confirm
+   whether `Skill` invocations inherit the caller's tool permissions or need
+   explicit listing.
+
+5. **Behavior when `/review:resolve` finds zero unresolved threads.** This is
+   a clean success — report "No open threads to resolve" and exit. Not a
+   failure. Worth making the wrapper's final report distinguish "resolved N
+   threads" from "no threads found" for clarity.
+
+6. **`plugin.json` registration.** _Resolved during planning:_
+   `plugins/yellow-review/.claude-plugin/plugin.json` has no `commands`
+   array — commands are auto-discovered from the directory layout. No
+   manifest registration is required. (See plan
+   `plans/review-sweep-wrapper-command.md` "Files NOT to Modify".)

--- a/plans/review-sweep-wrapper-command.md
+++ b/plans/review-sweep-wrapper-command.md
@@ -1,0 +1,264 @@
+# Feature: `/review:sweep` — Wrapper Command Chaining `/review:pr` → `/review:resolve`
+
+## Problem Statement
+
+After running `/review:pr` on a PR, users still need to manually invoke
+`/review:resolve` to clear bot and human reviewer comment threads on the same
+PR. Both commands operate on a single PR and share the same `gh`/Graphite auth
+context, so the two-step invocation is friction with no benefit. A single
+wrapper command should run both in sequence on the same PR.
+
+## Current State
+
+- `plugins/yellow-review/commands/review/review-pr.md` — multi-agent AI code
+  review with autonomous P0/P1 fix loop. Accepts PR#, GitHub URL, branch name,
+  or empty (auto-detect). At Step 9, prompts user to push fixes via
+  `gt submit`. **Decline path produces only prose** ("changes remain
+  uncommitted for manual review"), no exit code or machine-readable signal.
+- `plugins/yellow-review/commands/review/resolve-pr.md` — parallel resolution
+  of unresolved GitHub review threads (bot and human). Accepts numeric PR# or
+  empty. Does NOT accept URL or branch name.
+- `plugins/yellow-review/commands/review/review-all.md` — chains
+  `/review:pr` across multiple PRs by **inlining the entire pipeline**, not
+  by Skill-invoking `/review:pr`. Deliberate choice noted in the file.
+
+**Critical finding from research:** the `Skill` tool does not surface exit
+status from invoked commands. There is no programmatic way for a wrapper to
+detect "review-pr errored" vs "user declined Step 9 push" vs "review-pr
+completed cleanly with changes pushed." Detection must happen via user prompt
+at the wrapper boundary, not via inspecting Skill output.
+
+<!-- deepen-plan: external -->
+> **Research:** Confirmed by Anthropic Claude Code docs (`code.claude.com/docs/en/skills`) and community reverse-engineering: the `Skill` tool is a context-injection mechanism, not a function call. It expands the target skill's body into Claude's context but returns no exit code, success flag, or error text. The only documented pattern for cross-command status detection is a sentinel file written by the sub-command — which is unavailable here because the brainstorm forbids modifying `/review:pr`. Source: <https://code.claude.com/docs/en/skills>; community analysis at <https://mikhail.io/2025/10/claude-code-skills/>.
+<!-- /deepen-plan -->
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Direct precedent for `Skill`-invoking `review:pr` already exists at `plugins/yellow-core/commands/workflows/review.md:54` (uses `skill: "review:pr"` with no downstream status inspection). This is a closer analog than the `linear/work.md` reference cited later — same target skill, same no-status pattern. Confirms our design matches existing convention.
+<!-- /deepen-plan -->
+
+## Proposed Solution
+
+Create `plugins/yellow-review/commands/review/sweep.md` — a thin orchestration
+command. Sequence:
+
+1. Resolve PR number once from the wrapper's argument (mirrors `/review:pr`'s
+   accept-anything arg shape: PR#, URL, branch, empty). Convert URL/branch to
+   numeric PR# so the same value can be passed to `/review:resolve` (which
+   only accepts numeric).
+2. Invoke `/review:pr <PR#>` via the `Skill` tool. Skill returns control when
+   `/review:pr` exits its execution.
+3. Use `AskUserQuestion` to confirm clean completion before proceeding:
+   "Did `/review:pr` complete successfully (review finished, fixes pushed or
+   not needed)? Proceed to resolve open comment threads on PR #X?"
+   - **Yes** → proceed to step 4.
+   - **No** → stop. Print summary "Resolve step skipped — re-run
+     `/review:resolve <PR#>` manually when ready."
+4. Invoke `/review:resolve <PR#>` via the `Skill` tool.
+5. Print final summary: PR number, review outcome (per user), resolve outcome
+   (from Skill output).
+
+**Why this design satisfies the brainstorm's "stop on review failure"
+requirement (choice B):** since no programmatic signal exists, the user
+becomes the failure-boundary signal at step 3. They have just observed
+`/review:pr`'s output and know whether it errored or whether they declined
+the push. One question, two choices, no friction beyond a single confirmation.
+
+**Why not inline the `/review:pr` pipeline** (like `review-all.md` does):
+inlining would duplicate ~700 lines of orchestration logic that already lives
+in `review-pr.md`, and any future change to `/review:pr` would need to be
+mirrored here. The wrapper is meant to be a thin convenience, not a fork.
+Skill-invocation + boundary prompt accepts one extra question in exchange for
+keeping the wrapper at ~50 lines.
+
+## Implementation Plan
+
+### Phase 1: Foundation
+
+- [ ] **1.1** Create `plugins/yellow-review/commands/review/sweep.md` with
+  frontmatter:
+  - `name: review:sweep`
+  - `description:` single-line "Use when..." trigger clause
+  - `allowed-tools: Bash, Skill, AskUserQuestion`
+  - `argument-hint: [pr-number | github-url | branch-name | (empty for current branch)]`
+- [ ] **1.2** Add the standard "What it does" + "When to use" prose at top of
+  body (matches existing review command style).
+
+### Phase 2: Implementation
+
+- [ ] **2.1** Arg-parsing block (mirror `review-pr.md` lines 31–40):
+  - If `$ARGUMENTS` numeric → use as PR#.
+  - Else if matches `github.com.*\/pull\/[0-9]+` → extract PR#.
+  - Else if non-empty → treat as branch name, run
+    `gh pr view "$ARGUMENTS" --json number -q .number`.
+  - Else → auto-detect from current branch:
+    `gh pr view --json number -q .number`.
+  - Validate result is numeric and non-empty. If not, exit with error.
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Original draft used `gh pr list --head "$BRANCH" --json number -q '.[0].number'` for the branch case. The actual `review-pr.md` (lines 31–40) uses `gh pr view "$ARGUMENTS" --json number -q .number` — passes the branch name directly to `gh pr view`. The simpler form is what reviewers expect to see and is what the wrapped command uses, so the wrapper should mirror it exactly. Plan corrected above.
+<!-- /deepen-plan -->
+- [ ] **2.2** Invoke `/review:pr <PR#>` via the `Skill` tool with
+  `skill: "review:pr"` and `args: "<PR#>"`. Wait for completion.
+- [ ] **2.3** `AskUserQuestion` boundary gate:
+  - Question: `"/review:pr finished. Did it complete cleanly (review
+    succeeded, fixes pushed or not needed)? Proceed to resolve open comment
+    threads on PR #<PR#>?"`
+  - Options: `Proceed`, `Stop`. Treat any non-`Proceed` outcome (Stop,
+    dismiss, timeout, no response, non-interactive environment) as Stop.
+  - _Note (post-implementation correction):_ an earlier draft included an
+    `Other` (free-text) option, but per the MEMORY.md anti-pattern
+    "AskUserQuestion 'Other' is the ONLY free-text button" and the
+    prompt-injection surface that prose-driven intent parsing on user-typed
+    text creates, the `Other` option was dropped before merge. The Edge
+    Cases section below has been updated to match.
+- [ ] **2.4** On `Stop`: print `[review:sweep] Resolve step skipped. Re-run
+  /review:resolve <PR#> manually when ready.` Exit 0.
+- [ ] **2.5** On `Proceed`: invoke `/review:resolve <PR#>` via the `Skill`
+  tool with `skill: "review:resolve"` and `args: "<PR#>"`.
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Original draft incorrectly used `skill: "review:resolve-pr"`. The actual frontmatter `name:` field at `plugins/yellow-review/commands/review/resolve-pr.md:2` is `review:resolve` (the file is named `resolve-pr.md` but the slash command name is `review:resolve`). Using `review:resolve-pr` would silently fail to invoke the skill. Plan corrected above. **This is a hard requirement — the implementor must use `skill: "review:resolve"` exactly.**
+<!-- /deepen-plan -->
+- [ ] **2.6** Final summary block: PR number, review-pr outcome (as reported
+  by user at boundary), resolve-pr outcome (echo Skill summary or "no
+  threads found" if applicable).
+
+### Phase 3: Quality
+
+- [ ] **3.1** Ensure no `Bash` block references variables defined in another
+  block (functions don't survive bash blocks — re-define in each, per memory
+  rule). Slug regex check on PR#: `^[0-9]+$`.
+- [ ] **3.2** Confirm `allowed-tools` lists every tool used in body (Skill,
+  AskUserQuestion, Bash). Run `pnpm validate:plugins`.
+- [ ] **3.3** Add a changeset: `pnpm changeset` → minor bump for
+  yellow-review (new command = additive change).
+- [ ] **3.4** Update `plugins/yellow-review/CLAUDE.md` — current text reads
+  "Commands (4)" with each command listed by name. Bump to "Commands (5)"
+  and add a description line for `/review:sweep`.
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Confirmed: `plugins/yellow-review/CLAUDE.md` enumerates the four current commands (`/review:setup`, `/review:pr`, `/review:resolve`, `/review:all`) and prefixes the section with "Commands (4)". Both the count and the enumeration must be updated atomically — count drift is a known anti-pattern in this repo (see MEMORY.md "Multi-file MCP count drift"). No `output-styles` directory entries need updating; that surface is shared across commands.
+<!-- /deepen-plan -->
+- [ ] **3.5** Update `plugins/yellow-review/README.md` (or top-level docs) to
+  mention `/review:sweep` alongside `/review:pr` and `/review:resolve`.
+
+## Technical Details
+
+### Files to Create
+
+- `plugins/yellow-review/commands/review/sweep.md` — the wrapper command
+  (~80–120 lines).
+
+### Files to Modify
+
+- `plugins/yellow-review/CLAUDE.md` — add `/review:sweep` to command list (if
+  it enumerates).
+- `plugins/yellow-review/README.md` — add a one-line mention.
+- `.changeset/<auto>.md` — minor bump for `yellow-review`.
+
+### Files NOT to Modify
+
+- `plugins/yellow-review/commands/review/review-pr.md` — unchanged.
+- `plugins/yellow-review/commands/review/resolve-pr.md` — unchanged.
+- `plugins/yellow-review/.claude-plugin/plugin.json` — no `commands` array
+  exists; commands are auto-discovered by Claude Code from the directory
+  layout. No registration step.
+
+### No Dependencies Added
+
+The wrapper uses only tools already available in the plugin: `Bash`, `Skill`,
+`AskUserQuestion`. No new MCP servers, no new agents, no new skills.
+
+## Acceptance Criteria
+
+1. Running `/review:sweep 123` invokes `/review:pr 123`, prompts the user
+   at the boundary, and (on approval) invokes `/review:resolve 123`.
+2. Running `/review:sweep <github-url>` and `/review:sweep <branch>` both
+   resolve to the correct numeric PR# and behave identically to (1).
+3. Running `/review:sweep` with no args auto-detects PR from the current
+   branch.
+4. If the user selects "Stop" at the boundary, `/review:resolve` is NOT
+   invoked, and the user sees a clear "skipped — run X manually" message.
+5. If `/review:resolve` finds zero unresolved threads, the wrapper reports
+   "No open threads to resolve" rather than treating it as a failure.
+6. `pnpm validate:plugins` passes; `pnpm validate:schemas` passes.
+7. The plugin's changeset is recorded as a minor bump for `yellow-review`.
+
+## Edge Cases
+
+- **PR not found from branch:** `gh pr view "$ARGUMENTS"` returns an
+  error or non-numeric output → wrapper exits with
+  `[review:sweep] Error: no PR found for branch <X>` before invoking
+  `/review:pr`.
+- **Invalid arg:** non-numeric, non-URL, non-branch (e.g. fails the
+  `^[A-Za-z0-9/_.-]+$` charset guard) → exit with descriptive error.
+  `$ARGUMENTS` is sanitized before being echoed in the error to prevent
+  terminal escape injection.
+- **`/review:pr` completes with no findings and no changes to push:** user
+  selects "Proceed" at boundary; wrapper continues to resolve. This is the
+  expected happy path for already-clean PRs that just have human/bot threads
+  to clear.
+- **`/review:resolve` errors mid-run:** Skill returns; wrapper prints
+  whatever summary it can and exits non-zero. (No retry logic — YAGNI.)
+
+<!-- deepen-plan: external -->
+> **Research:** GitHub's `resolveReviewThread` GraphQL mutation requires `contents: write` permission on the GitHub App/token, **not just `pull_requests: write`**. The default `gh auth login` token has both, but custom GitHub Apps often request only the latter and silently fail with "Resource not accessible by integration." This is a `/review:resolve` concern (the wrapper just delegates), but worth verifying that `/review:resolve`'s setup docs or error handling surface this clearly. If they don't, file a follow-up issue against `/review:resolve` rather than expanding this plan. Source: <https://github.com/orgs/community/discussions/44650>.
+<!-- /deepen-plan -->
+
+<!-- deepen-plan: external -->
+> **Research:** Community convention for bot-thread auto-resolution (drawn from `gh-aw` reference, reviewdog issue #1720): filter on `author.__typename == "Bot"` AND `comments.totalCount == 1` before mass-resolving — i.e., resolve only solo bot threads with no human reply. This is `/review:resolve`'s concern, not the wrapper's. The brainstorm confirms `/review:resolve` already routes each thread through a `pr-comment-resolver` agent that decides fix-vs-FP-response per thread; the wrapper inherits that behavior. Source: <https://github.github.com/gh-aw/reference/safe-outputs-pull-requests/>.
+<!-- /deepen-plan -->
+- **User dismisses boundary question (Escape, timeout, non-interactive
+  environment, no response):** treat as Stop and follow the Stop path.
+  The implementation has only `Proceed` and `Stop` buttons (no `Other`
+  free-text option — see step 2.3 note); any non-`Proceed` outcome must
+  be treated as Stop to avoid silently advancing to `/review:resolve` on
+  an un-confirmed review state.
+
+## YAGNI Boundary
+
+This plan deliberately excludes:
+
+- A `--no-confirm` flag to skip the boundary question. If users find the
+  question annoying, that's a follow-up; for now the question is the only
+  reliable failure-boundary signal.
+- Modifying `/review:pr` to emit a structured exit signal (state file,
+  sentinel string). The brainstorm explicitly forbids changing existing
+  commands.
+
+<!-- deepen-plan: external -->
+> **Research:** A community-documented pattern for cross-`Skill` status detection is the sentinel-file approach — the producer (`/review:pr`) writes a state file the consumer (`/review:sweep`) reads — but it requires both sides to coordinate on a shared format. Since the brainstorm forbids modifying `/review:pr`, this option is closed. The `AskUserQuestion`-at-boundary design is the YAGNI-correct fallback. If a future decision opens up modifying `/review:pr`, revisit this plan to swap the boundary prompt for a sentinel-file read. Third-party reference (treat as community observation, not Anthropic guidance): <https://www.mindstudio.ai/blog/claude-code-skill-collaboration-chaining-workflows/>.
+<!-- /deepen-plan -->
+- Inlining the `/review:pr` pipeline (~700 lines duplicated). Skill
+  invocation is sufficient.
+- A second iteration after resolve completes (e.g., re-running `/review:pr`
+  on the now-fixed PR). Out of scope.
+- Stack-aware sweeping (running across multiple stacked PRs). That's
+  `/review:all`'s job; do not overlap.
+
+## References
+
+- Brainstorm: `docs/brainstorms/2026-04-30-review-pr-chain-resolve-brainstorm.md`
+- Existing commands:
+  - `plugins/yellow-review/commands/review/review-pr.md`
+  - `plugins/yellow-review/commands/review/resolve-pr.md`
+  - `plugins/yellow-review/commands/review/review-all.md`
+- Plugin manifest: `plugins/yellow-review/.claude-plugin/plugin.json`
+- Skill-tool delegation precedents:
+  - `plugins/yellow-core/commands/workflows/review.md:54` — closer analog,
+    invokes `skill: "review:pr"` directly
+  - `plugins/yellow-linear/commands/linear/work.md:183` — generic Skill
+    invocation pattern
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** No precedent in this repo for `AskUserQuestion` used as a control-flow gate between two delegated `Skill` invocations. Existing `AskUserQuestion` calls handle input disambiguation, destructive-action confirmation, and routing — never sequential-skill boundary gating. The pattern in this plan is novel for this codebase. Architecturally sound, but implementors should not expect a copy-paste template. The closest reference is the M3-confirmation pattern documented in MEMORY.md.
+<!-- /deepen-plan -->
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Changeset precedent — both existing yellow-review changesets in `.changeset/` (`learnings-researcher-sentinel-fix.md`, `changelog-3-segment-and-cache-refresh-doc.md`) record `"yellow-review": patch`. A new command is correctly classified as `minor` per project semver conventions (per `docs/CLAUDE.md` "minor — new command, skill, or agent"), but no existing yellow-review changeset uses `minor` — this will be the first. No conflict, but reviewers may flag for double-check.
+<!-- /deepen-plan -->
+- Memory rules referenced:
+  - `feedback_agent_file_size.md` (line counts are guidelines)
+  - Bash-block isolation: functions don't survive subprocess boundaries
+  - `allowed-tools` must enumerate every tool used in body
+  - Skill descriptions must be single-line

--- a/plugins/yellow-review/CLAUDE.md
+++ b/plugins/yellow-review/CLAUDE.md
@@ -21,7 +21,7 @@ resolution, and sequential stack review. Graphite-native workflow.
 
 ## Plugin Components
 
-### Commands (4)
+### Commands (5)
 
 - `/review:setup` — Validate GitHub, jq, Graphite, and optional yellow-core
   integration before reviewing PRs
@@ -31,6 +31,8 @@ resolution, and sequential stack review. Graphite-native workflow.
   GraphQL
 - `/review:all` — Sequential review of multiple PRs (Graphite stack, all open,
   or single PR)
+- `/review:sweep` — Wrapper that runs `/review:pr` then `/review:resolve` on
+  the same PR with a user-confirmed boundary gate between them
 
 ### Agents (14)
 
@@ -96,6 +98,9 @@ resolution, and sequential stack review. Graphite-native workflow.
   order (base → tip). Best before submitting a stack for review.
 - **`/review:all scope=all`** — Batch-review all your open non-draft PRs. Best
   for catching up on review backlog.
+- **`/review:sweep`** — Run `/review:pr` then `/review:resolve` sequentially
+  on a single PR. Best when you want both an AI review pass and cleanup of
+  any open bot/human comment threads in one invocation.
 - **`/workflows:review`** (yellow-core) — Session-level review against a plan
   file. Evaluates plan adherence, cross-PR coherence, and scope drift.
   Complementary to `/review:pr` (per-PR code quality) — use both for full

--- a/plugins/yellow-review/README.md
+++ b/plugins/yellow-review/README.md
@@ -28,6 +28,7 @@ yellow-core integration before reviewing real PRs.
 | `/review:pr`      | Adaptive multi-agent review of a single PR with automatic fix application |
 | `/review:resolve` | Parallel resolution of unresolved PR review comments                      |
 | `/review:all`     | Sequential review of multiple PRs (Graphite stack, all open, or single)   |
+| `/review:sweep`   | Run `/review:pr` then `/review:resolve` on the same PR in one invocation  |
 
 ## Agents
 

--- a/plugins/yellow-review/commands/review/sweep.md
+++ b/plugins/yellow-review/commands/review/sweep.md
@@ -1,0 +1,179 @@
+---
+name: review:sweep
+description: 'Run /review:pr then /review:resolve on the same PR in one invocation. Use when you want both an AI review pass and cleanup of any open bot or human reviewer comment threads without manually re-invoking on the same PR number.'
+argument-hint: '[PR# | URL | branch]'
+allowed-tools:
+  - Bash
+  - Skill
+  - AskUserQuestion
+---
+
+# Sweep: Review + Resolve in One Pass
+
+Run a full review-and-cleanup pass on a single PR: invoke `/review:pr`
+for adaptive multi-agent code review with autonomous fix application,
+then `/review:resolve` for parallel resolution of all open reviewer
+comment threads. Both skills run against the same PR, with a
+user-confirmed boundary gate between them (the `Skill` tool surfaces no
+machine-readable exit status, so user confirmation is the failure
+signal).
+
+Use when you want both an AI review pass and cleanup of any open bot or
+human comment threads in a single invocation. Use `/review:pr` directly
+to skip the resolve step, or `/review:resolve` directly to skip the
+review. For multi-PR or stack-wide sweeps, use `/review:all` —
+`/review:all scope=<PR#>` covers similar ground on a single PR but also
+invokes a post-review compounding step, while `/review:sweep` is the
+lighter alternative for review-then-resolve without compounding.
+
+## Workflow
+
+### Step 1: Resolve PR
+
+Determine the target PR from `$ARGUMENTS`:
+
+1. **If matches `^[0-9]+$`** (positive integer; no sign, decimal, or
+   exponent): Use directly as PR number.
+2. **If URL** (contains `github.com` and `/pull/`): Extract PR number
+   with regex `/pull/([0-9]+)(?:[/?#]|$)`, capturing group 1. The
+   trailing `(?:[/?#]|$)` anchor requires a delimiter (slash, query,
+   fragment, or end-of-string) after the digits — otherwise a malformed
+   URL like `…/pull/12abc` would silently extract the partial `12` and
+   review the wrong PR. If the pattern does not match, treat as
+   extraction failure and fall through to the validation guard below.
+3. **If branch name**: First validate the value matches
+   `^[A-Za-z0-9_][A-Za-z0-9/_.-]*$` to reject flag-injection attempts —
+   the first character must be alphanumeric or `_`, which excludes a
+   leading `-` even though `-` is allowed mid-string for branch names
+   like `feat-x`. On match, run
+   `gh pr view -- "$ARGUMENTS" --json number -q .number` (the `--`
+   end-of-options marker is a defense-in-depth guard so `gh` cannot
+   reinterpret the argument as a flag even if validation is later
+   relaxed). On mismatch, treat as input error and stop.
+4. **If empty**: Detect from current branch:
+   `gh pr view --json number -q .number`
+
+Validate the resolved value is numeric and non-empty. If not, sanitize
+`$ARGUMENTS` for display (strip every byte outside `[A-Za-z0-9#/:._-]` —
+this prevents terminal escape injection from a malformed input) and
+report:
+
+```text
+[review:sweep] Error: could not resolve PR number from input <sanitized $ARGUMENTS>.
+```
+
+Then stop.
+
+Confirm the working directory is clean (both `/review:pr` and
+`/review:resolve` will refuse to run on a dirty tree, and `/review:pr`
+running via the `Skill` tool surfaces no exit status — so a wrapper-level
+check eliminates the ambiguity at the Step 3 gate before it appears):
+
+```bash
+set -eu
+[ -z "$(git status --porcelain)" ] || {
+  printf '[review:sweep] Error: uncommitted changes detected. Commit or stash first.\n' >&2
+  exit 1
+}
+```
+
+Confirm the PR is open:
+
+```bash
+set -eu
+gh pr view <PR#> --json state -q .state
+```
+
+If the command fails or the state is not `OPEN`, report
+`[review:sweep] Error: PR #<PR#> is not open or could not be fetched.` and
+stop.
+
+### Step 2: Run /review:pr
+
+Invoke the `Skill` tool with `skill: "review:pr"` and `args: "<PR#>"`.
+Wait for it to complete.
+
+`/review:pr` runs its full pipeline: adaptive agent selection, parallel
+multi-agent review, autonomous P0/P1 fix application, the
+push-confirmation gate, and the final report.
+
+### Step 3: Confirm clean completion (failure-boundary gate)
+
+The `Skill` tool returns no machine-readable exit status, so the wrapper
+cannot programmatically detect whether `/review:pr` errored, the user
+declined the push at its push-confirmation gate, or the review completed
+cleanly. The user is the authoritative signal at this boundary.
+
+Use the `AskUserQuestion` tool with:
+
+- Question: ``/review:pr` finished. Did it complete cleanly (review
+  succeeded; fixes were pushed or none were needed)? Proceed to resolve
+  open comment threads on PR #<PR#>?``
+- Options:
+  - **Proceed** — continue to Step 4
+  - **Stop** — skip the resolve step
+
+If the user selects **Stop** — OR the prompt is dismissed, times out, or
+cannot be shown (non-interactive environment, Escape, no response) — do
+NOT invoke `/review:resolve`. Treat any non-`Proceed` outcome as Stop.
+Print:
+
+```text
+[review:sweep] Resolve step skipped. Re-run /review:resolve <PR#>
+manually when ready.
+```
+
+Then stop. Do not proceed to Step 4 or Step 5.
+
+### Step 4: Run /review:resolve
+
+If the user selected **Proceed** in Step 3, invoke the `Skill` tool with
+`skill: "review:resolve"` and `args: "<PR#>"`. The skill name is
+`review:resolve` (the value of the `name:` frontmatter field in
+`resolve-pr.md`) — do NOT use `review:resolve-pr`, which is the
+filename, not the slash-command name, and would silently fail to invoke
+the skill.
+
+`/review:resolve` fetches all unresolved review threads on the PR via
+GraphQL (no author-type filter — both bot and human threads are
+addressed) and routes each thread through a `pr-comment-resolver` agent
+that either submits a fix or posts a false-positive response and marks
+the thread resolved.
+
+### Step 5: Final summary
+
+Reached only when the user selected **Proceed** at Step 3 and Step 4 ran.
+Print a summary line for the run:
+
+```text
+[review:sweep] PR #<PR#>
+  Review:  completed (per user confirmation)
+  Resolve: <one-line summary from /review:resolve, e.g., "5 threads
+            resolved, 2 fixes applied" or "no open threads found">
+```
+
+If `/review:resolve`'s output cannot be reduced to a one-line summary,
+report `Resolve: completed (output unavailable — see above)` rather
+than synthesizing a plausible-looking summary.
+
+## Error Handling
+
+- **Argument unresolvable** (input is not numeric, a recognizable
+  GitHub PR URL, a valid branch name, and the current branch has no PR):
+  `[review:sweep] Error: could not resolve PR number from input
+  <sanitized $ARGUMENTS>.` and stop.
+- **PR not open / not found**: `[review:sweep] Error: PR #<PR#> is not
+  open or could not be fetched.` and stop.
+- **Dirty working directory** at Step 1: `[review:sweep] Error:
+  uncommitted changes detected. Commit or stash first.` and stop.
+  Both downstream skills enforce this independently; the wrapper-level
+  check eliminates the ambiguity at the Step 3 gate before it appears
+  (see Step 1 rationale).
+- **`/review:pr` failed or push declined**: surfaced via the
+  user-confirmed Step 3 gate. On any non-`Proceed` outcome the resolve
+  step is skipped; re-run `/review:resolve <PR#>` manually when ready.
+- **`/review:resolve` returns no extractable summary**: report
+  `Resolve: completed (output unavailable — see above)` rather than
+  synthesizing one.
+- **Zero unresolved threads** is a clean outcome — `/review:resolve`
+  reports that as success and `/review:sweep` does the same.


### PR DESCRIPTION
Run /review:pr followed by /review:resolve on the same PR in one
invocation — adaptive multi-agent code review with autonomous fixes,
then parallel resolution of all open bot and human reviewer threads.

Because the Skill tool surfaces no machine-readable exit status from
invoked commands, the wrapper uses an AskUserQuestion between the two
steps as the failure-boundary signal. Pure orchestration — no logic
added to /review:pr or /review:resolve, both of which remain
invokable directly.

Includes brainstorm, deep-research-enriched plan, and minor changeset.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced /review:sweep to run a PR review and then, after a user-confirmed gate, resolve all open review threads (bot and human) in a single invocation; /review:pr and /review:resolve remain individually invokable.

* **Documentation**
  * Added user-facing docs covering argument formats and validation, dirty-tree/PR checks, the confirmation failure boundary, zero-unresolved-threads behavior, and updated command listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `/review:sweep`, a thin orchestration wrapper that invokes `/review:pr` via the `Skill` tool, gates on an `AskUserQuestion` confirmation (the only viable failure-boundary given `Skill` exposes no exit status), then invokes `/review:resolve` on the same PR number. Existing commands are unchanged; the PR also correctly updates `CLAUDE.md` command count (4→5), `README.md` command table, and records a `minor` changeset bump.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only P2 style findings, no logic defects or security concerns.

All findings are P2 (step heading naming and a missing argument-hint hint). No P0/P1 issues found. The core orchestration logic, bash security patterns (set -eu, quoted variables, input validation, -- guards), and cross-file count updates are all correct.

plugins/yellow-review/commands/review/sweep.md — two minor style issues on lines 4 and 31.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/yellow-review/commands/review/sweep.md | New wrapper command orchestrating /review:pr → AskUserQuestion gate → /review:resolve; two P2 style issues: misleading "Resolve PR" step heading and truncated argument-hint missing the empty-args case. |
| plugins/yellow-review/CLAUDE.md | Commands count bumped from 4 to 5 and /review:sweep description added atomically — no drift detected. |
| plugins/yellow-review/README.md | One-line entry for /review:sweep added to the command table; agent counts unchanged and still accurate. |
| .changeset/review-sweep-wrapper-command.md | Correctly records a minor bump for yellow-review (new command = additive change); first minor bump for this package per plan notes. |
| plans/review-sweep-wrapper-command.md | Well-researched plan with inline codebase and external research annotations; implementation matches all phase requirements. |
| docs/brainstorms/2026-04-30-review-pr-chain-resolve-brainstorm.md | Design brainstorm documenting the AskUserQuestion boundary-gate rationale and YAGNI exclusions; documentation only. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor User
    participant sweep as /review:sweep
    participant bash as Bash (gh/git)
    participant pr as /review:pr (Skill)
    participant gate as AskUserQuestion
    participant resolve as /review:resolve (Skill)

    User->>sweep: /review:sweep [PR# | URL | branch]
    sweep->>bash: Parse $ARGUMENTS → numeric PR#
    bash-->>sweep: PR# (or error → stop)
    sweep->>bash: git status --porcelain (dirty check)
    bash-->>sweep: clean (or error → stop)
    sweep->>bash: gh pr view PR# --json state
    bash-->>sweep: OPEN (or error → stop)
    sweep->>pr: skill: review:pr, args: PR#
    pr-->>sweep: (no exit status returned)
    sweep->>gate: Did /review:pr complete cleanly? Proceed?
    gate-->>User: Show options: Proceed / Stop
    alt User selects Proceed
        User-->>gate: Proceed
        gate-->>sweep: Proceed
        sweep->>resolve: skill: review:resolve, args: PR#
        resolve-->>sweep: summary (N threads resolved)
        sweep->>User: [review:sweep] PR #X — Review: completed, Resolve: N threads resolved
    else User selects Stop (or non-interactive / dismissed)
        User-->>gate: Stop
        gate-->>sweep: Stop
        sweep->>User: [review:sweep] Resolve step skipped. Re-run /review:resolve PR# manually.
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `plugins/yellow-review/commands/review/sweep.md`, line 564-574 ([link](https://github.com/kinginyellows/yellow-plugins/blob/eb0c1048faa6e97c6148ce7751a1520e1c7f2b1a/plugins/yellow-review/commands/review/sweep.md#L564-L574)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Unreachable Stop branch in Step 5 creates double-output risk**

   Step 3 already prints the "Resolve step skipped" message and says to "exit with status 0," so the Stop case in Step 5 is never reached. However, because command files are LLM-read instructions rather than compiled code, Claude might reach Step 5 and print a redundant summary line (`Resolve: skipped — see message above`) on top of the Step 3 exit message. The two paths should be consolidated: either handle all output in Step 3 and omit the Stop clause from Step 5, or defer all output to Step 5 (remove the early print in Step 3 and just fall through).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: plugins/yellow-review/commands/review/sweep.md
   Line: 564-574

   Comment:
   **Unreachable Stop branch in Step 5 creates double-output risk**

   Step 3 already prints the "Resolve step skipped" message and says to "exit with status 0," so the Stop case in Step 5 is never reached. However, because command files are LLM-read instructions rather than compiled code, Claude might reach Step 5 and print a redundant summary line (`Resolve: skipped — see message above`) on top of the Step 3 exit message. The two paths should be consolidated: either handle all output in Step 3 and omit the Stop clause from Step 5, or defer all output to Step 5 (remove the early print in Step 3 and just fall through).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Freview-sweep-command%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Freview-sweep-command%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plugins%2Fyellow-review%2Fcommands%2Freview%2Fsweep.md%0ALine%3A%20564-574%0A%0AComment%3A%0A**Unreachable%20Stop%20branch%20in%20Step%205%20creates%20double-output%20risk**%0A%0AStep%203%20already%20prints%20the%20%22Resolve%20step%20skipped%22%20message%20and%20says%20to%20%22exit%20with%20status%200%2C%22%20so%20the%20Stop%20case%20in%20Step%205%20is%20never%20reached.%20However%2C%20because%20command%20files%20are%20LLM-read%20instructions%20rather%20than%20compiled%20code%2C%20Claude%20might%20reach%20Step%205%20and%20print%20a%20redundant%20summary%20line%20%28%60Resolve%3A%20skipped%20%E2%80%94%20see%20message%20above%60%29%20on%20top%20of%20the%20Step%203%20exit%20message.%20The%20two%20paths%20should%20be%20consolidated%3A%20either%20handle%20all%20output%20in%20Step%203%20and%20omit%20the%20Stop%20clause%20from%20Step%205%2C%20or%20defer%20all%20output%20to%20Step%205%20%28remove%20the%20early%20print%20in%20Step%203%20and%20just%20fall%20through%29.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

2. `plugins/yellow-review/commands/review/sweep.md`, line 470-472 ([link](https://github.com/kinginyellows/yellow-plugins/blob/eb0c1048faa6e97c6148ce7751a1520e1c7f2b1a/plugins/yellow-review/commands/review/sweep.md#L470-L472)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`description` field overloads what the plan calls a "trigger clause"**

   The plan (Phase 1, step 1.1) specifies the `description` should be a single-line "Use when…" trigger clause. At 241 characters the current value is the longest in the plugin — it front-loads a full "what it does" summary before the "Use when" phrase, which duplicates the body's "What It Does" and "When to Use" sections. Trimming it to something close to the `review:resolve` length (157 chars) would match the existing convention and keep the field as a routing hint rather than a mini-README.

   **Context Used:** plugins/yellow-review/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=331e26fc-49a1-4e0b-b953-b2aaca8f4007))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: plugins/yellow-review/commands/review/sweep.md
   Line: 470-472
   
   Comment:
   **`description` field overloads what the plan calls a "trigger clause"**
   
   The plan (Phase 1, step 1.1) specifies the `description` should be a single-line "Use when…" trigger clause. At 241 characters the current value is the longest in the plugin — it front-loads a full "what it does" summary before the "Use when" phrase, which duplicates the body's "What It Does" and "When to Use" sections. Trimming it to something close to the `review:resolve` length (157 chars) would match the existing convention and keep the field as a routing hint rather than a mini-README.
   
   **Context Used:** plugins/yellow-review/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=331e26fc-49a1-4e0b-b953-b2aaca8f4007))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
   
   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Freview-sweep-command%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Freview-sweep-command%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plugins%2Fyellow-review%2Fcommands%2Freview%2Fsweep.md%0ALine%3A%20470-472%0A%0AComment%3A%0A**%60description%60%20field%20overloads%20what%20the%20plan%20calls%20a%20%22trigger%20clause%22**%0A%0AThe%20plan%20%28Phase%201%2C%20step%201.1%29%20specifies%20the%20%60description%60%20should%20be%20a%20single-line%20%22Use%20when%E2%80%A6%22%20trigger%20clause.%20At%20241%20characters%20the%20current%20value%20is%20the%20longest%20in%20the%20plugin%20%E2%80%94%20it%20front-loads%20a%20full%20%22what%20it%20does%22%20summary%20before%20the%20%22Use%20when%22%20phrase%2C%20which%20duplicates%20the%20body's%20%22What%20It%20Does%22%20and%20%22When%20to%20Use%22%20sections.%20Trimming%20it%20to%20something%20close%20to%20the%20%60review%3Aresolve%60%20length%20%28157%20chars%29%20would%20match%20the%20existing%20convention%20and%20keep%20the%20field%20as%20a%20routing%20hint%20rather%20than%20a%20mini-README.%0A%0A**Context%20Used%3A**%20plugins%2Fyellow-review%2FCLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D331e26fc-49a1-4e0b-b953-b2aaca8f4007%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

3. `plugins/yellow-review/commands/review/sweep.md`, line 532-535 ([link](https://github.com/kinginyellows/yellow-plugins/blob/eb0c1048faa6e97c6148ce7751a1520e1c7f2b1a/plugins/yellow-review/commands/review/sweep.md#L532-L535)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Bash block missing `set -eu` per POSIX security convention**

   `plugins/yellow-review/CLAUDE.md` requires all shell scripts to follow POSIX security patterns including `set -eu`. The bash block at Step 1 that validates PR state does not include this preamble. Adding it ensures any unexpected failure from `gh` exits loudly rather than silently proceeding with a bad state.

   **Context Used:** plugins/yellow-review/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=331e26fc-49a1-4e0b-b953-b2aaca8f4007))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: plugins/yellow-review/commands/review/sweep.md
   Line: 532-535
   
   Comment:
   **Bash block missing `set -eu` per POSIX security convention**
   
   `plugins/yellow-review/CLAUDE.md` requires all shell scripts to follow POSIX security patterns including `set -eu`. The bash block at Step 1 that validates PR state does not include this preamble. Adding it ensures any unexpected failure from `gh` exits loudly rather than silently proceeding with a bad state.
   
   **Context Used:** plugins/yellow-review/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=331e26fc-49a1-4e0b-b953-b2aaca8f4007))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Freview-sweep-command%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Freview-sweep-command%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plugins%2Fyellow-review%2Fcommands%2Freview%2Fsweep.md%0ALine%3A%20532-535%0A%0AComment%3A%0A**Bash%20block%20missing%20%60set%20-eu%60%20per%20POSIX%20security%20convention**%0A%0A%60plugins%2Fyellow-review%2FCLAUDE.md%60%20requires%20all%20shell%20scripts%20to%20follow%20POSIX%20security%20patterns%20including%20%60set%20-eu%60.%20The%20bash%20block%20at%20Step%201%20that%20validates%20PR%20state%20does%20not%20include%20this%20preamble.%20Adding%20it%20ensures%20any%20unexpected%20failure%20from%20%60gh%60%20exits%20loudly%20rather%20than%20silently%20proceeding%20with%20a%20bad%20state.%0A%0A**Context%20Used%3A**%20plugins%2Fyellow-review%2FCLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D331e26fc-49a1-4e0b-b953-b2aaca8f4007%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Freview-sweep-command%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Freview-sweep-command%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aplugins%2Fyellow-review%2Fcommands%2Freview%2Fsweep.md%3A31%0AThe%20heading%20%22Step%201%3A%20Resolve%20PR%22%20uses%20%22Resolve%22%20as%20the%20plugin's%20loaded%20vocabulary%20term%20%E2%80%94%20%60%2Freview%3Aresolve%60%20is%20the%20thread-resolution%20command%20that%20follows%20in%20Step%204.%20An%20LLM%20executing%20this%20file%20uses%20headings%20as%20navigational%20anchors%3B%20%22Resolve%20PR%22%20at%20Step%201%20could%20cause%20it%20to%20pattern-match%20to%20the%20thread-resolution%20concept%20before%20%60%2Freview%3Apr%60%20has%20run.%20Renaming%20to%20a%20neutral%20term%20%28%22Determine%20Target%20PR%22%20or%20%22Parse%20PR%20Number%22%29%20disambiguates%20cleanly.%0A%0A%60%60%60suggestion%0A%23%23%23%20Step%201%3A%20Determine%20Target%20PR%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aplugins%2Fyellow-review%2Fcommands%2Freview%2Fsweep.md%3A4%0AThe%20%60argument-hint%60%20omits%20the%20empty-argument%20case%20even%20though%20Step%201%20explicitly%20documents%20auto-detection%20from%20the%20current%20branch%20%28%60gh%20pr%20view%20--json%20number%20-q%20.number%60%29.%20The%20plan%20specified%20%60%5Bpr-number%20%7C%20github-url%20%7C%20branch-name%20%7C%20%28empty%20for%20current%20branch%29%5D%60%3B%20dropping%20the%20%60%28empty%20for%20current%20branch%29%60%20hint%20means%20users%20won't%20know%20they%20can%20invoke%20%60%2Freview%3Asweep%60%20with%20no%20arguments%20to%20auto-detect%20the%20PR%20from%20their%20current%20branch%20%E2%80%94%20the%20same%20discoverability%20that%20%60%2Freview%3Apr%60%20provides.%0A%0A%60%60%60suggestion%0Aargument-hint%3A%20'%5BPR%23%20%7C%20URL%20%7C%20branch%20%7C%20%28empty%20for%20current%20branch%29%5D'%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
plugins/yellow-review/commands/review/sweep.md:31
The heading "Step 1: Resolve PR" uses "Resolve" as the plugin's loaded vocabulary term — `/review:resolve` is the thread-resolution command that follows in Step 4. An LLM executing this file uses headings as navigational anchors; "Resolve PR" at Step 1 could cause it to pattern-match to the thread-resolution concept before `/review:pr` has run. Renaming to a neutral term ("Determine Target PR" or "Parse PR Number") disambiguates cleanly.

```suggestion
### Step 1: Determine Target PR
```

### Issue 2 of 2
plugins/yellow-review/commands/review/sweep.md:4
The `argument-hint` omits the empty-argument case even though Step 1 explicitly documents auto-detection from the current branch (`gh pr view --json number -q .number`). The plan specified `[pr-number | github-url | branch-name | (empty for current branch)]`; dropping the `(empty for current branch)` hint means users won't know they can invoke `/review:sweep` with no arguments to auto-detect the PR from their current branch — the same discoverability that `/review:pr` provides.

```suggestion
argument-hint: '[PR# | URL | branch | (empty for current branch)]'
```


`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: address review findings on /review:..."](https://github.com/kinginyellows/yellow-plugins/commit/65ed2a9843cf788367cda7e75c9d2a616b4b5ef7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30410270)</sub>

**Context used:**

- Context used - plugins/yellow-review/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=331e26fc-49a1-4e0b-b953-b2aaca8f4007))

<!-- /greptile_comment -->