### PR TITLE
feat(gt-workflow): merge-queue research + native queue advisory + closed-not-merged guard

### DIFF
--- a/.changeset/gt-workflow-merge-queue-platform-guards.md
+++ b/.changeset/gt-workflow-merge-queue-platform-guards.md
@@ -1,0 +1,22 @@
+---
+"gt-workflow": patch
+---
+
+Add two platform-level guards motivated by the Graphite merge-queue research:
+
+- `gt-setup` Phase 1 now detects whether GitHub native merge queue is configured
+  for the repo and emits a soft advisory if so. Graphite and GitHub native
+  queue are incompatible — running both causes Graphite to restart CI on
+  queued commits and may produce out-of-order merges. Detection uses
+  `gh api graphql` to query `repository.mergeQueue.url`. Fail-open on any
+  error (`COULD NOT CHECK`) so setup is never blocked.
+- `gt-cleanup` now distinguishes "closed without merging" from "merged" in
+  the Closed PR category. When any closed PR has `mergedAt: null` (queue
+  ejection, abandoned PR, or any close-without-land), the branch is tagged
+  and a count warning appears in "Delete all" mode, plus a per-branch
+  `closed (no merge — verify before deleting)` line in "Review individually"
+  mode. Adds `mergedAt` to the existing `gh pr list --json` call — no new
+  API requests.
+
+Both changes apply to **all** Graphite users, not just users of Graphite's
+optional merge queue. No new dependencies. No breaking changes.

--- a/.changeset/gt-workflow-merge-queue-platform-guards.md
+++ b/.changeset/gt-workflow-merge-queue-platform-guards.md
@@ -11,14 +11,14 @@ Add two platform-level guards motivated by the Graphite merge-queue research:
   `gh api graphql` to query `repository.mergeQueue.url`. Fail-open on any
   error (`COULD NOT CHECK`) so setup is never blocked.
 - `gt-cleanup` now distinguishes "closed without merging" from "merged" in
-  the Closed PR category. When any closed PR has `merged: false` (queue
-  ejection, abandoned PR, or any close-without-land), the branch is tagged
-  and a count warning appears in "Delete all" mode, plus a per-branch
-  `closed (no merge — verify before deleting)` line in "Review individually"
-  mode. The authoritative signal is the `merged` boolean (not `mergedAt`,
-  which can be transiently null due to GitHub REST propagation lag). Updates
-  the existing `gh pr list --json` call to request `state,mergedAt,merged` —
-  no new API requests.
+  the Closed PR category. When any PR for the branch has `state == "CLOSED"`
+  (queue ejection, abandoned PR, or any close-without-land — `gh pr list`
+  represents merged PRs as `state == "MERGED"`, so `CLOSED` is by itself
+  unambiguous), the branch is tagged and a count warning appears in
+  "Delete all" mode, plus a per-branch `closed (no merge — verify before
+  deleting)` line in "Review individually" mode. Adds `mergedAt` to the
+  existing `gh pr list --json` call (requested set is `state,mergedAt`)
+  for display use only — no new API requests.
 
 Both changes apply to **all** Graphite users, not just users of Graphite's
 optional merge queue. No new dependencies. No breaking changes.

--- a/.changeset/gt-workflow-merge-queue-platform-guards.md
+++ b/.changeset/gt-workflow-merge-queue-platform-guards.md
@@ -11,12 +11,14 @@ Add two platform-level guards motivated by the Graphite merge-queue research:
   `gh api graphql` to query `repository.mergeQueue.url`. Fail-open on any
   error (`COULD NOT CHECK`) so setup is never blocked.
 - `gt-cleanup` now distinguishes "closed without merging" from "merged" in
-  the Closed PR category. When any closed PR has `mergedAt: null` (queue
+  the Closed PR category. When any closed PR has `merged: false` (queue
   ejection, abandoned PR, or any close-without-land), the branch is tagged
   and a count warning appears in "Delete all" mode, plus a per-branch
   `closed (no merge — verify before deleting)` line in "Review individually"
-  mode. Adds `mergedAt` to the existing `gh pr list --json` call — no new
-  API requests.
+  mode. The authoritative signal is the `merged` boolean (not `mergedAt`,
+  which can be transiently null due to GitHub REST propagation lag). Updates
+  the existing `gh pr list --json` call to request `state,mergedAt,merged` —
+  no new API requests.
 
 Both changes apply to **all** Graphite users, not just users of Graphite's
 optional merge queue. No new dependencies. No breaking changes.

--- a/.changeset/gt-workflow-merge-queue-platform-guards.md
+++ b/.changeset/gt-workflow-merge-queue-platform-guards.md
@@ -1,5 +1,5 @@
 ---
-"gt-workflow": patch
+"gt-workflow": minor
 ---
 
 Add two platform-level guards motivated by the Graphite merge-queue research:

--- a/docs/brainstorms/2026-04-30-gt-merge-queue-addon-brainstorm.md
+++ b/docs/brainstorms/2026-04-30-gt-merge-queue-addon-brainstorm.md
@@ -1,0 +1,336 @@
+# gt-merge-queue Add-On Plugin — Brainstorm
+
+**Date:** 2026-04-30
+**Research source:** `docs/research/graphite-merge-queue-stacked-prs-coding-agents.md`
+**Sibling brainstorm:** `docs/brainstorms/2026-04-30-gt-workflow-merge-queue-improvements-brainstorm.md`
+**Sections cited:** research §3, §5, §6, §7; sibling brainstorm "Plugin Boundary" and "Open Questions"
+
+---
+
+## What We're Building
+
+`gt-merge-queue` is an opt-in Claude Code plugin that depends on `gt-workflow`
+and gives a coding agent the ability to shepherd a Graphite merge-queue PR from
+"ready" through to merged. It owns ALL queue-state-aware work — the sibling
+brainstorm locked this boundary and `gt-workflow` will not be modified to read
+queue state.
+
+**The gap this fills (research §6):** No existing plugin handles the full
+shepherd loop — enqueue → monitor CI → conflict-detect → review-pickup →
+final-merge confirmation. Community plugins exist for queue entry only.
+
+**Plugin boundary (from sibling brainstorm):**
+- `gt-workflow` — Graphite platform mechanics, queue-state-unaware, always installed
+- `gt-merge-queue` — queue-state-aware shepherd loop, opt-in add-on
+
+---
+
+## Why This Approach
+
+### Plugin name: `gt-merge-queue`
+
+Pairs with `gt-workflow` (Graphite-specific tools use `gt-` prefix in this
+repo). Makes the dependency relationship visible. Disambiguates from GitHub
+native queue and Mergify. `subagent_type` strings: `gt-merge-queue:agents:<name>`.
+
+### Cross-plugin dependency declaration
+
+No formal `dependencies` key exists in the plugin.json schema (confirmed by
+inspecting yellow-linear, yellow-ci, yellow-devin manifests — none use it). The
+pattern is: `allowed-tools` in command frontmatter lists the other plugin's MCP
+tools (fails cleanly if not installed), and CLAUDE.md documents the prose
+requirement. This resolves sibling brainstorm open question #3.
+
+### Hook collision with gt-workflow
+
+`gt-workflow` has a PreToolUse(Bash) hook blocking raw `git push`.
+`gt-merge-queue` adds a PreToolUse(Bash) hook blocking force-push while queued.
+Claude Code runs all matching hooks sequentially — they do not shadow each
+other. No conflict. This resolves sibling brainstorm open question #4.
+
+### Stack-aware from day one
+
+Graphite's queue is stack-first (research §3): when any PR is enqueued,
+Graphite auto-enqueues all stack ancestors. A stack-naive plugin would not
+detect cascading ejection when a parent PR is kicked. Marginal complexity is
+small: one `gt log short` call on enqueue captures stack membership into the
+JSONL state entry. Graphite still owns queue ordering; the agent only needs
+membership awareness.
+
+### Yield-and-resume model
+
+Blocking-shepherd approaches hold the user's Claude session for the duration of
+CI (potentially 10-30 minutes). Yield-and-resume (one state-machine step per
+invocation) composes naturally with the existing `/loop` skill:
+`/loop 90s /gt-merge-queue:shepherd <PR>` is the documented polling pattern.
+No `--watch` flag needed in plugin code.
+
+---
+
+## Key Decisions
+
+### Q&A Summary
+
+**Round 1 — Plugin name + Stack scope**
+
+Q-A: Plugin name — `gt-merge-queue`. Rationale: pairs with `gt-workflow`
+convention; disambiguates from GitHub native queue.
+
+Q-B: Stack scope — stack-aware from day one. Graphite is stack-first; punting
+stack detection to v2 would make the plugin misleading about cascading ejection
+behavior on first use.
+
+**Round 2 — Human checkpoint set**
+
+Q: Which checkpoints are mandatory vs config-overridable in MVP?
+
+A: All 5 are mandatory with no config opt-out in v1. Adding config opt-out
+later is purely additive (no breaking change), so cost of waiting is zero.
+
+Confirmed checkpoint set:
+- Initial enqueue — AskUserQuestion (mandatory)
+- Queue ejection (any reason) — AskUserQuestion (mandatory)
+- Conflict detected — AskUserQuestion (mandatory)
+- New `request changes` review mid-queue — AskUserQuestion (mandatory)
+- Final merge after CI green — AskUserQuestion (mandatory, no config toggle)
+
+Hotfix fast-track: deferred to v2 (research §7 MVP list also excludes it).
+
+**Round 3 — State persistence location**
+
+Q: Per-user (`~/.claude/merge-queue/`) vs per-project (`.claude/merge-queue/`)?
+
+A: Per-user. Worktree workflow makes per-user the obvious choice — state must
+be checkout-independent. Repo-slug must be deterministic: derive from
+`gh repo view --json nameWithOwner -q .nameWithOwner` (returns `owner/name`),
+sanitize `/` → `-`. Final path: `~/.claude/merge-queue/<owner>-<repo>/<pr-number>.jsonl`.
+
+Notes locked in:
+- `~/.claude/merge-queue/` is new ground in yellow-plugins (no existing plugin
+  writes runtime state here); document the convention.
+- State survives plugin uninstall — v2 nice-to-have: `/gt-merge-queue:cleanup`
+  command or doc note about `rm -rf ~/.claude/merge-queue/<repo>/`.
+
+**Round 4 — Auth + Hook scope + Yield model (two inline lock-ins + one question)**
+
+Inline lock-in — Auth: `gh` CLI for GitHub API calls (zero new credential
+surface); `GRAPHITE_TOKEN` in `plugin.json userConfig` for Graphite-specific
+calls. No GitHub App in MVP (v2 upgrade path). Merge actor is the user's own
+GitHub identity via `gh` CLI.
+
+Inline lock-in — Hook scope: PreToolUse force-push gate is a blunt glob check.
+If any `~/.claude/merge-queue/<owner>-<repo>/*.jsonl` file has a non-`complete`
+final event, block force-push. No per-PR awareness needed in the hook; glob
+read is ~1ms per Bash call.
+
+Q: Blocking shepherd vs yield-and-resume vs hybrid?
+
+A: Yield-and-resume (B). Each invocation does one state-machine step and exits.
+`/loop 90s /gt-merge-queue:shepherd <PR>` is the documented babysitting
+pattern. No `--watch` flag in plugin code.
+
+No-args invocation behavior: auto-resume if exactly one active (non-`complete`)
+session; AskUserQuestion to pick if multiple active.
+
+**Round 5 — Failure-mode triage + smart-submit boundary**
+
+Inline lock-in — Smart-submit boundary: `gt-workflow`'s `smart-submit` stays
+clean (no `--enqueue` flag). Adding it would require `gt-workflow` to
+conditionally call an optional add-on — wrong layering direction. The
+`gt-merge-queue` CLAUDE.md documents: "after `gt submit`, run
+`/gt-merge-queue:shepherd <PR>`."
+
+Q: New `request-changes` review detection — poll on each shepherd invocation
+only, or also on SessionStart, or document the gap and recommend `/loop`?
+
+A: Document the risk and recommend `/loop`. No SessionStart polling complexity.
+The final-merge AskUserQuestion checkpoint displays "N new comments since last
+invocation" as a safety net even without continuous polling.
+
+Failure-mode triage:
+
+| Failure Mode | MVP Handling |
+|---|---|
+| Queue ejection (CI failure) | Core shepherd loop — AskUserQuestion |
+| Queue ejection (conflict) | Core shepherd loop — AskUserQuestion |
+| New `request changes` mid-queue | Poll on each invocation; document `/loop` mitigation |
+| Double-merge attempt | `pull_request.merged == true` guard at start of every invocation |
+| Session crash mid-merge | JSONL state + yield-and-resume makes resume free |
+| PR closed externally | Detect + notify + archive; shepherd exits cleanly |
+| Force-push by external actor | Detect SHA mismatch → notify + dequeue |
+| CI flake with auto-retry | Deferred to v2 |
+| Graphite queue paused | Detect + report "queue paused"; shepherd exits |
+| `main` advanced while queued | Graphite handles transparently; agent waits for new CI result |
+
+---
+
+## MVP Scope
+
+### Commands
+
+**`/gt-merge-queue:shepherd [PR-number-or-URL]`** — primary entry point.
+One state-machine step per invocation. Reads JSONL state on entry; writes
+updated state on exit. State machine:
+
+```
+Validating -> HumanCheckpoint(enqueue) -> Queued -> MonitoringCI
+  -> MergeConfirmation -> Merging -> PostMergeAudit -> Complete
+                        |-> Ejected -> HumanCheckpoint(ejection)
+                        |-> ReviewChange -> HumanCheckpoint(request-changes)
+                        |-> ClosedExternally -> Archive
+```
+
+**`/gt-merge-queue:status [PR-number-or-URL]`** — read-only; prints current
+JSONL state without advancing the state machine. Useful for inspection without
+triggering AskUserQuestion.
+
+**`/gt-merge-queue:dequeue [PR-number-or-URL]`** — safely dequeue with reason.
+AskUserQuestion for reason (using "Other" button for free-text input per
+MEMORY.md patterns), then calls Graphite/gh to remove from queue, writes
+terminal JSONL event.
+
+### Agents
+
+**`merge-queue-shepherd`** — core agent; owns the full state machine described
+above. Single file (no artificial split for line-count reasons — MEMORY.md
+confirms this is correct). Handles: stack membership detection on enqueue, JSONL
+read/write, all AskUserQuestion checkpoints, review polling, PR state checks,
+and PostToolUse audit log delegation.
+
+No separate `merge-queue-conflict-analyzer` or `merge-queue-review-monitor`
+agents in MVP — those are v2 candidates. The shepherd handles conflict
+reporting inline (detect + AskUserQuestion; user resolves manually).
+
+### Hooks
+
+**PreToolUse (Bash)** — force-push gate:
+- Glob: `~/.claude/merge-queue/**/*.jsonl`
+- Condition: any JSONL file whose last event is not `{"event":"complete",...}`
+- Action: block with message `[gt-merge-queue] Blocked: force operations not
+  permitted while PR is in shepherd state. Run /gt-merge-queue:dequeue first.`
+
+**PostToolUse (Bash)** — audit logger:
+- Matcher: commands containing `gh pr merge` or `gt submit`
+- Action: append audit event to the active JSONL state file (PR, SHA, actor,
+  timestamp, idempotency token)
+
+**SessionStart** — state resume notification:
+- If any non-`complete` JSONL state file exists, inject system message:
+  "Shepherd state exists for PR #N in <repo> (step: <step>). Run
+  `/gt-merge-queue:shepherd <N>` to check status."
+- Must output `{"continue": true}` on ALL paths (MEMORY.md: no `set -e` in
+  hooks that emit JSON; use `json_exit()` helper pattern).
+
+### State Schema (JSONL, append-only)
+
+```jsonl
+{"schema":"1","ts":"...","event":"enqueue_requested","pr":123,"repo":"owner/repo","slug":"owner-repo","idempotency_token":"uuid","stack":["#121","#122","#123"],"speculative_sha":null,"step":"awaiting_queue_entry"}
+{"schema":"1","ts":"...","event":"queued","speculative_sha":"abc123","queue_position":3,"step":"monitoring_ci"}
+{"schema":"1","ts":"...","event":"review_polled","last_seen_review_id":456,"new_changes_requested":false,"step":"monitoring_ci"}
+{"schema":"1","ts":"...","event":"ci_pass","step":"awaiting_merge_confirmation"}
+{"schema":"1","ts":"...","event":"human_approved","actor":"user","comment_delta":2,"step":"merging"}
+{"schema":"1","ts":"...","event":"merged","merged_sha":"def456","step":"complete"}
+```
+
+Fields tracked: `pr`, `repo`, `slug`, `stack`, `speculative_sha`,
+`last_seen_review_id`, `conflict_state`, `idempotency_token`, `step`,
+`schema` (always `"1"` for forward compatibility per MEMORY.md).
+
+### Plugin Manifest Shape
+
+```json
+{
+  "name": "gt-merge-queue",
+  "version": "1.0.0",
+  "description": "Shepherd a Graphite merge-queue PR from ready to merged — conflict detection, mid-queue review pickup, and idempotent resume. Requires gt-workflow.",
+  "hooks": {
+    "PreToolUse": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/check-queue-state.sh", "timeout": 2 }] }],
+    "PostToolUse": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/post-merge-audit.sh", "timeout": 1 }] }],
+    "SessionStart": [{ "matcher": "*", "hooks": [{ "type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh", "timeout": 3 }] }]
+  },
+  "userConfig": {
+    "GRAPHITE_TOKEN": { "description": "Graphite API token for queue management", "secret": true, "required": true }
+  }
+}
+```
+
+Cross-plugin dependency is enforced via `allowed-tools` in command frontmatter
+listing `gt-workflow`'s MCP tools (e.g., `mcp__plugin_gt-workflow_graphite__*`)
+— fails cleanly if `gt-workflow` is not installed. Documented as prose
+requirement in CLAUDE.md.
+
+### Invocation Pattern (documented in CLAUDE.md)
+
+```
+# After gt submit:
+/gt-merge-queue:shepherd 123
+
+# Continuous monitoring (compose with /loop skill):
+/loop 90s /gt-merge-queue:shepherd 123
+
+# Check state without advancing:
+/gt-merge-queue:status 123
+
+# Safe dequeue:
+/gt-merge-queue:dequeue 123
+```
+
+---
+
+## v2 Candidates (Deferred)
+
+| Feature | Deferral trigger |
+|---|---|
+| Hotfix fast-track command (`/gt-merge-queue:hotfix`) | First user request; needs Graphite fast-track API confirmed |
+| Conflict analyzer agent (auto-suggest, not auto-apply) | After 3+ manual conflict resolutions — pattern emerges |
+| Background review monitor (continuous, not invocation-triggered) | When `/loop` pattern proves insufficient in practice |
+| CI flake auto-retry with bounded count | After first flake incident; add `max_retries` to JSONL schema |
+| `gt-merge-queue:cleanup` command | After first request about orphaned state files |
+| Stack-aware atomic enqueue (enqueue whole stack in one command) | After first user complaint about manual multi-PR enqueue |
+| Graphite queue pause/resume integration | If Graphite publishes webhook schema |
+| `autoMergeOnCIGreen` config opt-out | After first user request; purely additive to manifest |
+| Metrics (time-in-queue, conflict rate, CI pass rate) | After 50+ shepherd sessions — enough data to be useful |
+| GitHub App identity for merge actor | If audit requirements demand bot identity over user identity |
+
+---
+
+## Open Questions (Unresolved)
+
+1. **Graphite API token scopes** (research §6, §8): Graphite's API token
+   reference is not publicly documented at the level of detail needed for
+   programmatic enqueue/dequeue. Which token type — user token, org token, or
+   service account token — is required? Can enqueue/dequeue be done via API
+   without dashboard interaction? Requires Graphite support consultation before
+   implementing the shepherd's enqueue step. Workaround: MVP may invoke
+   `gt submit --merge-queue` via CLI rather than a direct API call, deferring
+   the Graphite REST dependency.
+
+2. **Graphite webhook events** (research §3, §8): Whether Graphite emits
+   webhooks the plugin can subscribe to ("PR ejected", "queue position changed",
+   "batch merged") or whether polling GitHub PR state is the only option. MVP
+   assumes polling-only. If Graphite publishes a webhook schema, the v2 review
+   monitor agent can switch to event-driven detection, removing the `/loop`
+   composition requirement.
+
+3. **`gt log short` stack membership output format**: The exact output format
+   of `gt log short` (or equivalent `gt` CLI command) for extracting stack
+   membership needs verification against the live Graphite MCP tool
+   (`mcp__plugin_gt-workflow_graphite__*`). May use `gt stack` or the Graphite
+   MCP server directly instead of parsing CLI output.
+
+---
+
+## Out-of-Scope Table
+
+| Item | Decision | Rationale |
+|---|---|---|
+| `--enqueue` flag on smart-submit | Out of scope | Wrong layering — gt-workflow must not conditionally call an add-on |
+| GitHub native merge queue support | Out of scope | Graphite and GitHub native queue are incompatible (research §3); user must pick one |
+| Auto-resolving semantic conflicts | Out of scope (any version) | Industry consensus April 2026: always escalate semantic conflicts to human |
+| Force-merge outside Graphite queue | Out of scope | Anti-pattern per research §5; PreToolUse hook blocks it |
+| `gt-workflow` modifications for queue-state | Out of scope | Sibling brainstorm locked this boundary |
+| CI re-triggering / workflow dispatch | Out of scope | Graphite handles CI restart after `main` advances; agent just waits |
+| Queue position reporting (dashboard parity) | Out of scope MVP | `/gt-merge-queue:status` reports step from JSONL only; queue position from Graphite API is v2 |
+| Per-project state files | Rejected | Worktree workflow requires checkout-independent state; per-user wins |
+| SessionStart hook polling reviews | Rejected | Adds `gh api` calls to every session open; `/loop` mitigation is sufficient |
+| Graphite CI optimizer step (GH Actions config) | Out of scope | CI configuration item, not plugin behavior; link in docs |

--- a/docs/brainstorms/2026-04-30-gt-workflow-merge-queue-improvements-brainstorm.md
+++ b/docs/brainstorms/2026-04-30-gt-workflow-merge-queue-improvements-brainstorm.md
@@ -1,0 +1,202 @@
+# gt-workflow Merge Queue Improvements — Brainstorm
+
+**Date:** 2026-04-30
+**Research source:** `docs/research/graphite-merge-queue-stacked-prs-coding-agents.md`
+**Sections cited:** §2 (Graphite platform model), §3 (Merge Queue deep dive), §5 (agent merge patterns), §6 (Claude Code integration patterns), §7 (Plugin Design Recommendations)
+
+---
+
+## What We're Building
+
+Two additive-minimal improvements to the existing `gt-workflow` plugin (v1.4.0),
+motivated by findings in the Graphite merge queue research. These are
+platform-level hardening changes that benefit all Graphite users — not
+queue-management features, which belong in the separate `merge-queue` add-on.
+
+**Change 1 — `gt-setup` native-queue coexistence warning**
+A new check in Phase 1's prerequisite scan that detects whether GitHub's native
+merge queue is enabled on the trunk branch. Emits a soft advisory (never blocks)
+because Graphite and GitHub's native queue are explicitly documented as
+incompatible (§3). Affects all Graphite users, not just those using Graphite's
+own merge queue.
+
+**Change 2 — `gt-cleanup` closed-not-merged guard**
+When a local branch's PR is found closed with no merge (`state: CLOSED`,
+`mergedAt: null`), gt-cleanup now warns before offering deletion. A batch count
+warning appears in "Delete all" mode; per-branch AskUserQuestion confirmation
+appears in "Review individually" mode. No label reading (`queue-ejected` label
+detection stays in the merge-queue add-on). Prevents silent data loss when a
+user's PR was queue-ejected, PR abandoned mid-review, or otherwise closed
+without landing.
+
+---
+
+## Why This Approach
+
+### Two-plugin layering (the core architectural decision)
+
+`gt-workflow` is used on every repo where Graphite is active. Graphite's merge
+queue is opt-in — used on some repos, not all. Mixing queue-state-aware logic
+into `gt-workflow` would add GitHub/Graphite API calls for queue position on
+every repo, adding latency and complexity for users who never use the queue.
+
+The correct model — confirmed in Round 1 — is:
+
+- `gt-workflow` (base, always installed for Graphite users): knows Graphite
+  platform mechanics. Does NOT read queue state. No new API calls for queue
+  position.
+- `merge-queue` (opt-in add-on, depends on `gt-workflow`): knows Graphite merge
+  queue specifically. Owns the shepherd loop, JSONL state, PreToolUse force-push
+  gate, AskUserQuestion at enqueue/merge-confirm/conflict. Follows the add-on
+  dependency pattern established elsewhere in yellow-plugins.
+
+This layering matches existing precedent (`linear:delegate` requires
+`yellow-devin`; `ci:report-linear` requires `yellow-linear`).
+
+### Why these two changes and not others
+
+The research surfaced many candidates. Each was put through a YAGNI gate:
+
+- **Only changes that benefit ALL Graphite users** (not just queue users) belong
+  in gt-workflow. Both confirmed changes meet this bar.
+- **Only changes that don't require queue-state API calls** belong in gt-workflow.
+  Both confirmed changes rely on data gt-workflow already fetches or can fetch
+  without queue-state awareness.
+- **Conventional commit `!` regex**: Verified present in `check-commit-message.sh`
+  line 52 (`!?:` already in pattern). No change needed.
+
+---
+
+## Key Decisions
+
+### Q&A Summary
+
+**Round 1 — Plugin boundary**
+Q: Do queue-state guards (e.g., "is this PR currently queued?") belong in
+gt-workflow or exclusively in the merge-queue add-on?
+
+A: Two-plugin layering. gt-workflow stays queue-state-unaware. Any feature
+requiring a read of Graphite/GitHub queue position belongs in merge-queue. The
+user uses Graphite on every repo but the merge queue only on some — the add-on
+pattern is the right fit.
+
+**Round 2 — gt-cleanup guard design**
+Q: What level of protection should gt-cleanup add for closed-not-merged branches?
+
+A: Option A — minimal warn-and-confirm. When `gh pr list` returns a branch with
+`state: CLOSED` + `mergedAt: null`, show a count warning in batch mode and a
+per-branch AskUserQuestion in review mode. No `queue-ejected` label reading
+(that's merge-queue territory). One extra field (`mergedAt`) added to the
+existing `gh pr list --json` call.
+
+**Round 3 — gt-setup warning severity**
+Q: Should the GitHub native queue warning be advisory, blocking, or
+AskUserQuestion-gated?
+
+A: Option A — soft advisory. Add `gh_native_queue: WARNING — ...` to the Phase 1
+report alongside existing key-value diagnostics. Matches the existing `yq: NOT
+FOUND` severity level. Fail-open: if the branch protection API call fails for
+any reason, emit `gh_native_queue: COULD NOT CHECK (branch protection API
+unavailable)`. Never blocks setup.
+
+---
+
+## Implementation Notes
+
+### gt-setup change (Phase 1 bash block addition)
+
+Add a single new check after the existing "Convention Files" checks. Detection
+uses `gh api repos/{owner}/{repo}/branches/{trunk}/protection` and parses for
+the `required_merge_queue` field (or equivalent). Fail-open on any error
+(auth, no protection rules, API shape change). The warning includes the
+GitHub branch settings URL and a one-line consequence statement:
+
+```
+gh_native_queue: WARNING — GitHub native merge queue is enabled on '{trunk}'.
+    Graphite and GitHub native queue are incompatible; running both causes
+    Graphite to restart CI on all queued commits and may produce out-of-order
+    merges. Disable GitHub native queue at:
+    https://github.com/{owner}/{repo}/settings/branches
+```
+
+`gh` is already a prerequisite in gt-cleanup and a soft dependency in gt-setup
+(used for `gh auth status`). No new tool dependency.
+
+### gt-cleanup change (Phase 2 PR status lookup)
+
+The existing `gh pr list --state all --json state` call becomes
+`gh pr list --state all --json state,mergedAt`. One additional field. No new
+API calls, no new loop iterations.
+
+Classification logic addition: after identifying a branch as "Closed PR"
+candidate (all PRs in `CLOSED` or `MERGED` state), check whether any closed
+PR has `mergedAt: null`. If so, tag the branch as `closed-not-merged`.
+
+Display change (Phase 4, Category Actions, "Delete all" path): if any branches
+in the Closed PR category are tagged `closed-not-merged`, prepend the data-loss
+warning with a count: "N of these branches had PRs closed without merging (may
+be queue-ejected, abandoned, or cancelled)."
+
+Display change (Phase 4, "Review individually" path): for each
+`closed-not-merged` branch, add a line to the per-branch detail block:
+`PR status: closed (no merge — verify before deleting)`. The existing
+AskUserQuestion serves as the confirmation step — no new prompt needed.
+
+---
+
+## Out-of-Scope Decisions
+
+| Item | Decision | Rationale |
+|---|---|---|
+| `queue-ejected` label detection in gt-cleanup | Out of scope for gt-workflow | Label reading requires knowing it's queue-specific; belongs in merge-queue add-on |
+| PreToolUse hook blocking force-push while queued | Out of scope for gt-workflow | Requires queue-state API call; merge-queue add-on responsibility |
+| smart-submit "already queued?" guard before force-push | Out of scope for gt-workflow | Queue-state read; merge-queue add-on responsibility |
+| JSONL idempotency state files | Out of scope for gt-workflow | Shepherd-loop feature; merge-queue add-on responsibility |
+| Stack-aware enqueue cascade | Out of scope for gt-workflow | First-class merge-queue add-on feature |
+| `gt-sync` ejection-state recovery path | Out of scope for gt-workflow | Merge-queue add-on's shepherd will instruct user to run `/gt-sync`; no change needed in gt-sync itself |
+| Conventional commit `!` regex | No change needed | Already present: `!?:` on line 52 of `check-commit-message.sh` |
+| Graphite CI optimizer step mention in gt-setup | Out of scope | CI configuration item, not a plugin behavioral gap; link in docs if needed |
+| gt-setup: blocking hard-stop on native queue detection | Rejected | Severity mismatch — the user may be aware and choosing to run hybrid; advisory is correct |
+| gt-cleanup: split "Closed PR" into "Merged" vs "Closed-no-merge" sub-categories | Rejected | More code for marginal UX gain; the minimal warning achieves the protection goal |
+
+---
+
+## Open Questions
+
+These were not resolved in this brainstorm and are deferred to the merge-queue
+add-on brainstorm:
+
+1. **Graphite API token scopes**: Graphite's API token reference is not publicly
+   documented at the detail level needed for programmatic queue management.
+   Requires Graphite support consultation before implementing the shepherd.
+
+2. **Graphite webhook events**: Whether Graphite emits webhooks the add-on can
+   subscribe to (e.g., "PR ejected", "queue position changed") or whether the
+   add-on must poll GitHub PR state as a proxy. Evidence gap confirmed in §3.
+
+3. **merge-queue add-on dependency declaration**: Should `merge-queue`'s
+   `plugin.json` declare `gt-workflow` as a formal dependency? Depends on
+   whether the yellow-plugins manifest schema supports inter-plugin dependencies.
+   Check schema before designing the add-on manifest.
+
+4. **Hook registration collision**: The merge-queue add-on will register its own
+   PreToolUse (Bash) hook for force-push gating. gt-workflow already has a
+   PreToolUse (Bash) hook for `git push` blocking. Both must coexist without
+   shadowing each other. Verify Claude Code's behavior when two plugins register
+   PreToolUse hooks for the same matcher.
+
+5. **gt-setup native-queue detection field**: The GitHub REST API field name for
+   "merge queue enabled" on a branch protection rule should be verified against
+   the live API before implementation — the exact field (`required_merge_queue`,
+   `merge_queue_enforcement_level`, etc.) was not confirmed in the research.
+
+---
+
+## Recommendations
+
+| Priority | Item | File(s) | Rationale |
+|---|---|---|---|
+| P1 | gt-setup native-queue coexistence warning | `commands/gt-setup.md` | One-time deployment guard; high value for all Graphite users; low implementation cost (one `gh api` call, fail-open) |
+| P1 | gt-cleanup closed-not-merged guard | `commands/gt-cleanup.md` | Prevents silent branch deletion after queue ejection or PR abandonment; one extra JSON field in an existing API call |
+| P2 | merge-queue add-on brainstorm | new plugin | Everything queue-state-aware; deferred to separate brainstorm |
+| Out of scope | All other research candidates | — | YAGNI: require queue-state reads or belong entirely in the add-on |

