### PR TITLE
feat(yellow-debt): scanner output schema v2.0 with confidence-rubric calibration (W3.13b)

### DIFF
--- a/.changeset/yellow-debt-v2-confidence-calibration.md
+++ b/.changeset/yellow-debt-v2-confidence-calibration.md
@@ -3,6 +3,7 @@
 ---
 
 # Scanner output schema v2.0 — failure_scenario field, audit-synthesizer
+
 confidence-rubric gate, dual-read v1.0/v2.0 transition window (W3.13b)
 
 Bumps `debt-conventions/SKILL.md` from `schema_version: "1.0"` to `"2.0"` and

--- a/.changeset/yellow-debt-v2-confidence-calibration.md
+++ b/.changeset/yellow-debt-v2-confidence-calibration.md
@@ -1,0 +1,40 @@
+---
+"yellow-debt": minor
+---
+
+Scanner output schema v2.0 — failure_scenario field, audit-synthesizer
+confidence-rubric gate, dual-read v1.0/v2.0 transition window (W3.13b)
+
+Bumps `debt-conventions/SKILL.md` from `schema_version: "1.0"` to `"2.0"` and
+restructures the scanner output shape:
+
+- `affected_files[]` (array) → `file` (single object); multi-file findings emit
+  one finding per file instead of packing them into one entry
+- `title` + `description` → flat `finding` string
+- `suggested_remediation` → `fix`
+- new required `failure_scenario` field (string or `null`) — one-to-two-sentence
+  concrete production failure: trigger → execution path → user-visible or
+  operational outcome. Borrowed from upstream
+  `EveryInc/compound-engineering-plugin` `ce-adversarial-reviewer.agent.md` at
+  locked SHA `e5b397c9d1883354f03e338dd00f98be3da39f9f`.
+
+`audit-synthesizer` gains a category-specific confidence-rubric gate (Step 4):
+security-debt/architecture ≥0.80, complexity/duplication ≥0.70, ai-pattern
+≥0.60. Critical findings survive at ≥0.50 (mirrors the Wave 2 P0-at-anchor-50
+exception). Migrated v1.0 inputs receive a +0.05 threshold bump to compensate
+for the missing `failure_scenario` signal.
+
+The synthesizer dual-reads `schema_version: "1.0"` and `"2.0"` artifacts during
+the transition window, normalizing v1.0 inputs to the v2.0 in-memory shape so
+existing `.debt/scanner-output/*.json` files do not break re-runs. Suppressed
+findings are preserved in a `suppressed[]` array on the audit report (with the
+gate that suppressed them) rather than silently dropped.
+
+All 5 scanner agents (`ai-pattern`, `architecture`, `complexity`, `duplication`,
+`security-debt`) updated with category-specific `failure_scenario` framing
+guidance in their Output Requirements sections. The yellow-debt README todo
+template gains a `## Failure Scenario` section so triage reviewers see the
+production-impact framing alongside the debt description.
+
+This is a breaking change to the on-disk JSON contract; the dual-read window
+keeps existing artifacts working while scanners migrate to v2.0.

--- a/.changeset/yellow-debt-v2-confidence-calibration.md
+++ b/.changeset/yellow-debt-v2-confidence-calibration.md
@@ -2,7 +2,7 @@
 "yellow-debt": minor
 ---
 
-Scanner output schema v2.0 — failure_scenario field, audit-synthesizer
+# Scanner output schema v2.0 — failure_scenario field, audit-synthesizer
 confidence-rubric gate, dual-read v1.0/v2.0 transition window (W3.13b)
 
 Bumps `debt-conventions/SKILL.md` from `schema_version: "1.0"` to `"2.0"` and
@@ -36,5 +36,7 @@ guidance in their Output Requirements sections. The yellow-debt README todo
 template gains a `## Failure Scenario` section so triage reviewers see the
 production-impact framing alongside the debt description.
 
-This is a breaking change to the on-disk JSON contract; the dual-read window
-keeps existing artifacts working while scanners migrate to v2.0.
+Schema evolution: scanner output is renamed v1.0 → v2.0 with field renames and
+a new required failure_scenario field. The audit-synthesizer's dual-read
+transition window normalizes v1.0 inputs in-memory, so existing scanner outputs
+continue to work without modification during the transition window.

--- a/plugins/yellow-debt/README.md
+++ b/plugins/yellow-debt/README.md
@@ -146,6 +146,7 @@ priority: p2
 category: complexity
 severity: high
 effort: small
+confidence: 0.85
 scanner: complexity-scanner
 audit_date: '2026-02-13'
 affected_files:
@@ -162,18 +163,30 @@ content_hash: 'a3f2b1c4'
 
 [Description of the issue]
 
+## Failure Scenario
+
+[One-to-two-sentence concrete production failure: trigger → execution path →
+user-visible or operational outcome. Sourced from the scanner's
+`failure_scenario` field (v2.0 schema). Empty if the scanner emitted `null`.]
+
 ## Context
 
 [Code snippet]
 
-## Suggested Remediation
+## Fix
 
