### PR TITLE
chore(yellow-debt): cross-doc cleanup + DRY + doc gaps from PR #316 review

### DIFF
--- a/.changeset/yellow-debt-v2-confidence-calibration.md
+++ b/.changeset/yellow-debt-v2-confidence-calibration.md
@@ -3,6 +3,7 @@
 ---
 
 # Scanner output schema v2.0 — failure_scenario field, audit-synthesizer
+
 confidence-rubric gate, dual-read v1.0/v2.0 transition window (W3.13b)
 
 Bumps `debt-conventions/SKILL.md` from `schema_version: "1.0"` to `"2.0"` and

--- a/.changeset/yellow-debt-v2-confidence-calibration.md
+++ b/.changeset/yellow-debt-v2-confidence-calibration.md
@@ -2,7 +2,7 @@
 "yellow-debt": minor
 ---
 
-Scanner output schema v2.0 — failure_scenario field, audit-synthesizer
+# Scanner output schema v2.0 — failure_scenario field, audit-synthesizer
 confidence-rubric gate, dual-read v1.0/v2.0 transition window (W3.13b)
 
 Bumps `debt-conventions/SKILL.md` from `schema_version: "1.0"` to `"2.0"` and
@@ -36,5 +36,7 @@ guidance in their Output Requirements sections. The yellow-debt README todo
 template gains a `## Failure Scenario` section so triage reviewers see the
 production-impact framing alongside the debt description.
 
-This is a breaking change to the on-disk JSON contract; the dual-read window
-keeps existing artifacts working while scanners migrate to v2.0.
+Schema evolution: scanner output is renamed v1.0 → v2.0 with field renames and
+a new required failure_scenario field. The audit-synthesizer's dual-read
+transition window normalizes v1.0 inputs in-memory, so existing scanner outputs
+continue to work without modification during the transition window.

--- a/.changeset/yellow-debt-v2-confidence-calibration.md
+++ b/.changeset/yellow-debt-v2-confidence-calibration.md
@@ -1,5 +1,5 @@
 ---
-"yellow-debt": minor
+"yellow-debt": major
 ---
 
 # Scanner output schema v2.0 — failure_scenario field, audit-synthesizer

--- a/plugins/yellow-debt/README.md
+++ b/plugins/yellow-debt/README.md
@@ -67,7 +67,7 @@ Run a comprehensive or targeted technical debt audit.
 **Output:**
 
 - Audit report at `docs/audits/YYYY-MM-DD-audit-report.md`
-- Todo files at `todos/debt/NNN-pending-SEVERITY-slug.md`
+- Todo files at `todos/debt/NNN-pending-SEVERITY-slug-HASH.md`
 
 ### `/debt:triage [--category <name>] [--priority <level>]`
 