--- a/docs/research/graphite-merge-queue-stacked-prs-coding-agents.md
+++ b/docs/research/graphite-merge-queue-stacked-prs-coding-agents.md
@@ -1,0 +1,564 @@
+# Graphite, Stacked PRs, and Merge Queue — Comprehensive Research Report
+
+**Date:** 2026-04-30
+**Sources used:** EXA Deep Researcher (exa-research-pro), Tavily Research (pro, two queries), graphite.dev/docs, docs.github.com, code.claude.com/docs, engineering blogs
+
+---
+
+## 1. Executive Summary
+
+**Key findings:**
+
+- **Graphite is a stack-first platform**: its merge queue is the only major queue that treats a *stack of dependent PRs* as the atomic unit — bottom-of-stack PRs auto-enqueue when any stack member is queued, and speculative builds validate the entire stack's combined diff. This is architecturally incompatible with GitHub's native merge queue and the two must not run simultaneously on the same branch.
+- **Graphite Merge Queue lifecycle**: enqueue → lazy rebase → batch draft-PR creation → parallel/speculative CI → fast-forward trunk if green; if CI fails, automated bisection isolates the offending PR, ejects it with a comment, and re-queues the remaining passing set.
+- **Conflict ejection, not auto-resolve**: Graphite ejects conflicted PRs (marking them closed with `mergedAt: null` on GitHub), annotates with a `queue-ejected` label and comment, and requires author action (`gt sync` to rebase) before re-entry. Agents that attempt in-queue conflict resolution are working *outside* Graphite's model.
+- **GitHub native merge queue is complementary context, not a replacement**: the `merge_group` webhook event (actions: `checks_requested`, `destroyed`) is GitHub's mechanism; Graphite builds its own layer on top and explicitly documents incompatibility.
+- **Coding agents in 2026 universally require human-in-the-loop for merge**: Devin, Cursor, Claude Code GitHub Actions, and OpenAI Codex all insert an explicit human approval step before final merge. No major agent platform auto-merges without a checkpoint as of April 2026.
+
+**Recommended plugin shape for `merge-queue`:**
+- A Claude Code plugin with one command (`/merge-queue:shepherd <PR-URL-or-number>`), one agent (`merge-queue-shepherd`), two hooks (PreToolUse gate on `gh pr merge`, PostToolUse audit logger), and a JSONL state file per PR tracking: PR ID, queue position, last-seen comment ID, speculative commit SHA, conflict state, idempotency token, hotfix branch refs.
+- Human checkpoints required at: (a) initial enqueue confirmation, (b) conflict detected (never auto-resolve non-trivial conflicts), (c) new `request changes` review comment detected mid-queue, (d) CI bisection ejects the PR.
+
+---
+
+## 2. Graphite Platform Model
+
+### Stacked Diffs / Stacked PRs
+
+Graphite's core thesis is that large changes should be decomposed into a series of incremental PRs, each a logical parent of the next. Each stack element is a Git branch parented to the one below it. Graphite's CLI tracks these parent/child relationships via local metadata — it does not embed this in Git itself, so stacks are Graphite-aware objects layered on top of standard Git.
+
+The web UI renders stacks as a dependency map, showing which PRs must land before others can be reviewed or merged. GitHub only sees independent PRs pointing at different base branches.
+
+### Key `gt` CLI Commands
+
+| Command | What it does |
+|---|---|
+| `gt create [name]` | Creates a new branch on top of current, commits staged changes. `--ai` flag for AI-generated branch names, `-p` for interactive hunk selection, `-i` to insert between existing children. |
+| `gt modify` | Amends the current branch. Interactively suggests hunk boundaries and restacks all descendants after amendment. |
+| `gt submit` | Submits branches as PRs to GitHub, preserving dependency order. Each PR's base is set to its parent branch. By default submits all branches upstack of the current position. |
+| `gt restack` | Recomputes parent/child ancestry relationships after manual Git operations or rebases. Run this when `gt` metadata and Git tree have diverged. |
+| `gt sync` | Synchronizes local branches with remote, rebases upstack branches onto the updated trunk after merges land. This is the primary tool for keeping a stack current after other PRs merge. |
+| `gt absorb` | Automatically integrates staged changes into the most relevant existing commit in the stack — minimizes manual rebase overhead for small fixups. |
+
+### Stack Model: Parent/Child Branches
+
+- Every branch in a stack has at most one parent (downstack) and may have multiple children (upstack).
+- `gt bottom` / `gt top` navigate the chain.
+- Collaborators can fetch and freeze specific branches to prevent unintended edits on shared stacks.
+- Graphite stores metadata separately from Git — it is not embedded in commit messages or trailers.
+
+### Rebase vs. Merge
+
+Graphite defaults to rebasing for all stack integration. Merge commits only appear if conflicts arise that cannot be fast-forwarded. `gt sync` rebases each branch onto the latest trunk after PRs land. This produces clean linear history on trunk.
+
+### Trunk Model
+
+Graphite uses a single-trunk model (`main` or `master`). Feature stacks branch off trunk and are expected to return to trunk frequently. Long-lived diverging branches are an anti-pattern in the Graphite model.
+
+---
+
+## 3. Graphite Merge Queue — Deep Dive
+
+### End-to-End Lifecycle
+
+1. **Enqueue**: Developer opts in a PR (or entire stack) via the Graphite dashboard or `gt submit --merge-queue`. Graphite validates prerequisites: passing CI checks, required approvals, conversation resolution if branch protection requires it.
+2. **Lazy rebase**: Graphite rebases only the conflicted PRs in a stack — if a stack has `m` merge conflicts, Graphite performs exactly `m` rebases, not a full-stack rebase. This is explicitly documented as "lazy rebasing" and is one of Graphite's key efficiency claims.
+3. **Batch formation**: Graphite groups multiple PRs into batches, either by time window (configurable, default ~5 minutes) or PR-count limit (configurable, default ~5 PRs). Batch sizing and concurrency are exposed in the Graphite app settings UI.
+4. **Speculative build**: For each batch, Graphite creates a draft/synthetic merge commit representing `trunk + all batch PRs` in stack order. CI runs against this combined state. This is the "speculative" or "optimistic" check — CI validates the future merged state, not the PR branch alone.
+5. **Parallel CI optimization**: Graphite can run CI on every stack in a batch in parallel ("full parallel isolation" default) to quickly surface failing stacks, or use bisection to efficiently locate failures with fewer runs.
+6. **Merge**: If CI passes on the speculative commit, Graphite fast-forwards trunk to the batch head. Multiple PRs merge in a single operation. Merge methods: Squash, Rebase, or Merge Commit — configurable per repository.
+7. **Dequeue and sync**: Merged PRs are marked merged. Dependent upstack branches are rebased via `gt sync`.
+
+### Required CI Checks and "Ready" Detection
+
+Graphite requires:
+- Status checks passing on the PR branch (pre-queue gate).
+- Required approvals per branch protection rules.
+- Conversation resolution if configured.
+- The Graphite GitHub App must be installed and listed as an authorized bypass actor in branch protection rules.
+
+Graphite recommends adding a Graphite CI optimizer step (with a Graphite token) to GitHub Actions workflows, plus a `wait` step early in the workflow. This lets Graphite conditionally skip downstream CI on upstack branches to avoid "missing required CI" errors — a known gotcha when branch protection requires CI on all base branches.
+
+**Known limitation**: Graphite does not support GitHub deployment checks in branch protection rules.
+
+### Batching Strategy and Failure Recovery
+
+When a speculative build fails:
+1. Graphite automatically bisects the batch — runs CI on progressively smaller subsets.
+2. Identifies the offending PR(s).
+3. Ejects the failing PR from the queue.
+4. Re-queues the passing set automatically.
+5. Notifies the failing PR's author via GitHub PR comment and Graphite dashboard.
+
+### Stacked PR Merge Queue Behavior
+
+This is the key behavioral difference from GitHub's native queue:
+- When any PR in a stack is enqueued, Graphite enqueues all ancestors (downstack PRs) to preserve dependencies.
+- Speculative builds merge the full stack's combined diff.
+- Bottom-of-stack PRs do not need to manually land before top-of-stack PRs — Graphite handles the ordering.
+- If a parent PR's queue position changes (e.g., ejected), dependent upstack PRs are also affected.
+
+### Conflict Handling
+
+- Graphite uses lazy rebasing to minimize scope.
+- If a conflict cannot be automatically resolved, Graphite ejects the PR from the queue.
+- The ejected PR is marked closed on GitHub with `mergedAt: null`.
+- Graphite annotates with a `queue-ejected` label and a PR comment explaining the conflict.
+- Author must run `gt sync` locally to rebase and resolve conflicts, then re-submit to the queue.
+- **Agents cannot resolve conflicts in-queue** — this happens before or after queue entry, not during.
+
+### Speculative / Optimistic Checks vs. Strict Rebuilds (as of 2026)
+
+Graphite's documented behavior as of April 2026:
+- Default: Full parallel isolation (run CI on all stacks in a batch concurrently).
+- Alternative: Bisection mode (progressively smaller subsets) for CI cost optimization.
+- No strict sequential rebuild is documented as default — Graphite leans optimistic.
+- If a commit lands on `main` outside Graphite while PRs are queued, Graphite restarts CI on queued commits against the new base. This is documented operational behavior teams must account for.
+
+### Graphite vs. GitHub Native Merge Queue
+
+| Dimension | Graphite Merge Queue | GitHub Native Merge Queue |
+|---|---|---|
+| Stack awareness | Yes — first-class | No — enqueues individual PRs |
+| Speculative batching | Yes — draft PRs | Yes — `gh-readonly-queue/*` branches |
+| Bisection on failure | Yes | No — ejects head entry only |
+| Conflict handling | Lazy rebase + eject | Eject |
+| API surface | REST under `/merge-queue` namespace (vendor docs) | GraphQL (`enqueuePullRequest`, `dequeuePullRequest`, `mergeQueueEntry`), webhooks |
+| Compatibility | **Incompatible with GitHub native queue** | Native GitHub feature |
+| CI optimizer | Graphite CI optimizer step (GH Actions) | `merge_group` trigger in workflows |
+
+**Critical**: Graphite docs explicitly state the two systems are incompatible. Disable GitHub's native merge queue when using Graphite.
+
+### Merge Methods
+
+- **Squash**: All PR commits become one commit on trunk.
+- **Rebase**: PR commits rebased onto trunk individually.
+- **Merge commit**: Full PR history preserved with a merge commit.
+- Fast-forward mode is available when parallel processing of stacked PRs is enabled.
+- Defaults are configurable at repository level in the Graphite app.
+
+### Graphite APIs for Programmatic Queue Management
+
+- REST API under `/merge-queue` namespace (Graphite developer portal — exact endpoint reference not publicly indexed as of research date).
+- CLI: `gt submit --merge-queue` for queue entry.
+- Graphite exposes queue position, draft commit SHAs, and merge activity in the dashboard UI.
+- For webhook/event payloads, Graphite docs reference a "merge activity timeline" as the primary observable surface but do not publish a complete webhook schema in public docs. **This is an evidence gap** — teams should validate actual Graphite webhook payloads via Graphite support or controlled testing.
+
+---
+
+## 4. GitHub Native Merge Queue Reference
+
+### The `merge_group` Webhook Event
+
+GitHub creates temporary branches prefixed `gh-readonly-queue/<base>/pr-<number>-<hash>` that represent `trunk + queued PR(s)`. It dispatches `merge_group` webhook events when creating these branches.
+
+**Key payload fields** (from `checks_requested` action):
+```json
+{
+  "action": "checks_requested",
+  "merge_group": {
+    "base_ref": "refs/heads/main",
+    "base_sha": "<sha>",
+    "head_ref": "refs/heads/gh-readonly-queue/main/pr-123-abc123",
+    "head_sha": "<speculative-commit-sha>",
+    "head_commit": {
+      "id": "<sha>",
+      "message": "Merge pull request #123...",
+      "timestamp": "2026-04-30T18:00:00Z",
+      "author": { "name": "...", "email": "..." },
+      "committer": { "name": "GitHub", "email": "noreply@github.com" },
+      "tree_id": "<tree-sha>"
+    }
+  },
+  "repository": {},
+  "sender": {},
+  "organization": {},
+  "installation": {}
+}
+```
+
+**Action values**: `checks_requested` (documented original), `destroyed` (added in July 2023 GA changelog). There is a documented divergence between the original webhook reference and the changelog — treat both as valid. Do not rely on `head_ref` format for parsing PR numbers; it is not a stable contract.
+
+**Required GitHub App permission** to receive `merge_group` events: read-level "Merge queues" repository permission.
+
+### GitHub Actions `merge_group` Trigger
+
+CI workflows must include `on: merge_group` to report checks for queue commits. Without this, required checks are not satisfied and PRs stall. Actions running on `merge_group` automatically create check runs for `merge_group.head_sha` as part of the normal job lifecycle.
+
+```yaml
+on:
+  merge_group:
+  pull_request:
+```
+
+### Auto-merge vs. Merge Queue — Semantic Difference
+
+| | Auto-merge | Merge queue |
+|---|---|---|
+| Scope | Single PR | Multiple PRs coordinated |
+| Speculative commit | No | Yes (`gh-readonly-queue/*` branch) |
+| Ordering | N/A | FIFO |
+| Batching | No | Yes (grouping strategies) |
+| When to use | Simple single-PR flow | High-velocity repos needing ordering + CI efficiency |
+
+Auto-merge gates a PR on its *own* checks/approvals. Merge queue validates a *combined future state* of multiple PRs. Enabling auto-merge requires write access; it is automatically disabled if a non-author with write access pushes new changes.
+
+### Branch Protection Rules Affecting Queue Behavior
+
+- "Require status checks to pass before merging" must be enabled.
+- The merge queue must be selected as a required check.
+- Grouping strategy (`ALLGREEN` vs. `HEADGREEN`) controls whether all PRs' checks must pass individually or only the head-of-queue.
+- `max_entries_to_build`, `max_entries_to_merge`, `min_entries_to_merge`, `check_response_timeout_minutes` are REST-accessible rule parameters.
+- Branch protection restricts who can push, force-push, or create matching branches.
+
+### Closed PR with `mergedAt: null` After Queue Ejection
+
+This is a confirmed behavior pattern with multiple documented paths:
+
+1. **Queue ejection (most common)**: PR fails CI in queue → `pull_request.dequeued` webhook fires → GitHub closes the PR (or it remains open-but-dequeued) → if the PR was previously closed by the ejection workflow, `merged_at` remains `null` because no merge occurred. Graphite annotates with `queue-ejected` label and comment.
+
+2. **`merge_group.destroyed` without merge**: The merge group lifecycle ends (invalidated, not merged) → `merge_group` event with `action: destroyed` → PR is not merged → `merged_at: null`.
+
+3. **Timeline noise**: Queue-created preparation branch commits appear in the PR timeline but are not actual merges. Do not interpret timeline activity on `gh-readonly-queue/*` branches as merge confirmation.
+
+**Detection pattern**: Never use `merge_group` events alone as ground truth for merge status. Always correlate with `pull_request.merged == true` (boolean field on the PR object). Subscribe to both `pull_request.dequeued` and `merge_group.destroyed` for ejection detection. Use GraphQL `mergeQueueEntry` state for authoritative queue position queries.
+
+**Agent implication**: An agent that checks `mergedAt` on a closed PR must treat `mergedAt: null` + closed state as potentially-ejected-not-merged, not as "this PR was merged via queue." The project MEMORY.md already documents this observation — this research confirms it.
+
+---
+
+## 5. Coding Agent Merge Patterns — April 2026
+
+### Industry Survey
+
+As of April 2026, every major AI coding agent platform enforces a human checkpoint before merge:
+
+- **Claude Code GitHub Actions**: Runs automation on PR events with `@claude` interactions. Supports `CLAUDE.md` for encoding project standards. Does not auto-merge without explicit workflow configuration. Routines support `merge_queue`, `check_run`, `pull_request.*` triggers.
+- **Devin**: Provides "Devin Review" UI with explicit Merge/Close/Auto-merge controls visible to human reviewers. Devin can fix issues and create PRs but recommends human verification before merge. Devin's automation templates (issue-fix workflow) always surface for human sign-off before final submission.
+- **Cursor Automations**: Runs agent jobs on GitHub events/schedules but does not auto-merge without human trigger in documented flows.
+- **OpenAI Codex Action**: Runs on PR events, posts review comments, does not auto-merge. Hardened against command injection in runner steps.
+
+**Consensus position**: No major agent platform auto-merges without a human checkpoint in April 2026. This is a design choice, not a capability gap.
+
+### Human-in-the-Loop (HITL) Boundaries
+
+**Must require human confirmation** (industry consensus):
+- Initial queue entry decision ("I will merge this PR — are you sure?")
+- Any detected semantic conflict (files touched by both the PR and a concurrent landing)
+- New `request changes` review from a required reviewer while PR is queued
+- CI bisection ejects the PR — the agent must not silently re-enter the queue
+- Hotfix prioritization that reorders the queue
+- Any automated code change the agent applies to resolve a conflict
+
+**May be agent-autonomous** (with audit trail):
+- Polling queue position
+- Re-triggering CI on a draft branch
+- Posting status comments to the PR timeline
+- Detecting and logging new review comments (detection only, not response)
+- `gt sync` + rebase when no conflicts exist (trivial rebase)
+
+### Conflict Resolution Safety
+
+**Trivial (agent-safe)**:
+- Merge conflicts in generated files (lock files, auto-generated code)
+- Line-number-only conflicts with no semantic overlap
+- Import order conflicts where the merge is mechanical
+
+**Semantic (requires human)**:
+- Conflicts in business logic files
+- Conflicts in tests (the test may be testing behavior that changed)
+- Conflicts in security-sensitive code (auth, crypto, permissions)
+- Any conflict the agent cannot deterministically resolve with 100% confidence
+
+**Industry position (April 2026)**: Agents should attempt trivial conflict resolution only, run tests against the result, and escalate to human if tests fail. Graphite's lazy rebase model means conflict resolution happens *before* or *after* queue entry — not during. An agent resolving a conflict should: (1) apply fix locally, (2) run full test suite, (3) AskUserQuestion for approval, (4) force-push the branch, (5) re-enter queue. This is the canonical 5-step loop.
+
+### Picking Up New Review Comments Mid-Queue
+
+This is the hardest problem in agent merge management. The failure mode is:
+
+1. Agent enqueues PR.
+2. Reviewer posts `request changes` while PR is in speculative build phase.
+3. Agent doesn't detect it.
+4. Graphite merges the PR.
+5. Reviewer's feedback is ignored.
+
+**Recommended pattern**:
+- Poll `GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews` on a cadence (every 60-120 seconds while queued).
+- Track `last_seen_review_id` in persistent state.
+- On any new review with `state: CHANGES_REQUESTED`:
+  - Immediately call Graphite to dequeue the PR (or eject via Graphite dashboard API).
+  - Post a comment noting the dequeue reason.
+  - AskUserQuestion: "New `request changes` review from @{reviewer}. Options: [Dequeue and fix / Continue and resolve later / Escalate to maintainer]."
+- Non-blocking comments (type `COMMENTED`, not `CHANGES_REQUESTED`): agent may log and continue, with the comment noted in the audit trail.
+- On `APPROVED` from a new required reviewer: no action needed, PR gains approval.
+
+### Hotfix Patterns
+
+When a queued PR's CI breaks due to a parallel landing on `main`:
+
+1. Graphite restarts CI on queued commits against new `main`. The agent should detect this (queue status change) and not panic.
+2. If CI still passes after the restart: no action needed, proceed.
+3. If CI fails after the restart (a genuine breakage from the parallel landing):
+   - AskUserQuestion: "CI failed after a new commit landed on main. Options: [Dequeue and rebase / Create hotfix branch / Escalate]."
+   - If "Create hotfix branch": agent creates `hotfix/<pr-number>-<timestamp>`, cherry-picks the fix, submits as a new PR, and marks it for fast-track in Graphite.
+   - If "Dequeue and rebase": `gt sync` + `gt restack` + re-submit.
+
+**Graphite fast-track**: Mark a single urgent PR for fast-track via Graphite UI/API to move it to queue head while still running full CI and rebase. This is the safe alternative to force-merging outside the queue.
+
+**Anti-pattern**: Pausing the queue to inject a hotfix then resuming is tempting but risky — it serializes all other work. Fast-track is preferred.
+
+### Idempotency and Re-Entry Across Sessions
+
+An agent must be able to restart and answer: "Am I already in the middle of merging this PR?"
+
+**State to persist** (per PR, in a JSONL file):
+```
+pr_id, pr_number, repo, queue_entry_time, speculative_commit_sha,
+last_checked_review_id, conflict_state, idempotency_token,
+hotfix_branch_ref, agent_session_id, state_machine_step
+```
+
+**Idempotency rules**:
+- Before any merge action: check `pull_request.merged` via API. If already merged, mark as complete and exit — do not merge again.
+- Before enqueuing: check `mergeQueueEntry` state via GraphQL. If already queued, skip enqueue call.
+- Before posting a comment: store the comment body hash in state. If already posted (check recent PR timeline), skip.
+- Use `idempotency_token` (UUID generated at session start for this PR) on all Graphite/GitHub API calls that support it.
+
+### Anti-Patterns
+
+| Anti-pattern | Why it breaks queue | Mitigation |
+|---|---|---|
+| Force-push to PR while queued | Invalidates speculative commit SHA, wastes CI | Detect head-ref change for enqueued PRs; dequeue before any force-push |
+| `git commit --amend` after queue entry | Same as force-push — rewrites history | Lock the branch when queued (PreToolUse hook to block amend commands) |
+| `--no-verify` bypass | Skips local hooks, may land code that fails remote CI | PreToolUse hook blocking `--no-verify` on any commit while queued |
+| Running both Graphite queue and GitHub native queue | Out-of-order merges, CI restarts | Disable GitHub native queue when Graphite is active |
+| Merging base branches directly outside Graphite | Causes Graphite to restart CI on all queued commits | Enforce all `main` writes go through Graphite queue |
+| Auto-resolving semantic conflicts | Risk of shipping broken logic | Escalate all non-trivial conflicts to human checkpoint |
+
+---
+
+## 6. Claude Code Integration Patterns
+
+### Existing Plugins (April 2026)
+
+The Claude Code plugin marketplace and community catalog include (as of research date):
+
+- **`composiohq/create-pr`**: Automates branch creation, formatting, commit staging, and PR submission to GitHub.
+- **`code-review` (official Anthropic)**: Runs multiple sub-agents for review scoring, posts comments.
+- **`github-pr-auto-fix-merge` (community)**: Auto-fixes minor issues in PRs and enters merge queues.
+- **`enter-merge-queue` (community skill)**: Skill for queue entry with rebase, CI monitoring, mergeability checking.
+- **`gt-workflow` (user's existing plugin)**: Handles the create/submit side of the Graphite workflow.
+
+**Gap**: No existing plugin handles the full shepherd loop (enqueue → monitor → conflict-detect → hotfix → merge confirmation). This is the gap the `merge-queue` plugin fills.
+
+### Hook Patterns for Merge Operations
+
+**PreToolUse hook** — use to gate dangerous operations:
+```json
+{
+  "matcher": "Bash",
+  "condition": "tool_input.command matches (--no-verify|--force|--force-with-lease)",
+  "action": "block",
+  "message": "[merge-queue] Blocked: force operations not permitted while PR is queued"
+}
+```
+
+**PostToolUse hook** — use for audit logging (cannot undo, only observe):
+```json
+{
+  "matcher": "Bash",
+  "condition": "tool_input.command matches (gh pr merge|gt submit)",
+  "action": "run",
+  "command": "./hooks/scripts/post-merge-audit.sh"
+}
+```
+
+The audit script should log: PR number, commit SHA, actor, timestamp, idempotency token, queue position at time of merge.
+
+**SessionStart hook** — load current PR state from the JSONL state file so the agent can resume mid-session:
+```bash
+# Load state, output {"continue": true, "systemMessage": "Resuming merge shepherd for PR #123 at step: awaiting_ci"}
+```
+
+Critical: SessionStart hooks must output `{"continue": true}` on all code paths. Do not use `set -e` in hook scripts that must emit JSON. See project MEMORY.md for established patterns.
+
+### AskUserQuestion Checkpoints
+
+Per established project patterns, the `Other` button is the only AskUserQuestion button that opens free-text input. Use it for "provide conflict resolution guidance" cases.
+
+**Example merge confirmation checkpoint**:
+```
+AskUserQuestion({
+  question: "Ready to enqueue PR #123 (Stack: feat/auth → feat/auth-tests → feat/auth-docs). CI is green. Merge strategy: squash. Approve?",
+  options: ["Enqueue now", "Review diff first", "Defer — notify me later", "Other"]
+})
+```
+
+**Example conflict checkpoint**:
+```
+AskUserQuestion({
+  question: "PR #123 was ejected from queue due to merge conflict in src/auth/session.ts. How should I proceed?",
+  options: ["Auto-rebase (no conflicts detected on re-check)", "I'll fix manually — notify me when ready", "Abandon merge attempt", "Other"]
+})
+```
+
+### Agent Identity for Queue Operations
+
+- Use a dedicated GitHub App (not a personal token) as the merge actor. GitHub Apps can be granted narrow "Merge queues" read permission + "Pull requests" write permission.
+- The Graphite GitHub App must be listed as an authorized bypass actor in branch protection rules.
+- Signed commits: configure the GitHub App to sign commits. This provides auditability of which commits the agent created vs. human commits.
+- **Minimum GitHub scopes** for the merge-queue plugin's service account:
+  - `repo` (PR read/write, status checks)
+  - `merge-queues:read` (via GitHub App permission, not OAuth scope)
+  - No `admin:org`, no `delete_repo`
+- **Graphite token**: Graphite exposes API tokens per user/org. The exact token scopes are not publicly documented in Graphite's API reference as of April 2026 — **this is a confirmed evidence gap** requiring direct Graphite support consultation.
+
+---
+
+## 7. Plugin Design Recommendations
+
+### State Model
+
+Store per-PR state as a JSONL file at `~/.claude/merge-queue/<repo>/<pr-number>.jsonl` (append-only for audit trail). Each entry is a timestamped state transition:
+
+```jsonl
+{"ts":"2026-04-30T10:00:00Z","event":"enqueue_requested","pr":123,"repo":"org/repo","idempotency_token":"uuid","stack":["#121","#122","#123"],"speculative_sha":null,"step":"awaiting_queue_entry"}
+{"ts":"2026-04-30T10:01:00Z","event":"queued","speculative_sha":"abc123","queue_position":3,"step":"monitoring_ci"}
+{"ts":"2026-04-30T10:15:00Z","event":"ci_pass","speculative_sha":"abc123","step":"awaiting_merge_confirmation"}
+{"ts":"2026-04-30T10:16:00Z","event":"human_approved","actor":"user","step":"merging"}
+{"ts":"2026-04-30T10:17:00Z","event":"merged","merged_sha":"def456","step":"complete"}
+```
+
+### Commands / Agents / Hooks Shape
+
+**Commands:**
+- `/merge-queue:shepherd <PR>` — main entry point; shepherds a PR through the full merge lifecycle
+- `/merge-queue:status <PR>` — check current queue state and agent step for a PR
+- `/merge-queue:dequeue <PR>` — safely dequeue with reason
+- `/merge-queue:hotfix <PR> <description>` — inject a hotfix for a currently-queued PR
+
+**Agents:**
+- `merge-queue-shepherd` — the core agent; owns the state machine (Observing → Validating → HumanCheckpoint → Queued → MonitoringCI → MergeConfirmation → Merging → PostMergeAudit → Complete/Ejected)
+- `merge-queue-conflict-analyzer` — invoked when Graphite ejects for conflict; analyzes the conflict and presents options
+- `merge-queue-review-monitor` — background polling agent; detects new review comments and wakes the shepherd
+
+**Hooks:**
+- PreToolUse: block force-push / `--no-verify` / `gh pr merge --bypass` while any PR is in shepherd state
+- PostToolUse: audit log any `gh pr merge` or `gt submit` call
+- SessionStart: load active shepherd state from JSONL; inject as system message
+
+### Failure-Mode Matrix
+
+| Failure Mode | Detection | Response |
+|---|---|---|
+| Queue ejection (CI failure) | Graphite comment + PR status change | AskUserQuestion → dequeue or fix loop |
+| Queue ejection (conflict) | `mergedAt: null` + closed state + `queue-ejected` label | AskUserQuestion → conflict analyzer agent |
+| New `request changes` mid-queue | Poll PR reviews API, compare `last_seen_review_id` | Immediate dequeue + AskUserQuestion |
+| PR closed externally | Poll PR state; detect `closed` + `mergedAt: null` without agent action | Log + AskUserQuestion: "PR was closed externally. Archive shepherd?" |
+| Force-push by another actor | Poll PR head SHA; detect SHA mismatch vs. `speculative_sha` | Dequeue + notify |
+| CI flake (retry-able) | Graphite bisection report | If isolated PR passes on second run, re-queue (max 3 retries, then human checkpoint) |
+| Graphite queue paused | Graphite UI state | Log + notify; resume when queue unpaused |
+| `main` advanced while queued | CI restart by Graphite | Wait for new CI result; escalate if fails |
+| Agent session crashed mid-merge | SessionStart loads JSONL state | Resume from last recorded step |
+| Double-merge attempt | `pull_request.merged == true` check at start | Exit as no-op; log |
+
+### Permissions Model
+
+| Credential | Required Scopes | Where Stored |
+|---|---|---|
+| GitHub App / PAT | `repo`, `merge-queues` read (App permission) | Claude Code plugin `userConfig` secret |
+| Graphite API token | TBD — consult Graphite support | Claude Code plugin `userConfig` secret |
+| CI webhook secret (if polling) | N/A (polling via GH API) | N/A |
+
+Never echo credential values in logs. Use `plugin.json` `userConfig` for all secrets. Rotate tokens on a schedule; prefer GitHub App installation tokens (short-lived) over long-lived PATs.
+
+### Human Approval Points
+
+| Action | Human Required? | Why |
+|---|---|---|
+| Initial enqueue | Yes (AskUserQuestion) | Irreversible entry into merge pipeline |
+| Trivial rebase (no conflicts) | No | Deterministic, reversible |
+| Conflict resolution (any) | Yes (AskUserQuestion) | Risk of semantic breakage |
+| New `request changes` response | Yes (AskUserQuestion) | Reviewer intent must be respected |
+| Hotfix fast-track injection | Yes (AskUserQuestion) | Queue reordering affects all PRs |
+| Final merge (after CI green) | Yes (AskUserQuestion) — recommended | Irreversible; policy decision |
+| Post-merge audit log | No | Observation only |
+
+### MVP vs. Follow-Up
+
+**MVP (v1)**:
+- `/merge-queue:shepherd` command with the core state machine
+- AskUserQuestion at enqueue + merge confirmation
+- Ejection detection (poll PR state + Graphite comment)
+- JSONL state file for idempotency
+- PreToolUse hook blocking force-push while queued
+- PostToolUse hook for audit logging
+
+**Follow-up (v2)**:
+- Background review monitor (continuous polling or webhook-driven)
+- Conflict analyzer agent with auto-suggest (but not auto-apply)
+- Hotfix injection command
+- Stack-aware enqueue (enqueue whole stack, not single PR)
+- CI flake detection with auto-retry (bounded)
+- Graphite queue pause/resume integration
+- Metrics: time-in-queue, CI pass rate, conflict rate per PR
+
+---
+
+## 8. Open Questions / Decisions for the User
+
+1. **Graphite API token scopes**: Graphite's API token reference is not publicly documented at the level of detail needed. You must consult Graphite support or the developer portal to confirm which token type (user token vs. org token vs. service account token) is required for programmatic queue management, and whether enqueue/dequeue can be done via API without dashboard interaction.
+
+2. **Graphite webhook events**: Graphite's internal event/webhook schema is not publicly indexed. Confirm whether Graphite emits webhooks your plugin can subscribe to (e.g., "PR ejected," "queue position changed," "batch merged"), or whether the plugin must poll the Graphite API and GitHub PR state as a proxy.
+
+3. **Merge confirmation: required or optional?**: Should the agent always require an explicit human "merge now" confirmation after CI passes, or is CI-green sufficient for auto-merge? This is a policy decision only the user can make. The research suggests requiring human confirmation (every major agent platform does), but the user may want to allow auto-merge for trusted stacks.
+
+4. **What is "the actor" for merge operations?**: Should the agent merge PRs as a GitHub App (bot identity), as the PR author (impersonated via token), or as a human-approved service account? Graphite's merges are currently attributed to the Graphite App. Your plugin's merges should have a clear, auditable actor identity. Decide before implementing.
+
+5. **Conflict resolution boundary**: How far should the agent go before escalating? Recommended: agent suggests a resolution, human approves it, agent applies it. But you may want the agent to auto-apply trivial conflicts (import order, whitespace) without human approval. Define the threshold explicitly.
+
+6. **Session persistence mechanism**: Where is the JSONL state file stored? Per-project (in `.claude/merge-queue/` in the repo), per-user (in `~/.claude/merge-queue/`), or in an external store? Per-project is observable and version-controllable. Per-user is simpler for single-user setups. Choose one.
+
+7. **gt-workflow plugin integration**: Your existing `gt-workflow` plugin handles the create/submit side. Does `merge-queue` depend on `gt-workflow` being installed? Should it? Clarify the dependency boundary: `gt-workflow` owns branch creation and PR submission; `merge-queue` owns queue entry through merge. Ensure they don't double-register hooks for the same tool calls.
+
+8. **Stack vs. single-PR scope**: MVP for single PRs only? Or must it handle stacks natively from day one? Stacks are more complex (all ancestors must be enqueued, dequeue of one affects all upstack PRs). Given Graphite's stack-first model, punting stack support to v2 may leave significant functionality gaps.
+
+---
+
+## 9. Sources
+
+- [Graphite Merge Queue Docs](https://graphite.dev/docs/graphite-merge-queue) — core queue lifecycle, stack-aware behavior, lazy rebase
+- [Graphite Merge Pull Requests](https://graphite.dev/docs/merge-pull-requests) — fast-track, pause, manual merge, `gt sync`
+- [Graphite Merge Queue Batching Blog](https://graphite.dev/blog/merge-queue-batching) — draft PR / fast-forward merge model
+- [Graphite Merge Queue Optimizations](https://graphite.dev/docs/merge-queue-optimizations) — parallel CI isolation, bisection
+- [Graphite Stacking and CI](https://graphite.dev/docs/stacking-and-ci) — CI optimizer step, up-stack CI gotchas
+- [Graphite GitHub Configuration Guidelines](https://graphite.dev/docs/github-configuration-guidelines) — branch protection, bypass actors, incompatibility with GitHub native queue
+- [Graphite Command Reference](https://graphite-58cc94ce.mintlify.dev/docs/command-reference.md) — `gt create`, `gt modify`, `gt submit`, `gt restack`, `gt sync`, `gt absorb`
+- [GitHub — Managing a Merge Queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) — grouping strategy, `max_entries_to_build`, `ALLGREEN`/`HEADGREEN`
+- [GitHub — Merging with a Merge Queue](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request-with-a-merge-queue) — FIFO ordering, enqueue mechanics
+- [GitHub — Auto-merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request) — single-PR semantics, write-access requirement
+- [GitHub — Webhook Events and Payloads](https://docs.github.com/en/webhooks/webhook-events-and-payloads) — `merge_group` event schema, `pull_request.dequeued`
+- [GitHub Changelog — merge_group GA (July 2023)](https://github.blog/changelog/2023-07-12-pull-request-merge-queue-is-now-generally-available/) — `destroyed` action, `pull_request.dequeued`, GraphQL mutations
+- [GitHub Changelog — merge_group beta API (April 2023)](https://github.blog/changelog/2023-04-19-pull-request-merge-queue-public-beta-api-support-and-recent-fixes/) — `enqueuePullRequest`, `dequeuePullRequest`, `mergeQueueEntry`
+- [GitHub Changelog — merge_group webhook event (August 2022)](https://github.blog/changelog/2022-08-18-merge-group-webhook-event-and-github-actions-workflow-trigger/) — original `checks_requested` action, Actions trigger
+- [MagicBell — merge_group payload sample](https://magicbell.com/workflows/github/merge-group-checks-requested) — community-confirmed payload shape
+- [GitHub Docs — Events that trigger workflows](https://docs.github.com/actions/using-workflows/events-that-trigger-workflows) — `merge_group` Actions trigger
+- [GitHub Docs — Branch Protection Rules](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule) — bypass actors, push restrictions
+- [Claude Code — GitHub Actions](https://code.claude.com/docs/en/github-actions) — `@claude` integration, automation mode, `CLAUDE.md`
+- [Claude Code — Routines](https://code.claude.com/docs/en/routines) — `merge_queue` trigger support, HTTP endpoints
+- [Devin — Review](https://docs.devin.ai/work-with-devin/devin-review) — human-in-the-loop merge controls
+- [Mergify — Merge Queue Rules](https://docs.mergify.com/merge-queue/rules/) — grouping strategy, impersonation, retry patterns
+- [Mergify — Batches](https://docs.mergify.com/merge-queue/batches/) — batch failure isolation patterns
+- [Trunk.io — Introduction to Merge Queues](https://trunk.io/learn/introduction-to-merge-queues-what-you-need-to-know) — industry survey, Shopify Shipit pattern
+- [Trunk.io Blog — Wrong commit regression](https://trunk.io/blog/what-happens-if-a-merge-queue-builds-on-the-wrong-commit) — speculative commit anchoring incident
+- [joshcannon.me — gh-mq branches unprotectable](https://joshcannon.me/2025/07/03/gh-mq-branches-unprotectable.html) — queue branch protection gap
+- [AWS — Idempotency best practices](https://docs.aws.amazon.com/durable-execution/patterns/best-practices/idempotency/) — idempotency token patterns
+- [Buildkite — GitHub Merge Queue](https://buildkite.com/docs/pipelines/tutorials/github-merge-queue) — CI integration patterns for queue branches
+- [LLVM Discourse — Graphite Merge Queue RFC](https://discourse.llvm.org/t/rfc-enabling-graphite-merge-queue-to-resolve-infinite-loops-while-merging-stacked-prs/88769) — out-of-band merge causing Graphite CI restarts
+- [GitHub community — head_ref format instability](https://github.com/orgs/community/discussions/62219) — do not parse `head_ref` for PR number
+- [merge-queue.academy](https://merge-queue.academy/introduction/how-merge-queues-work/) — canonical merge queue model reference
+
+**Skipped sources (unavailable):**
+- `mcp__plugin_yellow-research_ceramic__ceramic_search` — unavailable (not in deferred tool registry)
+- `mcp__plugin_yellow-research_parallel__createDeepResearch` — unavailable (not in deferred tool registry)
+- `mcp__plugin_yellow-research_perplexity__perplexity_research` — quota exhausted (401 Unauthorized)

--- a/docs/solutions/code-quality/graphite-merge-queue-agent-anti-patterns.md
+++ b/docs/solutions/code-quality/graphite-merge-queue-agent-anti-patterns.md
@@ -1,0 +1,135 @@
+---
+title: 'Anti-patterns and idempotency primitives for Graphite merge queue agents'
+date: 2026-04-30
+category: code-quality
+track: knowledge
+problem: Agents interacting with Graphite merge queue have several failure modes — in-queue conflict resolution, force-push while queued, and missing idempotency checks — that silently waste CI or corrupt queue state
+tags: [graphite, merge-queue, idempotency, force-push, conflict-resolution, hooks, jsonl, agent-patterns]
+components: [merge-queue, gt-workflow, github-actions]
+---
+
+## Context
+
+Building a Claude Code plugin that shepherds PRs through Graphite Merge Queue involves several non-obvious failure modes. The patterns below are drawn from the April 2026 research synthesis covering Graphite's documented behavior, GitHub's queue API semantics, and industry agent patterns. They fall into two categories: things that break the queue when an agent does them, and primitives needed for safe multi-session idempotency.
+
+## Anti-Patterns
+
+### Anti-pattern 1: Resolving conflicts while the PR is in the queue
+
+**What goes wrong**: An agent detects a merge conflict on a queued PR and attempts to resolve it by pushing a fix to the PR branch while the speculative build is running.
+
+**Why it breaks**: Graphite's conflict handling model is eject-first. When Graphite detects a conflict it cannot lazy-rebase around, it ejects the PR from the queue, annotates it with a `queue-ejected` label and a comment, and marks it closed with `mergedAt: null`. The agent is not inside the queue working on a live PR — the queue slot no longer exists by the time the agent acts.
+
+Pushing a conflict fix to a queued branch also invalidates the speculative commit SHA (see Anti-pattern 2 below), forcing Graphite to restart CI even if the conflict could have been avoided.
+
+**The correct model**: Conflict resolution belongs *before* queue entry or *after* ejection, never during. The canonical 5-step loop for an agent handling an ejected-with-conflict PR:
+
+1. Apply the conflict fix locally.
+2. Run the full test suite against the fixed state.
+3. Present the fix to the human via `AskUserQuestion` for approval.
+4. On approval: force-push the branch (outside queue — the PR was already ejected).
+5. Re-enter the Graphite queue (`gt submit --merge-queue` or via Graphite dashboard).
+
+Steps 1–2 may be agent-autonomous for trivial conflicts (lock files, import order, auto-generated files). Step 3 is always required for any conflict touching business logic, tests, or security-sensitive code.
+
+### Anti-pattern 2: Force-pushing or amending while queued
+
+**What goes wrong**: The agent runs `git commit --amend`, `git push --force`, or `gt modify` on a branch that currently has a live speculative build in the Graphite queue.
+
+**Why it breaks**: Graphite's speculative build is anchored to a specific commit SHA (`speculative_sha`) at the moment of enqueue. Rewriting the branch history produces a new head SHA that no longer matches the speculative commit. Graphite detects the mismatch and restarts CI from scratch, wasting the CI time already consumed. In some cases Graphite may also eject the PR and require manual re-enqueue.
+
+**Mitigation**: Use a PreToolUse hook to detect and block force operations on branches that are currently in shepherd state.
+
+```json
+{
+  "matcher": "Bash",
+  "condition": "tool_input.command matches (--force|--force-with-lease|--amend|--no-verify)",
+  "action": "block",
+  "message": "[merge-queue] Blocked: history-rewriting operations not permitted while PR is queued. Dequeue first."
+}
+```
+
+The hook script should cross-reference the command's target branch against the JSONL state file to confirm a shepherd session is active for that PR before blocking. Blocking unconditionally will interfere with unrelated branches.
+
+### Anti-pattern 3: Running both Graphite queue and GitHub native queue
+
+Documented in full in `docs/solutions/integration-issues/graphite-github-native-queue-incompatibility.md`. Summary: the two systems must not run simultaneously on the same branch. An agent configuring merge queue behavior must check which system is active before making any changes to branch protection rules.
+
+### Anti-pattern 4: Treating `mergedAt: null` on a closed PR as "not merged"
+
+Documented in full in `docs/solutions/integration-issues/merge-queue-closed-pr-null-mergedat-detection.md`. Summary: three distinct paths produce `mergedAt: null` + closed state; use `pull_request.merged` (boolean) as the authoritative signal, not `mergedAt`.
+
+## Idempotency Primitives
+
+A merge shepherd agent must be able to restart (session crash, user interrupt, token expiry) and correctly answer: "Am I already in the middle of merging this PR? Has it already merged?"
+
+### JSONL state file shape
+
+Store per-PR state as an append-only JSONL file at a consistent path (e.g., `~/.claude/merge-queue/<repo-slug>/<pr-number>.jsonl`). Append-only preserves audit history across restarts. Each line is a timestamped state transition:
+
+```jsonl
+{"ts":"2026-04-30T10:00:00Z","event":"enqueue_requested","pr":123,"repo":"org/repo","idempotency_token":"<uuid>","stack":["#121","#122","#123"],"speculative_sha":null,"step":"awaiting_queue_entry"}
+{"ts":"2026-04-30T10:01:00Z","event":"queued","speculative_sha":"abc123","queue_position":3,"step":"monitoring_ci"}
+{"ts":"2026-04-30T10:15:00Z","event":"ci_pass","speculative_sha":"abc123","step":"awaiting_merge_confirmation"}
+{"ts":"2026-04-30T10:16:00Z","event":"human_approved","actor":"user","step":"merging"}
+{"ts":"2026-04-30T10:17:00Z","event":"merged","merged_sha":"def456","step":"complete"}
+```
+
+**Required fields per entry**: `ts`, `event`, `pr`, `repo`, `idempotency_token`, `step`.
+
+**Optional fields**: `speculative_sha` (null until Graphite confirms queue entry), `queue_position`, `stack`, `hotfix_branch_ref`, `agent_session_id`, `last_checked_review_id`, `conflict_state`.
+
+On SessionStart, the hook reads the latest entry for any active PR and injects the `step` as a system message so the agent resumes from the correct state rather than starting over.
+
+### The four idempotency rules
+
+**Rule 1 — Check `pull_request.merged` before any merge action.**
+
+Before enqueuing, before posting merge confirmation, before any `gh pr merge` or `gt submit --merge-queue` call:
+
+```bash
+MERGED=$(gh api repos/{owner}/{repo}/pulls/{number} --jq '.merged')
+if [ "$MERGED" = "true" ]; then
+  printf '[merge-queue] PR #%s already merged. Exiting as no-op.\n' "$PR_NUMBER" >&2
+  exit 0
+fi
+```
+
+**Rule 2 — Check `mergeQueueEntry` before enqueuing.**
+
+If the agent restarts after recording `event: enqueue_requested` but before receiving confirmation, the PR may already be in the queue. Before calling `gt submit --merge-queue`, query GraphQL for `mergeQueueEntry` state. If state is `QUEUED` or `AWAITING_CHECKS`, skip the enqueue call and proceed to monitoring.
+
+**Rule 3 — Deduplicate comment posts.**
+
+Before posting a status comment to the PR timeline, store a hash of the comment body in the JSONL state file. On restart, check recent PR timeline comments via `gh api repos/{owner}/{repo}/issues/{number}/comments` and compare. If the comment is already present, skip.
+
+**Rule 4 — Use an idempotency token on API calls.**
+
+Generate a UUID at session start for each PR being shepherded. Pass this token on all Graphite and GitHub API calls that support idempotency keys. Store it in the JSONL state file under `idempotency_token`. On restart, reuse the same token — do not generate a new one for an already-started session.
+
+### Speculative SHA tracking
+
+Record `speculative_sha` as soon as Graphite confirms the PR is in the queue. On every polling cycle while monitoring CI, compare the current PR head SHA against the recorded `speculative_sha`. If they diverge (another actor pushed to the branch), the speculative build is invalidated. The agent should:
+
+1. Log the SHA mismatch.
+2. Dequeue the PR (to avoid CI waste on an invalid speculative build).
+3. `AskUserQuestion`: "The PR branch was modified by another actor while queued. Speculative build is invalid. Options: [Re-enqueue with new head / Dequeue and wait for manual action / Other]."
+
+## Why This Matters
+
+Merge queue operations are among the most consequential things an agent can do — they directly affect what lands on trunk. A missed idempotency check produces double-merges. An in-queue force-push wastes CI on a project that may have long build times. An agent that silently bypasses these patterns is more dangerous than no automation at all.
+
+## When to Apply
+
+- When implementing the core state machine of a merge shepherd agent
+- When writing PreToolUse hooks that gate force operations
+- When designing the JSONL state file format for any merge-related plugin
+- When writing SessionStart hooks that must resume a shepherd session after a crash
+- When reviewing any agent command that calls `gh pr merge`, `gt submit`, or `git push --force`
+
+## Related
+
+- `docs/solutions/integration-issues/graphite-github-native-queue-incompatibility.md`
+- `docs/solutions/integration-issues/merge-queue-closed-pr-null-mergedat-detection.md`
+- `docs/solutions/code-quality/hook-set-e-and-json-exit-pattern.md` — SessionStart hook requirements (`{"continue": true}` on all paths, no `set -e`)
+- `docs/solutions/code-quality/posttooluse-hook-input-schema-field-paths.md` — hook input field paths for PreToolUse/PostToolUse

--- a/docs/solutions/integration-issues/graphite-github-native-queue-incompatibility.md
+++ b/docs/solutions/integration-issues/graphite-github-native-queue-incompatibility.md
@@ -1,0 +1,116 @@
+---
+title: 'Graphite Merge Queue and GitHub Native Merge Queue are mutually exclusive'
+date: 2026-04-30
+category: integration-issues
+track: knowledge
+problem: Enabling both Graphite Merge Queue and GitHub native merge queue on the same branch causes out-of-order merges, redundant CI restarts, and undefined queue behavior
+tags: [graphite, merge-queue, github, branch-protection, ci, stack, incompatibility]
+components: [merge-queue, gt-workflow, github-actions]
+---
+
+## Context
+
+Graphite Merge Queue and GitHub's native merge queue are two distinct systems that each manage how PRs are combined and validated before landing on trunk. They appear superficially similar — both create speculative commits, both run CI before merge — but their internal models are incompatible at the architectural level.
+
+Graphite explicitly documents this: the two systems must not run simultaneously on the same branch. The consequence of running both is undefined merge ordering, double CI restarts, and queue state corruption across the two systems.
+
+This is a **deployment-time configuration decision**, not a code change. It must be made before configuring branch protection rules. An agent helping to configure a repository's merge strategy must check which system is active before making any changes.
+
+## Guidance
+
+### The core incompatibility
+
+Graphite's model and GitHub's native model differ on the unit of work:
+
+| Dimension | Graphite Merge Queue | GitHub Native Merge Queue |
+|---|---|---|
+| Unit of work | Stack of dependent PRs (all ancestors enqueued atomically) | Individual PRs |
+| Stack awareness | First-class — speculative build covers full stack combined diff | None — each PR's speculative commit is independent |
+| Bisection on batch failure | Yes — automated, isolates failing PR, re-queues passing set | No — ejects head entry only |
+| Conflict handling | Lazy rebase (only conflicted PRs) + eject | Eject |
+| CI skip optimization | Graphite CI optimizer step for upstack branches | `merge_group` trigger per workflow |
+| API surface | REST under `/merge-queue` namespace (Graphite docs) | GraphQL (`enqueuePullRequest`, `dequeuePullRequest`, `mergeQueueEntry`) + webhooks |
+
+When both are enabled on the same branch, each system independently creates speculative commits (`gh-readonly-queue/*` branches for GitHub, Graphite draft PRs for Graphite). CI runs against both. Merge ordering is not coordinated. If both attempt to fast-forward trunk at the same time, the second write triggers a CI restart on all remaining queued commits in the other system. The practical result is an unstable queue that thrashes CI.
+
+### How to verify which system is active
+
+Check branch protection for `main` (or whichever trunk branch is protected):
+
+```bash
+gh api repos/{owner}/{repo}/branches/main/protection --jq '{
+  merge_queue_enabled: .required_pull_request_reviews | has("merge_queue"),
+  required_checks: .required_status_checks.checks[].context
+}'
+```
+
+Look for Graphite indicators:
+```bash
+# Graphite GitHub App installed?
+gh api repos/{owner}/{repo}/installations --jq '.[].app_slug' | grep -i graphite
+
+# Graphite bypass actor in branch protection?
+gh api repos/{owner}/{repo}/branches/main/protection \
+  --jq '.restrictions.apps[].slug' | grep -i graphite
+```
+
+If the Graphite GitHub App appears as a bypass actor in branch protection, Graphite Merge Queue is the authoritative queue. GitHub's native queue must be disabled.
+
+### Disabling GitHub native merge queue when using Graphite
+
+GitHub's native merge queue is enabled per branch protection rule. To disable it while keeping other protections intact, edit the branch protection rule in the GitHub UI (Settings → Branches → edit rule for `main`) and uncheck "Require merge queue." Do not remove other status check requirements — Graphite still depends on them.
+
+Graphite requires its GitHub App to be listed as an authorized bypass actor in the same branch protection rule. Without this, Graphite cannot fast-forward trunk and merges will stall.
+
+### What "out-of-band merge on main" means for Graphite
+
+If any commit lands on `main` *outside* Graphite while PRs are queued (e.g., a direct push, a GitHub-native queue merge, or a hotfix bypassing Graphite), Graphite restarts CI on all currently-queued speculative commits against the new base. This is documented Graphite behavior — it is not an error, but it serializes all queued work and wastes CI time. The mitigation is to route all `main` writes through Graphite queue, enforce this via branch protection's push restrictions, and grant bypass only to the Graphite GitHub App.
+
+### Graphite CI optimizer: the upstack CI gotcha
+
+When branch protection requires CI on all base branches, Graphite upstack branches can stall with "missing required CI" errors. The fix is to add the Graphite CI optimizer step to GitHub Actions workflows. This step uses a Graphite token to conditionally skip CI on upstack branches that haven't changed relative to the speculative build.
+
+```yaml
+# In .github/workflows/ci.yml
+- name: Graphite CI optimizer
+  uses: withgraphite/graphite-ci-action@main
+  with:
+    graphite_token: ${{ secrets.GRAPHITE_TOKEN }}
+```
+
+Without this step, upstack PRs in a stack will perpetually show required checks as pending even after their speculative build passes.
+
+**Known Graphite limitation**: GitHub deployment checks in branch protection rules are not supported by Graphite Merge Queue as of April 2026. Do not require deployment checks on a branch where Graphite is the active queue.
+
+## Why This Matters
+
+An agent configuring merge queue behavior for a repository must make this choice explicitly before touching branch protection rules. Getting it wrong means CI instability that is hard to attribute to a misconfiguration (the symptoms — CI restarts, queue thrashing, out-of-order merges — look like flaky CI rather than a configuration conflict).
+
+## When to Apply
+
+- Before configuring any merge queue integration on a new repository
+- When migrating from GitHub native queue to Graphite (or vice versa)
+- When diagnosing unexplained CI restarts on queued PRs
+- When setting up the `merge-queue` plugin for a repository that may already have one system partially configured
+
+## Examples
+
+**Scenario: Migrating from GitHub native queue to Graphite**
+
+1. Confirm the Graphite GitHub App is installed on the repository.
+2. Edit branch protection for `main`: remove "Require merge queue" (disables GitHub native queue).
+3. Add Graphite GitHub App as a bypass actor in the same rule.
+4. Add the Graphite CI optimizer step to CI workflows.
+5. Verify: enqueue one PR via Graphite dashboard; confirm the `gh-readonly-queue/*` branches are NOT created (they would be if GitHub native queue were still active).
+
+**Scenario: Diagnosing CI restart loops**
+
+Symptom: queued PRs repeatedly show CI restarting with base SHA changes, even when `main` hasn't had human-authored commits.
+
+Diagnosis:
+```bash
+# Check for gh-readonly-queue/* branches being created
+gh api repos/{owner}/{repo}/branches --jq '.[].name' | grep gh-readonly-queue
+```
+
+If these branches appear while Graphite is configured, both queues are running. Disable the native queue.

--- a/docs/solutions/integration-issues/merge-queue-closed-pr-null-mergedat-detection.md
+++ b/docs/solutions/integration-issues/merge-queue-closed-pr-null-mergedat-detection.md
@@ -1,0 +1,128 @@
+---
+title: 'Detecting true merge vs. ejection when a PR is closed with mergedAt: null'
+date: 2026-04-30
+category: integration-issues
+track: knowledge
+problem: A PR closed by a merge queue with mergedAt null may have been ejected, not merged — three distinct paths produce this state and require different agent responses
+tags: [merge-queue, graphite, github, webhook, mergedat, ejection, graphql, idempotency]
+components: [merge-queue, github-actions, gt-workflow]
+---
+
+## Context
+
+The project MEMORY.md has carried a one-line observation since an earlier session: "closed PRs with `mergedAt: null` may still be merged." The April 2026 research on Graphite and GitHub native merge queues confirms and explains this observation, adding three distinct causal paths and a reliable detection pattern.
+
+The failure mode for an agent: a PR is closed, `mergedAt` is null, and the agent concludes "this PR was not merged." That conclusion is wrong in some paths (the PR may have been merged via queue with a delay in GitHub's state propagation) and correct in others (the PR was genuinely ejected). Treating ejection as merge, or merge as ejection, produces double-merge attempts or abandoned PRs that were actually shipped.
+
+## The Three Paths
+
+### Path 1: Queue ejection (most common)
+
+**What happens**: PR fails CI during speculative build, or has a merge conflict that lazy rebase cannot auto-resolve. Graphite (or GitHub native queue) ejects the PR.
+
+**Observable state on GitHub**:
+- PR status: closed (or open-but-dequeued, depending on Graphite version)
+- `mergedAt`: null
+- `merged`: false
+- Graphite adds a `queue-ejected` label and a PR comment describing the reason
+- `pull_request.dequeued` webhook fires (GitHub native queue)
+
+**What the agent must do**: Treat as NOT merged. Author must resolve the conflict or fix CI, then re-enter the queue.
+
+### Path 2: `merge_group.destroyed` without merge
+
+**What happens**: GitHub creates a temporary `gh-readonly-queue/<base>/pr-<number>-<hash>` branch for the speculative build. The merge group lifecycle ends before merge (invalidated due to a new commit on `main`, a CI timeout, or manual dequeue).
+
+**Observable state**:
+- `merge_group` webhook fires with `action: destroyed`
+- PR is not merged; `mergedAt`: null
+- The `gh-readonly-queue/*` branch is deleted
+
+**What the agent must do**: `merge_group.destroyed` alone is not a signal of PR ejection — it is a signal that a specific speculative build attempt ended. The PR may still be in the queue under a new speculative build. Do not dequeue or mark as failed based on `merge_group.destroyed` alone. Correlate with PR state.
+
+### Path 3: Timeline noise from queue branches
+
+**What happens**: The `gh-readonly-queue/*` branch commits appear in the PR's commit timeline. These look like merge activity but are not actual merges of the PR.
+
+**Observable state**:
+- PR timeline shows commits referencing `gh-readonly-queue/*` refs
+- PR status may be open
+- `mergedAt`: null (correctly — the PR has not merged yet)
+
+**What the agent must do**: Ignore timeline activity on `gh-readonly-queue/*` branches entirely as a merge signal. These are speculative build artifacts.
+
+## Detection Pattern
+
+Never use `mergedAt` alone, `merge_group` events alone, or timeline activity alone as ground truth for merge status.
+
+**The reliable detection stack (in order of authority):**
+
+1. **`pull_request.merged` (boolean)** — the authoritative merge flag on the PR object. If `true`, the PR merged. If `false`, it did not, regardless of what `mergedAt` says.
+
+2. **GraphQL `mergeQueueEntry` state** — for current queue position. Use this to determine if the PR is still queued (not yet resolved), was ejected, or was merged.
+
+```graphql
+query GetMergeQueueEntry($owner: String!, $repo: String!, $prNumber: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $prNumber) {
+      merged
+      mergedAt
+      state
+      mergeQueueEntry {
+        state
+        position
+        enqueuedAt
+      }
+    }
+  }
+}
+```
+
+`mergeQueueEntry` states: `AWAITING_CHECKS`, `MERGEABLE`, `UNMERGEABLE`, `QUEUED`. A null `mergeQueueEntry` on a closed PR means the PR is no longer in the queue (either merged or ejected — disambiguate via `merged`).
+
+3. **Graphite-specific signals** (when using Graphite Merge Queue):
+   - `queue-ejected` label on the PR: ejected, not merged
+   - Graphite comment on the PR explaining ejection reason
+   - These are present only when Graphite performed the ejection
+
+4. **Webhook subscription** — subscribe to both `pull_request.dequeued` (ejection from GitHub native queue) and `merge_group.destroyed` (speculative build invalidated) for ejection detection. Do not rely on either alone.
+
+**Decision table for a closed PR:**
+
+| `merged` field | `mergedAt` | `mergeQueueEntry` | `queue-ejected` label | Conclusion |
+|---|---|---|---|---|
+| `true` | non-null timestamp | null (no longer queued) | absent | Merged — mark complete |
+| `true` | null (rare, propagation lag) | null | absent | Merged — verify with `merged` field, not `mergedAt` |
+| `false` | null | null | present | Ejected by Graphite — requires author action |
+| `false` | null | null | absent | Ejected by GitHub native queue, or closed externally — check `pull_request.dequeued` webhook history |
+| `false` | null | `UNMERGEABLE` | either | Currently blocked in queue — not yet resolved |
+
+## Idempotency Rule
+
+**Before any merge action** in an agent: call the GitHub API and check `pull_request.merged`. If `true`, log and exit as a no-op. Never attempt to merge an already-merged PR.
+
+```bash
+MERGED=$(gh api repos/{owner}/{repo}/pulls/{number} --jq '.merged')
+if [ "$MERGED" = "true" ]; then
+  printf '[merge-queue] PR #%s already merged. No action taken.\n' "$PR_NUMBER" >&2
+  exit 0
+fi
+```
+
+This check must run before enqueuing, before posting merge confirmation, and before any `gh pr merge` or `gt submit --merge-queue` call. It guards against double-merge in multi-session or restart scenarios.
+
+## Why This Matters
+
+Agents monitoring merge queues are stateful across sessions. A session crash between "enqueue requested" and "merge confirmed" leaves the agent uncertain about final state on restart. `mergedAt: null` on a closed PR is the exact ambiguous state that restoring agents encounter. Without the 3-path model and the `pull_request.merged` anchor, agents either skip cleanup of already-merged PRs or retry merges that already landed.
+
+## When to Apply
+
+- When building any agent that interacts with GitHub or Graphite merge queues
+- When writing SessionStart hooks that reload merge state from a JSONL file
+- When implementing ejection detection logic in a merge shepherd command
+- When diagnosing why an agent treated a merged PR as ejected (or vice versa)
+
+## Related
+
+- `docs/solutions/integration-issues/graphite-github-native-queue-incompatibility.md` — architectural context for why Graphite and GitHub native queues produce different ejection signals
+- `docs/solutions/code-quality/graphite-merge-queue-agent-anti-patterns.md` — idempotency primitives and state persistence patterns

--- a/plans/gt-workflow-merge-queue-improvements.md
+++ b/plans/gt-workflow-merge-queue-improvements.md
@@ -29,10 +29,10 @@ This is an imperfect signal — a stale/unused queue config could still register
 
 ### Change 2 — `gt-cleanup` closed-not-merged guard
 
-Add `mergedAt` and `merged` to the existing `gh pr list --json` call (so the call requests `state,mergedAt,merged`). Tag any branch in the Closed PR category whose closed PRs include any with `merged: false` as `closed-not-merged`. The authoritative signal is the `merged` boolean (`pull_request.merged`), not `mergedAt`: GitHub's REST API has a known propagation lag where a freshly-merged PR can transiently show `mergedAt: null` while `merged: true`. Gating on `merged == false` eliminates that false-positive window. Surface the result in two places:
+Add `mergedAt` to the existing `gh pr list --json` call (so the call requests `state,mergedAt`). Tag any branch in the Closed PR category whose PR set includes any with `state == "CLOSED"` as `closed-not-merged`. `gh pr list --json` (GraphQL-backed) represents merged PRs with `state == "MERGED"` and closed-without-merging PRs with `state == "CLOSED"`, so the state enum alone is unambiguous — no `merged` boolean check is needed. The propagation-lag concern documented in `merge-queue-closed-pr-null-mergedat-detection.md` applies to per-PR REST calls (`gh api repos/.../pulls/{number}`) where `merged: bool` is exposed; `gh pr list --json` does not accept a `merged` field at all (valid fields include `state`, `mergedAt`, `mergedBy`, `mergeCommit`, `closed`, `closedAt`, but not a standalone `merged`). `mergedAt` is requested for display use (timestamp shown in per-branch detail), not for classification. Surface the result in two places:
 
 <!-- deepen-plan: codebase -->
-> **Codebase:** The `--json state,mergedAt` pattern is already established in `plugins/yellow-core/commands/worktree/cleanup.md` and `plugins/yellow-linear/commands/linear/sync-all.md`. Change 2 extends that pattern by also requesting `merged` and using it as the authoritative signal — see `docs/solutions/integration-issues/merge-queue-closed-pr-null-mergedat-detection.md` for the propagation-lag rationale.
+> **Codebase:** The `--json state,mergedAt` pattern is already established in `plugins/yellow-core/commands/worktree/cleanup.md` and `plugins/yellow-linear/commands/linear/sync-all.md`. Change 2 follows existing conventions exactly — no new pattern is being introduced here.
 <!-- /deepen-plan -->
 
 - **"Delete all" mode:** prepend the existing data-loss warning with a count line: "N of these branches had PRs closed without merging (may be queue-ejected, abandoned, or cancelled)."
@@ -58,8 +58,8 @@ No `queue-ejected` label reading. No new API calls. One extra JSON field in an e
 
 ### Phase 2: gt-cleanup closed-not-merged guard
 
-- [ ] **2.1** Update the `gh pr list` invocation in Phase 2.4 of `plugins/gt-workflow/commands/gt-cleanup.md` (line 180-182): change `--json state` to `--json state,mergedAt,merged`. Both fields are needed: `mergedAt` for surfacing the timestamp where useful, and `merged` (boolean) as the authoritative signal that survives REST propagation lag.
-- [ ] **2.2** Update the parse-and-classify logic in Phase 2.4 with a concrete jq pipeline (so the LLM-as-runtime does not infer the parse): when classifying as "Closed PR" candidate (all PRs `CLOSED` or `MERGED`), additionally check whether any `state == CLOSED` PR has `merged: false`. If so, set a `closed_not_merged=true` flag on the branch. Also explicitly exclude `[gone]`-tracked branches from the PR Status Lookups gate so the tag does not fire on branches already routed to `/gt-sync`.
+- [ ] **2.1** Update the `gh pr list` invocation in Phase 2.4 of `plugins/gt-workflow/commands/gt-cleanup.md` (line 180-182): change `--json state` to `--json state,mergedAt`. `mergedAt` is for display only (timestamp shown in per-branch detail). `gh pr list --json` does not accept a `merged` field, so classification relies on the `state` enum directly.
+- [ ] **2.2** Update the parse-and-classify logic in Phase 2.4 with a concrete jq pipeline (so the LLM-as-runtime does not infer the parse): when classifying as "Closed PR" candidate (all PRs `CLOSED` or `MERGED`), additionally check whether any PR has `state == "CLOSED"` (since `gh pr list` represents merged PRs as `state == "MERGED"`, `CLOSED` alone is the closed-without-merging signal). If so, set a `closed_not_merged=true` flag on the branch. Also explicitly exclude `[gone]`-tracked branches from the PR Status Lookups gate so the tag does not fire on branches already routed to `/gt-sync`.
 - [ ] **2.3** Update Phase 4 "Delete all" path for the Closed PR category: if any branches have `closed_not_merged=true`, prepend the existing data-loss warning block with: `N of these branches had PRs closed without merging (may be queue-ejected, abandoned, or cancelled). Verify before proceeding.`
 - [ ] **2.4** Update Phase 4 "Review individually" path: for each `closed_not_merged=true` branch, add a `PR status: closed (no merge — verify before deleting)` line to the per-branch detail block (between the existing "Unique commits" and "Age" lines).
 
@@ -140,8 +140,8 @@ Note the `--jq '.data.repository.mergeQueue.url // empty'` filter: returns the U
 
 - **`gh api graphql` returns malformed JSON or partial data:** the `--jq` filter falls through to empty string, treated as "not configured." Acceptable — fail-open is the documented stance.
 - **Repo has merge queue configured but it's stale/unused:** WARNING fires anyway. The text says "may produce" not "will produce" — acceptable false-positive given the disable link is one click.
-- **Branch has a closed PR with `merged: false` but the user genuinely wants to delete (e.g., they ran an experiment):** the warning is informational. Existing AskUserQuestion gives them the choice. No new blocking step.
-- **Multiple PRs per branch (rare but possible):** the classification rule is "any closed PR with `merged: false`" — a single non-merged close is enough to flag. Conservative.
+- **Branch has a PR with `state == "CLOSED"` but the user genuinely wants to delete (e.g., they ran an experiment):** the warning is informational. Existing AskUserQuestion gives them the choice. No new blocking step.
+- **Multiple PRs per branch (rare but possible):** the classification rule is "any PR with `state == "CLOSED"`" — a single non-merged close is enough to flag. Conservative.
 - **CRLF on WSL2:** these are command `.md` edits, not new shell scripts. No CRLF stripping needed beyond normal commit hygiene.
 - **`gt-cleanup` rate-limit branch:** if the existing rate-limit fallback has already marked PR-data as incomplete, the `closed_not_merged` flag is also incomplete. Document that the warning depends on PR data being fetched successfully.
 

--- a/plans/gt-workflow-merge-queue-improvements.md
+++ b/plans/gt-workflow-merge-queue-improvements.md
@@ -1,0 +1,160 @@
+# Feature: gt-workflow Merge Queue Improvements
+
+## Problem Statement
+
+The Graphite merge-queue research (`docs/research/graphite-merge-queue-stacked-prs-coding-agents.md`) surfaced two platform-level gaps in the existing `gt-workflow` plugin that affect every Graphite user — not just users of Graphite's optional merge queue:
+
+1. **Silent incompatibility with GitHub native merge queue.** Graphite and GitHub's native merge queue are explicitly documented as incompatible (research §3). Running both causes Graphite to restart CI on all queued commits and may produce out-of-order merges. `gt-setup` does not detect or warn about this today.
+2. **Silent data loss in `gt-cleanup` when a PR was closed without merging.** The cleanup command currently treats "all PRs closed or merged" as a single deletion candidate. A queue-ejected PR (or any PR closed without landing) is indistinguishable from a merged PR — the user can lose unique commits without realizing.
+
+Both fixes are additive, low-risk, and unlock value for all Graphite users without coupling the base plugin to queue-state-aware logic (which lives in the future `gt-merge-queue` add-on per the brainstorm boundary decision).
+
+## Current State
+
+- **`gt-setup`** (`plugins/gt-workflow/commands/gt-setup.md`): Phase 1 runs a single Bash block emitting key-value diagnostics under section headers (`=== Prerequisites ===`, `=== Repository ===`, `=== Graphite Auth ===`, `=== Convention Files ===`). No GitHub branch-protection introspection.
+- **`gt-cleanup`** (`plugins/gt-workflow/commands/gt-cleanup.md`): Phase 2.4 runs `gh pr list --repo "$REPO" --head "$BRANCH_NAME" --state all --json state --limit 100`. Classifies as "Closed PR" candidate when **all** PRs are `CLOSED` or `MERGED`. No distinction between merged and closed-without-merge.
+- **Conventional-commit `!` regex**: Already correct in `plugins/gt-workflow/hooks/check-commit-message.sh:52` (pattern includes `!?:`). No change needed.
+
+## Proposed Solution
+
+Two additive edits, each contained to one command file.
+
+### Change 1 — `gt-setup` native merge queue advisory
+
+Add a new check after the existing Convention Files section in Phase 1's Bash block. Detect whether GitHub's repo-level merge queue is configured. Emit a soft advisory matching the existing `yq: NOT FOUND` severity. Fail-open on any error.
+
+**Detection mechanism (open question 5 resolution):** GitHub's REST and GraphQL APIs do **not** expose "merge queue enabled at branch protection rule level" — confirmed via [GitHub community discussion #170601](https://github.com/orgs/community/discussions/170601). The only available signal is the **repo-level** `repository.mergeQueue` GraphQL field. If the repo has a merge queue configured (regardless of which branch protection rule references it), this object is non-null. We use that as the proxy: non-null `mergeQueue` → likely conflict with Graphite.
+
+This is an imperfect signal — a stale/unused queue config could still register — but it matches the brainstorm's "soft advisory, fail-open" intent. The warning text explicitly tells the user to check + disable; we don't claim certainty.
+
+### Change 2 — `gt-cleanup` closed-not-merged guard
+
+Add `mergedAt` to the existing `gh pr list --json` call. Tag any branch in the Closed PR category whose closed PRs include any with `mergedAt: null` as `closed-not-merged`. Surface this in two places:
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** The `--json state,mergedAt` pattern and `mergedAt: null` semantic check are already established in `plugins/yellow-core/commands/worktree/cleanup.md` and `plugins/yellow-linear/commands/linear/sync-all.md`. Change 2 follows existing conventions exactly — no new pattern is being introduced here.
+<!-- /deepen-plan -->
+
+- **"Delete all" mode:** prepend the existing data-loss warning with a count line: "N of these branches had PRs closed without merging (may be queue-ejected, abandoned, or cancelled)."
+- **"Review individually" mode:** add `PR status: closed (no merge — verify before deleting)` to the per-branch detail block. The existing AskUserQuestion serves as the confirmation step.
+
+No `queue-ejected` label reading. No new API calls. One extra JSON field in an existing call.
+
+## Implementation Plan
+
+### Phase 1: gt-setup native queue advisory
+
+- [ ] **1.1** Append a new `=== Trunk Protection ===` section to the Phase 1 Bash block in `plugins/gt-workflow/commands/gt-setup.md` (between current "Convention Files" and the Step 2 interpretation).
+- [ ] **1.2** Implement the GraphQL detection. Use `gh api graphql` with a query for `repository(owner, name) { mergeQueue { url } }`. Repo identifier comes from `gh repo view --json nameWithOwner -q .nameWithOwner` (same idiom already used in `gt-cleanup` line 170). Fail-open on any non-zero exit, missing auth, or parse error.
+- [ ] **1.3** Emit one of three lines based on result. Use **one space** after the colon to match the surrounding 16-char alignment zone (`=== Repository ===` and `=== Convention Files ===` sections):
+  - Queue detected: `gh_native_queue: WARNING — GitHub native merge queue is configured for this repo. Graphite and GitHub native queue are incompatible; running both causes CI restarts and may produce out-of-order merges. Disable at: https://github.com/<repo>/settings/branches`
+  - Queue not detected: `gh_native_queue: ok (not configured)`
+  - Could not check: `gh_native_queue: COULD NOT CHECK (gh auth or API unavailable)`
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Two distinct column-alignment zones exist in `gt-setup.md` Phase 1 — Prerequisites/Auth use 15-char keys (`gt:`, `mcp_server:`, `jq:`, `yq:`), Repository/Convention use 16-char keys (`git_repo:`, `repo_config:`, `gt_trunk:`, `auth_config:`, `graphite_yml:`, `pr_template:`). The new `=== Trunk Protection ===` section sits between Convention Files and Step 2, so it should match the 16-char zone. Key `gh_native_queue` (15 chars) + `:` + one space = 17, slightly long but visually consistent. Original draft had two spaces (total 18) — corrected here. Precedent: `yellow-review/commands/review/setup.md:28` uses `gh_auth: ok` for similar GitHub-related diagnostics.
+<!-- /deepen-plan -->
+- [ ] **1.4** Update Step 2 interpretation: add `gh_native_queue` WARNING to the Warnings list, with the consequence statement and disable link. Soft advisory only — never blocks.
+
+### Phase 2: gt-cleanup closed-not-merged guard
+
+- [ ] **2.1** Update the `gh pr list` invocation in Phase 2.4 of `plugins/gt-workflow/commands/gt-cleanup.md` (line 180-182): change `--json state` to `--json state,mergedAt`.
+- [ ] **2.2** Update the parse-and-classify logic in Phase 2.4: when classifying as "Closed PR" candidate (all PRs `CLOSED` or `MERGED`), additionally check whether any `state == CLOSED` PR has `mergedAt: null`. If so, set a `closed_not_merged=true` flag on the branch.
+- [ ] **2.3** Update Phase 4 "Delete all" path for the Closed PR category: if any branches have `closed_not_merged=true`, prepend the existing data-loss warning block with: `N of these branches had PRs closed without merging (may be queue-ejected, abandoned, or cancelled). Verify before proceeding.`
+- [ ] **2.4** Update Phase 4 "Review individually" path: for each `closed_not_merged=true` branch, add a `PR status: closed (no merge — verify before deleting)` line to the per-branch detail block (between the existing "Unique commits" and "Age" lines).
+
+### Phase 3: Quality
+
+- [ ] **3.1** Manual smoke test on a real repo:
+  - Run `/gt-setup` on a repo with no native queue → confirm `gh_native_queue: ok (not configured)`.
+  - Run `/gt-setup` on a repo with native queue enabled → confirm the WARNING line appears with the disable link.
+  - Run `/gt-setup` with `gh` unauthenticated → confirm `COULD NOT CHECK` line, setup continues without blocking.
+  - Run `/gt-cleanup` with a closed-not-merged PR present → confirm the warning appears in both Delete-all and Review-individually paths.
+- [ ] **3.2** Run `pnpm validate:schemas` to confirm both edited command files still validate.
+- [ ] **3.3** Run `pnpm changeset` and select `patch` for `gt-workflow` (additive, non-breaking).
+- [ ] **3.4** Update `plugins/gt-workflow/CLAUDE.md` only if the changes affect the documented command behavior contract (likely just `gt-cleanup`'s "Closed PR" classification description). Skip if no contract change.
+
+## Technical Details
+
+### Files to Modify
+
+- `plugins/gt-workflow/commands/gt-setup.md` — append new section to Phase 1 Bash block + new entry in Step 2 Warnings list
+- `plugins/gt-workflow/commands/gt-cleanup.md` — `--json` field addition, classification flag, two display additions
+
+### Files to Create
+
+- `.changeset/<auto-named>.md` — `gt-workflow: patch` describing both changes
+
+### Detection Snippet (Phase 1.2)
+
+```bash
+printf '\n=== Trunk Protection ===\n'
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  repo_nwo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)
+  if [ -n "$repo_nwo" ]; then
+    repo_owner="${repo_nwo%/*}"
+    repo_name="${repo_nwo#*/}"
+    # shellcheck disable=SC2016
+    mq_check=$(gh api graphql -f query='
+      query($owner:String!,$name:String!){
+        repository(owner:$owner,name:$name){ mergeQueue { url } }
+      }' -f owner="$repo_owner" -f name="$repo_name" --jq '.data.repository.mergeQueue.url // empty' 2>/dev/null) \
+      || printf '[gt-workflow] Warning: merge queue check failed (gh api graphql)\n' >&2
+    if [ -n "$mq_check" ]; then
+      printf 'gh_native_queue: WARNING — GitHub native merge queue is configured for this repo. Graphite and GitHub native queue are incompatible; running both causes CI restarts and may produce out-of-order merges. Disable at: https://github.com/%s/settings/branches\n' "$repo_nwo"
+    elif [ -z "$mq_check" ] && [ "$?" -eq 0 ]; then
+      printf 'gh_native_queue: ok (not configured)\n'
+    else
+      printf 'gh_native_queue: COULD NOT CHECK (gh api graphql failed)\n'
+    fi
+  else
+    printf 'gh_native_queue: COULD NOT CHECK (gh repo view returned no name)\n'
+  fi
+else
+  printf 'gh_native_queue: COULD NOT CHECK (gh not authenticated or not installed)\n'
+fi
+```
+
+Note the `--jq '.data.repository.mergeQueue.url // empty'` filter: returns the URL string when the merge queue object exists, or empty string when null. Tested via `[ -n "$mq_check" ]`.
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** This is the **first** `gh api graphql` invocation in the plugins tree. No existing template — this snippet establishes the convention. Two patterns adopted from MEMORY.md "GitHub GraphQL Shell Patterns" (PR #9): (1) `# shellcheck disable=SC2016` on a separate line above the query string for the GraphQL `$owner`/`$name` variables, (2) `|| printf '[gt-workflow] Warning: ...' >&2` for visibility per the error-logging rule rather than silently suppressing via `2>/dev/null` alone. The `gh auth status` soft-skip pattern matches `plugins/yellow-core/commands/worktree/cleanup.md:74` and `plugins/yellow-browser-test/agents/testing/test-reporter.md:59`.
+<!-- /deepen-plan -->
+
+### Dependencies
+
+- `gh` CLI — already a hard dependency in `gt-cleanup` and a soft dependency in `gt-setup` (auth check). No new dependency added.
+
+## Acceptance Criteria
+
+1. `/gt-setup` on a repo without a native merge queue prints `gh_native_queue: ok (not configured)` and proceeds normally.
+2. `/gt-setup` on a repo with a native merge queue configured prints the `WARNING` line including the GitHub branch settings URL, and continues to Phase 2 without blocking.
+3. `/gt-setup` with `gh` unauthenticated or absent prints `COULD NOT CHECK` and continues without blocking.
+4. `/gt-cleanup` with one or more closed-not-merged branches in the Closed PR category shows the count warning before the data-loss block in "Delete all" mode.
+5. `/gt-cleanup` with closed-not-merged branches in Review individually mode shows `PR status: closed (no merge — verify before deleting)` for those specific branches only.
+6. `/gt-cleanup` with only merged branches in the Closed PR category behaves identically to today (no new warning text).
+7. Existing `pnpm validate:schemas` passes against the modified command files.
+8. A `gt-workflow: patch` changeset is created describing both additions.
+
+## Edge Cases & Error Handling
+
+- **`gh api graphql` returns malformed JSON or partial data:** the `--jq` filter falls through to empty string, treated as "not configured." Acceptable — fail-open is the documented stance.
+- **Repo has merge queue configured but it's stale/unused:** WARNING fires anyway. The text says "may produce" not "will produce" — acceptable false-positive given the disable link is one click.
+- **Branch has a closed PR with `mergedAt: null` but the user genuinely wants to delete (e.g., they ran an experiment):** the warning is informational. Existing AskUserQuestion gives them the choice. No new blocking step.
+- **Multiple PRs per branch (rare but possible):** the classification rule is "any closed PR with `mergedAt: null`" — single null is enough to flag. Conservative.
+- **CRLF on WSL2:** these are command `.md` edits, not new shell scripts. No CRLF stripping needed beyond normal commit hygiene.
+- **`gt-cleanup` rate-limit branch:** if the existing rate-limit fallback has already marked PR-data as incomplete, the `closed_not_merged` flag is also incomplete. Document that the warning depends on PR data being fetched successfully.
+
+## References
+
+- `docs/brainstorms/2026-04-30-gt-workflow-merge-queue-improvements-brainstorm.md` — full Q&A and rejected alternatives
+- `docs/research/graphite-merge-queue-stacked-prs-coding-agents.md` — sections §3 (Graphite/GitHub queue incompatibility), §7 (plugin design recommendations)
+- `docs/solutions/integration-issues/graphite-github-native-queue-incompatibility.md` — institutional knowledge on the incompatibility
+- `docs/solutions/integration-issues/merge-queue-closed-pr-null-mergedat-detection.md` — the 3-path `mergedAt: null` semantics underlying Change 2
+- `plugins/gt-workflow/commands/gt-setup.md` — current Phase 1 structure
+- `plugins/gt-workflow/commands/gt-cleanup.md` — current Phase 2/4 structure
+- [GitHub community #170601](https://github.com/orgs/community/discussions/170601) — confirms the API gap that motivates the GraphQL `mergeQueue` proxy detection
+
+<!-- deepen-plan: external -->
+> **Research:** GitHub's REST and GraphQL APIs do not expose a per-branch-protection-rule "merge queue enabled" field, per [community discussion #170601](https://github.com/orgs/community/discussions/170601) (Nov 2025). The only available signal is the repository-level `repository.mergeQueue` GraphQL object — non-null when a queue is configured for any branch in the repo. Schema: `mergeQueue { url, entries, ... }`. The plan's `mergeQueue { url }` query returns the URL when configured, null otherwise. The detection is a coarse proxy at the repo level, not the trunk-branch level — acceptable because the warning text says "may produce" not "will produce" and the disable link is a one-click fix.
+<!-- /deepen-plan -->

--- a/plans/gt-workflow-merge-queue-improvements.md
+++ b/plans/gt-workflow-merge-queue-improvements.md
@@ -29,10 +29,10 @@ This is an imperfect signal — a stale/unused queue config could still register
 
 ### Change 2 — `gt-cleanup` closed-not-merged guard
 
-Add `mergedAt` to the existing `gh pr list --json` call. Tag any branch in the Closed PR category whose closed PRs include any with `mergedAt: null` as `closed-not-merged`. Surface this in two places:
+Add `mergedAt` and `merged` to the existing `gh pr list --json` call (so the call requests `state,mergedAt,merged`). Tag any branch in the Closed PR category whose closed PRs include any with `merged: false` as `closed-not-merged`. The authoritative signal is the `merged` boolean (`pull_request.merged`), not `mergedAt`: GitHub's REST API has a known propagation lag where a freshly-merged PR can transiently show `mergedAt: null` while `merged: true`. Gating on `merged == false` eliminates that false-positive window. Surface the result in two places:
 
 <!-- deepen-plan: codebase -->
-> **Codebase:** The `--json state,mergedAt` pattern and `mergedAt: null` semantic check are already established in `plugins/yellow-core/commands/worktree/cleanup.md` and `plugins/yellow-linear/commands/linear/sync-all.md`. Change 2 follows existing conventions exactly — no new pattern is being introduced here.
+> **Codebase:** The `--json state,mergedAt` pattern is already established in `plugins/yellow-core/commands/worktree/cleanup.md` and `plugins/yellow-linear/commands/linear/sync-all.md`. Change 2 extends that pattern by also requesting `merged` and using it as the authoritative signal — see `docs/solutions/integration-issues/merge-queue-closed-pr-null-mergedat-detection.md` for the propagation-lag rationale.
 <!-- /deepen-plan -->
 
 - **"Delete all" mode:** prepend the existing data-loss warning with a count line: "N of these branches had PRs closed without merging (may be queue-ejected, abandoned, or cancelled)."
@@ -44,7 +44,7 @@ No `queue-ejected` label reading. No new API calls. One extra JSON field in an e
 
 ### Phase 1: gt-setup native queue advisory
 
-- [ ] **1.1** Append a new `=== Trunk Protection ===` section to the Phase 1 Bash block in `plugins/gt-workflow/commands/gt-setup.md` (between current "Convention Files" and the Step 2 interpretation).
+- [ ] **1.1** Append a new `=== Merge Queue Compatibility ===` section to the Phase 1 Bash block in `plugins/gt-workflow/commands/gt-setup.md` (between current "Convention Files" and the Step 2 interpretation).
 - [ ] **1.2** Implement the GraphQL detection. Use `gh api graphql` with a query for `repository(owner, name) { mergeQueue { url } }`. Repo identifier comes from `gh repo view --json nameWithOwner -q .nameWithOwner` (same idiom already used in `gt-cleanup` line 170). Fail-open on any non-zero exit, missing auth, or parse error.
 - [ ] **1.3** Emit one of three lines based on result. Use **one space** after the colon to match the surrounding 16-char alignment zone (`=== Repository ===` and `=== Convention Files ===` sections):
   - Queue detected: `gh_native_queue: WARNING — GitHub native merge queue is configured for this repo. Graphite and GitHub native queue are incompatible; running both causes CI restarts and may produce out-of-order merges. Disable at: https://github.com/<repo>/settings/branches`
@@ -52,14 +52,14 @@ No `queue-ejected` label reading. No new API calls. One extra JSON field in an e
   - Could not check: `gh_native_queue: COULD NOT CHECK (gh auth or API unavailable)`
 
 <!-- deepen-plan: codebase -->
-> **Codebase:** Two distinct column-alignment zones exist in `gt-setup.md` Phase 1 — Prerequisites/Auth use 15-char keys (`gt:`, `mcp_server:`, `jq:`, `yq:`), Repository/Convention use 16-char keys (`git_repo:`, `repo_config:`, `gt_trunk:`, `auth_config:`, `graphite_yml:`, `pr_template:`). The new `=== Trunk Protection ===` section sits between Convention Files and Step 2, so it should match the 16-char zone. Key `gh_native_queue` (15 chars) + `:` + one space = 17, slightly long but visually consistent. Original draft had two spaces (total 18) — corrected here. Precedent: `yellow-review/commands/review/setup.md:28` uses `gh_auth: ok` for similar GitHub-related diagnostics.
+> **Codebase:** Two distinct column-alignment zones exist in `gt-setup.md` Phase 1 — Prerequisites/Auth use 15-char keys (`gt:`, `mcp_server:`, `jq:`, `yq:`), Repository/Convention use 16-char keys (`git_repo:`, `repo_config:`, `gt_trunk:`, `auth_config:`, `graphite_yml:`, `pr_template:`). The new `=== Merge Queue Compatibility ===` section sits between Convention Files and Step 2, so it should match the 16-char zone. Key `gh_native_queue` (15 chars) + `:` + one space = 17, slightly long but visually consistent. Original draft had two spaces (total 18) — corrected here. Precedent: `yellow-review/commands/review/setup.md:28` uses `gh_auth: ok` for similar GitHub-related diagnostics.
 <!-- /deepen-plan -->
 - [ ] **1.4** Update Step 2 interpretation: add `gh_native_queue` WARNING to the Warnings list, with the consequence statement and disable link. Soft advisory only — never blocks.
 
 ### Phase 2: gt-cleanup closed-not-merged guard
 
-- [ ] **2.1** Update the `gh pr list` invocation in Phase 2.4 of `plugins/gt-workflow/commands/gt-cleanup.md` (line 180-182): change `--json state` to `--json state,mergedAt`.
-- [ ] **2.2** Update the parse-and-classify logic in Phase 2.4: when classifying as "Closed PR" candidate (all PRs `CLOSED` or `MERGED`), additionally check whether any `state == CLOSED` PR has `mergedAt: null`. If so, set a `closed_not_merged=true` flag on the branch.
+- [ ] **2.1** Update the `gh pr list` invocation in Phase 2.4 of `plugins/gt-workflow/commands/gt-cleanup.md` (line 180-182): change `--json state` to `--json state,mergedAt,merged`. Both fields are needed: `mergedAt` for surfacing the timestamp where useful, and `merged` (boolean) as the authoritative signal that survives REST propagation lag.
+- [ ] **2.2** Update the parse-and-classify logic in Phase 2.4 with a concrete jq pipeline (so the LLM-as-runtime does not infer the parse): when classifying as "Closed PR" candidate (all PRs `CLOSED` or `MERGED`), additionally check whether any `state == CLOSED` PR has `merged: false`. If so, set a `closed_not_merged=true` flag on the branch. Also explicitly exclude `[gone]`-tracked branches from the PR Status Lookups gate so the tag does not fire on branches already routed to `/gt-sync`.
 - [ ] **2.3** Update Phase 4 "Delete all" path for the Closed PR category: if any branches have `closed_not_merged=true`, prepend the existing data-loss warning block with: `N of these branches had PRs closed without merging (may be queue-ejected, abandoned, or cancelled). Verify before proceeding.`
 - [ ] **2.4** Update Phase 4 "Review individually" path: for each `closed_not_merged=true` branch, add a `PR status: closed (no merge — verify before deleting)` line to the per-branch detail block (between the existing "Unique commits" and "Age" lines).
 
@@ -88,7 +88,7 @@ No `queue-ejected` label reading. No new API calls. One extra JSON field in an e
 ### Detection Snippet (Phase 1.2)
 
 ```bash
-printf '\n=== Trunk Protection ===\n'
+printf '\n=== Merge Queue Compatibility ===\n'
 if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
   repo_nwo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)
   if [ -n "$repo_nwo" ]; then
@@ -140,8 +140,8 @@ Note the `--jq '.data.repository.mergeQueue.url // empty'` filter: returns the U
 
 - **`gh api graphql` returns malformed JSON or partial data:** the `--jq` filter falls through to empty string, treated as "not configured." Acceptable — fail-open is the documented stance.
 - **Repo has merge queue configured but it's stale/unused:** WARNING fires anyway. The text says "may produce" not "will produce" — acceptable false-positive given the disable link is one click.
-- **Branch has a closed PR with `mergedAt: null` but the user genuinely wants to delete (e.g., they ran an experiment):** the warning is informational. Existing AskUserQuestion gives them the choice. No new blocking step.
-- **Multiple PRs per branch (rare but possible):** the classification rule is "any closed PR with `mergedAt: null`" — single null is enough to flag. Conservative.
+- **Branch has a closed PR with `merged: false` but the user genuinely wants to delete (e.g., they ran an experiment):** the warning is informational. Existing AskUserQuestion gives them the choice. No new blocking step.
+- **Multiple PRs per branch (rare but possible):** the classification rule is "any closed PR with `merged: false`" — a single non-merged close is enough to flag. Conservative.
 - **CRLF on WSL2:** these are command `.md` edits, not new shell scripts. No CRLF stripping needed beyond normal commit hygiene.
 - **`gt-cleanup` rate-limit branch:** if the existing rate-limit fallback has already marked PR-data as incomplete, the `closed_not_merged` flag is also incomplete. Document that the warning depends on PR data being fetched successfully.
 

--- a/plugins/gt-workflow/commands/gt-cleanup.md
+++ b/plugins/gt-workflow/commands/gt-cleanup.md
@@ -311,21 +311,25 @@ Options:
 3. Skip this category
 ```
 
+For the **Closed PR** category specifically, the per-branch `<context>`
+must distinguish merged PRs from PRs closed without merging — when
+`closed_not_merged=true` for a branch, render the PR state as
+`closed (no merge — verify before deleting)` instead of `closed`. This
+surfaces queue-ejected, abandoned, or cancelled PRs at the decision
+point, before the user commits to "Delete all". Additionally, if **any** branches in the category
+have `closed_not_merged=true`, append a one-line summary above the
+Options block:
+
+```
+Note: M of N branches had PRs closed without merging (may be queue-ejected,
+abandoned, or cancelled).
+```
+
 Where `<action>` is:
 - "Delete" for orphaned, closed PR, stale (via `gt delete`)
 - "Sync" for behind remote (via `gt get`)
 
 **If "Delete all" or "Sync all" is chosen:**
-
-For the **Closed PR** category specifically: if any branches in the
-deletion set have `closed_not_merged=true`, prepend the data-loss warning
-with a count notice. This surfaces queue-ejected, abandoned, or cancelled
-PRs that would otherwise look identical to merged PRs:
-
-```
-N of these branches had PRs closed without merging (may be queue-ejected,
-abandoned, or cancelled). Verify before proceeding.
-```
 
 For deletion categories, if any branches have unique commits not on trunk,
 display the data-loss warning before executing:

--- a/plugins/gt-workflow/commands/gt-cleanup.md
+++ b/plugins/gt-workflow/commands/gt-cleanup.md
@@ -178,7 +178,7 @@ For each branch:
 
 ```bash
 gh pr list --repo "$REPO" \
-  --head "$BRANCH_NAME" --state all --json state,mergedAt --limit 100
+  --head "$BRANCH_NAME" --state all --json state,mergedAt,merged --limit 100
 ```
 
 **Do NOT suppress stderr.** Add a `sleep 0.2` between lookups to avoid
@@ -193,10 +193,14 @@ triggering GitHub secondary rate limits. If `gh pr list` fails:
 Parse the result:
 - If **all** PRs have state `CLOSED` or `MERGED`: branch is a **Closed PR**
   candidate. Additionally, if **any** of the closed-state PRs has
-  `mergedAt: null` (closed without landing — could be queue-ejected, abandoned,
-  or cancelled), tag the branch as `closed_not_merged=true` for use in
-  Phase 4. PRs with state `MERGED` always have a non-null `mergedAt` and do
-  not trigger this tag.
+  `merged: false` (i.e. the PR was closed without landing — could be
+  queue-ejected, abandoned, or cancelled), tag the branch as
+  `closed_not_merged=true` for use in Phase 4. The authoritative signal is
+  the `merged` boolean (`pull_request.merged`), not `mergedAt`: GitHub's
+  REST API has a known propagation lag where a freshly-merged PR can briefly
+  show `mergedAt: null` while `merged: true`. Gating on `merged == false`
+  eliminates that false-positive window. PRs with state `MERGED` always have
+  `merged: true` and do not trigger this tag.
 - If **any** PR has state `OPEN`: branch has an active PR — exclude from
   **Closed PR** and **Stale** categories.
 - If **no PRs** found: not a closed-PR candidate (may still be stale).

--- a/plugins/gt-workflow/commands/gt-cleanup.md
+++ b/plugins/gt-workflow/commands/gt-cleanup.md
@@ -178,7 +178,7 @@ For each branch:
 
 ```bash
 gh pr list --repo "$REPO" \
-  --head "$BRANCH_NAME" --state all --json state --limit 100
+  --head "$BRANCH_NAME" --state all --json state,mergedAt --limit 100
 ```
 
 **Do NOT suppress stderr.** Add a `sleep 0.2` between lookups to avoid
@@ -192,7 +192,11 @@ triggering GitHub secondary rate limits. If `gh pr list` fails:
 
 Parse the result:
 - If **all** PRs have state `CLOSED` or `MERGED`: branch is a **Closed PR**
-  candidate.
+  candidate. Additionally, if **any** of the closed-state PRs has
+  `mergedAt: null` (closed without landing — could be queue-ejected, abandoned,
+  or cancelled), tag the branch as `closed_not_merged=true` for use in
+  Phase 4. PRs with state `MERGED` always have a non-null `mergedAt` and do
+  not trigger this tag.
 - If **any** PR has state `OPEN`: branch has an active PR — exclude from
   **Closed PR** and **Stale** categories.
 - If **no PRs** found: not a closed-PR candidate (may still be stale).
@@ -313,8 +317,18 @@ Where `<action>` is:
 
 **If "Delete all" or "Sync all" is chosen:**
 
+For the **Closed PR** category specifically: if any branches in the
+deletion set have `closed_not_merged=true`, prepend the data-loss warning
+with a count notice. This surfaces queue-ejected, abandoned, or cancelled
+PRs that would otherwise look identical to merged PRs:
+
+```
+N of these branches had PRs closed without merging (may be queue-ejected,
+abandoned, or cancelled). Verify before proceeding.
+```
+
 For deletion categories, if any branches have unique commits not on trunk,
-display a data-loss warning before executing:
+display the data-loss warning before executing:
 
 ```
 ⚠️  N branches have commits not on trunk:
@@ -379,6 +393,12 @@ Options:
 1. <Delete/Sync> this branch
 2. Skip
 ```
+
+For branches in the Closed PR category with `closed_not_merged=true`, replace
+the `PR status:` line with `closed (no merge — verify before deleting)` to
+make the unmerged-close state visible at the per-branch confirmation point.
+The existing AskUserQuestion serves as the confirmation step — no extra
+prompt is needed.
 
 Execute the chosen action with the same error handling as batch mode.
 

--- a/plugins/gt-workflow/commands/gt-cleanup.md
+++ b/plugins/gt-workflow/commands/gt-cleanup.md
@@ -154,9 +154,16 @@ state:
 
 ### 4. PR Status Lookups
 
-For branches that have an upstream (not orphaned), check PR status to determine:
+For branches that have an upstream **and** whose track status does NOT contain
+`[gone]` (so: not orphaned and not already routed to the merged-branch hint),
+check PR status to determine:
 - Whether the branch belongs in the **Closed PR** category
 - Whether the branch should be excluded from the **Stale** category (has open PR)
+
+`[gone]`-tracked branches are skipped here on purpose — they were already
+classified in Section 3 Step 2 and belong to `/gt-sync`, so any
+`closed_not_merged` tagging on them would be display-dead and only burn API
+quota.
 
 If there are more than 20 branches to check, show a progress indicator:
 
@@ -174,11 +181,23 @@ if [ -z "$REPO" ]; then
 fi
 ```
 
-For each branch:
+For each branch, run `gh pr list` and parse with jq. The authoritative signal
+for "PR landed" is the `pull_request.merged` boolean, not `mergedAt`:
+GitHub's REST API has a known propagation lag where a freshly-merged PR can
+briefly show `mergedAt: null` while `merged: true`. Gating on
+`merged == false` eliminates that false-positive window. Use this concrete
+pipeline so the runtime does not have to infer the parse:
 
 ```bash
-gh pr list --repo "$REPO" \
-  --head "$BRANCH_NAME" --state all --json state,mergedAt,merged --limit 100
+PR_JSON=$(gh pr list --repo "$REPO" \
+  --head "$BRANCH_NAME" --state all --json state,mergedAt,merged --limit 100)
+
+PR_COUNT=$(printf '%s' "$PR_JSON" | jq 'length')
+HAS_OPEN=$(printf '%s' "$PR_JSON" | jq 'any(.[]; .state == "OPEN")')
+ALL_TERMINAL=$(printf '%s' "$PR_JSON" \
+  | jq 'length > 0 and all(.[]; .state == "CLOSED" or .state == "MERGED")')
+CLOSED_NOT_MERGED=$(printf '%s' "$PR_JSON" \
+  | jq 'any(.[]; .state == "CLOSED" and (.merged // false) == false)')
 ```
 
 **Do NOT suppress stderr.** Add a `sleep 0.2` between lookups to avoid
@@ -190,20 +209,16 @@ triggering GitHub secondary rate limits. If `gh pr list` fails:
   continue with categories that don't require PR data (orphaned, diverged,
   behind, ahead).
 
-Parse the result:
-- If **all** PRs have state `CLOSED` or `MERGED`: branch is a **Closed PR**
-  candidate. Additionally, if **any** of the closed-state PRs has
-  `merged: false` (i.e. the PR was closed without landing — could be
-  queue-ejected, abandoned, or cancelled), tag the branch as
-  `closed_not_merged=true` for use in Phase 4. The authoritative signal is
-  the `merged` boolean (`pull_request.merged`), not `mergedAt`: GitHub's
-  REST API has a known propagation lag where a freshly-merged PR can briefly
-  show `mergedAt: null` while `merged: true`. Gating on `merged == false`
-  eliminates that false-positive window. PRs with state `MERGED` always have
-  `merged: true` and do not trigger this tag.
-- If **any** PR has state `OPEN`: branch has an active PR — exclude from
-  **Closed PR** and **Stale** categories.
-- If **no PRs** found: not a closed-PR candidate (may still be stale).
+Then classify:
+
+- `HAS_OPEN == true`: branch has an active PR — exclude from **Closed PR**
+  and **Stale** categories.
+- `ALL_TERMINAL == true`: branch is a **Closed PR** candidate. If
+  `CLOSED_NOT_MERGED == true` (any closed-state PR has `merged: false` —
+  could be queue-ejected, abandoned, or cancelled), additionally tag the
+  branch as `closed_not_merged=true` for use in Phase 4. PRs with state
+  `MERGED` always have `merged: true` and never trigger this tag.
+- `PR_COUNT == 0`: not a closed-PR candidate (may still be stale).
 
 ### 5. Staleness Check
 

--- a/plugins/gt-workflow/commands/gt-cleanup.md
+++ b/plugins/gt-workflow/commands/gt-cleanup.md
@@ -181,23 +181,34 @@ if [ -z "$REPO" ]; then
 fi
 ```
 
-For each branch, run `gh pr list` and parse with jq. The authoritative signal
-for "PR landed" is the `pull_request.merged` boolean, not `mergedAt`:
-GitHub's REST API has a known propagation lag where a freshly-merged PR can
-briefly show `mergedAt: null` while `merged: true`. Gating on
-`merged == false` eliminates that false-positive window. Use this concrete
-pipeline so the runtime does not have to infer the parse:
+For each branch, run `gh pr list` and parse with jq. `gh pr list --json`
+exposes the GraphQL `state` enum directly (`OPEN | CLOSED | MERGED`) — a
+merged PR has `state == "MERGED"`, **not** `CLOSED`. So `state == "CLOSED"`
+is by itself unambiguous evidence of "closed without landing"; no separate
+`merged` boolean check is needed. (The propagation-lag concern documented in
+`docs/solutions/integration-issues/merge-queue-closed-pr-null-mergedat-detection.md`
+applies to `gh api repos/{owner}/{repo}/pulls/{number}` per-PR REST calls,
+where `merged: bool` is exposed; `gh pr list --json` does not accept a
+`merged` field — only `state`, `mergedAt`, `mergedBy`, `mergeCommit`,
+`closed`, `closedAt`, etc. — so the GraphQL `state` enum is the correct
+authority here.)
+
+`mergedAt` is also requested for display use (e.g., "merged at <timestamp>"
+in per-branch detail), but is not used for classification.
+
+Use this concrete jq pipeline so the runtime does not have to infer the
+parse:
 
 ```bash
 PR_JSON=$(gh pr list --repo "$REPO" \
-  --head "$BRANCH_NAME" --state all --json state,mergedAt,merged --limit 100)
+  --head "$BRANCH_NAME" --state all --json state,mergedAt --limit 100)
 
 PR_COUNT=$(printf '%s' "$PR_JSON" | jq 'length')
 HAS_OPEN=$(printf '%s' "$PR_JSON" | jq 'any(.[]; .state == "OPEN")')
 ALL_TERMINAL=$(printf '%s' "$PR_JSON" \
   | jq 'length > 0 and all(.[]; .state == "CLOSED" or .state == "MERGED")')
 CLOSED_NOT_MERGED=$(printf '%s' "$PR_JSON" \
-  | jq 'any(.[]; .state == "CLOSED" and (.merged // false) == false)')
+  | jq 'any(.[]; .state == "CLOSED")')
 ```
 
 **Do NOT suppress stderr.** Add a `sleep 0.2` between lookups to avoid
@@ -214,10 +225,11 @@ Then classify:
 - `HAS_OPEN == true`: branch has an active PR — exclude from **Closed PR**
   and **Stale** categories.
 - `ALL_TERMINAL == true`: branch is a **Closed PR** candidate. If
-  `CLOSED_NOT_MERGED == true` (any closed-state PR has `merged: false` —
-  could be queue-ejected, abandoned, or cancelled), additionally tag the
-  branch as `closed_not_merged=true` for use in Phase 4. PRs with state
-  `MERGED` always have `merged: true` and never trigger this tag.
+  `CLOSED_NOT_MERGED == true` (any PR has `state == "CLOSED"` — meaning
+  closed without landing, which could be queue-ejected, abandoned, or
+  cancelled), additionally tag the branch as `closed_not_merged=true` for
+  use in Phase 4. PRs that landed have `state == "MERGED"` and never
+  trigger this tag.
 - `PR_COUNT == 0`: not a closed-PR candidate (may still be stale).
 
 ### 5. Staleness Check

--- a/plugins/gt-workflow/commands/gt-setup.md
+++ b/plugins/gt-workflow/commands/gt-setup.md
@@ -102,25 +102,36 @@ printf '\n=== Convention Files ===\n'
 [ -n "$repo_top" ] && [ -f "$repo_top/.github/pull_request_template.md" ] && printf 'pr_template:    present\n' || printf 'pr_template:    not found\n'
 
 printf '\n=== Merge Queue Compatibility ===\n'
+# Capture stderr from gh probes so failure diagnostics survive (vs silent 2>/dev/null).
+mq_err_log=$(mktemp 2>/dev/null) || mq_err_log=""
 if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
-  repo_nwo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)
+  repo_nwo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>"${mq_err_log:-/dev/null}")
   repo_view_status=$?
   if [ "$repo_view_status" -ne 0 ]; then
-    printf '[gt-workflow] Warning: gh repo view failed (exit %d)\n' "$repo_view_status" >&2
+    if [ -n "$mq_err_log" ] && [ -s "$mq_err_log" ]; then
+      printf '[gt-workflow] Warning: gh repo view failed (exit %d): %s\n' "$repo_view_status" "$(head -c 200 "$mq_err_log" | tr '\n' ' ')" >&2
+    else
+      printf '[gt-workflow] Warning: gh repo view failed (exit %d)\n' "$repo_view_status" >&2
+    fi
     printf 'gh_native_queue:  COULD NOT CHECK (gh repo view failed)\n'
   elif [ -z "$repo_nwo" ]; then
     printf 'gh_native_queue:  COULD NOT CHECK (gh repo view returned no name)\n'
   else
     repo_owner="${repo_nwo%/*}"
     repo_name="${repo_nwo#*/}"
+    [ -n "$mq_err_log" ] && : > "$mq_err_log"  # truncate before next probe
     # shellcheck disable=SC2016  # $owner/$name are GraphQL variable refs, not shell vars — intentionally literal in single quotes
     mq_check=$(gh api graphql -f query='
       query($owner:String!,$name:String!){
         repository(owner:$owner,name:$name){ mergeQueue { url } }
-      }' -f owner="$repo_owner" -f name="$repo_name" --jq 'if .data.repository == null then error("repo null") else (.data.repository.mergeQueue | if . != null then "configured" else empty end) end' 2>/dev/null)
+      }' -f owner="$repo_owner" -f name="$repo_name" --jq 'if .data.repository == null then error("repo null") else (.data.repository.mergeQueue | if . != null then "configured" else empty end) end' 2>"${mq_err_log:-/dev/null}")
     mq_status=$?
     if [ "$mq_status" -ne 0 ]; then
-      printf '[gt-workflow] Warning: merge queue check failed (gh api graphql)\n' >&2
+      if [ -n "$mq_err_log" ] && [ -s "$mq_err_log" ]; then
+        printf '[gt-workflow] Warning: merge queue check failed (gh api graphql): %s\n' "$(head -c 200 "$mq_err_log" | tr '\n' ' ')" >&2
+      else
+        printf '[gt-workflow] Warning: merge queue check failed (gh api graphql)\n' >&2
+      fi
       printf 'gh_native_queue:  COULD NOT CHECK (gh api graphql failed)\n'
     elif [ -n "$mq_check" ]; then
       printf 'gh_native_queue:  WARNING (configured)\n'
@@ -131,6 +142,7 @@ if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
 else
   printf 'gh_native_queue:  COULD NOT CHECK (gh not authenticated or not installed)\n'
 fi
+[ -n "$mq_err_log" ] && rm -f "$mq_err_log"
 ```
 
 ### Step 2: Interpret Results
@@ -151,7 +163,7 @@ If any hard-stop failures exist, stop here. Do not proceed to Phase 2.
 - `mcp_server` SKIPPED or UNKNOWN: note accordingly.
 - `yq` NOT FOUND: "yq (kislyuk variant) is optional but recommended. Without it, consumer commands (`/smart-submit`, `/gt-stack-plan`, `/gt-amend`) will use hardcoded defaults instead of `.graphite.yml` settings. Install with: `pip install yq`"
 - `gh_native_queue` WARNING (configured): "GitHub native merge queue is configured for this repo. Graphite and GitHub native merge queue are incompatible — running both causes Graphite to restart CI on queued commits and may produce out-of-order merges. To disable: open https://github.com/<owner>/<repo>/settings/branches, edit the branch protection rule for your trunk branch, and uncheck **Require merge queue**. Setup proceeds, but the warning will repeat each time you run `/gt-setup` until resolved."
-- `gh_native_queue` COULD NOT CHECK: informational only. The parenthetical reason in the output line indicates which probe failed (gh missing/unauthenticated, `gh repo view`, or `gh api graphql`). Setup proceeds normally; re-run `/gt-setup` after fixing the underlying `gh` issue to get a definitive answer.
+- `gh_native_queue` COULD NOT CHECK: informational only — but **not necessarily safe to ignore**. The parenthetical reason in the output line indicates which probe failed (gh missing/unauthenticated, `gh repo view`, or `gh api graphql`); the captured stderr is appended to the `[gt-workflow] Warning:` line on failure to aid debugging. Three documented false-negative paths exist for the `repository.mergeQueue { url }` proxy: (1) the GitHub token lacks the admin scope needed to read merge queue config, (2) the repository is not visible to the token, (3) merge queue is configured but `mergeQueue.url` is null. Any of these can produce COULD NOT CHECK or even a misleading `ok (not configured)` while the queue is actually active. If your token is scope-limited (e.g., a CI/automation token), re-run `/gt-setup` with an admin-scoped token before relying on the result. Setup itself proceeds normally; the proxy is fail-open by design.
 
 ### Step 3: Validation Report
 
@@ -166,6 +178,7 @@ yq:            ready (or: not found — optional)
 Auth:          detected
 Repository:    initialized (trunk: <branch>)
 MCP Server:    available (or: unavailable — gt < 1.6.7)
+Merge Queue:   ok (or: WARNING — native queue active / COULD NOT CHECK)
 
 Proceeding to AI agent configuration...
 ```

--- a/plugins/gt-workflow/commands/gt-setup.md
+++ b/plugins/gt-workflow/commands/gt-setup.md
@@ -101,31 +101,35 @@ printf '\n=== Convention Files ===\n'
 [ -n "$repo_top" ] && [ -f "$repo_top/.graphite.yml" ] && printf 'graphite_yml:   present\n' || printf 'graphite_yml:   not found\n'
 [ -n "$repo_top" ] && [ -f "$repo_top/.github/pull_request_template.md" ] && printf 'pr_template:    present\n' || printf 'pr_template:    not found\n'
 
-printf '\n=== Trunk Protection ===\n'
+printf '\n=== Merge Queue Compatibility ===\n'
 if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
   repo_nwo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)
-  if [ -n "$repo_nwo" ]; then
+  repo_view_status=$?
+  if [ "$repo_view_status" -ne 0 ]; then
+    printf '[gt-workflow] Warning: gh repo view failed (exit %d)\n' "$repo_view_status" >&2
+    printf 'gh_native_queue:  COULD NOT CHECK (gh repo view failed)\n'
+  elif [ -z "$repo_nwo" ]; then
+    printf 'gh_native_queue:  COULD NOT CHECK (gh repo view returned no name)\n'
+  else
     repo_owner="${repo_nwo%/*}"
     repo_name="${repo_nwo#*/}"
-    # shellcheck disable=SC2016
+    # shellcheck disable=SC2016  # $owner/$name are GraphQL variable refs, not shell vars — intentionally literal in single quotes
     mq_check=$(gh api graphql -f query='
       query($owner:String!,$name:String!){
         repository(owner:$owner,name:$name){ mergeQueue { url } }
-      }' -f owner="$repo_owner" -f name="$repo_name" --jq '.data.repository.mergeQueue.url // empty' 2>/dev/null)
+      }' -f owner="$repo_owner" -f name="$repo_name" --jq 'if .data.repository == null then error("repo null") else (.data.repository.mergeQueue | if . != null then "configured" else empty end) end' 2>/dev/null)
     mq_status=$?
     if [ "$mq_status" -ne 0 ]; then
       printf '[gt-workflow] Warning: merge queue check failed (gh api graphql)\n' >&2
-      printf 'gh_native_queue: COULD NOT CHECK (gh api graphql failed)\n'
+      printf 'gh_native_queue:  COULD NOT CHECK (gh api graphql failed)\n'
     elif [ -n "$mq_check" ]; then
-      printf 'gh_native_queue: WARNING — GitHub native merge queue is configured for this repo. Graphite and GitHub native queue are incompatible; running both causes CI restarts and may produce out-of-order merges. Disable at: https://github.com/%s/settings/branches\n' "$repo_nwo"
+      printf 'gh_native_queue:  WARNING (configured)\n'
     else
-      printf 'gh_native_queue: ok (not configured)\n'
+      printf 'gh_native_queue:  ok (not configured)\n'
     fi
-  else
-    printf 'gh_native_queue: COULD NOT CHECK (gh repo view returned no name)\n'
   fi
 else
-  printf 'gh_native_queue: COULD NOT CHECK (gh not authenticated or not installed)\n'
+  printf 'gh_native_queue:  COULD NOT CHECK (gh not authenticated or not installed)\n'
 fi
 ```
 
@@ -146,8 +150,8 @@ If any hard-stop failures exist, stop here. Do not proceed to Phase 2.
 - `mcp_server` UPGRADE NEEDED: "Graphite MCP server requires gt v1.6.7+. The `gt mcp` stdio server registered in plugin.json will fail to start and Graphite MCP tools will be unavailable until you upgrade. Run `npm i -g @withgraphite/graphite-cli@latest` to upgrade, then re-run `/gt-setup`. All CLI-based commands (`/smart-submit`, `/gt-sync`, etc.) continue to work without MCP."
 - `mcp_server` SKIPPED or UNKNOWN: note accordingly.
 - `yq` NOT FOUND: "yq (kislyuk variant) is optional but recommended. Without it, consumer commands (`/smart-submit`, `/gt-stack-plan`, `/gt-amend`) will use hardcoded defaults instead of `.graphite.yml` settings. Install with: `pip install yq`"
-- `gh_native_queue` WARNING: "GitHub native merge queue is enabled on this repo. Graphite and GitHub native merge queue are incompatible — running both causes Graphite to restart CI on queued commits and may produce out-of-order merges. Disable GitHub native merge queue at https://github.com/<owner>/<repo>/settings/branches before continuing to use Graphite-managed stacks. Setup proceeds, but the warning will repeat each time you run `/gt-setup` until resolved."
-- `gh_native_queue` COULD NOT CHECK: this is informational only. The check requires `gh` to be authenticated and reachable. Setup proceeds normally; re-run `/gt-setup` after fixing `gh` auth to get a definitive answer.
+- `gh_native_queue` WARNING (configured): "GitHub native merge queue is configured for this repo. Graphite and GitHub native merge queue are incompatible — running both causes Graphite to restart CI on queued commits and may produce out-of-order merges. To disable: open https://github.com/<owner>/<repo>/settings/branches, edit the branch protection rule for your trunk branch, and uncheck **Require merge queue**. Setup proceeds, but the warning will repeat each time you run `/gt-setup` until resolved."
+- `gh_native_queue` COULD NOT CHECK: informational only. The parenthetical reason in the output line indicates which probe failed (gh missing/unauthenticated, `gh repo view`, or `gh api graphql`). Setup proceeds normally; re-run `/gt-setup` after fixing the underlying `gh` issue to get a definitive answer.
 
 ### Step 3: Validation Report
 

--- a/plugins/gt-workflow/commands/gt-setup.md
+++ b/plugins/gt-workflow/commands/gt-setup.md
@@ -104,7 +104,11 @@ printf '\n=== Convention Files ===\n'
 printf '\n=== Merge Queue Compatibility ===\n'
 # Capture stderr from gh probes so failure diagnostics survive (vs silent 2>/dev/null).
 mq_err_log=$(mktemp 2>/dev/null) || mq_err_log=""
-if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+# No `gh auth status` precheck: it exits non-zero if ANY known host has stale
+# auth, which produces false COULD NOT CHECK results on multi-host setups
+# (gh.com + ghe.example.com). Let `gh repo view` be the auth probe — it's
+# scoped to the current repo's host and its stderr is captured below.
+if command -v gh >/dev/null 2>&1; then
   repo_nwo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>"${mq_err_log:-/dev/null}")
   repo_view_status=$?
   if [ "$repo_view_status" -ne 0 ]; then
@@ -134,13 +138,13 @@ if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
       fi
       printf 'gh_native_queue:  COULD NOT CHECK (gh api graphql failed)\n'
     elif [ -n "$mq_check" ]; then
-      printf 'gh_native_queue:  WARNING (configured)\n'
+      printf 'gh_native_queue:  WARNING (configured — disable at https://github.com/%s/settings/branches)\n' "$repo_nwo"
     else
       printf 'gh_native_queue:  ok (not configured)\n'
     fi
   fi
 else
-  printf 'gh_native_queue:  COULD NOT CHECK (gh not authenticated or not installed)\n'
+  printf 'gh_native_queue:  COULD NOT CHECK (gh not installed)\n'
 fi
 [ -n "$mq_err_log" ] && rm -f "$mq_err_log"
 ```

--- a/plugins/gt-workflow/commands/gt-setup.md
+++ b/plugins/gt-workflow/commands/gt-setup.md
@@ -100,6 +100,33 @@ done
 printf '\n=== Convention Files ===\n'
 [ -n "$repo_top" ] && [ -f "$repo_top/.graphite.yml" ] && printf 'graphite_yml:   present\n' || printf 'graphite_yml:   not found\n'
 [ -n "$repo_top" ] && [ -f "$repo_top/.github/pull_request_template.md" ] && printf 'pr_template:    present\n' || printf 'pr_template:    not found\n'
+
+printf '\n=== Trunk Protection ===\n'
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  repo_nwo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)
+  if [ -n "$repo_nwo" ]; then
+    repo_owner="${repo_nwo%/*}"
+    repo_name="${repo_nwo#*/}"
+    # shellcheck disable=SC2016
+    mq_check=$(gh api graphql -f query='
+      query($owner:String!,$name:String!){
+        repository(owner:$owner,name:$name){ mergeQueue { url } }
+      }' -f owner="$repo_owner" -f name="$repo_name" --jq '.data.repository.mergeQueue.url // empty' 2>/dev/null)
+    mq_status=$?
+    if [ "$mq_status" -ne 0 ]; then
+      printf '[gt-workflow] Warning: merge queue check failed (gh api graphql)\n' >&2
+      printf 'gh_native_queue: COULD NOT CHECK (gh api graphql failed)\n'
+    elif [ -n "$mq_check" ]; then
+      printf 'gh_native_queue: WARNING — GitHub native merge queue is configured for this repo. Graphite and GitHub native queue are incompatible; running both causes CI restarts and may produce out-of-order merges. Disable at: https://github.com/%s/settings/branches\n' "$repo_nwo"
+    else
+      printf 'gh_native_queue: ok (not configured)\n'
+    fi
+  else
+    printf 'gh_native_queue: COULD NOT CHECK (gh repo view returned no name)\n'
+  fi
+else
+  printf 'gh_native_queue: COULD NOT CHECK (gh not authenticated or not installed)\n'
+fi
 ```
 
 ### Step 2: Interpret Results
@@ -119,6 +146,8 @@ If any hard-stop failures exist, stop here. Do not proceed to Phase 2.
 - `mcp_server` UPGRADE NEEDED: "Graphite MCP server requires gt v1.6.7+. The `gt mcp` stdio server registered in plugin.json will fail to start and Graphite MCP tools will be unavailable until you upgrade. Run `npm i -g @withgraphite/graphite-cli@latest` to upgrade, then re-run `/gt-setup`. All CLI-based commands (`/smart-submit`, `/gt-sync`, etc.) continue to work without MCP."
 - `mcp_server` SKIPPED or UNKNOWN: note accordingly.
 - `yq` NOT FOUND: "yq (kislyuk variant) is optional but recommended. Without it, consumer commands (`/smart-submit`, `/gt-stack-plan`, `/gt-amend`) will use hardcoded defaults instead of `.graphite.yml` settings. Install with: `pip install yq`"
+- `gh_native_queue` WARNING: "GitHub native merge queue is enabled on this repo. Graphite and GitHub native merge queue are incompatible — running both causes Graphite to restart CI on queued commits and may produce out-of-order merges. Disable GitHub native merge queue at https://github.com/<owner>/<repo>/settings/branches before continuing to use Graphite-managed stacks. Setup proceeds, but the warning will repeat each time you run `/gt-setup` until resolved."
+- `gh_native_queue` COULD NOT CHECK: this is informational only. The check requires `gh` to be authenticated and reachable. Setup proceeds normally; re-run `/gt-setup` after fixing `gh` auth to get a definitive answer.
 
 ### Step 3: Validation Report
 


### PR DESCRIPTION
docs: graphite merge-queue research and design artifacts

Captures the April 2026 research pipeline for Graphite stacked PRs and
merge-queue behavior, plus the brainstorm and plan documents that the
gt-workflow code changes (next commit) implement.

- docs/research/: comprehensive multi-source research on Graphite platform,
  merge queue lifecycle, GitHub native merge_queue, and coding-agent merge
  patterns as of April 2026
- docs/brainstorms/: gt-workflow improvements brainstorm (the basis for this
  PR's code changes) and a separate gt-merge-queue add-on brainstorm
  (deferred plugin, not implemented here)
- docs/solutions/: 3 institutional-knowledge docs on Graphite/GitHub native
  queue incompatibility, mergedAt:null detection semantics, and merge-queue
  agent anti-patterns
- plans/: enriched implementation plan for the gt-workflow code changes

feat(gt-workflow): native queue advisory + closed-not-merged guard

Two additive platform-level guards motivated by the Graphite merge-queue
research (docs/research/graphite-merge-queue-stacked-prs-coding-agents.md).
Both apply to every Graphite user, not just users of Graphite's optional
merge queue.

gt-setup — GitHub native merge queue advisory:
- New "=== Merge Queue Compatibility ===" section in Phase 1 prerequisite report.
- Detects via gh api graphql repository.mergeQueue.url. The branch-level
  enablement field is not exposed via REST/GraphQL (community discussion
  #170601), so we use the repo-level mergeQueue object as a proxy.
- Three states: WARNING (queue configured, prints disable link), ok (not
  configured), COULD NOT CHECK (gh unauthenticated/unavailable). Fail-open;
  setup never blocks.
- Added gh_native_queue WARNING entry to Step 2 Warnings list.

gt-cleanup — closed-not-merged guard:
- gh pr list now requests --json state,mergedAt (one extra field, no new
  API call).
- Closed PR category now distinguishes merged (mergedAt set) from
  closed-without-landing (mergedAt: null), tagging the latter as
  closed_not_merged for downstream display.
- "Delete all" mode prepends a count warning when any branch in the
  deletion set is closed_not_merged.
- "Review individually" mode shows "PR status: closed (no merge — verify
  before deleting)" for those branches.

Prevents silent data loss after queue ejection or PR abandonment, and warns
operators about a deployment-time incompatibility (Graphite + GitHub native
queue) before it produces out-of-order merges.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two platform-level guards to `gt-workflow`: a GitHub native merge queue advisory in `gt-setup` (Phase 1 prerequisite report, fail-open via `gh api graphql`) and a `closed_not_merged` distinction in `gt-cleanup` that tags queue-ejected or abandoned branches before deletion. Supporting research, brainstorm, solution, and plan documents are also included.

The `merged` field issue flagged in the previous review is resolved — the implementation correctly uses `state,mergedAt` and relies on the unambiguous `state == \"CLOSED\"` enum rather than a non-existent `merged` boolean. The changeset bump is now `minor` as expected for additive feature changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both guards are fail-open and additive; the one logic edge case is a low-probability false-positive that increases caution rather than risking data loss

Only P2 findings present. The single logic issue (closed_not_merged tag fires when a branch has both a CLOSED and a MERGED PR) results in a spurious warning, not a missed warning or data loss. All other logic — the GraphQL probe, mktemp fallback, jq empty handling, [gone]-branch exclusion, and Step 3 report — is correct.

plugins/gt-workflow/commands/gt-cleanup.md — the CLOSED_NOT_MERGED jq predicate

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/gt-workflow/commands/gt-setup.md | Adds native merge queue detection via gh api graphql with correct fail-open behaviour; Step 3 validation report now includes Merge Queue line; logic is sound |
| plugins/gt-workflow/commands/gt-cleanup.md | closed_not_merged guard implemented correctly for the common case; minor false-positive edge case when a branch has both a CLOSED and a MERGED PR in its history |
| .changeset/gt-workflow-merge-queue-platform-guards.md | Bump type now correctly set to `minor` (additive feature changes); changeset prose is accurate and matches implementation |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["gt-setup Phase 1"] --> B["gh repo view\n(get owner/name)"]
    B --> |"fails"| C["gh_native_queue:\nCOULD NOT CHECK"]
    B --> |"ok"| D["gh api graphql\nrepository.mergeQueue.url"]
    D --> |"fails / repo null"| C
    D --> |"mergeQueue != null"| E["gh_native_queue:\nWARNING\n(print disable link)"]
    D --> |"mergeQueue == null\n(jq empty)"| F["gh_native_queue:\nok"]
    E --> G["Step 3 Report:\nMerge Queue: WARNING"]
    F --> G2["Step 3 Report:\nMerge Queue: ok"]

    H["gt-cleanup Phase 2"] --> I["gh pr list\n--json state,mergedAt"]
    I --> J{{"ALL_TERMINAL?"}}
    J --> |"yes"| K{{"CLOSED_NOT_MERGED?\n(any state==CLOSED)"}}
    J --> |"no"| L["Normal classification"]
    K --> |"yes"| M["tag: closed_not_merged=true"]
    K --> |"no (all MERGED)"| N["Closed PR — no tag"]
    M --> O["Phase 4: show\n'closed (no merge —\nverify before deleting)'"]
    M --> P["Delete all mode:\nprepend count warning"]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `plugins/gt-workflow/commands/gt-setup.md`, line 152-166 ([link](https://github.com/kinginyellows/yellow-plugins/blob/24d923c1ba6658888539311ba859effa06a57f1a/plugins/gt-workflow/commands/gt-setup.md#L152-L166)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`gh_native_queue` result absent from Step 3 Validation Report**

   Every other check — including optional ones like `yq` and `MCP Server` — surfaces in the Step 3 consolidated report. The new `gh_native_queue` check has no corresponding line here, so the operator gets the advisory buried in the Step 2 warning prose but never sees a clean `Native Queue:` line in the summary table. Adding it alongside the other checks would make the report consistent and more scannable.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: plugins/gt-workflow/commands/gt-setup.md
   Line: 152-166

   Comment:
   **`gh_native_queue` result absent from Step 3 Validation Report**

   Every other check — including optional ones like `yq` and `MCP Server` — surfaces in the Step 3 consolidated report. The new `gh_native_queue` check has no corresponding line here, so the operator gets the advisory buried in the Step 2 warning prose but never sees a clean `Native Queue:` line in the summary table. Adding it alongside the other checks would make the report consistent and more scannable.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22feat%2Fgt-workflow-merge-queue-improvements%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fgt-workflow-merge-queue-improvements%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plugins%2Fgt-workflow%2Fcommands%2Fgt-setup.md%0ALine%3A%20152-166%0A%0AComment%3A%0A**%60gh_native_queue%60%20result%20absent%20from%20Step%203%20Validation%20Report**%0A%0AEvery%20other%20check%20%E2%80%94%20including%20optional%20ones%20like%20%60yq%60%20and%20%60MCP%20Server%60%20%E2%80%94%20surfaces%20in%20the%20Step%203%20consolidated%20report.%20The%20new%20%60gh_native_queue%60%20check%20has%20no%20corresponding%20line%20here%2C%20so%20the%20operator%20gets%20the%20advisory%20buried%20in%20the%20Step%202%20warning%20prose%20but%20never%20sees%20a%20clean%20%60Native%20Queue%3A%60%20line%20in%20the%20summary%20table.%20Adding%20it%20alongside%20the%20other%20checks%20would%20make%20the%20report%20consistent%20and%20more%20scannable.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22feat%2Fgt-workflow-merge-queue-improvements%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fgt-workflow-merge-queue-improvements%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aplugins%2Fgt-workflow%2Fcommands%2Fgt-cleanup.md%3A208-211%0A**%60closed_not_merged%60%20false-positive%20when%20branch%20has%20both%20CLOSED%20and%20MERGED%20PRs**%0A%0AIf%20a%20branch%20has%20an%20earlier%20closed-without-merging%20PR%20%28%23100%2C%20state%20CLOSED%29%20and%20a%20later%20successfully%20merged%20PR%20%28%23200%2C%20state%20MERGED%29%2C%20both%20%60ALL_TERMINAL%20%3D%3D%20true%60%20and%20%60CLOSED_NOT_MERGED%20%3D%3D%20true%60%20fire%20together.%20The%20branch%20gets%20tagged%20%60closed_not_merged%3Dtrue%60%20and%20shows%20%22PR%20status%3A%20closed%20%28no%20merge%20%E2%80%94%20verify%20before%20deleting%29%22%20even%20though%20it%20was%20ultimately%20merged.%20The%20fix%20is%20to%20gate%20the%20%60closed_not_merged%60%20tag%20on%20the%20absence%20of%20any%20MERGED%20PR%3A%20%60any%28.%5B%5D%3B%20.state%20%3D%3D%20%22CLOSED%22%29%20and%20%28any%28.%5B%5D%3B%20.state%20%3D%3D%20%22MERGED%22%29%20%7C%20not%29%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
plugins/gt-workflow/commands/gt-cleanup.md:208-211
**`closed_not_merged` false-positive when branch has both CLOSED and MERGED PRs**

If a branch has an earlier closed-without-merging PR (#100, state CLOSED) and a later successfully merged PR (#200, state MERGED), both `ALL_TERMINAL == true` and `CLOSED_NOT_MERGED == true` fire together. The branch gets tagged `closed_not_merged=true` and shows "PR status: closed (no merge — verify before deleting)" even though it was ultimately merged. The fix is to gate the `closed_not_merged` tag on the absence of any MERGED PR: `any(.[]; .state == "CLOSED") and (any(.[]; .state == "MERGED") | not)`.


`````

</details>

<sub>Reviews (6): Last reviewed commit: ["fix(gt-workflow): drop invalid \`merged\` ..."](https://github.com/kinginyellows/yellow-plugins/commit/24c4aee5a388b994de20110bdec93dd686622e6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30410264)</sub>

<!-- /greptile_comment -->