-[How to fix it]
+[How to fix it. Sourced from the scanner's `fix` field (v2.0 schema; renamed
+from v1.0 `suggested_remediation`).]
 
 ## Effort Estimate
 
 **Small** (30min-2hr): Extract 2-3 methods, flatten nesting.
 ```
+
+**Schema mapping:** the on-disk `affected_files` array key is intentionally
+retained for backward compatibility with `debt-fixer.md` Step 3; see the
+"v2.0 → todo frontmatter mapping" table in `audit-synthesizer.md` Step 7
+for the full v2.0 (in-memory) → frontmatter (on-disk) mapping.
 
 ## State Machine
 

--- a/plugins/yellow-debt/agents/scanners/ai-pattern-scanner.md
+++ b/plugins/yellow-debt/agents/scanners/ai-pattern-scanner.md
@@ -73,11 +73,12 @@ Return top 50 findings max, ranked by severity × confidence. Write results to
 `.debt/scanner-output/ai-pattern-scanner.json` per the v2.0 schema in
 `debt-conventions`.
 
-Every finding requires a concrete `failure_scenario` (one to two sentences:
-trigger → execution path → user-visible or operational outcome). AI-pattern
-debt rarely produces a runtime failure on its own — frame the scenario around
-the maintenance failure that the debt enables (e.g., "a future engineer reads
-the 40% comment-to-code ratio, trusts a stale comment claiming the function
-is idempotent, ships a retry handler that double-charges users"). When no
-concrete scenario can be constructed, emit `null` — the synthesizer treats
-`null` as a downgrade signal.
+Every finding must include the `failure_scenario` field (string or null).
+Prefer a concrete scenario when possible (one to two sentences: trigger →
+execution path → user-visible or operational outcome); emit `null` only when
+no specific failure can be constructed. AI-pattern debt rarely produces a
+runtime failure on its own — frame the scenario around the maintenance failure
+that the debt enables (e.g., "a future engineer reads the 40% comment-to-code
+ratio, trusts a stale comment claiming the function is idempotent, ships a
+retry handler that double-charges users"). The synthesizer treats `null` as a
+downgrade signal.

--- a/plugins/yellow-debt/agents/scanners/ai-pattern-scanner.md
+++ b/plugins/yellow-debt/agents/scanners/ai-pattern-scanner.md
@@ -70,5 +70,14 @@ Follow all security and fencing rules from the `debt-conventions` skill.
 ## Output Requirements
 
 Return top 50 findings max, ranked by severity × confidence. Write results to
-`.debt/scanner-output/ai-pattern-scanner.json` per schema in debt-conventions
-skill.
+`.debt/scanner-output/ai-pattern-scanner.json` per the v2.0 schema in
+`debt-conventions`.
+
+Every finding requires a concrete `failure_scenario` (one to two sentences:
+trigger → execution path → user-visible or operational outcome). AI-pattern
+debt rarely produces a runtime failure on its own — frame the scenario around
+the maintenance failure that the debt enables (e.g., "a future engineer reads
+the 40% comment-to-code ratio, trusts a stale comment claiming the function
+is idempotent, ships a retry handler that double-charges users"). When no
+concrete scenario can be constructed, emit `null` — the synthesizer treats
+`null` as a downgrade signal.

--- a/plugins/yellow-debt/agents/scanners/architecture-scanner.md
+++ b/plugins/yellow-debt/agents/scanners/architecture-scanner.md
@@ -80,11 +80,12 @@ Return top 50 findings max, ranked by severity × confidence. Write results to
 `.debt/scanner-output/architecture-scanner.json` per the v2.0 schema in
 `debt-conventions`.
 
-Every finding requires a concrete `failure_scenario` (one to two sentences:
-trigger → execution path → user-visible or operational outcome). Architecture
-scenarios should name the specific change that triggers cascading rework
-(e.g., "swapping the in-process cache for Redis requires editing 14 files
-across 3 layers because UI components import the cache module directly,
-extending the migration from a 2-day spike to a 2-week project"). When no
-concrete scenario can be constructed, emit `null` — the synthesizer treats
-`null` as a downgrade signal.
+Every finding must include the `failure_scenario` field (string or null).
+Prefer a concrete scenario when possible (one to two sentences: trigger →
+execution path → user-visible or operational outcome); emit `null` only when
+no specific failure can be constructed — the synthesizer treats `null` as a
+downgrade signal. Architecture scenarios should name the specific change that
+triggers cascading rework (e.g., "swapping the in-process cache for Redis
+requires editing 14 files across 3 layers because UI components import the
+cache module directly, extending the migration from a 2-day spike to a
+2-week project").

--- a/plugins/yellow-debt/agents/scanners/architecture-scanner.md
+++ b/plugins/yellow-debt/agents/scanners/architecture-scanner.md
@@ -77,5 +77,14 @@ Follow all security and fencing rules from the `debt-conventions` skill.
 ## Output Requirements
 
 Return top 50 findings max, ranked by severity × confidence. Write results to
-`.debt/scanner-output/architecture-scanner.json` per schema in debt-conventions
-skill.
+`.debt/scanner-output/architecture-scanner.json` per the v2.0 schema in
+`debt-conventions`.
+
+Every finding requires a concrete `failure_scenario` (one to two sentences:
+trigger → execution path → user-visible or operational outcome). Architecture
+scenarios should name the specific change that triggers cascading rework
+(e.g., "swapping the in-process cache for Redis requires editing 14 files
+across 3 layers because UI components import the cache module directly,
+extending the migration from a 2-day spike to a 2-week project"). When no
+concrete scenario can be constructed, emit `null` — the synthesizer treats
+`null` as a downgrade signal.

--- a/plugins/yellow-debt/agents/scanners/complexity-scanner.md
+++ b/plugins/yellow-debt/agents/scanners/complexity-scanner.md
@@ -99,12 +99,12 @@ Return top 50 findings max, ranked by severity × confidence. Write results to
 `.debt/scanner-output/complexity-scanner.json` per the v2.0 schema in
 `debt-conventions`.
 
-Every finding requires a concrete `failure_scenario` (one to two sentences:
-trigger → execution path → user-visible or operational outcome). Complexity
-scenarios should name the specific change that the complexity makes risky
-(e.g., "an engineer adds a feature flag check inside a 300-line function with
-6 nested branches, intends it to bypass step 2 only, but the conditional
-short-circuits step 5 too because the early-return logic is implicit — the
-flag silently disables auditing"). When no concrete scenario can be
-constructed, emit `null` — the synthesizer treats `null` as a downgrade
-signal.
+Every finding must include the `failure_scenario` field (string or null).
+Prefer a concrete scenario when possible (one to two sentences: trigger →
+execution path → user-visible or operational outcome). Complexity scenarios
+should name the specific change that the complexity makes risky (e.g., "an
+engineer adds a feature flag check inside a 300-line function with 6 nested
+branches, intends it to bypass step 2 only, but the conditional short-circuits
+step 5 too because the early-return logic is implicit — the flag silently
+disables auditing"). Emit `null` only when no specific failure can be
+constructed — the synthesizer treats `null` as a downgrade signal.

--- a/plugins/yellow-debt/agents/scanners/complexity-scanner.md
+++ b/plugins/yellow-debt/agents/scanners/complexity-scanner.md
@@ -96,5 +96,15 @@ Skip unreadable or binary files without incrementing `files_scanned`.
 ## Output Requirements
 
 Return top 50 findings max, ranked by severity × confidence. Write results to
-`.debt/scanner-output/complexity-scanner.json` per schema in debt-conventions
-skill.
+`.debt/scanner-output/complexity-scanner.json` per the v2.0 schema in
+`debt-conventions`.
+
+Every finding requires a concrete `failure_scenario` (one to two sentences:
+trigger → execution path → user-visible or operational outcome). Complexity
+scenarios should name the specific change that the complexity makes risky
+(e.g., "an engineer adds a feature flag check inside a 300-line function with
+6 nested branches, intends it to bypass step 2 only, but the conditional
+short-circuits step 5 too because the early-return logic is implicit — the
+flag silently disables auditing"). When no concrete scenario can be
+constructed, emit `null` — the synthesizer treats `null` as a downgrade
+signal.

--- a/plugins/yellow-debt/agents/scanners/duplication-scanner.md
+++ b/plugins/yellow-debt/agents/scanners/duplication-scanner.md
@@ -99,11 +99,12 @@ Return top 50 findings max, ranked by severity × confidence. Write results to
 `.debt/scanner-output/duplication-scanner.json` per the v2.0 schema in
 `debt-conventions`.
 
-Every finding requires a concrete `failure_scenario` (one to two sentences:
-trigger → execution path → user-visible or operational outcome). Duplication
-scenarios should name the divergence-driven failure (e.g., "the validation
-helper is copied across 4 endpoints; a security patch fixes the canonical
-copy and the email-verification copy but misses the signup and password-reset
-copies, leaving two endpoints exploitable for 11 days until the next
-audit"). When no concrete scenario can be constructed, emit `null` — the
-synthesizer treats `null` as a downgrade signal.
+Every finding must include the `failure_scenario` field (string or null).
+Prefer a concrete scenario when possible (one to two sentences: trigger →
+execution path → user-visible or operational outcome). Duplication scenarios
+should name the divergence-driven failure (e.g., "the validation helper is
+copied across 4 endpoints; a security patch fixes the canonical copy and the
+email-verification copy but misses the signup and password-reset copies,
+leaving two endpoints exploitable for 11 days until the next audit"). Emit
+`null` only when no specific failure can be constructed — the synthesizer
+treats `null` as a downgrade signal.

--- a/plugins/yellow-debt/agents/scanners/duplication-scanner.md
+++ b/plugins/yellow-debt/agents/scanners/duplication-scanner.md
@@ -96,5 +96,14 @@ guarantee the ast-grep binary is installed — if an ast-grep call fails with
 ## Output Requirements
 
 Return top 50 findings max, ranked by severity × confidence. Write results to
-`.debt/scanner-output/duplication-scanner.json` per schema in debt-conventions
-skill.
+`.debt/scanner-output/duplication-scanner.json` per the v2.0 schema in
+`debt-conventions`.
+
+Every finding requires a concrete `failure_scenario` (one to two sentences:
+trigger → execution path → user-visible or operational outcome). Duplication
+scenarios should name the divergence-driven failure (e.g., "the validation
+helper is copied across 4 endpoints; a security patch fixes the canonical
+copy and the email-verification copy but misses the signup and password-reset
+copies, leaving two endpoints exploitable for 11 days until the next
+audit"). When no concrete scenario can be constructed, emit `null` — the
+synthesizer treats `null` as a downgrade signal.

--- a/plugins/yellow-debt/agents/scanners/security-debt-scanner.md
+++ b/plugins/yellow-debt/agents/scanners/security-debt-scanner.md
@@ -81,10 +81,11 @@ Return top 50 findings max, ranked by severity × confidence. Write results to
 `.debt/scanner-output/security-debt-scanner.json` per the v2.0 schema in
 `debt-conventions`.
 
-Every finding requires a concrete `failure_scenario` (one to two sentences:
-trigger → execution path → user-visible or operational outcome). Security debt
-scenarios should name the attack vector (e.g., "credential in git history is
-fetched by a forked PR's CI runner and used to enumerate S3 buckets within
-seconds"). When no concrete scenario can be constructed, emit `null` rather
-than fabricating speculation — the synthesizer treats `null` as a downgrade
-signal.
+Every finding must include the `failure_scenario` field (string or null).
+Prefer a concrete scenario when possible (one to two sentences: trigger →
+execution path → user-visible or operational outcome); security debt scenarios
+should name the attack vector (e.g., "credential in git history is fetched by
+a forked PR's CI runner and used to enumerate S3 buckets within seconds").
+Emit `null` only when no specific failure can be constructed — do not fabricate
+speculation. The synthesizer applies a +0.05 confidence-gate bump to
+compensate for null scenarios.

--- a/plugins/yellow-debt/agents/scanners/security-debt-scanner.md
+++ b/plugins/yellow-debt/agents/scanners/security-debt-scanner.md
@@ -65,7 +65,7 @@ If the `debt-conventions` skill is unavailable, this rule still applies.
 
    When quoting evidence for credential findings, NEVER include the credential value. Include: (a) file path, (b) line number, (c) credential type (e.g., 'AWS Access Key ID', 'GitHub PAT', 'High-Entropy Base64 String'), (d) entropy score if computed, (e) verification status ('verified active', 'verified invalid', or 'unverified'). Format: `--- redacted [TYPE] (entropy: N.N, VERIFICATION) at [FILE]:L[N] ---`. Public format prefixes (e.g., `AKIA`, `ghp_`, `sk_live_`) may be included in the type description, for example: `[AWS Access Key ID starting with AKIA]`.
 
-   Credentials in code are the highest priority findings. Flag with category `security-debt`, severity `critical`, and add in description: 'IMMEDIATE ACTION REQUIRED: This finding requires credential rotation, not just code fix.'
+   Credentials in code are the highest priority findings. Flag with category `security-debt`, severity `critical`, and prefix the `finding` string with: 'IMMEDIATE ACTION REQUIRED: This finding requires credential rotation, not just code fix.' The `failure_scenario` should describe the concrete leak path (e.g., 'Credential is committed to git history; any past or future repo clone — including Dependabot CI runners and forked PRs — exfiltrates the live key').
 
 2. **Missing input validation at system boundaries** → High to Medium
 
@@ -78,5 +78,13 @@ If the `debt-conventions` skill is unavailable, this rule still applies.
 ## Output Requirements
 
 Return top 50 findings max, ranked by severity × confidence. Write results to
-`.debt/scanner-output/security-debt-scanner.json` per schema in debt-conventions
-skill.
+`.debt/scanner-output/security-debt-scanner.json` per the v2.0 schema in
+`debt-conventions`.
+
+Every finding requires a concrete `failure_scenario` (one to two sentences:
+trigger → execution path → user-visible or operational outcome). Security debt
+scenarios should name the attack vector (e.g., "credential in git history is
+fetched by a forked PR's CI runner and used to enumerate S3 buckets within
+seconds"). When no concrete scenario can be constructed, emit `null` rather
+than fabricating speculation — the synthesizer treats `null` as a downgrade
+signal.

--- a/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
+++ b/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
@@ -123,7 +123,11 @@ per finding; the first rule that fires decides the outcome:
    the gate regardless of category or migration status. This is the Wave 2
    P0-at-anchor-50 exception
    (`RESEARCH/upstream-snapshots/e5b397c9d1883354f03e338dd00f98be3da39f9f/confidence-rubric.md`).
-   Stop; do not apply step 4 or step 5.
+   **Increment `stats.survived_severity_exception` by 1** for each finding
+   that exits via this rule (so the counter matches what is documented in
+   the stats schema below — without this, the counter is always 0 and gate
+   bypasses are invisible to operators). Stop; do not apply step 4 or
+   step 5.
 4. **Missing-failure-scenario bump.** If the finding is stamped
    `_migrated_from: "1.0"` OR has `failure_scenario == null`, add `+0.05` to
    the category threshold for this finding only. The bump compensates for
@@ -227,9 +231,15 @@ the on-disk frontmatter, not the in-memory v2.0 record.
 **CRITICAL SECURITY - Slug Derivation**:
 
 ```bash