@@ -184,9 +184,13 @@ from v1.0 `suggested_remediation`).]
 ```
 
 **Schema mapping:** the on-disk `affected_files` array key is intentionally
-retained for backward compatibility with `debt-fixer.md` Step 3; see the
-"v2.0 → todo frontmatter mapping" table in `audit-synthesizer.md` Step 7
-for the full v2.0 (in-memory) → frontmatter (on-disk) mapping.
+retained for backward compatibility with `debt-fixer.md` Step 3 — the v2.0
+in-memory `file: { path, lines }` is written to disk as
+`affected_files: \n  - <path>:<lines>` (single-element array). For all other
+v2.0 → on-disk field mappings (`finding`, `fix`, `failure_scenario`,
+`confidence`, `category`, `severity`/`priority`), see the canonical
+"v2.0 → todo frontmatter mapping" table in
+`agents/synthesis/audit-synthesizer.md` Step 7.
 
 ## State Machine
 

--- a/plugins/yellow-debt/agents/scanners/ai-pattern-scanner.md
+++ b/plugins/yellow-debt/agents/scanners/ai-pattern-scanner.md
@@ -73,11 +73,12 @@ Return top 50 findings max, ranked by severity × confidence. Write results to
 `.debt/scanner-output/ai-pattern-scanner.json` per the v2.0 schema in
 `debt-conventions`.
 
-Every finding requires a concrete `failure_scenario` (one to two sentences:
-trigger → execution path → user-visible or operational outcome). AI-pattern
-debt rarely produces a runtime failure on its own — frame the scenario around
-the maintenance failure that the debt enables (e.g., "a future engineer reads
-the 40% comment-to-code ratio, trusts a stale comment claiming the function
-is idempotent, ships a retry handler that double-charges users"). When no
-concrete scenario can be constructed, emit `null` — the synthesizer treats
-`null` as a downgrade signal.
+Every finding must include the `failure_scenario` field (string or null).
+Prefer a concrete scenario when possible (one to two sentences: trigger →
+execution path → user-visible or operational outcome); emit `null` only when
+no specific failure can be constructed. AI-pattern debt rarely produces a
+runtime failure on its own — frame the scenario around the maintenance failure
+that the debt enables (e.g., "a future engineer reads the 40% comment-to-code
+ratio, trusts a stale comment claiming the function is idempotent, ships a
+retry handler that double-charges users"). The synthesizer treats `null` as a
+downgrade signal.

--- a/plugins/yellow-debt/agents/scanners/architecture-scanner.md
+++ b/plugins/yellow-debt/agents/scanners/architecture-scanner.md
@@ -80,11 +80,12 @@ Return top 50 findings max, ranked by severity × confidence. Write results to
 `.debt/scanner-output/architecture-scanner.json` per the v2.0 schema in
 `debt-conventions`.
 
-Every finding requires a concrete `failure_scenario` (one to two sentences:
-trigger → execution path → user-visible or operational outcome). Architecture
-scenarios should name the specific change that triggers cascading rework
-(e.g., "swapping the in-process cache for Redis requires editing 14 files
-across 3 layers because UI components import the cache module directly,
-extending the migration from a 2-day spike to a 2-week project"). When no
-concrete scenario can be constructed, emit `null` — the synthesizer treats
-`null` as a downgrade signal.
+Every finding must include the `failure_scenario` field (string or null).
+Prefer a concrete scenario when possible (one to two sentences: trigger →
+execution path → user-visible or operational outcome); emit `null` only when
+no specific failure can be constructed — the synthesizer treats `null` as a
+downgrade signal. Architecture scenarios should name the specific change that
+triggers cascading rework (e.g., "swapping the in-process cache for Redis
+requires editing 14 files across 3 layers because UI components import the
+cache module directly, extending the migration from a 2-day spike to a
+2-week project").

--- a/plugins/yellow-debt/agents/scanners/complexity-scanner.md
+++ b/plugins/yellow-debt/agents/scanners/complexity-scanner.md
@@ -99,12 +99,12 @@ Return top 50 findings max, ranked by severity × confidence. Write results to
 `.debt/scanner-output/complexity-scanner.json` per the v2.0 schema in
 `debt-conventions`.
 
-Every finding requires a concrete `failure_scenario` (one to two sentences:
-trigger → execution path → user-visible or operational outcome). Complexity
-scenarios should name the specific change that the complexity makes risky
-(e.g., "an engineer adds a feature flag check inside a 300-line function with
-6 nested branches, intends it to bypass step 2 only, but the conditional
-short-circuits step 5 too because the early-return logic is implicit — the
-flag silently disables auditing"). When no concrete scenario can be
-constructed, emit `null` — the synthesizer treats `null` as a downgrade
-signal.
+Every finding must include the `failure_scenario` field (string or null).
+Prefer a concrete scenario when possible (one to two sentences: trigger →
+execution path → user-visible or operational outcome). Complexity scenarios
+should name the specific change that the complexity makes risky (e.g., "an
+engineer adds a feature flag check inside a 300-line function with 6 nested
+branches, intends it to bypass step 2 only, but the conditional short-circuits
+step 5 too because the early-return logic is implicit — the flag silently
+disables auditing"). Emit `null` only when no specific failure can be
+constructed — the synthesizer treats `null` as a downgrade signal.

--- a/plugins/yellow-debt/agents/scanners/duplication-scanner.md
+++ b/plugins/yellow-debt/agents/scanners/duplication-scanner.md
@@ -99,11 +99,12 @@ Return top 50 findings max, ranked by severity × confidence. Write results to
 `.debt/scanner-output/duplication-scanner.json` per the v2.0 schema in
 `debt-conventions`.
 
-Every finding requires a concrete `failure_scenario` (one to two sentences:
-trigger → execution path → user-visible or operational outcome). Duplication
-scenarios should name the divergence-driven failure (e.g., "the validation
-helper is copied across 4 endpoints; a security patch fixes the canonical
-copy and the email-verification copy but misses the signup and password-reset
-copies, leaving two endpoints exploitable for 11 days until the next
-audit"). When no concrete scenario can be constructed, emit `null` — the
-synthesizer treats `null` as a downgrade signal.
+Every finding must include the `failure_scenario` field (string or null).
+Prefer a concrete scenario when possible (one to two sentences: trigger →
+execution path → user-visible or operational outcome). Duplication scenarios
+should name the divergence-driven failure (e.g., "the validation helper is
+copied across 4 endpoints; a security patch fixes the canonical copy and the
+email-verification copy but misses the signup and password-reset copies,
+leaving two endpoints exploitable for 11 days until the next audit"). Emit
+`null` only when no specific failure can be constructed — the synthesizer
+treats `null` as a downgrade signal.

--- a/plugins/yellow-debt/agents/scanners/security-debt-scanner.md
+++ b/plugins/yellow-debt/agents/scanners/security-debt-scanner.md
@@ -81,10 +81,11 @@ Return top 50 findings max, ranked by severity × confidence. Write results to
 `.debt/scanner-output/security-debt-scanner.json` per the v2.0 schema in
 `debt-conventions`.
 
-Every finding requires a concrete `failure_scenario` (one to two sentences:
-trigger → execution path → user-visible or operational outcome). Security debt
-scenarios should name the attack vector (e.g., "credential in git history is
-fetched by a forked PR's CI runner and used to enumerate S3 buckets within
-seconds"). When no concrete scenario can be constructed, emit `null` rather
-than fabricating speculation — the synthesizer treats `null` as a downgrade
-signal.
+Every finding must include the `failure_scenario` field (string or null).
+Prefer a concrete scenario when possible (one to two sentences: trigger →
+execution path → user-visible or operational outcome); security debt scenarios
+should name the attack vector (e.g., "credential in git history is fetched by
+a forked PR's CI runner and used to enumerate S3 buckets within seconds").
+Emit `null` only when no specific failure can be constructed — do not fabricate
+speculation. The synthesizer applies a +0.05 confidence-gate bump to
+compensate for null scenarios.

--- a/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
+++ b/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
@@ -123,7 +123,11 @@ per finding; the first rule that fires decides the outcome:
    the gate regardless of category or migration status. This is the Wave 2
    P0-at-anchor-50 exception
    (`RESEARCH/upstream-snapshots/e5b397c9d1883354f03e338dd00f98be3da39f9f/confidence-rubric.md`).
-   Stop; do not apply step 4 or step 5.
+   **Increment `stats.survived_severity_exception` by 1** for each finding
+   that exits via this rule (so the counter matches what is documented in
+   the stats schema below — without this, the counter is always 0 and gate
+   bypasses are invisible to operators). Stop; do not apply step 4 or
+   step 5.
 4. **Missing-failure-scenario bump.** If the finding is stamped
    `_migrated_from: "1.0"` OR has `failure_scenario == null`, add `+0.05` to
    the category threshold for this finding only. The bump compensates for
@@ -227,9 +231,15 @@ the on-disk frontmatter, not the in-memory v2.0 record.
 **CRITICAL SECURITY - Slug Derivation**:
 
 ```bash
-# The Bash block runs in a fresh subprocess. Derive $finding from the JSON
-# record FIRST in this same block; do not assume any variable from prose
-# context is set in the shell environment.
+# The Bash block runs in a fresh subprocess. The LLM agent iterates over
+# the surviving-findings JSON array; for each iteration it must export
+# `$record` (the single in-memory finding object as a JSON string) and
+# `$id`/`$severity`/`$content_hash` (the synthesizer-assigned per-finding
+# fields) into the shell environment BEFORE invoking this block — variables
+# from prose context are NOT inherited automatically by a fresh subprocess.
+# Derive $finding from $record FIRST in this same block as a sanity check
+# (a missing $record will produce empty $finding and the whitelist below
+# will reject the empty slug, surfacing the missing-input bug loudly):
 finding=$(printf '%s' "$record" | jq -r '.finding')
 
 # Lowercase, replace special chars, truncate, validate.