-# The Bash block runs in a fresh subprocess. Derive $finding from the JSON
-# record FIRST in this same block; do not assume any variable from prose
-# context is set in the shell environment.
+# The Bash block runs in a fresh subprocess. The LLM agent iterates over
+# the surviving-findings JSON array; for each iteration it must export
+# `$record` (the single in-memory finding object as a JSON string) and
+# `$id`/`$severity`/`$content_hash` (the synthesizer-assigned per-finding
+# fields) into the shell environment BEFORE invoking this block — variables
+# from prose context are NOT inherited automatically by a fresh subprocess.
+# Derive $finding from $record FIRST in this same block as a sanity check
+# (a missing $record will produce empty $finding and the whitelist below
+# will reject the empty slug, surfacing the missing-input bug loudly):
 finding=$(printf '%s' "$record" | jq -r '.finding')
 
 # Lowercase, replace special chars, truncate, validate.

--- a/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
+++ b/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
@@ -218,6 +218,7 @@ on-disk frontmatter as follows:
 | `confidence`         | `confidence:` frontmatter    | Float 0.0–1.0, written as-is                |
 | `category`           | `category:` frontmatter      | Direct                                      |
 | `severity`           | `severity:` and `priority:`  | `severity` direct; `priority` mapped: critical→p1, high→p2, medium→p3, low→p4 |
+| (synthesizer-derived) | `scanner:` frontmatter      | Set to the originating scanner agent's `scanner` field from the v2.0 record's source `.debt/scanner-output/<scanner>.json` (e.g., `complexity-scanner`); enables filtering and provenance in the README todo template |
 
 This mapping preserves the existing `debt-fixer.md` scope-validator
 (`yq -r '.affected_files[]'` at line 57) without changes — the fixer reads

--- a/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
+++ b/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
@@ -21,30 +21,135 @@ assistant: "I'll merge and deduplicate all findings, then generate the audit rep
 </examples>
 
 You are a technical debt audit synthesizer. Merge scanner outputs, deduplicate
-findings, score severity, and generate audit reports with actionable todos.
+findings, apply confidence-rubric gates, and generate audit reports with
+actionable todos.
 
-Reference `debt-conventions` skill for: JSON schema, severity scoring, effort
-estimation, category definitions, and todo file template.
+Reference `debt-conventions` skill for: JSON schema (v2.0), severity scoring,
+effort estimation, category definitions, confidence-rubric thresholds, and
+todo file template. The synthesizer accepts both v1.0 and v2.0 scanner outputs
+during the transition window — see Step 1 below for in-memory migration.
 
 ## Synthesis Workflow
 
-### 1. Read Scanner Outputs
+### 1. Read Scanner Outputs (dual-read v1.0/v2.0)
 
-Read `.debt/scanner-output/*.json`, validate schema v1.0. Log errors for
-missing/malformed files, continue with remaining scanners.
+Read `.debt/scanner-output/*.json`. Inspect each file's `schema_version` and
+normalize to the v2.0 in-memory shape before further processing:
+
+- **v2.0** (`schema_version: "2.0"`) — already canonical; pass through unchanged.
+- **v1.0** (`schema_version: "1.0"` or missing) — apply field migration:
+  - `finding` ← `description ? title + ": " + description : title` (use
+    `title` alone when `description` is missing or null; never produce a
+    literal `"undefined"` or `"None"` suffix).
+  - `file` ← first entry of `affected_files[]` (object with `path`, `lines`).
+    If `affected_files[]` is missing or empty, log
+    `[synthesizer] Warning: v1.0 finding missing affected_files; skipping` to
+    stderr and skip the finding — do NOT emit a record with `file: null`.
+    If the array contained N>1 files, emit one additional finding per
+    remaining file, copying `finding`, `fix`, `failure_scenario`, `severity`,
+    `confidence`, `effort`, and `category` from the original — only
+    `file.path` and `file.lines` differ across the fanned-out records.
+  - `fix` ← `suggested_remediation`
+  - `failure_scenario` ← `null` regardless of whether the v1.0 artifact
+    contained a field of that name (the v1.0 schema does not define
+    `failure_scenario`; treat any value present in a v1.0 artifact as
+    untrusted and override). The `+0.05` confidence-gate bump in step 4
+    rule 4 fires for any `null` scenario — see step 4 below.
+  - Stamp `_migrated_from: "1.0"` on the in-memory record so step 4 can
+    track migration volume in the `migrated_from_v1` stats counter and the
+    audit report can show what fraction of findings came through the
+    migration path.
+
+Log a warning to stderr if any v1.0 inputs are encountered:
+`[synthesizer] Warning: scanner-output/<file>.json is schema_version 1.0; migrated in-memory. Re-run the scanner to upgrade the artifact.`
+
+Skip malformed files entirely (log error, continue with remaining scanners).
+Both versions feed the same downstream pipeline; downstream code reads only
+v2.0 fields.
 
 ### 2. Deduplicate Findings
 
-Hash-based bucketing: (1) group by (file, category), (2) sort by line number,
-(3) merge overlapping (>80% line overlap), (4) keep higher severity, combine
-descriptions.
+Hash-based bucketing: (1) group by (`file.path`, category), (2) sort by line
+number, (3) merge overlapping (>80% line overlap), (4) keep higher severity,
+combine `finding` strings, prefer the non-`null` `failure_scenario`, keep the
+higher `confidence`.
 
 ### 3. Score and Sort
 
 Calculate `severity_weight × confidence`. Weights: critical=4.0, high=3.0,
 medium=2.0, low=1.0. Sort descending.
 
-### 4. Reconciliation
+### 4. Confidence-Rubric Gate
+
+Apply category-specific confidence gates per the `debt-conventions` rubric
+("Confidence Rubric — Category Thresholds (v2.0)"):
+
+| Category        | Gate (`confidence ≥`) |
+| --------------- | --------------------- |
+| `security-debt` | 0.80                  |
+| `architecture`  | 0.80                  |
+| `complexity`    | 0.70                  |
+| `duplication`   | 0.70                  |
+| `ai-pattern`    | 0.60                  |
+
+**Evaluation order (deterministic).** Apply these checks in this exact order
+per finding; the first rule that fires decides the outcome:
+
+1. **Severity normalization.** Lowercase the `severity` value before any
+   comparison: `severity = severity.lower()`. Without this, an LLM scanner
+   that emits `"Critical"` or `"CRITICAL"` would silently fail the
+   case-sensitive string comparison below. Log
+   `[synthesizer] Warning: severity "<original>" normalized to "<lower>"` to
+   stderr when a normalization was needed so the casing drift is observable.
+2. **Confidence presence and type.** If `confidence` is missing, `null`, or
+   not a number, suppress the finding with reason
+   `missing_or_invalid_confidence` (recorded in `suppressed[]`) and log
+   `[synthesizer] Warning: <reviewer> emitted finding with missing/invalid confidence; suppressing` to stderr.
+   This check runs BEFORE the severity exception so a critical finding with
+   `confidence: null` cannot reach the `confidence ≥ 0.50` comparison and
+   crash a type-strict implementation or coerce silently in a permissive
+   one. Stop.
+3. **Severity exception (highest priority among numeric-confidence checks).**
+   If `severity == "critical"` and `confidence ≥ 0.50`, the finding survives
+   the gate regardless of category or migration status. This is the Wave 2
+   P0-at-anchor-50 exception
+   (`RESEARCH/upstream-snapshots/e5b397c9d1883354f03e338dd00f98be3da39f9f/confidence-rubric.md`).
+   Stop; do not apply step 4 or step 5.
+4. **Missing-failure-scenario bump.** If the finding is stamped
+   `_migrated_from: "1.0"` OR has `failure_scenario == null`, add `+0.05` to
+   the category threshold for this finding only. The bump compensates for
+   the missing concrete-failure signal — v1.0 records lack the field
+   entirely, and v2.0 records may legitimately emit `null` rather than
+   fabricate a scenario. The bump for v1.0-stamped records expires when the
+   transition window closes and v1.0 artifacts no longer appear in
+   `.debt/scanner-output/`; the bump for v2.0 `null` scenarios remains as a
+   permanent calibration mechanism.
+5. **Category gate.** Compare `confidence` against the (possibly bumped)
+   category threshold from the table above. If `confidence ≥ threshold`, the
+   finding survives. Otherwise, suppress with reason
+   `below_category_gate:<category>` (recorded in `suppressed[]`).
+
+**Unknown category default.** If the finding's `category` is not one of the
+five rows in the table above, apply a conservative default gate of `0.80`
+and log `[synthesizer] Warning: unknown category "<cat>"; applying default gate 0.80` to stderr.
+This prevents a future category from silently passing all findings or
+silently suppressing all findings depending on dictionary defaults.
+
+Suppressed findings are preserved in a separate `suppressed[]` array on the
+report (with the gate-name that suppressed them) so reviewers can audit gate
+calibration; they are NOT discarded silently.
+
+Record gate stats:
+
+```json
+"stats": {
+  "suppressed_by_confidence_gate": 12,
+  "survived_severity_exception": 2,
+  "migrated_from_v1": 4
+}
+```
+
+### 5. Reconciliation
 
 Count existing pending todos, confirm deletion via AskUserQuestion:
 
@@ -58,35 +163,70 @@ fi
 
 Preserve all other states (ready, in-progress, complete, deferred).
 
-### 5. Generate Audit Report
+### 6. Generate Audit Report
 
 Create `docs/audits/YYYY-MM-DD-audit-report.md`:
 
 - Executive summary (debt score, findings, effort)
 - Scanner status table (✓/✗, counts, duration)
 - Category breakdown (critical/high/medium/low)
+- Confidence-gate stats (suppressed counts per category, severity-exception
+  survivors, migrated-v1 count)
 - Hotspot files
 - Next steps (`/debt:triage`)
 
-### 6. Generate Todo Files
+### 7. Generate Todo Files
+
+**Iterate only over the surviving findings list from Step 4 — do NOT include
+entries from `suppressed[]`.** The suppressed array is preserved on the audit
+report for calibration review, not for todo generation. A finding that was
+gated out at Step 4 must not become a pending todo at Step 7.
 
 Format: `todos/debt/NNN-pending-SEVERITY-slug-HASH.md`
 
 - `NNN`: zero-padded ID (001, 002...)
 - `SEVERITY`: critical/high/medium/low
-- `slug`: kebab-case title (40 chars max)
+- `slug`: kebab-case derived from the v2.0 `finding` string (40 chars max)
 - `HASH`: SHA256(category:file:lines) first 8 chars
 