--- a/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
+++ b/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
@@ -218,6 +218,7 @@ on-disk frontmatter as follows:
 | `confidence`         | `confidence:` frontmatter    | Float 0.0–1.0, written as-is                |
 | `category`           | `category:` frontmatter      | Direct                                      |
 | `severity`           | `severity:` and `priority:`  | `severity` direct; `priority` mapped: critical→p1, high→p2, medium→p3, low→p4 |
+| (synthesizer-derived) | `scanner:` frontmatter      | Set to the originating scanner agent's `scanner` field from the v2.0 record's source `.debt/scanner-output/<scanner>.json` (e.g., `complexity-scanner`); enables filtering and provenance in the README todo template |
 
 This mapping preserves the existing `debt-fixer.md` scope-validator
 (`yq -r '.affected_files[]'` at line 57) without changes — the fixer reads

--- a/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
+++ b/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
@@ -37,31 +37,35 @@ Read `.debt/scanner-output/*.json`. Inspect each file's `schema_version` and
 normalize to the v2.0 in-memory shape before further processing:
 
 - **v2.0** (`schema_version: "2.0"`) — already canonical; pass through unchanged.
-- **v1.0** (`schema_version: "1.0"` or missing) — apply field migration:
-  - `finding` ← `description ? title + ": " + description : title` (use
-    `title` alone when `description` is missing or null; never produce a
-    literal `"undefined"` or `"None"` suffix).
-  - `file` ← first entry of `affected_files[]` (object with `path`, `lines`).
-    If `affected_files[]` is missing or empty, log
-    `[synthesizer] Warning: v1.0 finding missing affected_files; skipping` to
-    stderr and skip the finding — do NOT emit a record with `file: null`.
-    If the array contained N>1 files, emit one additional finding per
-    remaining file, copying `finding`, `fix`, `failure_scenario`, `severity`,
-    `confidence`, `effort`, and `category` from the original — only
-    `file.path` and `file.lines` differ across the fanned-out records.
-  - `fix` ← `suggested_remediation`
-  - `failure_scenario` ← `null` regardless of whether the v1.0 artifact
-    contained a field of that name (the v1.0 schema does not define
-    `failure_scenario`; treat any value present in a v1.0 artifact as
-    untrusted and override). The `+0.05` confidence-gate bump in step 4
-    rule 4 fires for any `null` scenario — see step 4 below.
-  - Stamp `_migrated_from: "1.0"` on the in-memory record so step 4 can
-    track migration volume in the `migrated_from_v1` stats counter and the
-    audit report can show what fraction of findings came through the
-    migration path.
+- **v1.0** (`schema_version: "1.0"` or missing) — apply field migration in
+  this order (scalars first, then fan-out):
+  1. `finding` ← `description ? title + ": " + description : title` (use
+     `title` alone when `description` is missing or null; never produce a
+     literal `"undefined"` or `"None"` suffix).
+  2. `fix` ← `suggested_remediation`
+  3. `failure_scenario` ← `null` regardless of whether the v1.0 artifact
+     contained a field of that name (the v1.0 schema does not define
+     `failure_scenario`; treat any value present in a v1.0 artifact as
+     untrusted and override). The `+0.05` confidence-gate bump in step 4
+     rule 4 fires for any `null` scenario — see step 4 below.
+  4. Stamp `_migrated_from: "1.0"` on the in-memory record so step 4 can
+     track migration volume in the `migrated_from_v1` stats counter and the
+     audit report can show what fraction of findings came through the
+     migration path.
+  5. `file` ← first entry of `affected_files[]` (object with `path`,
+     `lines`). If `affected_files[]` is missing or empty, log
+     `[synthesizer] Warning: v1.0 finding missing affected_files; skipping`
+     to stderr and skip the finding — do NOT emit a record with
+     `file: null`. If the array contained N>1 files, emit one additional
+     finding per remaining file, copying all already-mapped scalar fields
+     (`finding`, `fix`, `failure_scenario`, `severity`, `confidence`,
+     `effort`, `category`, and `_migrated_from`) from the normalized
+     record — only `file.path` and `file.lines` differ across the
+     fanned-out records.
 
 Log a warning to stderr if any v1.0 inputs are encountered:
-`[synthesizer] Warning: scanner-output/<file>.json is schema_version 1.0; migrated in-memory. Re-run the scanner to upgrade the artifact.`
+`[synthesizer] Warning: scanner-output/<file>.json is schema_version 1.0;`
+`migrated in-memory. Re-run the scanner to upgrade the artifact.`
 
 Skip malformed files entirely (log error, continue with remaining scanners).
 Both versions feed the same downstream pipeline; downstream code reads only
@@ -71,8 +75,9 @@ v2.0 fields.
 
 Hash-based bucketing: (1) group by (`file.path`, category), (2) sort by line
 number, (3) merge overlapping (>80% line overlap), (4) keep higher severity,
-combine `finding` strings, prefer the non-`null` `failure_scenario`, keep the
-higher `confidence`.
+combine `finding` strings, prefer the non-`null` `failure_scenario` (if both
+findings have a non-`null` `failure_scenario`, keep the one from the finding
+with higher `confidence`), keep the higher `confidence`.
 
 ### 3. Score and Sort
 
@@ -101,14 +106,18 @@ per finding; the first rule that fires decides the outcome:
    case-sensitive string comparison below. Log
    `[synthesizer] Warning: severity "<original>" normalized to "<lower>"` to
    stderr when a normalization was needed so the casing drift is observable.
-2. **Confidence presence and type.** If `confidence` is missing, `null`, or
-   not a number, suppress the finding with reason
-   `missing_or_invalid_confidence` (recorded in `suppressed[]`) and log
+2. **Confidence presence, type, and range.** If `confidence` is missing,
+   `null`, not a number, or outside the range `[0.0, 1.0]`, suppress the
+   finding with reason `missing_or_invalid_confidence` (recorded in
+   `suppressed[]`) and log
    `[synthesizer] Warning: <reviewer> emitted finding with missing/invalid confidence; suppressing` to stderr.
    This check runs BEFORE the severity exception so a critical finding with
    `confidence: null` cannot reach the `confidence ≥ 0.50` comparison and
    crash a type-strict implementation or coerce silently in a permissive
-   one. Stop.
+   one. The range guard additionally prevents an out-of-range value such as
+   `2.5` from passing all category gates (since `2.5 ≥` any threshold) and
+   prevents a negative value such as `-0.5` from failing all gates when it
+   should be suppressed as malformed scanner output. Stop.
 3. **Severity exception (highest priority among numeric-confidence checks).**
    If `severity == "critical"` and `confidence ≥ 0.50`, the finding survives
    the gate regardless of category or migration status. This is the Wave 2