-Use template from `debt-conventions` skill.
+#### v2.0 → todo frontmatter mapping (write side)
+
+The v2.0 in-memory record uses `file: { path, lines }` (single object) and
+flat `finding`/`fix` strings. The on-disk todo frontmatter format
+(documented in the README "Todo File Format" section, read by
+`debt-fixer.md` Step 3) intentionally retains the v1.0-style
+`affected_files: - path:lines` array key for backward compatibility with
+the existing fixer scope-validator. Map the in-memory v2.0 fields to the
+on-disk frontmatter as follows:
+
+| v2.0 in-memory field | On-disk todo frontmatter key | Mapping rule                                |
+| -------------------- | ---------------------------- | ------------------------------------------- |
+| `file.path`          | `affected_files[0]` prefix   | `affected_files: \n  - <file.path>:<file.lines>` (single-element array) |
+| `file.lines`         | `affected_files[0]` suffix   | (combined with path above)                  |
+| `finding`            | H1 title + `## Finding` body | Direct (see README todo template for example) |
+| `fix`                | `## Fix` body                | Direct body text                          |
+| `failure_scenario`   | `## Failure Scenario` body   | Empty body when scanner emitted `null`      |
+| `confidence`         | `confidence:` frontmatter    | Float 0.0–1.0, written as-is                |
+| `category`           | `category:` frontmatter      | Direct                                      |
+| `severity`           | `severity:` and `priority:`  | `severity` direct; `priority` mapped: critical→p1, high→p2, medium→p3, low→p4 |
+
+This mapping preserves the existing `debt-fixer.md` scope-validator
+(`yq -r '.affected_files[]'` at line 57) without changes — the fixer reads
+the on-disk frontmatter, not the in-memory v2.0 record.
 
 **CRITICAL SECURITY - Slug Derivation**:
 
 ```bash
-# Lowercase, replace special chars, truncate, validate
-slug=$(printf '%s' "$title" | tr '[:upper:]' '[:lower:]' | tr -c '[:alnum:]-' '-' | sed 's/-\+/-/g; s/^-\|-$//g' | cut -c1-40 | sed 's/-$//')
+# The Bash block runs in a fresh subprocess. Derive $finding from the JSON
+# record FIRST in this same block; do not assume any variable from prose
+# context is set in the shell environment.
+finding=$(printf '%s' "$record" | jq -r '.finding')
+
+# Lowercase, replace special chars, truncate, validate.
+slug=$(printf '%s' "$finding" | tr '[:upper:]' '[:lower:]' | tr -c '[:alnum:]-' '-' | sed 's/-\+/-/g; s/^-\|-$//g' | cut -c1-40 | sed 's/-$//')
 
 # CRITICAL: whitelist validation
-[[ "$slug" =~ ^[a-z0-9-]+$ ]] || slug=$(echo -n "$title" | sha256sum | cut -c1-16)
+[[ "$slug" =~ ^[a-z0-9-]+$ ]] || slug=$(printf '%s' "$finding" | sha256sum | cut -d' ' -f1 | cut -c1-16)
 
 todo_filename="todos/debt/${id}-pending-${severity}-${slug}-${content_hash}.md"
 
@@ -101,10 +241,10 @@ esac
 Prevents path traversal via: (1) whitelist validation, (2) hash fallback, (3)
 path canonicalization.
 
-### 7. Output Summary
+### 8. Output Summary
 
-Display scanner status, finding counts by severity, estimated effort, next
-steps.
+Display scanner status, finding counts by severity, confidence-gate stats,
+estimated effort, next steps.
 
 ## Safety Rules
 

--- a/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
+++ b/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
@@ -37,31 +37,35 @@ Read `.debt/scanner-output/*.json`. Inspect each file's `schema_version` and
 normalize to the v2.0 in-memory shape before further processing:
 
 - **v2.0** (`schema_version: "2.0"`) — already canonical; pass through unchanged.
-- **v1.0** (`schema_version: "1.0"` or missing) — apply field migration:
-  - `finding` ← `description ? title + ": " + description : title` (use
-    `title` alone when `description` is missing or null; never produce a
-    literal `"undefined"` or `"None"` suffix).
-  - `file` ← first entry of `affected_files[]` (object with `path`, `lines`).
-    If `affected_files[]` is missing or empty, log
-    `[synthesizer] Warning: v1.0 finding missing affected_files; skipping` to
-    stderr and skip the finding — do NOT emit a record with `file: null`.
-    If the array contained N>1 files, emit one additional finding per
-    remaining file, copying `finding`, `fix`, `failure_scenario`, `severity`,
-    `confidence`, `effort`, and `category` from the original — only
-    `file.path` and `file.lines` differ across the fanned-out records.
-  - `fix` ← `suggested_remediation`
-  - `failure_scenario` ← `null` regardless of whether the v1.0 artifact
-    contained a field of that name (the v1.0 schema does not define
-    `failure_scenario`; treat any value present in a v1.0 artifact as
-    untrusted and override). The `+0.05` confidence-gate bump in step 4
-    rule 4 fires for any `null` scenario — see step 4 below.
-  - Stamp `_migrated_from: "1.0"` on the in-memory record so step 4 can
-    track migration volume in the `migrated_from_v1` stats counter and the
-    audit report can show what fraction of findings came through the
-    migration path.
+- **v1.0** (`schema_version: "1.0"` or missing) — apply field migration in
+  this order (scalars first, then fan-out):
+  1. `finding` ← `description ? title + ": " + description : title` (use
+     `title` alone when `description` is missing or null; never produce a
+     literal `"undefined"` or `"None"` suffix).
+  2. `fix` ← `suggested_remediation`
+  3. `failure_scenario` ← `null` regardless of whether the v1.0 artifact
+     contained a field of that name (the v1.0 schema does not define
+     `failure_scenario`; treat any value present in a v1.0 artifact as
+     untrusted and override). The `+0.05` confidence-gate bump in step 4
+     rule 4 fires for any `null` scenario — see step 4 below.
+  4. Stamp `_migrated_from: "1.0"` on the in-memory record so step 4 can
+     track migration volume in the `migrated_from_v1` stats counter and the
+     audit report can show what fraction of findings came through the
+     migration path.
+  5. `file` ← first entry of `affected_files[]` (object with `path`,
+     `lines`). If `affected_files[]` is missing or empty, log
+     `[synthesizer] Warning: v1.0 finding missing affected_files; skipping`
+     to stderr and skip the finding — do NOT emit a record with
+     `file: null`. If the array contained N>1 files, emit one additional
+     finding per remaining file, copying all already-mapped scalar fields
+     (`finding`, `fix`, `failure_scenario`, `severity`, `confidence`,
+     `effort`, `category`, and `_migrated_from`) from the normalized
+     record — only `file.path` and `file.lines` differ across the
+     fanned-out records.
 
 Log a warning to stderr if any v1.0 inputs are encountered:
-`[synthesizer] Warning: scanner-output/<file>.json is schema_version 1.0; migrated in-memory. Re-run the scanner to upgrade the artifact.`
+`[synthesizer] Warning: scanner-output/<file>.json is schema_version 1.0;`
+`migrated in-memory. Re-run the scanner to upgrade the artifact.`
 
 Skip malformed files entirely (log error, continue with remaining scanners).
 Both versions feed the same downstream pipeline; downstream code reads only
@@ -71,8 +75,9 @@ v2.0 fields.
 
 Hash-based bucketing: (1) group by (`file.path`, category), (2) sort by line
 number, (3) merge overlapping (>80% line overlap), (4) keep higher severity,
-combine `finding` strings, prefer the non-`null` `failure_scenario`, keep the
-higher `confidence`.
+combine `finding` strings, prefer the non-`null` `failure_scenario` (if both
+findings have a non-`null` `failure_scenario`, keep the one from the finding
+with higher `confidence`), keep the higher `confidence`.
 
 ### 3. Score and Sort
 
@@ -101,14 +106,18 @@ per finding; the first rule that fires decides the outcome:
    case-sensitive string comparison below. Log
    `[synthesizer] Warning: severity "<original>" normalized to "<lower>"` to
    stderr when a normalization was needed so the casing drift is observable.
-2. **Confidence presence and type.** If `confidence` is missing, `null`, or
-   not a number, suppress the finding with reason
-   `missing_or_invalid_confidence` (recorded in `suppressed[]`) and log
+2. **Confidence presence, type, and range.** If `confidence` is missing,
+   `null`, not a number, or outside the range `[0.0, 1.0]`, suppress the
+   finding with reason `missing_or_invalid_confidence` (recorded in
+   `suppressed[]`) and log
    `[synthesizer] Warning: <reviewer> emitted finding with missing/invalid confidence; suppressing` to stderr.
    This check runs BEFORE the severity exception so a critical finding with
    `confidence: null` cannot reach the `confidence ≥ 0.50` comparison and
    crash a type-strict implementation or coerce silently in a permissive
-   one. Stop.
+   one. The range guard additionally prevents an out-of-range value such as
+   `2.5` from passing all category gates (since `2.5 ≥` any threshold) and
+   prevents a negative value such as `-0.5` from failing all gates when it
+   should be suppressed as malformed scanner output. Stop.
 3. **Severity exception (highest priority among numeric-confidence checks).**
    If `severity == "critical"` and `confidence ≥ 0.50`, the finding survives
    the gate regardless of category or migration status. This is the Wave 2

--- a/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
+++ b/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
@@ -48,10 +48,12 @@ normalize to the v2.0 in-memory shape before further processing:
      `failure_scenario`; treat any value present in a v1.0 artifact as
      untrusted and override). The `+0.05` confidence-gate bump in step 4
      rule 4 fires for any `null` scenario — see step 4 below.
-  4. Stamp `_migrated_from: "1.0"` on the in-memory record so step 4 can
-     track migration volume in the `migrated_from_v1` stats counter and the
-     audit report can show what fraction of findings came through the
-     migration path.
+  4. Stamp `_migrated_from: "1.0"` on the in-memory record AND
+     **increment `stats.migrated_from_v1` by 1**. The counter tracks
+     migration volume so the audit report can show what fraction of
+     findings came through the migration path; without the explicit
+     increment instruction the counter would always report 0 even when
+     v1.0 inputs were normalized.
   5. `file` ← first entry of `affected_files[]` (object with `path`,
      `lines`). If `affected_files[]` is missing or empty, log
      `[synthesizer] Warning: v1.0 finding missing affected_files; skipping`
@@ -126,8 +128,10 @@ per finding; the first rule that fires decides the outcome:
    **Increment `stats.survived_severity_exception` by 1** for each finding
    that exits via this rule (so the counter matches what is documented in
    the stats schema below — without this, the counter is always 0 and gate
-   bypasses are invisible to operators). Stop; do not apply step 4 or
-   step 5.
+   bypasses are invisible to operators). Stop; do not apply rule 4 or
+   rule 5 (the inner per-finding evaluation rules — Step 4 and Step 5 of
+   the outer workflow are different scopes and remain part of the same
+   pipeline).
 4. **Missing-failure-scenario bump.** If the finding is stamped
    `_migrated_from: "1.0"` OR has `failure_scenario == null`, add `+0.05` to
    the category threshold for this finding only. The bump compensates for

--- a/plugins/yellow-debt/skills/debt-conventions/SKILL.md
+++ b/plugins/yellow-debt/skills/debt-conventions/SKILL.md
@@ -20,27 +20,25 @@ This skill is the single source of truth for debt assessment across the plugin.
 
 ## Usage
 
-### Scanner Output Schema (v1.0)
+### Scanner Output Schema (v2.0)
 
 All scanner agents MUST produce output matching this JSON schema:
 
 ```json
 {
-  "schema_version": "1.0",
+  "schema_version": "2.0",
   "scanner": "complexity-scanner",
   "status": "success",
-  "timestamp": "2026-02-13T10:30:00Z",
+  "timestamp": "2026-05-01T10:30:00Z",
   "findings": [
     {
       "category": "complexity",
       "severity": "high",
       "effort": "small",
-      "title": "High Cyclomatic Complexity in UserService",
-      "description": "Function processUserRegistration has complexity 23 (threshold: 15)...",
-      "affected_files": [
-        { "path": "src/services/user-service.ts", "lines": "45-89" }
-      ],
-      "suggested_remediation": "Extract guard clauses and split into...",
+      "finding": "Function processUserRegistration in UserService has cyclomatic complexity 23 (threshold: 15) due to nested validation branches.",
+      "file": { "path": "src/services/user-service.ts", "lines": "45-89" },
+      "fix": "Extract validation guards into pure functions and split the registration flow into two methods.",
+      "failure_scenario": "A new validation rule lands in a branch that already mixes auth, throttling, and email checks; the engineer misses one path, production registrations succeed without throttle enforcement, and the abuse signal degrades silently.",
       "confidence": 0.85
     }
   ],
@@ -54,15 +52,57 @@ All scanner agents MUST produce output matching this JSON schema:
 
 **Field Constraints**:
 
-- `schema_version`: Always "1.0" (for forward compatibility)
+- `schema_version`: "2.0" for new findings; v1.0 inputs accepted by
+  `audit-synthesizer` during the transition window (see "Schema Migration"
+  below)
 - `status`: "success" | "partial" | "error"
 - `category`: "ai-pattern" | "complexity" | "duplication" | "architecture" |
   "security-debt"
 - `severity`: "critical" | "high" | "medium" | "low"
 - `effort`: "quick" | "small" | "medium" | "large"
 - `confidence`: 0.0-1.0 (how confident the scanner is in this finding)
-- `affected_files`: Array with minimum 1 item
-- `lines`: Format "start-end" (e.g., "45-89")
+- `finding`: Single string combining what was detected and why it matters
+  (replaces v1.0 `title` + `description`; one to three sentences)
+- `file`: Single object `{ path, lines }` (replaces v1.0 `affected_files[]`;
+  if multiple files share a finding, emit one finding per file)
+- `lines`: Format "start-end" (e.g., "45-89") or a single line ("45")
+- `fix`: Concrete remediation prose (replaces v1.0 `suggested_remediation`)
+- `failure_scenario`: One to two sentences naming a specific production failure
+  the debt enables — the trigger, the execution path, and the user-visible or
+  operational outcome. Not generic risk language ("could be hard to maintain"),
+  not speculation ("might cause bugs"). If no concrete scenario can be
+  constructed, set to `null` and the synthesizer applies the same `+0.05`
+  confidence-gate bump used for migrated v1.0 records (see
+  `audit-synthesizer.md` Step 4, rule 4). The bump compensates for the
+  missing concrete-failure signal regardless of whether `null` came from a
+  v1.0 migration or a v2.0 scanner that chose not to fabricate. Borrowed
+  from the upstream `ce-adversarial-reviewer` failure-scenario framing.
+
+### Confidence Rubric — Category Thresholds (v2.0)
+
+`audit-synthesizer` applies category-specific confidence gates after dedup and
+before todo generation. Findings below the gate are suppressed (recorded in
+stats as `suppressed_by_confidence_gate`) but never silently dropped from the
+audit report.
+
+| Category                 | Gate (`confidence ≥`) | Rationale                                          |
+| ------------------------ | --------------------- | -------------------------------------------------- |
+| `security-debt`          | 0.80                  | False positives waste triage time on critical path |
+| `architecture`           | 0.80                  | Structural fixes are expensive — avoid speculation |
+| `complexity`             | 0.70                  | Heuristic detection has known noise                |
+| `duplication`            | 0.70                  | Similar-but-not-identical code needs evidence      |
+| `ai-pattern`             | 0.60                  | Style-class debt; lower stakes per false positive  |
+
+Thresholds adapted from Diffray industry calibration (see
+`RESEARCH/upstream-snapshots/e5b397c9d1883354f03e338dd00f98be3da39f9f/confidence-rubric.md`
+"Comparable benchmarks"). The Wave 2 review-pr keystone uses integer anchors
+(0/25/50/75/100) over the same conceptual range; yellow-debt retains the v1.0
+float scale because scanners produce continuous heuristic confidence, not
+discrete reviewer-anchor judgments.
+
+**Severity exception:** A `critical` finding at `confidence ≥ 0.50` survives
+the gate (mirrors the Wave 2 P0-at-anchor-50 exception). The synthesizer
+records this as `survived_severity_exception` in stats.
 
 ### Severity Rubric
 
@@ -205,8 +245,7 @@ All scanner agents should follow this minimal structure (~40 lines):
 ```markdown
 ---
 name: <category>-scanner
-description:
-  '<category> analysis. Use when auditing code for <specific patterns>.'
+description: "<category> analysis. Use when auditing code for <specific patterns>."
 model: inherit
 skills:
   - debt-conventions
@@ -223,11 +262,13 @@ tools:
 You are a <category> detection specialist. Reference the `debt-conventions`
 skill for:
 
-- JSON output schema and validation
+- JSON output schema (v2.0) and validation
 - Severity scoring (Critical/High/Medium/Low)
 - Effort estimation (Quick/Small/Medium/Large)
 - Safety rules (prompt injection fencing)
 - Path validation requirements
+- `failure_scenario` framing (concrete trigger → path → outcome; `null`
+  permitted when no concrete scenario can be constructed)
 
 ## Detection Heuristics
 
@@ -237,7 +278,9 @@ skill for:
 ## Output Requirements
 
 Return top 50 findings max, ranked by severity × confidence. Write results to
-`.debt/scanner-output/<category>-scanner.json` per schema above.
+`.debt/scanner-output/<category>-scanner.json` per the v2.0 schema in the
+`debt-conventions` skill (single `file` object, flat `finding` and `fix`
+strings, required `failure_scenario` string-or-null).
 ```
 
 ## Error Handling
@@ -306,10 +349,31 @@ All shell scripts must use LF (Unix) line endings, not CRLF (Windows).
 
 ### Schema Version Mismatch
 
-Scanner output must use `"schema_version": "1.0"` for forward compatibility.
+Scanner output should use `"schema_version": "2.0"` (current). The
+`audit-synthesizer` accepts both 1.0 and 2.0 during the transition window
+(see "Schema Migration" below) so older `.debt/scanner-output/*.json` files
+do not break re-runs.
 
-**Remediation**: Update scanner agent to use current schema version from this
-skill.
+**Remediation**: Update new or modified scanner agents to emit v2.0. Leave
+older artifact files untouched — the synthesizer normalizes them in-memory.
+
+### Schema Migration (v1.0 → v2.0)
+
+Breaking changes from v1.0:
+
+| v1.0 field              | v2.0 field          | Migration                                                          |
+| ----------------------- | ------------------- | ------------------------------------------------------------------ |
+| `title`                 | `finding`           | `description ? title + ": " + description : title` — use `title` alone when `description` is null or missing; never produce a literal `"undefined"` or `"None"` suffix |
+| `description`           | `finding`           | Merged into `finding`                                              |
+| `affected_files[]`      | `file`              | Take first array entry; if `null`/empty/missing, log warning and skip the finding; if N>1, emit one additional finding per remaining file copying all other fields including `_migrated_from: "1.0"` so each sibling receives the Step 4 +0.05 confidence bump |
+| `suggested_remediation` | `fix`               | Direct rename                                                      |
+| _(new)_                 | `failure_scenario`  | v1.0 inputs default to `null` (synthesizer flags as upgradeable)   |
+
+The `audit-synthesizer` performs this normalization in-memory when it reads a
+`schema_version: "1.0"` artifact; scanner authors do not need migration code.
+The transition window remains open until all scanners on `main` emit v2.0 and
+no `.debt/scanner-output/*.json` files older than 30 days remain in active
+project trees.
 
 ### Confidence Out of Range
 
@@ -317,13 +381,27 @@ skill.
 
 **Remediation**: Clamp values: `confidence = Math.max(0, Math.min(1, value))`
 
-### Missing Affected Files
+### Missing File Field
 
-Every finding MUST include at least one entry in `affected_files` array with
-`path` and `lines` fields.
+Every finding MUST include a `file` object with `path` and `lines` fields. If a
+single debt pattern affects multiple files, emit one finding per file rather
+than packing them into one entry — this keeps dedup, todo generation, and
+hotspot scoring deterministic.
 
-**Remediation**: Ensure scanner agents populate this field with actual file
-locations.
+**Remediation**: Ensure scanner agents populate `file.path` and `file.lines`
+on every emitted finding.
+
+### Missing failure_scenario
+
+`failure_scenario` is required (string or `null`). When the scanner cannot
+construct a concrete production failure (trigger → path → outcome), emit
+`null` rather than fabricating speculation. The synthesizer treats `null`
+scenarios as a signal that the finding may be advisory-only.
+
+**Remediation**: Reference the upstream `ce-adversarial-reviewer` framing
+(`RESEARCH/upstream-snapshots/e5b397c9d1883354f03e338dd00f98be3da39f9f/plugins/compound-engineering/agents/ce-adversarial-reviewer.agent.md`)
+when authoring scenarios — describe a specific trigger, the execution path
+through the diffed code, and the user-visible or operational outcome.
 
 ### Validation References
 


### PR DESCRIPTION
Bump debt-conventions schema_version 1.0 → 2.0: rename affected_files[] → file (single object), merge title+description → flat finding, suggested_remediation → fix, add required failure_scenario string-or-null. Adapted from upstream EveryInc/compound-engineering-plugin ce-adversarial-reviewer at locked SHA e5b397c9d1883354f03e338dd00f98be3da39f9f.

Add Step 4 confidence-rubric gate to audit-synthesizer: security-debt/architecture ≥0.80, complexity/duplication ≥0.70, ai-pattern ≥0.60. Critical findings survive at ≥0.50 (mirrors Wave 2 P0-at-anchor-50 exception). Migrated v1.0 inputs receive +0.05 threshold bump to compensate for missing failure_scenario signal.

Synthesizer Step 1 dual-reads v1.0 and v2.0 artifacts during the transition window, normalizing v1.0 inputs to the v2.0 in-memory shape so existing .debt/scanner-output/*.json files do not break re-runs. Suppressed findings are preserved in a suppressed[] array on the audit report rather than silently dropped.

All 5 scanner agents gain category-specific failure_scenario framing guidance in their Output Requirements sections. README todo template gains a ## Failure Scenario section so triage reviewers see production-impact framing alongside the debt description.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Scanner output schema moves to v2.0 with a restructured finding shape: single file per finding, flattened finding text, renamed remediation → fix, and a required failure_scenario (string or null).

* **New Features**
  * Category-specific confidence gates with migrated-input +0.05 bump and critical-preservation rules.
  * Legacy v1.0 inputs are auto-normalized during transition; suppressed findings are preserved in audit reports.

* **Documentation**
  * Updated scanner guidance, templates, and todo/readme to reflect v2.0 fields and failure scenario guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the yellow-debt schema v2.0 migration: renames `affected_files[]→file`, `title`+`description`→`finding`, `suggested_remediation`→`fix`, adds required `failure_scenario`, and wires a 5-rule confidence-rubric gate into the audit-synthesizer (Step 4). A dual-read transition window normalizes v1.0 artifacts in-memory so existing scanner outputs don't break re-runs.

- **P1 (new):** `stats.suppressed_by_confidence_gate` has no explicit **Increment** directive in Step 4 Rules 2 or 5, even though this PR added such directives for `survived_severity_exception` and `migrated_from_v1` for the same reason — the counter will always report 0, making the gate's primary output metric invisible to operators.

<h3>Confidence Score: 3/5</h3>

Hold for the suppressed_by_confidence_gate counter gap; remaining issues are P2 clarity concerns.

One new P1: the primary stats counter for the confidence gate has no increment instruction, mirroring the exact class of bug this PR explicitly fixed for the other two stats counters. P2 issues do not lower the score further.

plugins/yellow-debt/agents/synthesis/audit-synthesizer.md — Step 4 evaluation rules 2 and 5 need explicit increment directives for stats.suppressed_by_confidence_gate.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/yellow-debt/agents/synthesis/audit-synthesizer.md | Major workflow expansion adding dual-read v1.0/v2.0 normalization, a 5-rule confidence-rubric gate (Step 4), and an explicit v2.0→frontmatter mapping table in Step 7. New gap: suppressed_by_confidence_gate counter has no explicit increment instruction despite the same pattern being applied to the other two stats counters. |
| plugins/yellow-debt/skills/debt-conventions/SKILL.md | Schema bumped 1.0→2.0 with full field rename documentation, confidence rubric thresholds table, migration table with null-guard for description→finding merge, and updated error-handling sections. Consistently aligned with audit-synthesizer changes. |
| plugins/yellow-debt/README.md | Todo template updated: confidence: 0.85 added to frontmatter, ## Failure Scenario section added, ## Suggested Remediation renamed to ## Fix. H1 example remains v1.0-style short title, creating ambiguity against the new audit-synthesizer Direct mapping instruction. |
| plugins/yellow-debt/agents/scanners/security-debt-scanner.md | Output Requirements updated for v2.0 schema with failure_scenario guidance. Phrasing about the +0.05 bump is inconsistent with the other four scanners' clearer downgrade signal language. |
| .changeset/yellow-debt-v2-confidence-calibration.md | New changeset documenting v2.0 schema changes. Breaking change versioning concern already flagged in a prior thread. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Step 1: Read Scanner Outputs\n(dual-read v1.0 / v2.0)"] --> B{schema_version?}
    B -- "2.0" --> C[Pass through unchanged]
    B -- "1.0 or missing" --> D["Migrate in-memory:\nfinding, fix, failure_scenario=null\n_migrated_from: '1.0'\n++stats.migrated_from_v1"]
    D --> E{affected_files empty?}
    E -- yes --> F[Log warning, skip finding]
    E -- "N≥1" --> G["Fan-out: 1 record per file"]
    C --> H
    G --> H["Step 2: Deduplicate"]
    H --> I["Step 3: Score & Sort"]
    I --> J["Step 4: Confidence-Rubric Gate"]
    J --> K{Rule 2: confidence valid?}
    K -- no --> L["Suppress → suppressed[]\n⚠️ no increment for suppressed_by_confidence_gate"]
    K -- yes --> M{Rule 3: critical ≥ 0.50?}
    M -- yes --> N["Survive\n++stats.survived_severity_exception"]
    M -- no --> O{Rule 4: _migrated_from=1.0 OR failure_scenario=null?}
    O -- yes --> P[threshold += 0.05]
    O -- no --> Q[threshold unchanged]
    P --> R
    Q --> R{Rule 5: confidence ≥ threshold?}
    R -- yes --> S[Finding survives]
    R -- no --> T["Suppress → suppressed[]\n⚠️ no increment for suppressed_by_confidence_gate"]
    N --> S
    S --> U["Steps 5-7: Reconciliation → Audit Report → Todo Files"]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `plugins/yellow-debt/README.md`, line 142-157 ([link](https://github.com/kinginyellows/yellow-plugins/blob/0a98167dfb5a309198d4fe60f4bcaa5d24b42ffa/plugins/yellow-debt/README.md#L142-L157)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`confidence:` frontmatter field missing from todo template**

   The synthesizer's Step 7 mapping table (new in this PR) explicitly writes `confidence` to a `confidence:` frontmatter key (`Float 0.0–1.0, written as-is`), but the `## Todo File Format` frontmatter block here was not updated to include that field. Any downstream tooling or reviewer consulting this template as canonical — including `debt-fixer.md` or future consumers — will not know the field exists, and the template's own example files will silently omit it.

   Add `confidence:` to the frontmatter block, e.g.:

   ```yaml
   content_hash: 'a3f2b1c4'
   confidence: 0.85
   ---
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: plugins/yellow-debt/README.md
   Line: 142-157

   Comment:
   **`confidence:` frontmatter field missing from todo template**

   The synthesizer's Step 7 mapping table (new in this PR) explicitly writes `confidence` to a `confidence:` frontmatter key (`Float 0.0–1.0, written as-is`), but the `## Todo File Format` frontmatter block here was not updated to include that field. Any downstream tooling or reviewer consulting this template as canonical — including `debt-fixer.md` or future consumers — will not know the field exists, and the template's own example files will silently omit it.

   Add `confidence:` to the frontmatter block, e.g.:

   ```yaml
   content_hash: 'a3f2b1c4'
   confidence: 0.85
   ---
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Fyellow-debt-confidence-calibration%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Fyellow-debt-confidence-calibration%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plugins%2Fyellow-debt%2FREADME.md%0ALine%3A%20142-157%0A%0AComment%3A%0A**%60confidence%3A%60%20frontmatter%20field%20missing%20from%20todo%20template**%0A%0AThe%20synthesizer's%20Step%207%20mapping%20table%20%28new%20in%20this%20PR%29%20explicitly%20writes%20%60confidence%60%20to%20a%20%60confidence%3A%60%20frontmatter%20key%20%28%60Float%200.0%E2%80%931.0%2C%20written%20as-is%60%29%2C%20but%20the%20%60%23%23%20Todo%20File%20Format%60%20frontmatter%20block%20here%20was%20not%20updated%20to%20include%20that%20field.%20Any%20downstream%20tooling%20or%20reviewer%20consulting%20this%20template%20as%20canonical%20%E2%80%94%20including%20%60debt-fixer.md%60%20or%20future%20consumers%20%E2%80%94%20will%20not%20know%20the%20field%20exists%2C%20and%20the%20template's%20own%20example%20files%20will%20silently%20omit%20it.%0A%0AAdd%20%60confidence%3A%60%20to%20the%20frontmatter%20block%2C%20e.g.%3A%0A%0A%60%60%60yaml%0Acontent_hash%3A%20'a3f2b1c4'%0Aconfidence%3A%200.85%0A---%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

2. `plugins/yellow-debt/agents/synthesis/audit-synthesizer.md`, line 364-376 ([link](https://github.com/kinginyellows/yellow-plugins/blob/fe8d22dfcfa8171532fd14ac822e7a7c57b072fc/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md#L364-L376)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`stats.suppressed_by_confidence_gate` has no explicit increment instruction**

   Rules 2 and 5 both record suppressions to `suppressed[]` but neither says to increment `stats.suppressed_by_confidence_gate`. This PR fixed the parallel gaps for `survived_severity_exception` (Rule 3) and `migrated_from_v1` (Step 1) by adding bold **Increment** directives. Without the same treatment here, an LLM following the evaluation order will emit `0` for `suppressed_by_confidence_gate` — making the gate's primary output metric always misleading.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
   Line: 364-376

   Comment:
   **`stats.suppressed_by_confidence_gate` has no explicit increment instruction**

   Rules 2 and 5 both record suppressions to `suppressed[]` but neither says to increment `stats.suppressed_by_confidence_gate`. This PR fixed the parallel gaps for `survived_severity_exception` (Rule 3) and `migrated_from_v1` (Step 1) by adding bold **Increment** directives. Without the same treatment here, an LLM following the evaluation order will emit `0` for `suppressed_by_confidence_gate` — making the gate's primary output metric always misleading.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Fyellow-debt-confidence-calibration%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Fyellow-debt-confidence-calibration%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plugins%2Fyellow-debt%2Fagents%2Fsynthesis%2Faudit-synthesizer.md%0ALine%3A%20364-376%0A%0AComment%3A%0A**%60stats.suppressed_by_confidence_gate%60%20has%20no%20explicit%20increment%20instruction**%0A%0ARules%202%20and%205%20both%20record%20suppressions%20to%20%60suppressed%5B%5D%60%20but%20neither%20says%20to%20increment%20%60stats.suppressed_by_confidence_gate%60.%20This%20PR%20fixed%20the%20parallel%20gaps%20for%20%60survived_severity_exception%60%20%28Rule%203%29%20and%20%60migrated_from_v1%60%20%28Step%201%29%20by%20adding%20bold%20**Increment**%20directives.%20Without%20the%20same%20treatment%20here%2C%20an%20LLM%20following%20the%20evaluation%20order%20will%20emit%20%600%60%20for%20%60suppressed_by_confidence_gate%60%20%E2%80%94%20making%20the%20gate's%20primary%20output%20metric%20always%20misleading.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Fyellow-debt-confidence-calibration%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Fyellow-debt-confidence-calibration%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aplugins%2Fyellow-debt%2Fagents%2Fsynthesis%2Faudit-synthesizer.md%3A364-376%0A**%60stats.suppressed_by_confidence_gate%60%20has%20no%20explicit%20increment%20instruction**%0A%0ARules%202%20and%205%20both%20record%20suppressions%20to%20%60suppressed%5B%5D%60%20but%20neither%20says%20to%20increment%20%60stats.suppressed_by_confidence_gate%60.%20This%20PR%20fixed%20the%20parallel%20gaps%20for%20%60survived_severity_exception%60%20%28Rule%203%29%20and%20%60migrated_from_v1%60%20%28Step%201%29%20by%20adding%20bold%20**Increment**%20directives.%20Without%20the%20same%20treatment%20here%2C%20an%20LLM%20following%20the%20evaluation%20order%20will%20emit%20%600%60%20for%20%60suppressed_by_confidence_gate%60%20%E2%80%94%20making%20the%20gate's%20primary%20output%20metric%20always%20misleading.%0A%0A%23%23%23%20Issue%202%20of%203%0Aplugins%2Fyellow-debt%2Fagents%2Fscanners%2Fsecurity-debt-scanner.md%3A89-91%0AThe%20closing%20sentence%20about%20the%20%2B0.05%20bump%20is%20phrased%20as%20though%20null%20emission%20benefits%20the%20finding%20%28%22compensate%20for%20null%20scenarios%22%20reads%20as%20the%20synthesizer%20helping%20the%20scanner%29.%20The%20other%20four%20scanners%20all%20say%20%22the%20synthesizer%20treats%20%60null%60%20as%20a%20downgrade%20signal%2C%22%20which%20correctly%20communicates%20that%20null%20emission%20is%20penalized%20%28higher%20threshold%29.%20Using%20inconsistent%20phrasing%20here%20could%20encourage%20a%20security-debt%20scanner%20author%20to%20emit%20%60null%60%20expecting%20a%20confidence%20boost%20rather%20than%20a%20stricter%20gate.%0A%0A%60%60%60suggestion%0AEmit%20%60null%60%20only%20when%20no%20specific%20failure%20can%20be%20constructed%20%E2%80%94%20do%20not%20fabricate%0Aspeculation.%20The%20synthesizer%20treats%20%60null%60%20as%20a%20downgrade%20signal%20%28raises%20the%0Acategory%20gate%20by%20%2B0.05%2C%20making%20the%20threshold%20stricter%29.%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aplugins%2Fyellow-debt%2Fagents%2Fsynthesis%2Faudit-synthesizer.md%3A223%0A**%60finding%20%E2%86%92%20H1%20title%20%2B%20%23%23%20Finding%20body%20%7C%20Direct%60%20is%20ambiguous%20against%20the%20README%20example**%0A%0AThe%20mapping%20says%20write%20the%20v2.0%20%60finding%60%20string%20verbatim%20to%20both%20the%20H1%20heading%20and%20the%20%60%23%23%20Finding%60%20body.%20But%20the%20README%20todo%20template%20still%20shows%20a%20short%20v1.0-style%20H1%20%28%60%23%20High%20Cyclomatic%20Complexity%20in%20UserService%60%2C%20derived%20from%20the%20old%20%60title%60%20field%29.%20A%20v2.0%20%60finding%60%20is%201%E2%80%933%20sentences%2C%20so%20%22Direct%22%20would%20produce%20a%20multi-sentence%20H1%20%E2%80%94%20and%20the%20same%20text%20again%20in%20%60%23%23%20Finding%60%2C%20making%20the%20body%20section%20redundant.%20An%20LLM%20consulting%20the%20README%20example%20would%20likely%20try%20to%20abbreviate%20the%20%60finding%60%20to%20match%20the%20short%20example%20title%2C%20conflicting%20with%20the%20%22Direct%22%20instruction.%20The%20README%20example%20H1%20should%20be%20updated%20to%20show%20a%20v2.0-style%20sentence-form%20%60finding%60%2C%20or%20the%20mapping%20rule%20should%20explicitly%20note%20that%20the%20H1%20uses%20the%20full%20%60finding%60%20string%20verbatim%20even%20when%20multi-sentence.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
plugins/yellow-debt/agents/synthesis/audit-synthesizer.md:364-376
**`stats.suppressed_by_confidence_gate` has no explicit increment instruction**

Rules 2 and 5 both record suppressions to `suppressed[]` but neither says to increment `stats.suppressed_by_confidence_gate`. This PR fixed the parallel gaps for `survived_severity_exception` (Rule 3) and `migrated_from_v1` (Step 1) by adding bold **Increment** directives. Without the same treatment here, an LLM following the evaluation order will emit `0` for `suppressed_by_confidence_gate` — making the gate's primary output metric always misleading.

### Issue 2 of 3
plugins/yellow-debt/agents/scanners/security-debt-scanner.md:89-91
The closing sentence about the +0.05 bump is phrased as though null emission benefits the finding ("compensate for null scenarios" reads as the synthesizer helping the scanner). The other four scanners all say "the synthesizer treats `null` as a downgrade signal," which correctly communicates that null emission is penalized (higher threshold). Using inconsistent phrasing here could encourage a security-debt scanner author to emit `null` expecting a confidence boost rather than a stricter gate.

```suggestion
Emit `null` only when no specific failure can be constructed — do not fabricate
speculation. The synthesizer treats `null` as a downgrade signal (raises the
category gate by +0.05, making the threshold stricter).
```

### Issue 3 of 3
plugins/yellow-debt/agents/synthesis/audit-synthesizer.md:223
**`finding → H1 title + ## Finding body | Direct` is ambiguous against the README example**

The mapping says write the v2.0 `finding` string verbatim to both the H1 heading and the `## Finding` body. But the README todo template still shows a short v1.0-style H1 (`# High Cyclomatic Complexity in UserService`, derived from the old `title` field). A v2.0 `finding` is 1–3 sentences, so "Direct" would produce a multi-sentence H1 — and the same text again in `## Finding`, making the body section redundant. An LLM consulting the README example would likely try to abbreviate the `finding` to match the short example title, conflicting with the "Direct" instruction. The README example H1 should be updated to show a v2.0-style sentence-form `finding`, or the mapping rule should explicitly note that the H1 uses the full `finding` string verbatim even when multi-sentence.


`````

</details>

<sub>Reviews (10): Last reviewed commit: ["fix: resolve PR #316 round-3 bot comment..."](https://github.com/kinginyellows/yellow-plugins/commit/fe8d22dfcfa8171532fd14ac822e7a7c57b072fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30427781)</sub>

<!-- /greptile_comment -->