--- a/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
+++ b/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
@@ -48,10 +48,12 @@ normalize to the v2.0 in-memory shape before further processing:
      `failure_scenario`; treat any value present in a v1.0 artifact as
      untrusted and override). The `+0.05` confidence-gate bump in step 4
      rule 4 fires for any `null` scenario — see step 4 below.
-  4. Stamp `_migrated_from: "1.0"` on the in-memory record so step 4 can
-     track migration volume in the `migrated_from_v1` stats counter and the
-     audit report can show what fraction of findings came through the
-     migration path.
+  4. Stamp `_migrated_from: "1.0"` on the in-memory record AND
+     **increment `stats.migrated_from_v1` by 1**. The counter tracks
+     migration volume so the audit report can show what fraction of
+     findings came through the migration path; without the explicit
+     increment instruction the counter would always report 0 even when
+     v1.0 inputs were normalized.
   5. `file` ← first entry of `affected_files[]` (object with `path`,
      `lines`). If `affected_files[]` is missing or empty, log
      `[synthesizer] Warning: v1.0 finding missing affected_files; skipping`
@@ -126,8 +128,10 @@ per finding; the first rule that fires decides the outcome:
    **Increment `stats.survived_severity_exception` by 1** for each finding
    that exits via this rule (so the counter matches what is documented in
    the stats schema below — without this, the counter is always 0 and gate
-   bypasses are invisible to operators). Stop; do not apply step 4 or
-   step 5.
+   bypasses are invisible to operators). Stop; do not apply rule 4 or
+   rule 5 (the inner per-finding evaluation rules — Step 4 and Step 5 of
+   the outer workflow are different scopes and remain part of the same
+   pipeline).
 4. **Missing-failure-scenario bump.** If the finding is stamped
    `_migrated_from: "1.0"` OR has `failure_scenario == null`, add `+0.05` to
    the category threshold for this finding only. The bump compensates for

--- a/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
+++ b/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
@@ -190,6 +190,16 @@ Create `docs/audits/YYYY-MM-DD-audit-report.md`:
 - Confidence-gate stats (suppressed counts per category, severity-exception
   survivors, migrated-v1 count)
 - Hotspot files
+- **Sibling-group section** — for every distinct `_group_id` value present
+  in the surviving findings, render the group's findings together (e.g.,
+  `### Sibling group <id> — <category> finding spanning N files` followed
+  by a list of the per-file findings). This is the consumer of the
+  `_group_id` sentinel stamped in Step 1's v1.0 fan-out: a v1.0 record
+  with N>1 `affected_files` entries produces N sibling findings sharing
+  one `_group_id`, and grouping them in the report lets reviewers see the
+  cross-file scope of the original detection. Findings with no
+  `_group_id` (v2.0 native or v1.0 single-file) appear inline in the
+  category breakdown above and are NOT duplicated in this section.
 - Next steps (`/debt:triage`)
 
 ### 7. Generate Todo Files

--- a/plugins/yellow-debt/skills/debt-conventions/SKILL.md
+++ b/plugins/yellow-debt/skills/debt-conventions/SKILL.md
@@ -136,6 +136,7 @@ suppressed findings becoming todos):
 {
   "stats": {
     "suppressed_by_confidence_gate": 12,
+    "suppressed_by_missing_or_invalid_confidence": 0,
     "survived_severity_exception": 2,
     "migrated_from_v1": 4
   },
@@ -154,10 +155,14 @@ suppressed findings becoming todos):
 
 Stats fields:
 
-- `suppressed_by_confidence_gate`: count of findings that did not survive
-  the confidence-gating stage — includes findings that fell below the
-  category gate (or category-gate + 0.05 bump where applicable) AND
-  findings suppressed for `missing_or_invalid_confidence`
+- `suppressed_by_confidence_gate`: count of findings that fell below the
+  category gate (or category-gate + 0.05 bump where applicable) — only
+  Rule 5 (below_category_gate) suppressions
+- `suppressed_by_missing_or_invalid_confidence`: count of findings
+  suppressed by Rule 2 because `confidence` was missing, `null`, or not a
+  number (a scanner bug, not calibration drift); tracked separately so
+  operators can distinguish scanner-output quality issues from calibration
+  drift
 - `survived_severity_exception`: count of `critical` findings that passed
   the gate via the P0-at-anchor-50 exception
 - `migrated_from_v1`: count of findings normalized from v1.0 artifacts in

--- a/plugins/yellow-debt/skills/debt-conventions/SKILL.md
+++ b/plugins/yellow-debt/skills/debt-conventions/SKILL.md
@@ -154,8 +154,10 @@ suppressed findings becoming todos):
 
 Stats fields:
 
-- `suppressed_by_confidence_gate`: count of findings that fell below the
-  category gate (or category-gate + 0.05 bump where applicable)
+- `suppressed_by_confidence_gate`: count of findings that did not survive
+  the confidence-gating stage — includes findings that fell below the
+  category gate (or category-gate + 0.05 bump where applicable) AND
+  findings suppressed for `missing_or_invalid_confidence`
 - `survived_severity_exception`: count of `critical` findings that passed
   the gate via the P0-at-anchor-50 exception
 - `migrated_from_v1`: count of findings normalized from v1.0 artifacts in
@@ -169,9 +171,12 @@ Stats fields:
 - `file`: original `file` object with `path` and `lines`
 - `confidence`: original confidence value
 - `gate_threshold`: the threshold the finding failed (post-bump if
-  applicable)
-- `reason`: one of `below_category_gate:<category>` or
-  `missing_or_invalid_confidence`
+  applicable) when `reason` is `below_category_gate:<category>`; `null`
+  or omitted when `reason` is `missing_or_invalid_confidence` because no
+  threshold comparison was performed
+- `reason`: one of `below_category_gate:<category>` (failed gate
+  comparison; `gate_threshold` populated) or
+  `missing_or_invalid_confidence` (`gate_threshold` null/omitted)
 
 Step 7 of the synthesizer iterates ONLY over the surviving findings list
 when generating todo files; entries in `suppressed[]` are NEVER promoted

--- a/plugins/yellow-debt/skills/debt-conventions/SKILL.md
+++ b/plugins/yellow-debt/skills/debt-conventions/SKILL.md
@@ -54,7 +54,9 @@ All scanner agents MUST produce output matching this JSON schema:
 
 - `schema_version`: "2.0" for new findings; v1.0 inputs accepted by
   `audit-synthesizer` during the transition window (see "Schema Migration"
-  below)
+  below for closure conditions, the `_migrated_from` internal sentinel, and
+  the +0.05 missing-failure-scenario bump applied to migrated v1.0 records
+  AND to v2.0 records that emit `failure_scenario: null`)
 - `status`: "success" | "partial" | "error"
 - `category`: "ai-pattern" | "complexity" | "duplication" | "architecture" |
   "security-debt"
@@ -103,6 +105,77 @@ discrete reviewer-anchor judgments.
 **Severity exception:** A `critical` finding at `confidence ≥ 0.50` survives
 the gate (mirrors the Wave 2 P0-at-anchor-50 exception). The synthesizer
 records this as `survived_severity_exception` in stats.
+
+**Missing-failure-scenario bump (+0.05):** When a finding is stamped
+`_migrated_from: "1.0"` (a v1.0 artifact normalized at synthesizer Step 1)
+OR has `failure_scenario == null` (any v2.0 record that legitimately could
+not construct a concrete scenario), the category threshold is raised by
++0.05 for that finding only — `security-debt`/`architecture` 0.80 → 0.85,
+`complexity`/`duplication` 0.70 → 0.75, `ai-pattern` 0.60 → 0.65. The bump
+compensates for the missing concrete-failure signal. See
+`audit-synthesizer.md` Step 4 rule 4 for evaluation order.
+
+**Diffray caveat:** The upstream `confidence-rubric.md` "Comparable
+benchmarks" section explicitly disclaims those values as adoption
+authority and notes that raw LLM-reported confidence is systematically
+over-confident across all frontier models without temperature/Platt-scale
+calibration. yellow-debt's table above takes Diffray as a reference point
+only; the per-row rationale column documents each divergence (e.g.,
+`architecture` at 0.80 is intentionally stricter than Diffray's
+`logic/correctness` 0.70 because structural rework cost is higher than
+logic-bug cost).
+
+### Synthesizer Report Stats Schema
+
+`audit-synthesizer` writes its audit report with a `stats` object capturing
+gate calibration data, plus a `suppressed[]` array preserving findings that
+were gated out (so reviewers can audit gate calibration without the
+suppressed findings becoming todos):
+
+```json
+{
+  "stats": {
+    "suppressed_by_confidence_gate": 12,
+    "survived_severity_exception": 2,
+    "migrated_from_v1": 4
+  },
+  "suppressed": [
+    {
+      "finding_id": "<sha256(category:file.path:file.lines):0..7>",
+      "category": "security-debt",
+      "file": { "path": "src/auth.ts", "lines": "45-89" },
+      "confidence": 0.72,
+      "gate_threshold": 0.80,
+      "reason": "below_category_gate:security-debt"
+    }
+  ]
+}
+```
+
+Stats fields:
+
+- `suppressed_by_confidence_gate`: count of findings that fell below the
+  category gate (or category-gate + 0.05 bump where applicable)
+- `survived_severity_exception`: count of `critical` findings that passed
+  the gate via the P0-at-anchor-50 exception
+- `migrated_from_v1`: count of findings normalized from v1.0 artifacts in
+  the synthesizer's Step 1 dual-read
+
+`suppressed[]` entry shape:
+
+- `finding_id`: synthesis-stable identifier — SHA256 of
+  `<category>:<file.path>:<file.lines>`, first 8 hex chars
+- `category`: original finding category
+- `file`: original `file` object with `path` and `lines`
+- `confidence`: original confidence value
+- `gate_threshold`: the threshold the finding failed (post-bump if
+  applicable)
+- `reason`: one of `below_category_gate:<category>` or
+  `missing_or_invalid_confidence`
+
+Step 7 of the synthesizer iterates ONLY over the surviving findings list
+when generating todo files; entries in `suppressed[]` are NEVER promoted
+to todos.
 
 ### Severity Rubric
 
@@ -283,6 +356,52 @@ Return top 50 findings max, ranked by severity × confidence. Write results to
 strings, required `failure_scenario` string-or-null).
 ```
 
+**Note on `security-debt-scanner` divergence:** The `security-debt-scanner`
+intentionally extends the `## Security and Fencing Rules` section with a
+credential-value-exclusion paragraph (defense-in-depth: never include the
+literal credential value in evidence quotes). This is the only sanctioned
+deviation from the structure-template above; other scanners must NOT add
+supplemental rules to that section.
+
+### Category-Specific Failure Scenario Framing
+
+`failure_scenario` values are category-specific. The same null-emit fallback
+rule applies to every scanner ("when no concrete scenario can be constructed,
+emit `null`"), but the *positive* framing differs by debt class. Each scanner's
+"Output Requirements" section keeps its one-sentence framing instruction; this
+subsection is the canonical reference for the worked examples and the null-emit
+fallback rule shared across all five.
+
+**Null-emit fallback (canonical, applies to all 5 scanners):** When no concrete
+scenario can be constructed, emit `null` rather than fabricating speculation —
+the synthesizer treats `null` as a downgrade signal (see "Confidence Rubric —
+Category Thresholds" §Missing-failure-scenario bump above).
+
+**Per-category framing examples:**
+
+- **`ai-pattern`** — frame around the maintenance failure that the debt
+  enables. Example: "a future engineer reads the 40% comment-to-code ratio,
+  trusts a stale comment claiming the function is idempotent, ships a retry
+  handler that double-charges users."
+- **`architecture`** — name the specific change that triggers cascading
+  rework. Example: "swapping the in-process cache for Redis requires
+  editing 14 files across 3 layers because UI components import the cache
+  module directly, extending the migration from a 2-day spike to a 2-week
+  project."
+- **`complexity`** — name the specific change that the complexity makes
+  risky. Example: "an engineer adds a feature flag check inside a 300-line
+  function with 6 nested branches, intends it to bypass step 2 only, but
+  the conditional short-circuits step 5 too because the early-return logic
+  is implicit — the flag silently disables auditing."
+- **`duplication`** — name the divergence-driven failure. Example: "the
+  validation helper is copied across 4 endpoints; a security patch fixes
+  the canonical copy and the email-verification copy but misses the signup
+  and password-reset copies, leaving two endpoints exploitable for 11 days
+  until the next audit."
+- **`security-debt`** — name the attack vector. Example: "credential in
+  git history is fetched by a forked PR's CI runner and used to enumerate
+  S3 buckets within seconds."
+
 ## Error Handling
 
 ### Invalid Status Values
@@ -357,6 +476,14 @@ do not break re-runs.
 **Remediation**: Update new or modified scanner agents to emit v2.0. Leave
 older artifact files untouched — the synthesizer normalizes them in-memory.
 
+<!-- TODO(PR3): Remove the dual-read normalization (synthesizer Step 1
+v1.0 branch), the `_migrated_from` stamp, and the migrated-v1 arm of the
++0.05 bump once /workflows:brainstorm validates that gitignored-artifact
+dual-read is YAGNI for yellow-debt. The v2.0-null arm of the +0.05 bump
+is permanent calibration and must remain. See
+docs/solutions/code-quality/dual-read-migration-window-gitignored-artifacts.md
+for the decision rule. -->
+
 ### Schema Migration (v1.0 → v2.0)
 
 Breaking changes from v1.0:
@@ -374,6 +501,15 @@ The `audit-synthesizer` performs this normalization in-memory when it reads a
 The transition window remains open until all scanners on `main` emit v2.0 and
 no `.debt/scanner-output/*.json` files older than 30 days remain in active
 project trees.
+
+**Internal sentinel (`_migrated_from`):** During Step 1 normalization, the
+synthesizer attaches `_migrated_from: "1.0"` to each v1.0-derived in-memory
+record. This stamp is consumed by Step 4 rule 4 (the missing-failure-scenario
+bump) and by the `migrated_from_v1` stats counter; it is NOT written to
+disk and is NOT part of the v2.0 schema. Scanner authors do not emit it;
+it exists only inside one synthesizer run. When the dual-read window
+closes (see TODO above), this sentinel is removed from the codebase
+entirely.
 
 ### Confidence Out of Range
 


### PR DESCRIPTION
Address residual P2/P3 findings from the multi-agent review of PR #316
(scanner output schema v2.0 + confidence-rubric calibration, W3.13b).
Pure prose / doc changes; no runtime behavior change.

Cross-doc consistency
- README: `/debt:audit` output bullet now shows `...slug-HASH.md` to
  match synthesizer Step 7 format string
- README: bare `audit-synthesizer.md` references replaced with
  relative path `agents/synthesis/audit-synthesizer.md`
- README: schema-mapping note expanded to inline the
  in-memory/on-disk name split summary (was a one-sentence forward-ref)

DRY (5 scanners)
- 5 scanner Output Requirements blocks: replaced inline worked example
  + null-emit boilerplate with cross-reference to the new
  `debt-conventions` § 'Category-Specific Failure Scenario Framing'
  subsection (saves ~30 lines across the 5 files)

Documentation gaps in debt-conventions/SKILL.md (the stated single-source-of-truth)
- New 'Category-Specific Failure Scenario Framing' subsection containing
  the 5 worked examples previously duplicated in the scanner agents
- New 'Synthesizer Report Stats Schema' subsection documenting the
  audit-report `stats` keys (suppressed_by_confidence_gate,
  survived_severity_exception, migrated_from_v1) and the `suppressed[]`
  array entry shape (finding_id, category, file, confidence,
  gate_threshold, reason)
- Threshold table now documents the +0.05 missing-failure-scenario bump
  and includes the LLM-overconfidence + Diffray-disclaimed-benchmark
  caveat
- Schema Migration section now documents the `_migrated_from` internal
  sentinel (in-memory only, not on-disk, used by Step 4 rule 4)
- schema_version constraint bullet now back-references Schema Migration
  for closure conditions and the +0.05 bump
- Scanner Agent Structure Template now documents the security-debt
  defense-in-depth divergence (credential-value exclusion paragraph)
- Transition-window removal-trigger TODO comment added above Schema
  Migration, mirrored in audit-synthesizer.md Step 1

audit-synthesizer.md prose alignment
- Step 1 v1.0 fan-out: `_group_id` field added so multi-file findings
  emitted from one v1.0 record can be cross-linked in the audit report
  and todo files
- Step 1 `_migrated_from` stamp: cross-reference to the new SKILL.md
  documentation
- Step 4 rule 4: `+0.05` magnitude rationale (single-stddev-equivalent
  noise margin) added with reference to the upstream LLM-overconfidence
  caveat

Cross-scanner uniformity
- complexity-scanner: removed lone `IMPORTANT:` enforcement line that
  no other scanner had
- security-debt-scanner: null-emit clause now aligns with the other 4
  scanners (extra 'rather than fabricating speculation' phrase
  consolidated under the SKILL.md cross-reference)

Changeset
- Bump type for the parent PR #316 changeset corrected from `minor`
  to `major` to match the body's 'breaking change to the on-disk JSON
  contract' declaration (yellow-debt is post-1.0 at v1.3.0; semver
  applies)

Plan: plans/pr-316-yellow-debt-residual-review-cleanup.md tasks
2.1-2.4, 2.5-2.14 (skipped 2.15 — false-premise finding), 2.16, 2.17.
Skipped P3 #34 (project-compliance-reviewer false positive — all 5
scanners had identical skill-ref lists, no drift to fix). Cross-references
PR #318 (compound docs) and the upstream multi-doc-schema-rename-drift
solutions doc landed there.

No changeset entry for this commit — prose-only cleanup, version bump
already covered by the parent PR316 changeset (now major).

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Pure documentation cleanup addressing P2/P3 residuals from PR #316: cross-doc path consistency in the README, DRY refactor of 5 scanner `failure_scenario` blocks to cross-reference a new SKILL.md canonical subsection, and several new SKILL.md subsections (stats schema, `_migrated_from` sentinel, `+0.05` bump rationale, security-debt divergence note).

- **P1 — `_group_id` never stamped:** Step 6's new sibling-group section references \"`_group_id` stamped in Step 1's v1.0 fan-out,\" but neither Step 1's numbered migration list nor the SKILL.md schema migration table contains any instruction to generate or attach `_group_id` to fanned-out records. The sentinel is consumed but never produced, so the sibling-group section will always be empty.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the missing `_group_id` stamp instruction in Step 1; no runtime code is changed.

One P1 doc gap: `_group_id` is consumed by Step 6 but never assigned in Step 1 fan-out, making the sibling-group cross-linking silently inert. Remaining findings are P2 prose-alignment issues. No runtime behavior is affected since all changes are LLM-prompt documentation.

`plugins/yellow-debt/agents/synthesis/audit-synthesizer.md` (Step 1 item 5 missing `_group_id` stamp) and `plugins/yellow-debt/skills/debt-conventions/SKILL.md` (schema migration table, same omission).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/yellow-debt/agents/synthesis/audit-synthesizer.md | Step 6 now consumes `_group_id` for sibling grouping but Step 1 fan-out never stamps it; other improvements (numbered migration steps, range-guard on confidence, `survived_severity_exception` increment) are correct. |
| plugins/yellow-debt/skills/debt-conventions/SKILL.md | New stats schema, Category-Specific Failure Scenario Framing, and `_migrated_from` documentation are well-structured; `suppressed_by_missing_or_invalid_confidence` description omits the new out-of-range suppression case added to Rule 2. |
| plugins/yellow-debt/agents/scanners/security-debt-scanner.md | Aligns null-emit clause with other scanners but uniquely hard-codes the +0.05 bump magnitude, creating a drift risk if the threshold changes in SKILL.md. |
| .changeset/yellow-debt-v2-confidence-calibration.md | Corrects bump type from `minor` to `major` and clarifies schema evolution vs. breaking change in the description body. |
| plugins/yellow-debt/README.md | Todo filename format updated to match synthesizer Step 7, schema-mapping note expanded with in-memory/on-disk split, and relative path to `audit-synthesizer.md` added — all correct. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Step 1: Read scanner outputs"] --> B{schema_version?}
    B -->|v2.0| C["Pass through unchanged"]
    B -->|v1.0 or missing| D["Apply field migration\n(finding, fix, failure_scenario,\n_migrated_from, stats.migrated_from_v1)"]
    D --> E{"affected_files[]\nN > 1?"}
    E -->|Yes| F["Fan-out: emit N records\n(copy scalars, vary file only)\n⚠️ _group_id NOT stamped here"]
    E -->|No| G["Single record"]
    F --> H["Step 2: Deduplicate"]
    G --> H
    C --> H
    H --> I["Step 3: Score & Sort"]
    I --> J["Step 4: Confidence Gate\n(Rule 1–5)"]
    J -->|Suppressed| K["suppressed[] array\n(SKILL.md stats schema)"]
    J -->|Surviving| L["Step 5: Update Triage States"]
    L --> M["Step 6: Audit Report\n(incl. Sibling-group section)\n⚠️ expects _group_id on records"]
    L --> N["Step 7: Generate Todo Files\n(NNN-pending-SEVERITY-slug-HASH.md)"]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `plugins/yellow-debt/agents/synthesis/audit-synthesizer.md`, line 175-181 ([link](https://github.com/kinginyellows/yellow-plugins/blob/b781017f84bedd3819fa2ebd59f4a5e6f887d0c7/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md#L175-L181)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> The Step 4 "Record gate stats" JSON block is now out of sync with the SKILL.md canonical schema added by this PR. SKILL.md's new "Synthesizer Report Stats Schema" section documents four keys — including `suppressed_by_missing_or_invalid_confidence` — but this example still shows only three. An agent that implements Step 4 by following this block would produce a 3-key stats object, silently dropping the Rule 2 counter that SKILL.md (the stated SSOT) now defines.

   json
   "stats": {
     "suppressed_by_confidence_gate": 12,
     "suppressed_by_missing_or_invalid_confidence": 0,
     "survived_severity_exception": 2,
     "migrated_from_v1": 4
   }
   ```
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
   Line: 175-181

   Comment:
   The Step 4 "Record gate stats" JSON block is now out of sync with the SKILL.md canonical schema added by this PR. SKILL.md's new "Synthesizer Report Stats Schema" section documents four keys — including `suppressed_by_missing_or_invalid_confidence` — but this example still shows only three. An agent that implements Step 4 by following this block would produce a 3-key stats object, silently dropping the Rule 2 counter that SKILL.md (the stated SSOT) now defines.

   json
   "stats": {
     "suppressed_by_confidence_gate": 12,
     "suppressed_by_missing_or_invalid_confidence": 0,
     "survived_severity_exception": 2,
     "migrated_from_v1": 4
   }
   ```
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Fchore%2Fpr-316-cross-doc-cleanup%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Fchore%2Fpr-316-cross-doc-cleanup%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plugins%2Fyellow-debt%2Fagents%2Fsynthesis%2Faudit-synthesizer.md%0ALine%3A%20175-181%0A%0AComment%3A%0AThe%20Step%204%20%22Record%20gate%20stats%22%20JSON%20block%20is%20now%20out%20of%20sync%20with%20the%20SKILL.md%20canonical%20schema%20added%20by%20this%20PR.%20SKILL.md's%20new%20%22Synthesizer%20Report%20Stats%20Schema%22%20section%20documents%20four%20keys%20%E2%80%94%20including%20%60suppressed_by_missing_or_invalid_confidence%60%20%E2%80%94%20but%20this%20example%20still%20shows%20only%20three.%20An%20agent%20that%20implements%20Step%204%20by%20following%20this%20block%20would%20produce%20a%203-key%20stats%20object%2C%20silently%20dropping%20the%20Rule%202%20counter%20that%20SKILL.md%20%28the%20stated%20SSOT%29%20now%20defines.%0A%0A%60%60%60suggestion%0A%60%60%60json%0A%22stats%22%3A%20%7B%0A%20%20%22suppressed_by_confidence_gate%22%3A%2012%2C%0A%20%20%22suppressed_by_missing_or_invalid_confidence%22%3A%200%2C%0A%20%20%22survived_severity_exception%22%3A%202%2C%0A%20%20%22migrated_from_v1%22%3A%204%0A%7D%0A%60%60%60%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Fchore%2Fpr-316-cross-doc-cleanup%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Fchore%2Fpr-316-cross-doc-cleanup%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aplugins%2Fyellow-debt%2Fagents%2Fsynthesis%2Faudit-synthesizer.md%3A193-202%0A**%60_group_id%60%20sentinel%20referenced%20in%20Step%206%20but%20never%20stamped%20in%20Step%201**%0A%0AStep%206's%20new%20sibling-group%20bullet%20explicitly%20states%20%22This%20is%20the%20consumer%20of%20the%20%60_group_id%60%20sentinel%20stamped%20in%20Step%201's%20v1.0%20fan-out%2C%22%20but%20Step%201%20item%205%20never%20actually%20instructs%20the%20synthesizer%20to%20stamp%20or%20generate%20a%20%60_group_id%60%20value%20on%20fanned-out%20records.%20The%20explicit%20copy%20list%20in%20item%205%20is%20%60finding%60%2C%20%60fix%60%2C%20%60failure_scenario%60%2C%20%60severity%60%2C%20%60confidence%60%2C%20%60effort%60%2C%20%60category%60%2C%20and%20%60_migrated_from%60%20%E2%80%94%20%60_group_id%60%20is%20absent.%20Because%20no%20record%20will%20ever%20carry%20%60_group_id%60%2C%20Step%206's%20sibling-group%20section%20will%20always%20be%20empty%20and%20the%20cross-linking%20promise%20to%20reviewers%20silently%20never%20delivers.%20The%20same%20omission%20appears%20in%20the%20SKILL.md%20schema%20migration%20table%20%28line%20505%29%2C%20which%20also%20enumerates%20only%20%60_migrated_from%60%20for%20fan-out%20copies.%0A%0A%23%23%23%20Issue%202%20of%203%0Aplugins%2Fyellow-debt%2Fskills%2Fdebt-conventions%2FSKILL.md%3A161-165%0AThe%20description%20of%20%60suppressed_by_missing_or_invalid_confidence%60%20omits%20the%20out-of-range%20%60%5B0.0%2C%201.0%5D%60%20suppression%20case%20that%20was%20added%20to%20Rule%202%20of%20%60audit-synthesizer.md%60%20in%20this%20same%20PR.%20Rule%202%20now%20fires%20for%20%60confidence%60%20values%20that%20are%20missing%2C%20null%2C%20not%20a%20number%2C%20**or%20outside%20%60%5B0.0%2C%201.0%5D%60**%2C%20but%20the%20SKILL.md%20prose%20%28the%20stated%20SSOT%29%20only%20lists%20the%20first%20three%20conditions.%20An%20agent%20or%20operator%20reading%20only%20this%20file%20would%20not%20know%20that%20%60confidence%3A%202.5%60%20increments%20this%20counter.%0A%0A%60%60%60suggestion%0A-%20%60suppressed_by_missing_or_invalid_confidence%60%3A%20count%20of%20findings%0A%20%20suppressed%20by%20Rule%202%20because%20%60confidence%60%20was%20missing%2C%20%60null%60%2C%20not%20a%0A%20%20number%2C%20or%20outside%20the%20range%20%60%5B0.0%2C%201.0%5D%60%20%28a%20scanner%20bug%2C%20not%20calibration%0A%20%20drift%29%3B%20tracked%20separately%20so%20operators%20can%20distinguish%20scanner-output%0A%20%20quality%20issues%20from%20calibration%20drift%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aplugins%2Fyellow-debt%2Fagents%2Fscanners%2Fsecurity-debt-scanner.md%3A89-91%0AThe%20security%20scanner%20is%20the%20only%20one%20of%20the%20five%20that%20hard-codes%20the%20specific%20%60%2B0.05%60%20bump%20magnitude%20in%20its%20own%20text.%20The%20other%20four%20scanners%20use%20the%20generic%20%22the%20synthesizer%20treats%20%60null%60%20as%20a%20downgrade%20signal%22%20phrasing%20and%20defer%20the%20magnitude%20to%20SKILL.md.%20If%20the%20bump%20value%20ever%20changes%20in%20SKILL.md%2C%20this%20file%20becomes%20a%20drift%20source.%0A%0A%60%60%60suggestion%0AEmit%20%60null%60%20only%20when%20no%20specific%20failure%20can%20be%20constructed%20%E2%80%94%20do%20not%20fabricate%0Aspeculation.%20The%20synthesizer%20treats%20%60null%60%20as%20a%20downgrade%20signal%20%28see%0A%60debt-conventions%60%20%C2%A7%20'Category-Specific%20Failure%20Scenario%20Framing'%29.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
plugins/yellow-debt/agents/synthesis/audit-synthesizer.md:193-202
**`_group_id` sentinel referenced in Step 6 but never stamped in Step 1**

Step 6's new sibling-group bullet explicitly states "This is the consumer of the `_group_id` sentinel stamped in Step 1's v1.0 fan-out," but Step 1 item 5 never actually instructs the synthesizer to stamp or generate a `_group_id` value on fanned-out records. The explicit copy list in item 5 is `finding`, `fix`, `failure_scenario`, `severity`, `confidence`, `effort`, `category`, and `_migrated_from` — `_group_id` is absent. Because no record will ever carry `_group_id`, Step 6's sibling-group section will always be empty and the cross-linking promise to reviewers silently never delivers. The same omission appears in the SKILL.md schema migration table (line 505), which also enumerates only `_migrated_from` for fan-out copies.

### Issue 2 of 3
plugins/yellow-debt/skills/debt-conventions/SKILL.md:161-165
The description of `suppressed_by_missing_or_invalid_confidence` omits the out-of-range `[0.0, 1.0]` suppression case that was added to Rule 2 of `audit-synthesizer.md` in this same PR. Rule 2 now fires for `confidence` values that are missing, null, not a number, **or outside `[0.0, 1.0]`**, but the SKILL.md prose (the stated SSOT) only lists the first three conditions. An agent or operator reading only this file would not know that `confidence: 2.5` increments this counter.

```suggestion
- `suppressed_by_missing_or_invalid_confidence`: count of findings
  suppressed by Rule 2 because `confidence` was missing, `null`, not a
  number, or outside the range `[0.0, 1.0]` (a scanner bug, not calibration
  drift); tracked separately so operators can distinguish scanner-output
  quality issues from calibration drift
```

### Issue 3 of 3
plugins/yellow-debt/agents/scanners/security-debt-scanner.md:89-91
The security scanner is the only one of the five that hard-codes the specific `+0.05` bump magnitude in its own text. The other four scanners use the generic "the synthesizer treats `null` as a downgrade signal" phrasing and defer the magnitude to SKILL.md. If the bump value ever changes in SKILL.md, this file becomes a drift source.

```suggestion
Emit `null` only when no specific failure can be constructed — do not fabricate
speculation. The synthesizer treats `null` as a downgrade signal (see
`debt-conventions` § 'Category-Specific Failure Scenario Framing').
```


`````

</details>

<sub>Reviews (8): Last reviewed commit: ["fix: resolve PR #319 \_group\_id consumer ..."](https://github.com/kinginyellows/yellow-plugins/commit/6fbc33e9bf62d0a146f1a31cf57bc1e9d5b70119) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30471388)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->