### PR TITLE
feat(yellow-council): plugin scaffold, manifests, and CLI spikes

### DIFF
--- a/.changeset/yellow-council-initial-release.md
+++ b/.changeset/yellow-council-initial-release.md
@@ -1,0 +1,5 @@
+---
+"yellow-council": minor
+---
+
+Initial release of yellow-council plugin: on-demand cross-lineage council command (`/council <mode>`) fanning out to Codex (via yellow-codex), Gemini, and OpenCode CLIs in parallel for advisory consensus. Four modes: `plan`, `review`, `debug`, `question`. Synchronous fan-out with 600s per-reviewer timeout and partial-result reporting on timeout. Inline synthesis (Headline / Agreement / Disagreement) plus persisted report at `docs/council/<date>-<mode>-<slug>.md`. PR1 ships the scaffold + manifests + spike documentation; full reviewer agents and `/council` command implementation land in subsequent stacked PRs (yellow-council-core-implementation, yellow-council-polish-and-tests).

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -170,6 +170,16 @@
       },
       "source": "./plugins/yellow-codex",
       "category": "development"
+    },
+    {
+      "name": "yellow-council",
+      "description": "On-demand cross-lineage code review fanning out to Codex, Gemini, and OpenCode CLIs in parallel for advisory consensus",
+      "version": "0.1.0",
+      "author": {
+        "name": "KingInYellows"
+      },
+      "source": "./plugins/yellow-council",
+      "category": "development"
     }
   ]
 }

--- a/docs/brainstorms/2026-05-03-godmodeskill-integration-brainstorm.md
+++ b/docs/brainstorms/2026-05-03-godmodeskill-integration-brainstorm.md
@@ -1,0 +1,379 @@
+# yellow-council: GodModeSkill Integration Brainstorm
+
+**Date:** 2026-05-03
+**Source investigation:** `research/GodModeSkill Integration Investigation.md`
+**GodModeSkill reference commit:** `b693d1da498cbcfc2e5cba1f85b3d341205bfeb0`
+
+---
+
+## What We're Building
+
+A new dedicated plugin — `yellow-council` — that provides on-demand, advisory,
+cross-lineage code review by fanning out to three external model families
+(Codex CLI, Gemini CLI, OpenCode CLI) in parallel, synthesizing their verdicts
+inline in the active conversation, and persisting the full report to
+`docs/council/<date>-<slug>.md`.
+
+The command surface is `/council <mode> [input]` with four explicit modes:
+`plan`, `review`, `debug`, `question`. The user invokes it deliberately,
+at any point in development — planning, implementation, debugging, or pre-merge
+review. It is not wired into the existing yellow-review 14-reviewer pipeline;
+that pipeline runs unchanged.
+
+V1 is synchronous, inline, and advisory. V2 evolves toward GodModeSkill's
+native persistent-session model with lineage-weighted quorum aggregation and
+quote-backed evidence verification. V1 must not foreclose V2.
+
+---
+
+## Why This Approach
+
+### Why a new plugin, not a modification of yellow-review
+
+The existing yellow-review pipeline is a Claude-only multi-agent system with
+a mature confidence-rubric aggregator, schema-validated compact-return findings,
+and a tiered persona dispatch table. Adding external binary dependencies (Codex,
+Gemini, OpenCode CLIs) to that pipeline would break the clean "no sidecar
+process" contract that every yellow-review reviewer follows. The council is a
+different kind of tool — it fans out to external runtimes the user has
+installed — and deserves its own manifest, its own command surface, and its own
+failure semantics (partial results on timeout, CLI not installed = graceful skip).
+
+### Why synchronous inline for V1
+
+The user explicitly invokes `/council` when they want cross-lineage input. They
+accept the wait. Async fire-and-watch adds session state management, a
+`/council status` command, and a polling or notification model — none of which
+are needed when the human is present and waiting. V1 accepts a 5-10 minute
+blocking wait; per-reviewer timeout is 600 seconds with partial-result reporting
+if any reviewer misses the cutoff.
+
+### Why yellow-codex as optional dep, not bundled
+
+Yellow-codex already encodes all correct Codex CLI invocation conventions:
+`codex exec` flags, exit-124 timeout detection, JSONL output parsing, structured
+review schema, credential redaction (8-pattern awk block), injection fencing.
+Duplicating that inside yellow-council would create two diverging implementations
+of the same underlying CLI. Instead, when yellow-codex is installed, yellow-council
+spawns `yellow-codex:review:codex-reviewer` via Task and gets the right output
+shape automatically. When it is absent, yellow-council soft-skips Codex with a
+warning and runs with 2 of 3 reviewers.
+
+### Why explicit modes, not magic inference
+
+The four modes (plan / review / debug / question) produce deterministic,
+per-mode context packs. The user always knows what context the council will
+receive before invoking it. This is both safer (no surprise context assembly)
+and V2-portable (GodModeSkill's XML pack templates map one-to-one to these
+same four modes).
+
+---
+
+## Key Decisions
+
+### Decision 1: External model families, separate pipeline, on-demand
+
+- This is NOT a modification of yellow-review. Separate plugin, separate
+  command surface, separate invocation lifecycle.
+- On-demand only. `/council` is never triggered automatically by
+  yellow-review, yellow-debt, or any other plugin.
+- Invocable at any point in the development process: planning, implementation,
+  debugging, or review. Input shape is flexible by mode.
+- Advisory output only. Results never block a merge, never trigger an automatic
+  fix pass, never auto-commit.
+
+### Decision 2: Synchronous parallel fan-out, 600s per-reviewer timeout
+
+- All three CLI reviewers are spawned in parallel (not sequentially).
+- Per-reviewer timeout: 600 seconds (configurable via `COUNCIL_TIMEOUT` env
+  var). This is intentionally generous — the user invoked the heavyweight tool
+  and accepts the wait.
+- Partial results on timeout: if Codex finishes in 90s but Gemini times out at
+  600s, the synthesis report includes Codex's verdict and notes
+  "Gemini timed out at 600s — omitted from council report."
+- Timeout detection follows the yellow-codex `codex-patterns` convention:
+  exit 124 from `timeout --signal=TERM --kill-after=10 600 <cli> ...`.
+- V1 design. V2 trajectory: persistent sessions, event-driven
+  `inotifywait`-equivalent wait, multi-round iterative review with `## DONE`
+  markers. V2 must be addable without breaking V1 single-shot semantics.
+
+### Decision 3: New `yellow-council` plugin, yellow-codex as optional dep
+
+Plugin layout (V1):
+
+```
+plugins/yellow-council/
+  .claude-plugin/
+    plugin.json
+  agents/
+    review/
+      gemini-reviewer.md
+      opencode-reviewer.md
+  commands/
+    council/
+      council.md          # main /council command (plan/review/debug/question)
+  skills/
+    council-patterns/
+      SKILL.md            # Gemini + OpenCode CLI flags, pack templates, timeout
+                          # patterns, output fencing. Cross-references
+                          # codex-patterns (yellow-codex) rather than duplicating.
+  docs/
+    council/              # runtime output directory (created on first use)
+  CLAUDE.md
+  README.md
+  package.json
+  CHANGELOG.md
+```
+
+- `yellow-codex` declared as optional dep (documentation-only convention,
+  same as yellow-codex's existing cross-plugin pattern — no `optionalDependencies`
+  field in plugin.json schema today).
+- `yellow-core` stays untouched. No binary deps enter the foundation.
+- V2 adds `agents/fleet/` and commands `council/fleet.md` under the same plugin
+  without restructuring.
+
+### Decision 4: Explicit mode + input
+
+Four V1 modes:
+
+| Mode | Invocation | Context packed |
+|------|-----------|----------------|
+| `plan` | `/council plan <path-or-text>` | File/text content + repo CLAUDE.md + relevant conventions |
+| `review` | `/council review [--base <ref>]` | Diff (HEAD vs base) + changed file content + base/head SHAs. Truncation guards from GodModeSkill `work-pack-build` pattern. |
+| `debug` | `/council debug "<symptom>" [--paths <files>]` | Symptom + cited file content + surrounding code + recent git log on those files |
+| `question` | `/council question "<text>" [--paths <files>]` | Question + optional file content + CLAUDE.md |
+
+- Bare `/council` with no args: print the four modes with one-line descriptions
+  and exit. No magic inference.
+- Per-mode pack templates live in `council-patterns` SKILL.md as markdown with
+  explicit slot fills. These are the V2 swap surface for GodModeSkill's XML pack
+  format (`<file-path>` / `<line-number>` / `<quoted-line>` CDATA evidence
+  contract).
+- Input sanitization: all user-supplied free text and file paths are wrapped in
+  injection fences before passing to any CLI. Path validation: reject `..`
+  traversal and any character outside `^[a-zA-Z0-9._/-]+$` before constructing
+  shell arguments. Follows MEMORY.md shell-script-security patterns.
+- `--paths` injection on debug/question modes: limit total injected content to
+  a per-mode cap (exact cap to be specified in plan phase — likely 8K chars per
+  file, 3 files max in V1 to avoid blowing context windows on Gemini/OpenCode).
+
+### Decision 5: Inline synthesis + file write
+
+**V1 synthesizer structure:**
+
+```
+## Council Report — <mode>: <topic> — <date>
+
+### Headline
+<All 3 reviewers APPROVE> / <Split — 2 APPROVE, 1 REVISE> / etc.
+Council ran with N of 3 reviewers. [If any skipped: "<name> timed out at 600s" /
+"<name> not installed (yellow-codex absent)"]
+
+### Agreement (cited by 2+ reviewers)
+- file:line — <finding>
+  - Codex: "<their phrasing>"
+  - Gemini: "<their phrasing>"
+
+### Disagreement (unique to one reviewer or conflicting verdicts)
+- <finding> — Codex only
+- Verdict conflict at path/to/file.ts:42: Codex APPROVE, Gemini REVISE
+
+Full reviewer outputs: see docs/council/<slug>.md
+```
+
+**Inline conversation:** synthesis report only (Headline + Agreement +
+Disagreement sections). Raw reviewer outputs are NOT pasted inline — they
+reference the file path.
+
+**File at `docs/council/YYYY-MM-DD-<slug>.md`:** synthesis report + three
+labeled raw output sections:
+
+```markdown
+## Codex Output
+--- begin council-output (reference only) ---
+<full Codex reviewer output, post-fence-redaction>
+--- end council-output ---
+
+## Gemini Output
+...
+
+## OpenCode Output
+...
+```
+
+**Slug derivation:** `<mode>-<first-N-words-of-topic>`, normalized to
+`^[a-z0-9]+(?:-[a-z0-9]+)*$` (no trailing or consecutive hyphens — per
+MEMORY.md path-validation rule). Same-day collision: append `-2`, `-3`, etc.
+
+**V1 synthesizer non-goals (explicit deferrals to V2):**
+- No lineage-weighted quorum (V1 uses raw count only)
+- No quote-verification pass against repository source (V1 trusts reviewer
+  output as-is, just fences and redacts it)
+- No XML-structured findings parsing — V1 parses loose markdown structure
+- No confidence scoring or priority weighting beyond each reviewer's own
+  P1/P2/P3 labels
+- No ranking of reviewers against each other
+- No `/council history` browse command (file is there; browsing is manual in V1)
+
+---
+
+## CLI Invocation Notes (from live environment check, 2026-05-03)
+
+Both Gemini and OpenCode CLIs are present on this machine.
+
+**Gemini CLI (`gemini`):**
+- Non-interactive one-shot: `gemini "prompt"` (positional, no `-p` flag —
+  deprecated)
+- Auto-accept all actions: `--approval-mode yolo` or `-y`
+- Structured output: `-o json` or `-o stream-json`
+- Model selection: `-m <model>`
+- Stdin: accepts piped context before the positional prompt
+- Output destination: stdout (capture with shell substitution or temp file)
+
+**OpenCode CLI (`opencode`):**
+- Non-interactive execution: `opencode run "message"`
+- File attachments: `-f <file>` (array, can repeat)
+- JSON event stream: `--format json`
+- Model selection: `-m provider/model`
+- Session management: `-c` (continue last), `-s <id>` (specific session)
+- Agent selection: `--agent <name>`
+- Variant (reasoning effort): `--variant high|max|minimal`
+
+**Spike needed in implementation phase:**
+- Confirm Gemini's `-o json` output schema for non-review prompts (the
+  structured output shape for freeform question/debug/plan modes is not yet
+  verified from live output)
+- Confirm `opencode run --format json` event schema and how to extract the
+  final assistant message (analogous to Codex's `agentMessage` / `text` field)
+- Verify Gemini `--approval-mode yolo` behavior for read-only review (does it
+  attempt any write actions that yolo would approve, or is it safe for
+  read-only council use?)
+- Determine if `opencode run` is truly ephemeral by default or if it persists
+  a session that needs explicit cleanup
+
+---
+
+## V2 Trajectory — What V1 Must Not Foreclose
+
+The following V2 features must be addable without rewriting V1:
+
+1. **XML evidence contract.** V1 asks each reviewer to emit findings as
+   markdown with `file:line` + quoted line where applicable. The per-mode
+   pack templates in `council-patterns` SKILL.md must be structured so that V2
+   can tighten the output spec to GodModeSkill's full XML evidence contract
+   (`<file-path>` / `<line-number>` / `<quoted-line><![CDATA[...]]></quoted-line>`)
+   by editing the template only — not by changing the agent or command structure.
+
+2. **Lineage-weighted quorum aggregation.** V1 uses raw count + verbatim
+   presentation. V2 swaps in quorum logic (agreement requires >=1 reviewer from
+   each available lineage, findings that cannot be verified against repository
+   source are downgraded). The V1 synthesizer must be isolated (its own
+   agent or prose section) so it can be replaced without touching the fan-out
+   or pack-build stages.
+
+3. **Multi-round iterative review.** V1 is single-shot. V2 must be able to add
+   `/council review --round 2` or a `resume` subcommand that injects the V1
+   output as prior context into a second council round, with round-aware context
+   trimming (unchanged long-tail context omitted in round 2 per GodModeSkill
+   `work-pack-build` pattern).
+
+4. **Fleet management subcommand surface.** V1 has no persistent sessions.
+   V2 will add `/council fleet status`, `/council fleet restart`, and
+   persistent tmux-style session management. The V1 command file
+   (`commands/council/council.md`) must reserve the `fleet` subcommand word
+   and print a "fleet management not available in V1" message if invoked, so
+   the V2 PR can wire it without a naming conflict.
+
+5. **`## DONE` event-driven waiting.** V1 blocks on subprocess exit.
+   V2 may move to inotifywait-style waiting for `## DONE` markers in reviewer
+   output. V1's per-reviewer timeout guard (exit 124) and partial-result
+   collection logic must be isolated in `council-patterns` SKILL.md so V2
+   can swap the wait mechanism.
+
+---
+
+## Open Questions for `/workflows:plan`
+
+These are unresolved specifics that the plan phase must address before writing
+implementation files:
+
+1. **Soft-skip vs minimal Codex bundle when yellow-codex absent.** Decision
+   is soft-skip (Council ran with 2 of 3 reviewers), but confirm: should
+   yellow-council ship a minimal fallback `codex-reviewer` of its own as a
+   future option, or is soft-skip permanent? Plan should specify which.
+
+2. **Gemini output parsing for non-review modes.** The `-o json` schema for
+   freeform `question`/`debug`/`plan` prompts must be verified with a live
+   spike before the gemini-reviewer agent is finalized. Plan should include a
+   spike step.
+
+3. **OpenCode final-message extraction from `--format json` event stream.**
+   The event schema for `opencode run --format json` is analogous to Codex's
+   JSONL but unverified. Spike required. If the schema is unstable or
+   undocumented, plan should note `--format default` (plain text capture) as
+   the safe fallback for V1.
+
+4. **`--paths` content cap for debug/question modes.** V1 needs an explicit
+   per-mode character limit on injected file content before passing to Gemini/
+   OpenCode (both have context window limits that differ from Codex's 128K).
+   Gemini 2.5 Pro has a 1M token window; OpenCode's limit depends on the
+   configured model. Plan should specify a conservative V1 default (suggestion:
+   8K chars per file, 3 files max) with a flag to override.
+
+5. **Slug derivation for `/council plan <path>`** when input is a file path:
+   use the filename stem (e.g., `plan-2026-05-03-yellow-council-design`) vs
+   the first N words of the file's first heading? Needs a concrete rule in the
+   plan to avoid ambiguity.
+
+6. **`plugin.json` `optionalDependencies` field.** Confirm whether the current
+   plugin schema supports this field (current evidence says no — yellow-codex's
+   cross-plugin dep is docs-only). If not, plan should document the convention
+   used (docs + graceful soft-skip guard) so a future schema addition does not
+   leave stale docs.
+
+7. **Credential redaction scope for Gemini and OpenCode output.** Yellow-codex's
+   8-pattern awk redaction block (sk-, ghp_, AKIA, Bearer, Authorization,
+   PEM keys) should be replicated in `council-patterns` SKILL.md as the
+   canonical redaction surface for all three reviewers. Confirm whether
+   OpenCode's JSON event stream requires redaction of any additional fields
+   (e.g., embedded tool-call arguments).
+
+---
+
+## Anti-Patterns Explicitly Avoided
+
+These patterns from GodModeSkill are intentionally excluded from both V1 and V2:
+
+- **tmux fleet management in V1.** No tmux session spawning, no babysit loops,
+  no `work-fleet-restart` equivalent. V2 may add persistent session support,
+  but V1 is pure subprocess spawn-and-wait.
+- **Home-directory binary placement.** No `~/.local/bin/council` executor.
+  All behavior lives in the plugin's markdown commands and agents under
+  `plugins/yellow-council/`.
+- **Global installer prompts.** No `INSTALL.md` paste-into-Claude flow. Yellow-
+  council installs via `/plugin marketplace add` like every other yellow-plugins
+  plugin.
+- **Auto-modifying git workflows.** The council never stages, commits, or pushes.
+  It reads diffs and files; it writes to `docs/council/` only.
+- **Blocking merge gating.** Council output is advisory. It is never wired into
+  CI, merge queues, or any automatic gate. The user decides what to do with
+  the verdicts.
+- **Magic mode inference.** Bare `/council` with no mode argument prints help
+  and exits. No attempt to infer intent from the input text.
+- **Duplicating yellow-codex Codex invocation conventions.** When yellow-codex
+  is installed, yellow-council reuses `codex-reviewer` via Task. No parallel
+  Codex implementation inside yellow-council.
+- **Pulling external CLI deps into yellow-core.** Yellow-core stays clean.
+  All binary-dependent agents live in yellow-council.
+
+---
+
+## Attribution
+
+GodModeSkill patterns referenced in this brainstorm are from
+`99xAgency/GodModeSkill` at commit `b693d1da498cbcfc2e5cba1f85b3d341205bfeb0`,
+licensed MIT. No code has been copied; this brainstorm borrows algorithmic
+ideas and workflow patterns only. If implementation files later lift verbatim
+code from `skill/work-converge` or `skill/work-pack-build`, add
+`third_party/GodModeSkill.LICENSE` and per-file headers noting source repo,
+original path, commit SHA, and modifications.

--- a/docs/spikes/gemini-cli-output-format-2026-05-04.md
+++ b/docs/spikes/gemini-cli-output-format-2026-05-04.md
@@ -1,0 +1,81 @@
+# Spike: Gemini CLI Output Format & Headless Invocation
+
+**Date:** 2026-05-04
+**Plan task:** PR1 task 1.1 + 1.4 (yellow-council)
+**Gemini CLI version tested:** 0.40.1
+
+## Summary
+
+The brainstorm research (2026-05-03) cited an outdated Gemini CLI behavior (positional prompt, `-p` deprecated, `-o json` broken per issue #9009). The current Gemini CLI v0.40.1 has materially changed:
+
+- **`-p` / `--prompt` is REQUIRED** for non-interactive (headless) mode — positional `gemini "prompt"` now defaults to interactive mode (TUI) and hangs in non-TTY contexts.
+- **`-o json` works** — issue #9009 has been resolved.
+- **`--approval-mode plan` is a NEW choice** — explicit read-only mode, exactly what yellow-council needs.
+- **`--skip-trust`** is required for non-interactive use in non-trusted directories (workspace trust mechanism overrides `--approval-mode plan` to `default` otherwise).
+
+The plan must be updated to reflect the v0.40+ invocation pattern.
+
+## Verified Invocation Pattern (from official docs)
+
+Source: <https://google-gemini.github.io/gemini-cli/docs/cli/headless.html>
+
+```bash
+# Direct prompt
+gemini -p "What is machine learning?"
+
+# Stdin pipe
+echo "Explain this code" | gemini --prompt "Review this"
+
+# File context
+cat README.md | gemini -p "Summarize this documentation"
+
+# Structured JSON output
+gemini -p "..." -o json
+```
+
+JSON response schema (per official headless docs):
+- `response`: assistant text answer (string)
+- `stats`: `{ models: ..., tools: ..., files: ... }`
+- `error`: present only on failure
+
+## Recommended yellow-council Invocation
+
+For `gemini-reviewer.md` agent body:
+
+```bash
+timeout --signal=TERM --kill-after=10 "${COUNCIL_TIMEOUT:-600}" \
+  gemini -p "<full-pack-prompt>" \
+    --approval-mode plan \
+    --skip-trust \
+    -o text \
+  > "$OUTPUT_FILE" 2> "$STDERR_FILE"
+```
+
+**Flag rationale:**
+- `-p` / `--prompt`: required for non-interactive mode (positional prompt enters TUI which hangs in non-TTY).
+- `--approval-mode plan`: read-only mode — model cannot invoke write/edit tools. Strictly safer than `--yolo` (which auto-approves writes).
+- `--skip-trust`: bypasses workspace trust check (would otherwise force `--approval-mode default` and prompt for input).
+- `-o text` (not `json`): for V1, plain text output is parsed for `Verdict:` / `Findings:` / `Summary:` markers per the council-patterns SKILL contract. Switching to `-o json` is a V2 option once the response schema is stable across all our invocation patterns.
+
+## Spike Test Environment Observations (2026-05-04, WSL2)
+
+In this WSL2 shell environment, `gemini -p "Hi"` hung indefinitely (timed out at 30–180s with no output beyond `.geminiignore not found` debug message). Auth state appears valid (`~/.gemini/oauth_creds.json` present, `google_accounts.json` configured). Stale `.tmp` files in `~/.gemini/projects.json.*.tmp` were cleaned up but the hang persisted.
+
+**Hypothesis:** Network/proxy or auth token re-validation issue specific to this WSL2 shell session. NOT a Gemini CLI bug; the documented invocation pattern is correct per official docs.
+
+**For PR2 implementation:** Live-test on a known-good gemini env before declaring `gemini-reviewer.md` agent done. If hang persists, document a "[gemini] CLI hung beyond timeout — skipping" graceful path (council runs with N<3 reviewers).
+
+## Gotchas to Watch For
+
+1. **`--yolo` / `--approval-mode yolo` still has known issues** (issue #13561 — auto-approves writes BUT may still prompt in some edge cases). yellow-council MUST NOT use `--yolo`. Use `--approval-mode plan` instead.
+2. **Workspace trust default is "untrusted"** for any folder gemini hasn't seen. `--skip-trust` is the explicit non-interactive override.
+3. **`.geminiignore` lookup happens at every invocation** — harmless but appears in `--debug` output.
+4. **Stale `~/.gemini/projects.json.*.tmp` files** can accumulate from killed processes. Periodic cleanup recommended.
+
+## References
+
+- Gemini CLI Headless Mode docs: <https://google-gemini.github.io/gemini-cli/docs/cli/headless.html>
+- Gemini CLI npm: <https://www.npmjs.com/package/@google/gemini-cli>
+- Repo: <https://github.com/google-gemini/gemini-cli>
+- Issue #9009 (`-o json`): closed/resolved as of v0.40+
+- Issue #13561 (`--yolo` still prompts): outstanding — avoid `--yolo`

--- a/docs/spikes/opencode-cli-format-json-2026-05-04.md
+++ b/docs/spikes/opencode-cli-format-json-2026-05-04.md
@@ -1,0 +1,135 @@
+# Spike: OpenCode CLI `--format json` Event Stream & Session Cleanup
+
+**Date:** 2026-05-04
+**Plan task:** PR1 task 1.2 + 1.3 (yellow-council)
+**OpenCode CLI version tested:** 1.14.33
+
+## Summary
+
+OpenCode CLI's non-interactive invocation is `opencode run "<message>"` with `--format json` for structured event stream. Key findings:
+
+- **Persistent SQLite sessions** in `~/.local/share/opencode/` — every `opencode run` invocation creates a new session that persists. Cleanup via `opencode session delete <id>` is required to prevent unbounded growth.
+- **Major-version upgrades trigger a one-time SQLite migration** that can take several minutes on first run after the upgrade. yellow-council must tolerate this (or document that users should run `opencode run "test"` once interactively after upgrading).
+- **JSON event stream schema** is loosely documented; community cheatsheet (takopi.dev) is the most reliable reference.
+- **Recommended install:** `curl -fsSL https://opencode.ai/install | bash` OR `npm install -g opencode-ai`. `opencode upgrade` works for self-update.
+
+## Verified Invocation Pattern (from official docs + community cheatsheet)
+
+Source: <https://opencode.ai/docs/cli/>
+
+```bash
+# Non-interactive run
+opencode run "Explain how closures work in JavaScript"
+
+# Structured JSON event stream
+opencode run --format json "..."
+
+# Continue last session
+opencode run --continue "follow-up question"
+
+# Specific session
+opencode run --session ses_XXXXX "follow-up"
+
+# Specific model + variant
+opencode run --model anthropic/claude-sonnet-4-5 --variant high "..."
+```
+
+### Event types in `--format json` stream (community-documented)
+
+Source: <https://takopi.dev/reference/runners/opencode/stream-json-cheatsheet/>
+
+| Event type | Key fields | Purpose |
+|------------|-----------|---------|
+| `step_start` | `sessionID`, `part.type="step-start"`, `part.snapshot` | Step begins |
+| `text` | `part.text` (string), `part.time` | Model text output (may emit multiple per turn) |
+| `tool_use` | `part.tool`, `part.state.input`, `part.state.output`, `part.state.status` | Tool invocations (read/write/edit) |
+| `step_finish` | `part.reason`, `part.cost`, `part.tokens` | Step ends — `reason: "stop"` is terminal |
+| `error` | `error.name`, `error.data.message` | Session error |
+
+**Final assistant message extraction (jq):**
+```bash
+ASSISTANT_TEXT=$(jq -r 'select(.type=="text") | .part.text' "$OUTPUT_FILE" | tr -d '\000')
+```
+
+Concatenate all `text` events for the full response. Multiple `text` events can be emitted per turn (streaming chunks).
+
+**Session ID extraction (jq):**
+```bash
+SESSION_ID=$(jq -r 'first(.part.snapshot.sessionID // empty)' "$OUTPUT_FILE" 2>/dev/null)
+```
+
+## Recommended yellow-council Invocation
+
+For `opencode-reviewer.md` agent body:
+
+```bash
+timeout --signal=TERM --kill-after=10 "${COUNCIL_TIMEOUT:-600}" \
+  opencode run \
+    --format json \
+    --variant "${COUNCIL_OPENCODE_VARIANT:-high}" \
+    "<full-pack-prompt>" \
+  > "$OUTPUT_FILE" 2> "$STDERR_FILE"
+CLI_EXIT=$?
+
+# Extract session ID for cleanup
+SESSION_ID=$(jq -r 'first(.part.snapshot.sessionID // empty)' "$OUTPUT_FILE" 2>/dev/null)
+
+# Check for error events FIRST (jq stops on first hit, fast)
+ERROR_MSG=$(jq -r 'select(.type=="error") | .error.data.message' "$OUTPUT_FILE" 2>/dev/null | head -1)
+
+if [ -n "$ERROR_MSG" ]; then
+  printf '[opencode-reviewer] OpenCode error: %s\n' "$ERROR_MSG" >&2
+  # mark this reviewer as ERROR exit_status; continue to cleanup
+fi
+
+# Extract assistant text (concatenate all text events)
+ASSISTANT_TEXT=$(jq -r 'select(.type=="text") | .part.text' "$OUTPUT_FILE" 2>/dev/null | tr -d '\000')
+
+# Apply 11-pattern redaction to ASSISTANT_TEXT (NOT to raw JSONL — JSONL contains tool_use events with embedded file content)
+
+# Cleanup session
+if [ -n "$SESSION_ID" ]; then
+  opencode session delete "$SESSION_ID" 2>/dev/null \
+    || printf '[opencode-reviewer] Warning: failed to delete session %s\n' "$SESSION_ID" >&2
+fi
+```
+
+**Flag rationale:**
+- `--format json`: structured event stream; required for reliable text extraction.
+- `--variant high`: default reasoning effort. `max` is significantly slower/costlier — reserve for explicit user override via `COUNCIL_OPENCODE_VARIANT=max`. `minimal` is too brief for council use.
+- `opencode session delete`: ALWAYS run after capture to prevent session accumulation in `~/.local/share/opencode/`.
+- **Do NOT use `--dangerously-skip-permissions`** (the OpenCode equivalent of Gemini `--yolo` — same risk profile).
+
+## Spike Test Environment Observations (2026-05-04, WSL2)
+
+In this WSL2 shell, `opencode run "..." --format json` triggered a one-time SQLite migration after the upgrade from 1.1.23 → 1.14.33. The migration emitted progress to stderr:
+```
+Performing one time database migration, may take a few minutes...
+sqlite-migration:0
+sqlite-migration:1
+...
+sqlite-migration:8
+```
+
+The migration exceeded the 60-second test timeout. Community-reported migration time on similar version jumps is 2–5 minutes. Subsequent invocations should not pay this cost.
+
+**For PR2 implementation:**
+- Document in CLAUDE.md "Known Limitations": after major OpenCode upgrades, the first invocation may take several minutes due to SQLite migration. Recommend users run `opencode run "test"` once interactively before invoking `/council`.
+- Add an opencode-reviewer warning if `STDERR_FILE` contains "sqlite-migration": message back to user "OpenCode is performing a one-time database migration; council results delayed."
+
+## Gotchas to Watch For
+
+1. **Persistent sessions accumulate.** `~/.local/share/opencode/` grows unbounded without explicit `opencode session delete`. yellow-council MUST clean up after every invocation.
+2. **`tool_use` events embed file content.** If the model decides to invoke `read`/`write`/`edit` tools (which it shouldn't for read-only review prompts), `part.state.input` and `part.state.output` contain full file contents. Apply credential redaction to the EXTRACTED assistant text, not just the raw JSONL — but never write the raw JSONL to `docs/council/` reports.
+3. **`--variant max` is significantly slower.** May approach the 600s timeout for complex prompts. `high` is the safe default.
+4. **Major-version upgrades trigger SQLite migration.** First invocation post-upgrade can take minutes. Document and tolerate.
+
+## References
+
+- OpenCode CLI docs: <https://opencode.ai/docs/cli/>
+- OpenCode config docs: <https://opencode.ai/docs/config/>
+- OpenCode `--format json` event schema (community): <https://takopi.dev/reference/runners/opencode/stream-json-cheatsheet/>
+- OpenCode CLI cheat sheet: <https://computingforgeeks.com/opencode-cli-cheat-sheet/>
+- SST release notes (latest opencode versions): <https://releasebot.io/updates/sst>
+- npm package: `opencode-ai` — <https://www.npmjs.com/package/opencode-ai>
+- Install script: `curl -fsSL https://opencode.ai/install | bash`

--- a/docs/spikes/opencode-cli-format-json-2026-05-04.md
+++ b/docs/spikes/opencode-cli-format-json-2026-05-04.md
@@ -55,7 +55,7 @@ Concatenate all `text` events for the full response. Multiple `text` events can 
 
 **Session ID extraction (jq):**
 ```bash
-SESSION_ID=$(jq -r 'first(.part.snapshot.sessionID // empty)' "$OUTPUT_FILE" 2>/dev/null)
+SESSION_ID=$(jq -r 'first(.sessionID // empty)' "$OUTPUT_FILE" 2>/dev/null)
 ```
 
 ## Recommended yellow-council Invocation
@@ -72,7 +72,7 @@ timeout --signal=TERM --kill-after=10 "${COUNCIL_TIMEOUT:-600}" \
 CLI_EXIT=$?
 
 # Extract session ID for cleanup
-SESSION_ID=$(jq -r 'first(.part.snapshot.sessionID // empty)' "$OUTPUT_FILE" 2>/dev/null)
+SESSION_ID=$(jq -r 'first(.sessionID // empty)' "$OUTPUT_FILE" 2>/dev/null)
 
 # Check for error events FIRST (jq stops on first hit, fast)
 ERROR_MSG=$(jq -r 'select(.type=="error") | .error.data.message' "$OUTPUT_FILE" 2>/dev/null | head -1)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yellow-plugins-root",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "description": "Git-native, schema-validated plugin marketplace for Claude Code",
   "author": "KingInYellows",

--- a/plans/yellow-council-godmodeskill-integration.md
+++ b/plans/yellow-council-godmodeskill-integration.md
@@ -1,0 +1,768 @@
+# Feature: yellow-council Plugin (GodModeSkill Integration V1)
+
+**Source brainstorm:** `docs/brainstorms/2026-05-03-godmodeskill-integration-brainstorm.md`
+**Source investigation:** `research/GodModeSkill Integration Investigation.md`
+**GodModeSkill reference commit:** `b693d1da498cbcfc2e5cba1f85b3d341205bfeb0`
+**Plan date:** 2026-05-03
+**Detail level:** COMPREHENSIVE
+
+---
+
+## Overview
+
+Add a new dedicated plugin — `yellow-council` — to the yellow-plugins marketplace. The plugin provides a single user-invoked command, `/council <mode> [input]`, that fans out a context pack to three external CLI reviewers (Codex via existing `yellow-codex:review:codex-reviewer`, Gemini via new `gemini-reviewer`, OpenCode via new `opencode-reviewer`) in parallel subprocesses, applies a 600-second per-reviewer timeout with partial-result reporting, synthesizes the verdicts inline in the active conversation, and persists the full report to `docs/council/<date>-<slug>.md` after an `AskUserQuestion` save gate.
+
+V1 is synchronous, advisory-only, and never blocks merges. V2 will evolve toward GodModeSkill's native persistent-session model with lineage-weighted quorum and quote-backed evidence verification — V1 must not foreclose that path.
+
+This plan reflects findings from two parallel research passes (repo conventions + external CLI best practices), with explicit corrections to the brainstorm where upstream upstream CLIs proved different from documented behavior (Gemini `-o json` was broken upstream; OpenCode `opencode run` creates persistent sessions; Gemini `--yolo` still prompts).
+
+---
+
+## Problem Statement
+
+### Current Pain Points
+
+The existing `yellow-review` plugin runs a 14-reviewer Claude-only pipeline with confidence-rubric aggregation. It is mature for in-Claude PR review, but:
+
+- It cannot bring in independent perspectives from other model lineages (OpenAI Codex, Google Gemini, Anthropic via OpenCode, etc.). Multi-LLM consensus on a tricky design decision is unreachable today.
+- It is bound to PR review semantics. There is no mechanism to ask "what do three different model families think about this planning doc / this debug symptom / this freeform question?" outside of a code-change context.
+- yellow-codex provides Codex as a single supplementary reviewer inside `review:pr`, but only there. There is no on-demand cross-lineage council surface.
+
+### User Impact
+
+When a developer hits a hard design decision, debugging a confusing failure, or evaluating a planning doc, they currently have to:
+1. Open three separate terminals (one per CLI), or
+2. Manually paste the same context into each tool, or
+3. Just trust the in-Claude review and move on.
+
+A single `/council <mode>` command that returns a synthesized cross-lineage verdict in 60–120 seconds is the missing tool.
+
+### Business Value
+
+- **Higher-confidence design decisions.** Cross-lineage agreement on an architectural choice is materially stronger evidence than single-model approval.
+- **Lower context-switching overhead.** No more juggling three terminal sessions for ad-hoc consultations.
+- **V2 lineage-quorum readiness.** V1 establishes the plugin shape and command surface so V2's GodModeSkill-style aggregation can drop in without rewriting any of the fan-out, pack-build, or output-capture stages.
+
+---
+
+## Proposed Solution
+
+### High-Level Architecture
+
+```
+User invokes /council <mode> [input]
+            │
+            ▼
+   ┌────────────────────┐
+   │  council command   │  (commands/council/council.md — bash flow)
+   │                    │
+   │  1. validate mode  │
+   │  2. build pack     │  (per-mode template from council-patterns SKILL.md)
+   │  3. fan-out        │  (parallel subprocess spawn with timeout 600)
+   │  4. wait + collect │  (wait "$pid" per-process, capture exit codes)
+   │  5. redact + fence │  (8-pattern awk + AIza/sk-ant-/ses_ extras)
+   │  6. synthesize     │  (Headline + Agreement + Disagreement)
+   │  7. M3 confirm     │  (AskUserQuestion gate before write)
+   │  8. atomic write   │  (mktemp same-dir → mv to docs/council/)
+   └────────────────────┘
+            │
+            ├─► Task: yellow-codex:review:codex-reviewer  (graceful skip if absent)
+            ├─► Bash: gemini "<prompt>"     (timeout 600 + temp file)
+            └─► Bash: opencode run "<prompt>" + opencode session delete
+```
+
+The command is the orchestrator; agents are reviewer wrappers. The skill (`council-patterns`) holds shared invocation conventions and per-mode pack templates.
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Actual fan-out model is Task-based, not bash-subprocess-based. council.md spawns three Task tool calls (Codex via `yellow-codex:review:codex-reviewer`, Gemini via `yellow-council:review:gemini-reviewer`, OpenCode via `yellow-council:review:opencode-reviewer`) in a single message; Claude Code's harness runs them concurrently. Each reviewer agent internally spawns ONE `timeout ... <cli> ...` bash subprocess — there is no multi-PID `wait` loop INSIDE council.md. Precedent: `plugins/yellow-review/commands/review/review-pr.md:392` ("Launch all selected agents EXCEPT `code-simplifier` in parallel via Task tool"); `plugins/yellow-codex/agents/review/codex-reviewer.md` is the per-agent single-CLI invocation pattern.
+<!-- /deepen-plan -->
+
+### Key Design Decisions
+
+| # | Decision | Rationale (locked in brainstorm + validated by research) |
+|---|----------|----------------------------------------------------------|
+| 1 | New plugin, not a modification of yellow-review | Different runtime contract (sidecar binaries vs in-Claude); separate failure semantics; clean V2 evolution surface |
+| 2 | Synchronous parallel fan-out, 600s per-reviewer timeout | User explicitly invoked the heavyweight tool; `wait "$pid"` per-process pattern is portable to Bash 4.3+; `timeout --kill-after=10 600` matches yellow-codex precedent |
+| 3 | yellow-codex as optional dep (Task spawn, not bundled Codex) | Avoids two diverging Codex implementations; `subagent_type="yellow-codex:review:codex-reviewer"` is the documented cross-plugin pattern |
+| 4 | Explicit modes (plan/review/debug/question), no magic inference | Deterministic pack assembly; user always knows what reviewers see; V2-portable to GodModeSkill's XML pack templates |
+| 5 | Inline synthesis + file write, simple V1 synthesizer | Synthesis is the V2 swap surface — keep it isolated and prose-simple in V1; raw count + verbatim presentation, not weighted quorum |
+
+### Trade-offs Considered
+
+- **A — sync inline (chosen) vs B — fire-and-watch with file polling.** Fire-and-watch was rejected because it would require a `/council status` command, polling state, and a notification model — none needed when the user is present and waiting. The 600s blocking wait is acceptable for an explicitly-invoked heavyweight tool.
+- **A — new plugin (chosen) vs B — extend yellow-codex vs C — yellow-core command.** Extending yellow-codex would entangle the "Codex is optional" story; yellow-core would drag binary deps into the foundation. New plugin is the only option that preserves both contracts.
+- **B — explicit modes (chosen) vs A — mode-tagged freeform.** Mode inference was rejected because failure mode is silent ("council seems off-topic") and prompt design must be deterministic for V2's structured-output evolution.
+- **A — inline synthesis + file (chosen) vs B — raw side-by-side vs C — inline only.** Synthesis is V2's swap surface — defining it in V1 means V2 just replaces logic, not also introducing synthesis. File write is the lowest-cost piece of the feature and provides V2's `/council history` foundation.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Discovery & Setup
+
+- [ ] **1.1: Spike — Gemini `-o json` schema.** Run `gemini -o json "What is 2+2?"` against current Gemini CLI installation. Verify whether the flag now works (issue #9009 was P1, closed as duplicate Sept 2025) and document the actual response shape (`response` field? `messages[]`? error envelope?). If broken, fall through to `--output-format text` for V1. Output: `docs/spikes/gemini-cli-output-format-2026-05-03.md` with verbatim CLI output samples.
+- [ ] **1.2: Spike — OpenCode `--format json` event stream.** Run `opencode run --format json "What is 2+2?"` and capture the full JSONL output. Document: which event types appear (`step_start` / `text` / `tool_use` / `step_finish` / `error`), how to extract the final assistant message (concatenate all `text` events vs last `text` before `step_finish`), and confirm the `sessionID` field is present in event 0 for cleanup. Output: `docs/spikes/opencode-cli-format-json-2026-05-03.md`.
+- [ ] **1.3: Spike — OpenCode session cleanup.** Run `opencode run "test" --format json`, capture the session ID, then run `opencode session delete <id>`. Verify: does `opencode session list` confirm deletion? Is there a batch delete option for stale sessions? Document the cleanup contract in the same spike doc.
+- [ ] **1.4: Spike — Gemini approval mode for read-only.** Run a benign read-only prompt against Gemini CLI WITHOUT `--yolo` (issue #13561 confirmed yolo still prompts in some cases). Document: does the default approval mode block the prompt waiting for input, or does a prompt that asks for analysis-only complete cleanly? If it blocks, document the exact non-interactive flag combination that works.
+- [ ] **1.5: Plugin scaffold.** Create `plugins/yellow-council/` with the directory structure from brainstorm Decision 3 (lines 102–126). Files to create as empty stubs first:
+  ```
+  plugins/yellow-council/
+    .claude-plugin/plugin.json
+    agents/review/gemini-reviewer.md
+    agents/review/opencode-reviewer.md
+    commands/council/council.md
+    skills/council-patterns/SKILL.md
+    CLAUDE.md
+    README.md
+    package.json
+    CHANGELOG.md
+  ```
+- [ ] **1.6: Manifest authoring.** Populate `plugins/yellow-council/.claude-plugin/plugin.json` and `plugins/yellow-council/package.json` mirroring the yellow-codex shape. Initial version: `0.1.0`. Required fields per `schemas/plugin.schema.json`: `name`, `version`, `description`, `author`. `repository` MUST be a string URL (not object). No `changelog` key.
+- [ ] **1.7: Marketplace registration.** Append yellow-council entry to `.claude-plugin/marketplace.json`:
+  ```json
+  {
+    "name": "yellow-council",
+    "description": "On-demand cross-lineage code review fanning out to Codex, Gemini, and OpenCode CLIs in parallel.",
+    "version": "0.1.0",
+    "author": { "name": "KingInYellows" },
+    "source": "./plugins/yellow-council",
+    "category": "development"
+  }
+  ```
+- [ ] **1.8: Catalog version bump.** Run `node scripts/catalog-version.js patch` to bump root `metadata.version`.
+- [ ] **1.9: Changeset + initial CHANGELOG.md.** Two files in tandem:
+  1. `.changeset/yellow-council-initial-release.md`:
+     ```markdown
+     ---
+     "yellow-council": minor
+     ---
+
+     Initial release of yellow-council plugin: on-demand cross-lineage council command (`/council <mode>`) fanning out to Codex, Gemini, and OpenCode CLIs in parallel.
+     ```
+  2. `plugins/yellow-council/CHANGELOG.md` pre-populated with `# yellow-council` header + `## 0.1.0` block (see "Files to Create" annotation above for exact content). Empty CHANGELOG.md will produce malformed output on first `pnpm apply:changesets` run — yellow-codex precedent ships the file pre-populated.
+- [ ] **1.10: W1.5 allowlist update.** Add `plugins/yellow-council/agents/review/gemini-reviewer.md` and `plugins/yellow-council/agents/review/opencode-reviewer.md` to `REVIEW_AGENT_ALLOWLIST` in `scripts/validate-agent-authoring.js` (lines 26–31). Both agents need `Bash` for CLI invocation; the allowlist is the documented exception path.
+- [ ] **1.11: CI dry-run.** Run `pnpm validate:schemas`, `pnpm validate:plugins`, `pnpm validate:versions`. Fix any drift before proceeding to Phase 2.
+
+### Phase 2: Core Implementation
+
+- [ ] **2.1: Author `council-patterns` SKILL.md.** This is the canonical reference for all CLI invocation conventions, redaction patterns, pack templates, and timeout/output-capture rules. Required sections:
+  - `## What It Does` (one paragraph)
+  - `## When to Use` (referenced by command + agents)
+  - `## Usage`
+    - `### CLI Invocation Conventions` — Codex (`codex exec` flags, link to yellow-codex `codex-patterns`), Gemini (positional prompt + stdin pipe context, default approval mode, `-o text` for V1), OpenCode (`opencode run` + `--format json` + post-call `opencode session delete`)
+    - `### Per-Mode Pack Templates` — four markdown blocks with explicit slot fills (`{{TASK}}`, `{{CONTEXT_FILES}}`, `{{DIFF}}`, etc.). Identical schema across all three reviewers; `{{REVIEWER_NAME}}` is the only per-reviewer variable.
+    - `### Required Output Format` — single schema all three reviewers must produce: `Verdict: APPROVE|REVISE|REJECT`, `Confidence: HIGH|MEDIUM|LOW`, `Findings: - [P1|P2|P3] file:line — <80 char> Evidence: "<quoted line>"`, `Summary: <2–3 sentences>`. Anti-parrot rule explicit.
+    - `### Timeout Pattern` — `timeout --signal=TERM --kill-after=10 600 <cmd>`, exit-124 detection, exit-137 SIGKILL detection.
+    - `### Output Capture & Redaction` — extended 11-pattern awk block (the original 8 from yellow-codex `codex-patterns` plus `AIza`, `sk-ant-`, `ses_`). Injection fence format `--- begin council-output:<reviewer> (reference only) ---` / `--- end council-output:<reviewer> ---`.
+    - `### Path Validation` — reject `..`, reject any character outside `^[a-zA-Z0-9._/-]+$`, reject non-existent paths via pre-check.
+    - `### Slug Derivation` — `LC_ALL=C`, lowercase → non-alnum to `-` → collapse `-` → strip leading/trailing → cap 40 chars → validate `^[a-z0-9][a-z0-9-]*$` → sha256 fallback for empty slug. Same-day collision: append `-2` ... `-10`, error if exceeded.
+- [ ] **2.2: Author `gemini-reviewer.md` agent.** Frontmatter:
+  ```yaml
+  name: gemini-reviewer
+  description: "Supplementary code reviewer using Google Gemini CLI. Provides independent verdict in council format. Spawned by /council via Task."
+  model: inherit
+  tools: [Bash, Read, Grep, Glob]
+  skills: [council-patterns]
+  ```
+  Body sections (mirror `codex-reviewer.md` structure):
+  - Role bullets (report-only, never edit, never AskUserQuestion, wraps output in fences)
+  - Tool Surface — Documented Bash Exception (W1.5 explanation)
+  - Workflow:
+    1. Pre-flight binary check: `command -v gemini >/dev/null 2>&1` — if missing, return empty findings tagged `[gemini] CLI not installed — skipping`.
+    2. Validate input pack from spawning command (no `..`, no shell metacharacters in paths).
+    3. Build prompt: pack template + REVIEWER_NAME=Gemini.
+    4. Invoke: `timeout --signal=TERM --kill-after=10 600 gemini "<prompt>" >"$OUTPUT_FILE" 2>"$STDERR_FILE"` — pipe stdin context if present (`(cat "$ctx_file"; echo) | timeout ... gemini "..."`).
+    5. Capture exit code; handle 124/137 (timeout), 1 (CLI error — grep stderr for `rate limit`/`auth`/`invalid`).
+    6. Apply 11-pattern redaction to `$OUTPUT_FILE`.
+    7. Wrap in injection fence: `--- begin council-output:gemini (reference only) --- ... --- end council-output:gemini ---`.
+    8. Parse `Verdict:`, `Confidence:`, `Findings:`, `Summary:` lines via grep + awk. If `Verdict:` line absent, mark verdict `UNKNOWN` and include full output in summary.
+
+       <!-- deepen-plan: codebase -->
+       > **Codebase (2nd pass):** No existing reviewer in yellow-review or yellow-codex implements a `Verdict:` contract — the plan is defining a new structured-output convention. This means there's no precedent for re-prompting on parse failure (which would cost another 30–90s per reviewer and require conversational state across Task invocations). Stick with the documented "mark UNKNOWN" path. Concrete fallback semantics for V1:
+       >
+       > - `Verdict:` line absent → `verdict=UNKNOWN`, `confidence=LOW`
+       > - Include the reviewer's full prose output (capped at 2K chars) in the synthesis report's raw section
+       > - Surface a one-line warning in the synthesis Headline: `[gemini] Warning: no Verdict: line found in output — marked UNKNOWN`
+       > - Do NOT count UNKNOWN verdicts toward the synthesis Headline majority computation (treat as missing reviewer for headline purposes; still surface findings prose in Disagreement section if any)
+       >
+       > **New acceptance criterion to add (AC 14):** When a reviewer's output does not contain a `Verdict:` line, the synthesizer marks that reviewer's verdict as `UNKNOWN` (not an error), logs a structured-output-failure warning in the Headline, and includes the reviewer's full prose output (capped at 2K chars) in the report's raw section.
+       <!-- /deepen-plan -->
+    9. Return structured findings to spawning command.
+  - Cleanup: `rm -f "$OUTPUT_FILE" "$STDERR_FILE"`.
+- [ ] **2.3: Author `opencode-reviewer.md` agent.** Same frontmatter shape as gemini-reviewer with `name: opencode-reviewer`. Workflow differences:
+  - Pre-flight: `command -v opencode >/dev/null 2>&1`.
+  - Invoke: `timeout 600 opencode run --format json --variant high "<prompt>" >"$OUTPUT_FILE" 2>"$STDERR_FILE"`. Default `--variant high` (not `max` — research showed max is significantly slower); env override `COUNCIL_OPENCODE_VARIANT`.
+  - Extract session ID from first event in `$OUTPUT_FILE`: `SESSION_ID=$(jq -r 'select(.part.snapshot.sessionID) | .part.snapshot.sessionID' "$OUTPUT_FILE" | head -1)`.
+  - Extract assistant text: `ASSISTANT_TEXT=$(jq -r 'select(.type=="text") | .part.text' "$OUTPUT_FILE" | tr -d '\000')` — concatenate all `text` events.
+  - Check for `error` events FIRST: `jq -r 'select(.type=="error") | .error.data.message' "$OUTPUT_FILE"` — if non-empty, treat as reviewer failure and skip parsing.
+  - Apply redaction to extracted text (NOT the raw JSONL — JSONL may contain `tool_use` events with embedded file content that includes credentials).
+  - Cleanup session: `opencode session delete "$SESSION_ID" 2>/dev/null || true` — failure is logged but does not fail the review.
+- [ ] **2.4: Author `commands/council/council.md`.** Frontmatter:
+  ```yaml
+  ---
+  description: On-demand cross-lineage code review via Codex, Gemini, and OpenCode CLIs.
+  argument-hint: <plan|review|debug|question> [args]
+  allowed-tools:
+    - Bash
+    - Read
+    - Grep
+    - Glob
+    - Task
+    - AskUserQuestion
+    - Write
+  ---
+  ```
+  Body steps:
+  1. **Argument parsing.** Parse `$ARGUMENTS` into mode + remaining args. If empty or unknown mode → print help (4 modes, one-line each) and exit. Reserve `fleet` mode word: print "fleet management not available in V1 — coming in V2" and exit.
+
+     <!-- deepen-plan: codebase -->
+     > **Codebase (2nd pass):** No existing yellow-* plugin reserves a subcommand word with a "coming in V2" stub — yellow-council is establishing this pattern. Concrete implementation:
+     >
+     > ```bash
+     > case "$MODE" in
+     >   plan|review|debug|question)
+     >     # main logic continues
+     >     ;;
+     >   fleet)
+     >     printf '[council] fleet management not available in V1 — coming in V2\n'
+     >     exit 0
+     >     ;;
+     >   "")
+     >     # bare /council — print help
+     >     printf '[council] Usage: /council <mode> [args]\n'
+     >     printf '  plan <path-or-text>             Council on a planning doc or design proposal\n'
+     >     printf '  review [--base <ref>]           Council on the current diff\n'
+     >     printf '  debug "<symptom>" [--paths]     Council on a debug investigation\n'
+     >     printf '  question "<text>" [--paths]    Open-ended council consultation\n'
+     >     exit 0
+     >     ;;
+     >   *)
+     >     printf '[council] Error: unknown mode "%s"\n' "$MODE" >&2
+     >     printf '[council] Valid modes: plan, review, debug, question\n' >&2
+     >     exit 1
+     >     ;;
+     > esac
+     > ```
+     >
+     > **Critical: `fleet` exits 0, not 1.** A reserved-but-deferred command is not an error — scripts that check exit codes should treat `fleet` as "intentionally no-op" not "invocation failed." Bare `/council` also exits 0 (help is success). Only unknown modes exit 1.
+     >
+     > **New acceptance criterion to add (AC 15):** `/council fleet` prints `[council] fleet management not available in V1 — coming in V2` and exits 0. No reviewer is spawned. `/council unknownmode` exits 1 with error + help. Bare `/council` exits 0 with help.
+     <!-- /deepen-plan -->
+  2. **Per-mode input validation.** `plan` requires path-or-text, `review` accepts optional `--base <ref>`, `debug` requires symptom + optional `--paths`, `question` requires text + optional `--paths`.
+
+     <!-- deepen-plan: codebase -->
+     > **Codebase (2nd pass):** Plan does not specify a default for `--base` when `/council review` is invoked without it. Use the same fallback as `codex-reviewer.md:98`:
+     >
+     > ```bash
+     > BASE_REF="${BASE_REF:-$(git merge-base HEAD "origin/$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null | sed 's|.*/||' || echo 'main')")}"
+     > ```
+     >
+     > Falls back to upstream-tracking-branch's merge-base; if no upstream, falls back to `origin/main`. Matches the established pattern; do not invent a different default.
+     <!-- /deepen-plan -->
+  3. **Path sanitization.** All `--paths` and `plan` file inputs validated via SKILL pattern (regex + `..` reject + existence check). Limit injected file content: 8K chars per file, 3 files max for V1. Configurable via `COUNCIL_PATH_CHAR_CAP` and `COUNCIL_PATH_MAX_FILES` env vars.
+  4. **Pack build.** Read per-mode template from SKILL, fill slots, output to a single context string per reviewer. All three reviewers receive structurally-identical packs (only `{{REVIEWER_NAME}}` differs).
+  5. **Parallel fan-out.** Spawn three reviewers:
+     - Task spawn for Codex: `Task(subagent_type="yellow-codex:review:codex-reviewer", prompt="<pack>")`. If yellow-codex absent, the Task spawn fails — catch and mark Codex as `UNAVAILABLE (yellow-codex not installed)`. Use the work.md graceful-skip prose pattern.
+     - Task spawn for Gemini: `Task(subagent_type="yellow-council:review:gemini-reviewer", prompt="<pack>")`.
+     - Task spawn for OpenCode: `Task(subagent_type="yellow-council:review:opencode-reviewer", prompt="<pack>")`.
+     - Spawn all three Tasks in a single message (parallel execution per Claude Code's tool-call concurrency).
+
+     <!-- deepen-plan: codebase -->
+     > **Codebase:** Earlier draft labeled Gemini/OpenCode rows as "Bash spawn" — corrected to "Task spawn." All three reviewers use the Task tool. Per-CLI bash invocation (`timeout 600 <cli> ...`) lives INSIDE each reviewer agent's body, not in council.md. Confirmed against `review-pr.md:392` parallelism pattern.
+     <!-- /deepen-plan -->
+  6. **Collect verdicts.** Each reviewer returns `verdict`, `confidence`, `findings[]`, `summary`, `raw_output_path`, `exit_status` (`OK` | `TIMEOUT` | `ERROR` | `UNAVAILABLE`).
+
+     <!-- deepen-plan: codebase -->
+     > **Codebase:** This return schema is **novel** — it does NOT match the existing yellow-review compact-return envelope (`{reviewer, findings[], residual_risks, testing_gaps}` per `plugins/yellow-review/skills/pr-review-workflow/SKILL.md:143-165`). That divergence is architecturally fine because council reviewers carry verdict/confidence semantics that yellow-review's PR-focused reviewers do not. The plan is defining a NEW contract specific to council, not "following an existing pattern." During implementation, ensure the schema is documented in `council-patterns/SKILL.md` so each reviewer agent can produce it consistently.
+     <!-- /deepen-plan -->
+  7. **Synthesis (V1 — simple).**
+     - Headline: count verdicts. Format per brainstorm Decision 5 lines 167–171.
+     - Agreement: dedupe findings by `<file>:<line>`. If ≥2 reviewers cite same coordinate, list once with each reviewer's phrasing.
+     - Disagreement: findings unique to one reviewer; verdict conflicts at same coordinate.
+     - Summary block: 2–3 sentences synthesizing the council's overall stance.
+  8. **M3 confirmation gate.** AskUserQuestion: show resolved `$REPORT_PATH` + headline summary + options `[Save report]` / `[Cancel]`. Only "Save" proceeds. "Cancel" prints `[council] Report not saved.` and exits.
+  9. **Atomic file write.** Compute slug per SKILL convention. `$REPORT_PATH = docs/council/$(date +%Y-%m-%d)-<mode>-<slug>.md`. Apply collision suffix loop (cap `-10`). Write to `${REPORT_PATH}.tmp.XXXXXX` via `mktemp` IN THE SAME DIRECTORY as destination (avoid cross-device EXDEV). Use Write tool to write the temp file. Then `mv` rename for atomicity.
+
+     <!-- deepen-plan: codebase -->
+     > **Codebase:** Two follow-ups before implementation:
+     >
+     > **1. .gitignore drift risk.** Root `.gitignore` ignores `*.tmp` (exact suffix), NOT `*.tmp.*` or `*.tmp.XXXXXX`. The proposed `${REPORT_PATH}.tmp.XXXXXX` pattern would NOT be caught by existing rules. If the same-dir mktemp pattern is kept, add `docs/council/*.tmp.*` to root `.gitignore` in this same PR.
+     >
+     > **2. Existing precedent diverges from this design.** No existing plugin writes temp files under `docs/`. Every existing `mktemp` in the codebase targets `/tmp/`: `codex-reviewer.md:121` (`mktemp /tmp/codex-reviewer-XXXXXX.txt`), `codex-executor.md:78`, `codex/review.md:91`. yellow-research `deep.md` and yellow-core `brainstorm-orchestrator.md` skip the temp-file stage entirely — both write directly to the final path via the Write tool (no atomicity, but matches the existing convention). Recommend two simpler alternatives:
+     > - **Option A (matches all precedent):** `mktemp /tmp/council-XXXXXX.md`, write content, then `mv` to `docs/council/<final>.md`. Cross-device EXDEV is theoretically possible but extremely rare in WSL2/Linux dev environments where `/tmp` and the project share the filesystem.
+     > - **Option B (matches brainstorm-orchestrator):** Use the Write tool directly to the final `docs/council/<final>.md` path, no temp file. Write tool failure leaves no partial file. This is what brainstorm-orchestrator does for an analogous single-file synthesis write. Lowest implementation cost.
+     >
+     > Recommend **Option B** for V1 — matches the closest precedent (brainstorm-orchestrator) and avoids the .gitignore concern entirely. Reserve atomic-write-via-rename for V2 if concurrent invocations become possible.
+     <!-- /deepen-plan -->
+  10. **Inline synthesis output.** Print synthesis report to user (Headline + Agreement + Disagreement + Summary). Reference the file path: "Full reviewer outputs: see `<REPORT_PATH>`". Do NOT paste raw reviewer outputs inline.
+- [ ] **2.5: Author `CLAUDE.md`.** Sections per yellow-codex precedent: Core Principle ("Council is on-demand and advisory; never blocks merges"), Required Environment (Gemini CLI, OpenCode CLI, optional yellow-codex for Codex reviewer), Conventions (CLI invocation rules, redaction, fencing, sanitization), Plugin Components (1 command, 2 agents, 1 skill), Cross-Plugin Dependencies (yellow-codex optional), When to Use What, Known Limitations, **Configuration**.
+
+  <!-- deepen-plan: codebase -->
+  > **Codebase (2nd pass):** The `COUNCIL_*` env var prefix is correct — confirmed against the predominant convention (`CODEX_*`, `DEBT_*`, `DEVIN_*`, `MORPH_*`, `CI_*`, all using the SHORT plugin name without `yellow-` prefix). No correction needed.
+  >
+  > **Add a `## Configuration` section to CLAUDE.md** (yellow-codex documents `CODEX_MODEL` under "Model Selection" — yellow-council needs an analogous section since it has FOUR env vars). Required content:
+  >
+  > | Var | Type | Default | Purpose |
+  > |-----|------|---------|---------|
+  > | `COUNCIL_TIMEOUT` | integer seconds | `600` | Per-reviewer timeout passed to GNU `timeout`. Increase for very slow models / very large packs. |
+  > | `COUNCIL_OPENCODE_VARIANT` | `high \| max \| minimal` | `high` | OpenCode `--variant` reasoning effort. `max` is significantly slower; reserve for `--verbose` mode. |
+  > | `COUNCIL_PATH_CHAR_CAP` | integer chars | `8000` | Per-file content cap for `--paths` injection in `debug`/`question` modes. |
+  > | `COUNCIL_PATH_MAX_FILES` | integer | `3` | Maximum number of files accepted via `--paths` in any single invocation. |
+  >
+  > Without a Configuration section, users will hit "why does the council take so long" or "why is OpenCode so slow" and have no documented knob to turn.
+  <!-- /deepen-plan -->
+- [ ] **2.6: Author `README.md`.** Standard structure: install via `/plugin marketplace add KingInYellows/yellow-plugins` then `/plugin install yellow-council@yellow-plugins`, four mode examples with sample output, link to brainstorm + plan.
+
+### Phase 3: Edge Cases & Polish
+
+- [ ] **3.1: Partial-result reporting on timeout.** If any reviewer exits 124/137, the synthesis must include `Council ran with N of 3 reviewers (<name> timed out at 600s — omitted from synthesis)`. The remaining reviewers' verdicts are still synthesized normally. Verify that the headline computation handles N<3 gracefully.
+- [ ] **3.2: yellow-codex absent path.** If Codex reviewer is unavailable (Task spawn fails because plugin not installed), output reads `Council ran with 2 of 3 reviewers (Codex not available — yellow-codex plugin not installed)`. This is permanent V1 behavior — no fallback bundled Codex.
+- [ ] **3.3: All-three-fail path.** If all three reviewers fail (timeout, missing CLI, or auth error), the synthesis report is `Council failed: 0 of 3 reviewers returned verdicts. See <REPORT_PATH> for individual failure details.` The file is still written with the failure details. The M3 gate still asks before write — user can cancel.
+- [ ] **3.4: Bash 4.3+ check at command entry.** Pre-flight `bash --version | head -1 | grep -E 'version (4\.[3-9]|[5-9]\.)'` or equivalent. If older, print `[council] Error: bash 4.3+ required for parallel wait pattern` and exit. (WSL2 Ubuntu typically ships 5.1+; this is a defensive check.)
+- [ ] **3.5: Same-day collision overflow.** If `<date>-<mode>-<slug>` collides 10 times in one day (unlikely but possible during testing), the suffix loop errors out: `[council] Error: too many same-day collisions for slug "<slug>" (>10)`. This matches brainstorm-orchestrator pattern.
+- [ ] **3.6: Empty input rejection.** `/council debug ""` and `/council question ""` reject empty text. Print mode-specific usage and exit.
+- [ ] **3.7: `--paths` cap enforcement.** If user passes `--paths file1,file2,file3,file4`, reject with `[council] Error: --paths limit is 3 files in V1 (got 4). Override via COUNCIL_PATH_MAX_FILES env var.`
+- [ ] **3.8: File content cap enforcement.** Per file, truncate to 8K chars and append `\n[... truncated for council, original was N chars]`. Document in the pack template that truncation occurred.
+- [ ] **3.9: Stale OpenCode session cleanup safety.** If `opencode session delete` fails, log to stderr but do not fail the review. Sessions accumulate but are not corruption-causing.
+- [ ] **3.10: Redaction completeness audit.** Run a synthetic test: feed each CLI a prompt that asks it to output `sk-test-1234567890`, `AIza` + 35 chars, `sk-ant-test`, `ses_test123`, a fake PEM block, and a fake `Bearer` token. Verify all five appear redacted in the captured output. (Document test procedure in `docs/spikes/`.)
+
+### Phase 4: Testing & Documentation
+
+- [ ] **4.1: Manual end-to-end test — review mode.** On a small test branch with a known diff, run `/council review`. Verify all three reviewers return verdicts within 300 seconds. Verify report file is written. Verify M3 gate appears. Verify cancel path works.
+- [ ] **4.2: Manual end-to-end test — plan mode.** Run `/council plan docs/brainstorms/2026-05-03-godmodeskill-integration-brainstorm.md` against this very plan's source. Verify reviewers produce thoughtful planning critiques.
+- [ ] **4.3: Manual end-to-end test — debug mode.** Run `/council debug "TypeError: undefined is not a function" --paths plugins/yellow-codex/agents/review/codex-reviewer.md`. Verify debug-specific context (recent git log on cited paths) appears in pack.
+- [ ] **4.4: Manual end-to-end test — question mode.** Run `/council question "Should yellow-council ship a bundled Codex fallback when yellow-codex is absent?"`. This is meta — the council answers a question about itself. Useful as a smoke test for question mode.
+- [ ] **4.5: Manual timeout test.** Set `COUNCIL_TIMEOUT=10` and run `/council review` against a large diff. Verify all three reviewers timeout and report partial results (or zero results) without crashing.
+- [ ] **4.6: Manual yellow-codex absent test.** Temporarily disable yellow-codex (rename its `plugin.json`), run `/council review`. Verify the report shows "Codex not available" without erroring the whole council.
+- [ ] **4.7: Documentation update — root README.md.** Add yellow-council to the plugin list (currently 16 plugins → 17). Update if the README has a count mismatch.
+- [ ] **4.8: Documentation update — plugin CLAUDE.md polish.** Review for completeness against yellow-codex's CLAUDE.md as the gold standard.
+- [ ] **4.9: CI green confirmation + fresh-machine install test.** `pnpm validate:schemas`, `pnpm validate:plugins`, `pnpm validate:versions`, `pnpm validate:agents` all pass. Local CI passes does NOT guarantee Claude Code's remote validator accepts the plugin (per MEMORY.md `Claude Code Plugin Manifest Validation Errors`) — perform the 8-step fresh-machine install test below before declaring the PR mergeable:
+
+  <!-- deepen-plan: codebase -->
+  > **Codebase (2nd pass):** No CI job exists in `.github/workflows/` for fresh-machine plugin install testing. There is no `pnpm test:install` script, no `claude plugin install` step in any workflow, and no automated verification that Claude Code's runtime accepts the manifest. Fresh-install testing is necessarily manual. Concrete 8-step procedure:
+  >
+  > ```
+  > 1. Open a NEW Claude Code session (fresh context, no cached plugin state).
+  > 2. Verify yellow-council is NOT already installed:
+  >      /plugin list
+  >      # yellow-council should not appear
+  > 3. Add the marketplace (if not already added):
+  >      /plugin marketplace add KingInYellows/yellow-plugins
+  >      # Must succeed without error
+  > 4. Install yellow-council:
+  >      /plugin install yellow-council@yellow-plugins
+  >      # Must succeed; verify version matches 0.1.0
+  > 5. Confirm command surfaces (BLOCKING):
+  >      /council
+  >      # Expected: 4-mode help table; exit 0
+  > 6. Confirm fleet reservation (BLOCKING):
+  >      /council fleet
+  >      # Expected: "fleet management not available in V1 — coming in V2"; exit 0
+  > 7. Confirm unknown mode (advisory):
+  >      /council unknownmode
+  >      # Expected: error + help; exit 1
+  > 8. Spot-check agent wiring (advisory; requires gemini or opencode installed):
+  >      /council question "What is 2+2?"
+  >      # Expected: synthesis report with at least one reviewer responding
+  > ```
+  >
+  > Steps 5 and 6 are blocking — they verify the manifest is parseable and the command + reserved-word handling work end-to-end. Steps 7 and 8 are advisory but recommended. Document the 8-step results in the PR description before requesting review.
+  <!-- /deepen-plan -->
+- [ ] **4.10: Compound learnings.** After PR merge, run `/workflows:compound` to capture: any spike findings that contradicted research; any redaction patterns discovered missing during testing; the final per-reviewer timing data (P50/P95) for post-V1 timeout tuning.
+
+---
+
+## Technical Specifications
+
+### Files to Create
+
+| Path | Purpose |
+|------|---------|
+| `plugins/yellow-council/.claude-plugin/plugin.json` | Plugin manifest (schema-validated) |
+| `plugins/yellow-council/package.json` | Changesets version source |
+| `plugins/yellow-council/CHANGELOG.md` | Pre-populated with header + v0.1.0 entry at PR creation; later versions appended by changesets |
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Earlier draft said "Empty initially; populated by changesets" — that is **wrong**. yellow-codex's initial commit (`4f5cfff6`) included a hand-written CHANGELOG.md with `# yellow-codex` header + `## 0.1.0` block + `### Minor Changes` + initial release line. Changesets generates entries on `pnpm apply:changesets` runs, but it prepends to the existing file — if the file is empty, the result is malformed (no plugin-name header). Pre-populate at PR creation per yellow-codex precedent:
+>
+> ```markdown
+> # yellow-council
+>
+> ## 0.1.0
+>
+> ### Minor Changes
+>
+> - Initial release: on-demand cross-lineage council command (`/council <mode>`) fanning out to Codex, Gemini, and OpenCode CLIs in parallel.
+> ```
+<!-- /deepen-plan -->
+| `plugins/yellow-council/CLAUDE.md` | Plugin-local agent context |
+| `plugins/yellow-council/README.md` | User-facing install + usage docs |
+| `plugins/yellow-council/commands/council/council.md` | The `/council` command body |
+| `plugins/yellow-council/agents/review/gemini-reviewer.md` | Gemini CLI wrapper agent |
+| `plugins/yellow-council/agents/review/opencode-reviewer.md` | OpenCode CLI wrapper agent |
+| `plugins/yellow-council/skills/council-patterns/SKILL.md` | Shared invocation conventions, pack templates, redaction, slug rules |
+| `.changeset/yellow-council-initial-release.md` | Required changeset for new plugin |
+| `docs/spikes/gemini-cli-output-format-2026-05-03.md` | Spike output (Phase 1.1) |
+| `docs/spikes/opencode-cli-format-json-2026-05-03.md` | Spike output (Phase 1.2 + 1.3) |
+
+### Files to Modify
+
+| Path | Change |
+|------|--------|
+| `.claude-plugin/marketplace.json` | Append `yellow-council` entry to `plugins` array; bump `metadata.version` |
+| `scripts/validate-agent-authoring.js` | Add yellow-council reviewers to `REVIEW_AGENT_ALLOWLIST` (lines 26–31) |
+| `README.md` (root) | Update plugin count from `14 plugins` to `17 plugins`. (Verified: marketplace.json has 16 plugins; root README line 2 is already drifted from 14 → 16; yellow-council makes 17.) |
+
+<!-- deepen-plan: codebase -->
+> **Codebase (2nd pass):** Verified counts: `jq '.plugins | length' .claude-plugin/marketplace.json` returns 16; root README.md line 2 still says "14 plugins" (drifted by 2 already, separate from this PR). yellow-council makes 17. The plan's Files-to-Modify text was previously ambiguous about which number to use as the starting point — corrected above. Recommend the README update edit go from `14 plugins` → `17 plugins` (skip the intermediate `16`; one edit, not two).
+<!-- /deepen-plan -->
+
+### Dependencies
+
+- **System tools (must be present at runtime):** `bash` 4.3+, `timeout` (GNU coreutils), `awk`, `sed`, `grep`, `jq`, `mktemp`, `mv`, `command`. All standard on Linux/WSL2/macOS.
+- **External CLIs (user-installed; soft-skipped if missing):** `gemini`, `opencode`. (`codex` is reused via `yellow-codex` plugin; not a direct dep of yellow-council.)
+- **Cross-plugin (optional):** `yellow-codex` ≥ 0.2.0 — provides the `yellow-codex:review:codex-reviewer` agent. If absent, council runs with 2 of 3 reviewers.
+- **No npm dependencies.** All logic is bash + markdown.
+
+### CLI Invocation Specs
+
+**Codex (via yellow-codex Task spawn):**
+```
+Task(subagent_type="yellow-codex:review:codex-reviewer", prompt="<pack>")
+```
+Pack must include: mode, task, context blocks, required output schema. Codex's existing review pipeline handles the rest. If yellow-codex absent, mark UNAVAILABLE.
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** The existing `codex-reviewer.md` uses `timeout --signal=TERM --kill-after=10 300` (5 minutes). yellow-council uses 600s (10 minutes) — deliberate difference because council is user-invoked and heavier than the in-pipeline review. The codex-reviewer agent spawned via Task will respect its OWN 300s timeout, NOT council's 600s. If a council invocation needs Codex to honor a longer timeout, the spawning Task would need to pass an override prompt-time flag — which yellow-codex does not currently expose. For V1, accept that Codex caps at 300s when invoked via the existing reviewer; if Codex routinely times out at 300s for council use, file a yellow-codex enhancement issue to add a `COUNCIL_TIMEOUT_OVERRIDE` knob. Do NOT modify codex-reviewer.md as part of this PR.
+<!-- /deepen-plan -->
+
+**Gemini (direct bash):**
+```bash
+timeout --signal=TERM --kill-after=10 "${COUNCIL_TIMEOUT:-600}" \
+  gemini "<prompt>" \
+  >"$OUTPUT_FILE" 2>"$STDERR_FILE" &
+```
+With stdin context:
+```bash
+( printf '%s\n\n' "$context_block"; printf '%s' "$prompt" ) | \
+  timeout --signal=TERM --kill-after=10 "${COUNCIL_TIMEOUT:-600}" \
+  gemini >"$OUTPUT_FILE" 2>"$STDERR_FILE" &
+```
+**Do NOT use `--yolo` / `--approval-mode yolo`** (issue #13561 — still prompts in some cases; safety risk for read-only review). **Do NOT use `-o json`** in V1 (issue #9009 — was broken; spike-verify before any V2 use).
+
+**OpenCode (direct bash):**
+```bash
+timeout --signal=TERM --kill-after=10 "${COUNCIL_TIMEOUT:-600}" \
+  opencode run --format json --variant "${COUNCIL_OPENCODE_VARIANT:-high}" "<prompt>" \
+  >"$OUTPUT_FILE" 2>"$STDERR_FILE" &
+```
+Post-call cleanup:
+```bash
+SESSION_ID=$(jq -r 'first(.part.snapshot.sessionID // empty)' "$OUTPUT_FILE" 2>/dev/null)
+[ -n "$SESSION_ID" ] && opencode session delete "$SESSION_ID" 2>/dev/null || \
+  printf '[council] Warning: failed to delete OpenCode session %s\n' "$SESSION_ID" >&2
+```
+Final assistant message extraction:
+```bash
+ASSISTANT_TEXT=$(jq -r 'select(.type=="text") | .part.text' "$OUTPUT_FILE" | tr -d '\000')
+```
+
+**Parallel wait pattern (location correction):**
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Earlier draft placed the multi-PID `wait "$pid"` loop in `council.md`. That is **incorrect**. council.md does not invoke CLIs directly — it spawns three Task agents and Claude Code's harness runs them concurrently. The bash multi-PID wait pattern is unnecessary at the orchestrator level. **Each reviewer agent (gemini-reviewer.md, opencode-reviewer.md) spawns ONE CLI subprocess, so even within an agent body there's no need for a multi-PID wait loop — a simple `timeout ... <cli> ... > "$outfile" 2>&1` (no backgrounding) is sufficient.** The `&` and `wait "$pid"` machinery is only required if a single agent ever spawns multiple subprocesses, which V1 does not.
+>
+> The actual orchestrator-level "fan-out" in council.md is:
+>
+> ```
+> # In a single message, three Task tool calls:
+> Task(subagent_type="yellow-codex:review:codex-reviewer", prompt=$PACK)
+> Task(subagent_type="yellow-council:review:gemini-reviewer", prompt=$PACK)
+> Task(subagent_type="yellow-council:review:opencode-reviewer", prompt=$PACK)
+> # Claude Code runs all three in parallel; council.md collects their return values after all complete.
+> ```
+>
+> Each agent then runs (synchronously inside its own context):
+>
+> ```bash
+> OUTPUT_FILE=$(mktemp /tmp/council-<reviewer>-XXXXXX.txt)
+> STDERR_FILE=$(mktemp /tmp/council-<reviewer>-err-XXXXXX.txt)
+> timeout --signal=TERM --kill-after=10 "${COUNCIL_TIMEOUT:-600}" \
+>   <cli-invocation> >"$OUTPUT_FILE" 2>"$STDERR_FILE"
+> CLI_EXIT=$?
+> # parse, redact, fence, return structured findings
+> rm -f "$OUTPUT_FILE" "$STDERR_FILE"
+> ```
+<!-- /deepen-plan -->
+
+(Codex's exit status comes from the `yellow-codex:review:codex-reviewer` Task return; Gemini and OpenCode exit statuses come from their respective agent Task returns.)
+
+### Redaction Pattern Set (extends yellow-codex's 8 patterns)
+
+```awk
+# Existing 8 (from yellow-codex codex-patterns SKILL.md):
+/sk-proj-[A-Za-z0-9_-]{20,}/        # OpenAI project key
+/sk-[A-Za-z0-9]{20,}/               # OpenAI legacy key
+/gh[pous]_[A-Za-z0-9]{36,}/         # GitHub PAT prefix variants
+/github_pat_[A-Za-z0-9_]{40,}/      # GitHub fine-grained PAT
+/AKIA[0-9A-Z]{16}/                  # AWS Access Key ID
+/Bearer [A-Za-z0-9._~+\/-]{20,}/    # Bearer tokens
+/Authorization: [A-Za-z0-9 ._~+\/-]{20,}/  # Auth header
+/-----BEGIN [A-Z ]+PRIVATE KEY-----/  # PEM key block (multi-line state)
+
+# yellow-council additions (from research findings):
+/AIza[0-9A-Za-z_-]{35}/             # Google API key (Gemini)
+/sk-ant-[A-Za-z0-9_-]{20,}/         # Anthropic API key (OpenCode may use)
+/ses_[A-Za-z0-9]{16,}/              # OpenCode session IDs
+```
+
+Each match line is replaced with `--- redacted credential at line N ---`.
+
+### Per-Mode Pack Templates (in `council-patterns` SKILL)
+
+All four modes share this structural envelope; only the `## Task` block differs:
+
+```
+You are {{REVIEWER_NAME}}, a code reviewer performing an INDEPENDENT analysis.
+Do not reference what other reviewers might say. Only report findings you can
+cite with a file:line reference. Do not write any files; analyze only.
+
+## Task: {{MODE}}
+{{MODE_SPECIFIC_CONTEXT}}
+
+## Required Output Format
+Verdict: APPROVE | REVISE | REJECT
+Confidence: HIGH | MEDIUM | LOW
+Findings:
+- [P1|P2|P3] file:line — <80-char summary>
+  Evidence: "<exact quoted line from file>"
+[repeat per finding; if none: write "Findings: none"]
+Summary: <2–3 sentences in your own words>
+
+## Rules
+- P1 = security/correctness blocker; P2 = quality issue; P3 = style/nit
+- Cite file paths relative to repository root
+- If a finding has no quotable line (e.g., "missing function"), write `Evidence: N/A — <reason>`
+- The `Verdict:` line is required and must appear exactly as shown
+```
+
+Per-mode `{{MODE_SPECIFIC_CONTEXT}}` block:
+
+| Mode | Context block contents |
+|------|------------------------|
+| `plan` | `### Planning Document` + fenced full content + `### Repo Conventions` + truncated CLAUDE.md |
+| `review` | `### Diff (HEAD vs <BASE>)` + fenced `git diff` output + `### Changed Files` + truncated content of each |
+
+<!-- deepen-plan: codebase -->
+> **Codebase (2nd pass):** Plan body says "truncation guards from `work-pack-build` pattern" but never specifies the algorithm. The only existing diff-size pattern in the repo is `codex-reviewer.md:101-116` — a pre-flight `wc -c` check that estimates tokens at 4 bytes/token and SKIPS the reviewer entirely if estimate exceeds 100K tokens (no head/tail truncation, no per-file cap). yellow-council needs a real truncation algorithm because skipping is unacceptable for the council use case (user explicitly asked for cross-lineage input).
+>
+> **V1 algorithm to specify in `council-patterns` SKILL "Pack Build — Review Mode":**
+>
+> ```
+> 1. DIFF_BYTES=$(git diff "${BASE_REF}...HEAD" | wc -c)
+> 2. If DIFF_BYTES > 200000 (≈50K tokens at 4 bytes/token):
+>    a. Inject `git diff --stat` output as the diff header
+>    b. Append first 200 lines of raw `git diff`
+>    c. Append marker: "[... truncated — full diff is N lines; showing first 200 ...]"
+> 3. Per changed file injected into ## Changed Files: cap at 4K chars per file
+> 4. Total pack hard cap: 100K chars before injection fencing
+>    (drives under Codex's 128K token budget with ~22% headroom; Gemini 1M and OpenCode are larger so this is the binding constraint)
+> ```
+>
+> Designing to Codex's tightest window means all three reviewers receive identical packs. Gemini and OpenCode could handle larger packs but uniformity > capacity for synthesis comparability.
+>
+> **New acceptance criterion to add (AC 13):** When `git diff` for a `review` mode invocation exceeds 200K bytes, the injected diff block contains `git diff --stat` + first 200 lines of raw diff + a truncation marker; each changed file is capped at 4K chars; total pack fits within 100K chars.
+<!-- /deepen-plan -->
+| `debug` | `### Symptom` + user text + `### Cited Files` + content + `### Recent History` + `git log -10 --oneline -- <paths>` |
+| `question` | `### Question` + user text + (optional) `### Referenced Files` + content + `### Repo Conventions` + truncated CLAUDE.md |
+
+---
+
+## Testing Strategy
+
+- **Unit testing:** N/A — bash command + agent files. Validation is via the existing `pnpm validate:*` scripts plus manual smoke tests.
+- **Integration testing:** Phase 4.1–4.6 manual smoke tests. Run each mode end-to-end with both happy-path and failure-path scenarios.
+- **Spike-driven verification:** Phase 1.1–1.4 spikes are themselves tests of the upstream CLI behavior. Their findings update this plan before Phase 2 begins.
+- **CI gates:** All four `pnpm validate:*` scripts must pass; changeset present; W1.5 allowlist updated.
+- **Cross-platform:** WSL2/Linux is the primary target. macOS should work (same `bash`/`timeout`/`jq`). Windows native is not supported (no `bash` in default env).
+
+---
+
+## Acceptance Criteria
+
+1. **`/council` is a registered command** discoverable via `/plugin install yellow-council@yellow-plugins` and surfaces in Claude Code's command list.
+2. **All four modes produce a synthesis report inline** when invoked with valid inputs and external CLIs are present (verifiable via Phase 4.1–4.4).
+3. **Synthesis report format matches Decision 5 spec:** Headline + Agreement + Disagreement + reference to file path. No raw reviewer outputs inline.
+4. **File at `docs/council/<date>-<mode>-<slug>.md`** is written after M3 confirmation, contains synthesis report + three labeled raw output sections with injection fences (verifiable via Phase 4.1).
+5. **Per-reviewer timeout enforced:** A reviewer exceeding `${COUNCIL_TIMEOUT:-600}` seconds is marked TIMEOUT and excluded from synthesis (verifiable via Phase 4.5).
+6. **Partial-result tolerance:** If 1 or 2 of 3 reviewers fail (timeout, missing CLI, error), the council still produces a report with the remaining verdicts (verifiable via Phase 4.5 + 4.6).
+7. **yellow-codex graceful soft-skip:** When yellow-codex is not installed, `/council review` reports "Codex not available" and runs with 2 of 3 reviewers without erroring (verifiable via Phase 4.6).
+8. **All credential patterns redacted:** None of the 11 credential patterns appear unredacted in the written report file (verifiable via Phase 3.10).
+9. **Path sanitization rejects malicious input:** `/council debug "test" --paths "../../etc/passwd"` is rejected with a sanitization error (manual test).
+10. **M3 gate prevents accidental writes:** Selecting `[Cancel]` at the M3 gate prevents the file write and exits cleanly (verifiable via Phase 4.1).
+11. **All `pnpm validate:*` scripts pass** with the new plugin in place.
+12. **Three-way version sync** between `package.json`, `plugin.json`, and `marketplace.json` for `yellow-council`.
+
+<!-- deepen-plan: codebase -->
+> **Codebase (2nd pass):** Three additional acceptance criteria added from second-pass research findings — these cover gaps in structured-output failure handling, the diff-truncation algorithm, and the V2 reservation pattern.
+<!-- /deepen-plan -->
+
+13. **Diff truncation for large `review` invocations:** When `git diff` exceeds 200K bytes, the injected diff block contains `git diff --stat` + first 200 lines of raw diff + a truncation marker; each changed file is capped at 4K chars; total pack fits within 100K chars. Verifiable via Phase 4.5 with a synthetic large-diff test.
+14. **`UNKNOWN` verdict on structured-output failure:** When a reviewer's output does not contain a `Verdict:` line, the synthesizer marks that reviewer's verdict as `UNKNOWN` (not an error), logs a structured-output-failure warning in the synthesis Headline, and includes the reviewer's full prose output (capped at 2K chars) in the report's raw section. UNKNOWN verdicts are excluded from headline majority count. Verifiable via a synthetic test where the prompt asks the reviewer to "answer in haiku" instead of structured form.
+15. **`fleet` reservation:** `/council fleet` prints `[council] fleet management not available in V1 — coming in V2` and exits 0 (success). No reviewer is spawned. `/council unknownmode` exits 1. Bare `/council` exits 0 with help. Verifiable via Phase 4.9 fresh-install test steps 5 and 6.
+
+---
+
+## Edge Cases & Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Bare `/council` (no mode) | Print 4-mode help table and exit 0 |
+| `/council fleet` | Print "fleet management not available in V1 — coming in V2" and exit 0 (reserves the word for V2) |
+| `/council unknown-mode` | Print error + 4-mode help and exit 1 |
+| Path with `..` traversal | Reject with `[council] Error: path traversal not allowed` |
+| Path with shell metacharacters | Reject with `[council] Error: invalid characters in path` |
+| Missing path in `--paths` | Reject with `[council] Error: file not found: <path>` |
+| Empty `debug`/`question` text | Reject with mode-specific usage |
+| Reviewer timeout (exit 124/137) | Mark TIMEOUT in synthesis; exclude from agreement/disagreement; report ran with N<3 |
+| Reviewer auth error (stderr keyword `auth`) | Mark ERROR in synthesis; include short error excerpt |
+| Reviewer rate limit (stderr keyword `rate limit`) | Mark ERROR; suggest retry in synthesis prose |
+| All three reviewers fail | Write report with all-failure details; M3 gate still asks |
+| Slug collision >10 same-day | Error: `too many same-day collisions for slug "<slug>" (>10)` |
+| Empty slug after normalization | Use sha256 fallback (debt-synthesizer pattern) |
+| `bash` < 4.3 | Pre-flight error and exit |
+| `jq` missing | Pre-flight error: required for OpenCode JSON parsing |
+| `timeout` missing | Pre-flight error: required for per-reviewer timeout |
+| OpenCode session cleanup fails | Log warning to stderr; do not fail review |
+| `docs/council/` not writable | `mkdir -p` fails with explicit error |
+| Cross-device temp file | Avoided by `mktemp` in same dir as destination |
+
+---
+
+## Performance Considerations
+
+- **Total wall time per `/council` invocation:** ≈ max(t_codex, t_gemini, t_opencode). Empirical estimates from research: 60–180 seconds for moderate inputs; up to 600 seconds at the timeout cap.
+- **Subprocess overhead:** negligible (3 short-lived bash processes + 3 CLI invocations).
+- **Memory:** each CLI may consume 100–500 MB transiently; total peak around 1.5 GB during fan-out.
+- **Disk:** temp files in `/tmp` (cleaned up after parse); single report file per invocation in `docs/council/` (~10–100 KB each).
+- **Network:** each CLI makes its own provider API call. Concurrent calls may hit per-provider rate limits — partial-result reporting handles this gracefully.
+
+No optimization is needed for V1. If repeat invocations become common, V2's persistent-session model amortizes per-invocation startup cost.
+
+---
+
+## Security Considerations
+
+- **No auth handling in plugin.** Each CLI uses its own credential store (Codex uses `OPENAI_API_KEY` or `~/.codex/auth.json`; Gemini uses Google auth; OpenCode uses provider-configured creds). yellow-council never reads, writes, or transports credentials.
+- **Output redaction is mandatory.** Even if the CLIs do not echo credentials in their primary output, error messages, debug logs, and `tool_use` event payloads in OpenCode's JSON stream may contain them. The 11-pattern awk block runs on every reviewer output before fencing.
+- **Injection fencing is mandatory.** All reviewer output is wrapped in `--- begin council-output:<reviewer> (reference only) ---` / `--- end council-output:<reviewer> ---` fences before being included in the report file or surfaced inline. This prevents the council report itself from being weaponized as a prompt-injection vector for downstream consumers.
+- **Path validation rejects traversal and metacharacters.** All file paths derived from user input pass through the SKILL's path-validation pattern before being constructed into shell arguments.
+- **No `--yolo` / `--dangerously-skip-permissions` flags.** Both Gemini and OpenCode have flags that auto-approve all tool calls including file writes. yellow-council does NOT use these flags. Read-only behavior is enforced via prompt design ("do not write any files; analyze only") not via CLI flags.
+- **OpenCode session cleanup.** Persistent sessions in `~/.local/share/opencode/` are explicitly deleted after each invocation. Failure to clean up is logged but does not fail the review (sessions accumulate but are not corruption-causing).
+- **`tool_use` event redaction in OpenCode.** OpenCode's `--format json` event stream may contain `tool_use` events whose `part.state.input` and `part.state.output` fields embed full file contents read by the assistant. Redaction is applied to the EXTRACTED assistant text, not just the raw JSONL — but the JSONL itself is never written to the report file. Only the extracted text + injection fence makes it to disk.
+- **No exposure of internal reasoning.** Gemini's `--variant` and reasoning chains are NOT included in the report. Only the final assistant text plus structured verdict/findings/summary fields.
+
+---
+
+## V2 Trajectory — Constraints V1 Must Preserve
+
+V2 will evolve toward GodModeSkill's native model. V1 design choices that protect V2:
+
+1. **`council-patterns` SKILL is the swap surface for the XML evidence contract.** V2 replaces the markdown `Verdict: ... Findings: ...` template with GodModeSkill's `<file-path>` / `<line-number>` / `<quoted-line><![CDATA[...]]></quoted-line>` XML. No agent code changes.
+2. **Synthesizer logic is isolated in `council.md` Step 7.** V2 swaps Step 7 with lineage-weighted quorum aggregation + quote-verification pass. Fan-out, pack-build, and output-capture stages stay unchanged.
+3. **Mode word `fleet` is reserved.** V2 adds `/council fleet status`, `/council fleet restart`. V1's reservation prevents naming conflict.
+4. **Per-reviewer timeout + partial-result collection are isolated in SKILL.** V2 swaps subprocess-with-timeout for `inotifywait`-style event-driven waiting on `## DONE` markers. The collection logic (which reviewers returned, which timed out, how to format partial results) is re-used as-is.
+5. **Multi-round support via `--round 2` flag.** V1 single-shot semantics. V2 adds a flag that injects V1 output as prior context with round-aware trimming. The pack-build stage is the only thing that changes.
+
+---
+
+## Open Questions Resolved by Research
+
+The brainstorm listed 7 open questions. Research outcomes:
+
+1. **Soft-skip vs minimal Codex bundle.** **Resolved: soft-skip permanent.** Bundling a fallback Codex would mean maintaining two parallel Codex implementations. yellow-codex is the canonical Codex integration; if user wants Codex in council, they install yellow-codex. Plan documents this in CLAUDE.md.
+
+2. **Gemini `-o json` schema.** **Resolved: do NOT use in V1.** Issue #9009 confirmed `-o json` was broken upstream; closed-as-duplicate suggests recurring. Phase 1.1 spike verifies current state on this machine; default is plain text capture for V1.
+
+3. **OpenCode `--format json` event schema.** **Resolved: confirmed.** `text` events with `part.text` field; concatenate all `text` events for final assistant message. `step_finish` with `reason: "stop"` indicates terminal response. Phase 1.2 spike verifies live; jq selector documented in agent body.
+
+4. **`--paths` content cap.** **Resolved: 8K chars per file, 3 files max for V1.** Configurable via env vars `COUNCIL_PATH_CHAR_CAP` and `COUNCIL_PATH_MAX_FILES`.
+
+5. **Slug derivation for `/council plan <path>`.** **Resolved: filename stem when input is a path; first N words of leading heading when input is text.** Implementation in council.md Step 9: `if [ -f "$INPUT" ]; then SLUG_BASE=$(basename "$INPUT" .md); else SLUG_BASE=$(printf '%s' "$INPUT" | head -c 80); fi` then normalize.
+
+6. **`plugin.json` `optionalDependencies`.** **Resolved: not in current schema.** yellow-codex's cross-plugin dep is documentation-only. yellow-council follows the same pattern: CLAUDE.md "Cross-Plugin Dependencies" table marks yellow-codex as `Optional`; runtime soft-skip on Task spawn failure.
+
+7. **Credential redaction scope for Gemini and OpenCode.** **Resolved: extend the 8-pattern awk block to 11 patterns** with `AIza` (Google), `sk-ant-` (Anthropic), `ses_` (OpenCode session IDs). Apply to extracted assistant text for OpenCode (JSONL never written to disk).
+
+---
+
+## References
+
+### Plan and Brainstorm
+- [GodModeSkill Integration Brainstorm (2026-05-03)](../docs/brainstorms/2026-05-03-godmodeskill-integration-brainstorm.md)
+- [GodModeSkill Integration Investigation](../research/GodModeSkill%20Integration%20Investigation.md)
+
+### Repository Patterns to Mirror
+- [yellow-codex plugin manifest](../plugins/yellow-codex/.claude-plugin/plugin.json)
+- [yellow-codex package.json](../plugins/yellow-codex/package.json)
+- [yellow-codex CHANGELOG.md](../plugins/yellow-codex/CHANGELOG.md)
+- [yellow-codex CLAUDE.md](../plugins/yellow-codex/CLAUDE.md)
+- [codex-reviewer agent (binary check, timeout, redaction precedent)](../plugins/yellow-codex/agents/review/codex-reviewer.md)
+- [codex-patterns SKILL (8-pattern awk redaction, exit code catalog)](../plugins/yellow-codex/skills/codex-patterns/SKILL.md)
+- [Plugin schema](../schemas/plugin.schema.json)
+- [Marketplace JSON](../.claude-plugin/marketplace.json)
+- [W1.5 agent allowlist](../scripts/validate-agent-authoring.js)
+- [pr-review-workflow SKILL (cross-plugin Task spawn pattern)](../plugins/yellow-review/skills/pr-review-workflow/SKILL.md)
+- [yellow-core work.md (graceful-skip prose)](../plugins/yellow-core/commands/workflows/work.md)
+- [brainstorm-orchestrator (slug + collision + AskUserQuestion gate precedent)](../plugins/yellow-core/agents/workflow/brainstorm-orchestrator.md)
+- [yellow-research deep.md (slug pattern)](../plugins/yellow-research/commands/research/deep.md)
+- [audit-synthesizer (sha256 fallback for empty slug)](../plugins/yellow-debt/agents/synthesis/audit-synthesizer.md)
+
+### External Documentation
+- [GodModeSkill repo (commit b693d1d)](https://github.com/99xAgency/GodModeSkill/tree/b693d1da498cbcfc2e5cba1f85b3d341205bfeb0)
+- [Gemini CLI Headless Mode docs](https://google-gemini.github.io/gemini-cli/docs/cli/headless.html)
+- [Gemini CLI issue #9009 — `-o json` broken](https://github.com/google-gemini/gemini-cli/issues/9009)
+- [Gemini CLI issue #13561 — yolo still prompts](https://github.com/google-gemini/gemini-cli/issues/13561)
+- [OpenCode CLI docs](https://opencode.ai/docs/cli/)
+- [OpenCode `--format json` event schema (community cheatsheet)](https://takopi.dev/reference/runners/opencode/stream-json-cheatsheet/)
+- [OWASP LLM01:2025 Prompt Injection](https://genai.owasp.org/llmrisk/llm01-prompt-injection/)
+- [OWASP LLM Prompt Injection Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.html)
+- [GNU `timeout` man page](https://www.man7.org/linux/man-pages/man1/timeout.1.html)
+- [POSIX `rename()` specification](https://pubs.opengroup.org/onlinepubs/9699919799/functions/rename.html)
+- [Kinde LLM Fan-Out 101](https://www.kinde.com/learn/ai-for-software-engineering/workflows/llm-fan-out-101-self-consistency-consensus-and-voting-patterns/)
+
+### MEMORY.md Conventions Applied
+- Shell script security patterns (PR #5, #10) — path validation, printf safety, symlink skipping
+- Bash hook patterns (PR #10, #73, #74) — jq @sh consolidation, exit-code fallback, jq variant check
+- Command authoring anti-patterns (PR #35, #71, #74) — ToolSearch in allowed-tools, subagent_type literal, AskUserQuestion for mid-step input, M3 before bulk writes (no threshold)
+- Plugin manifest validation (2026-02-18, PR #66) — repository as string, no `changelog` key, no unknown keys
+- Plugin authoring quality rules — single-line description in frontmatter, three SKILL.md headings, LF line endings
+- Heredoc delimiter collision (P1 from session) — use `__EOF_<CONTEXT>__` style for any user-input heredocs
+
+---
+
+## Stack Decomposition
+
+<!-- stack-trunk: main -->
+<!-- stack-topology: linear -->
+
+### 1. agent/feat/yellow-council-scaffold-and-spikes
+- **Type:** feat
+- **Description:** plugin scaffold, manifests, and CLI spikes
+- **Scope:** plugins/yellow-council/.claude-plugin/plugin.json, plugins/yellow-council/package.json, plugins/yellow-council/CHANGELOG.md (pre-populated v0.1.0), plugins/yellow-council/CLAUDE.md (skeleton), plugins/yellow-council/README.md (skeleton), .claude-plugin/marketplace.json, .changeset/yellow-council-initial-release.md, scripts/validate-agent-authoring.js, docs/spikes/gemini-cli-output-format-2026-05-04.md, docs/spikes/opencode-cli-format-json-2026-05-04.md
+- **Tasks:** 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11
+- **Depends on:** (none)
+
+### 2. agent/feat/yellow-council-core-implementation
+- **Type:** feat
+- **Description:** council-patterns skill, reviewer agents, /council command
+- **Scope:** plugins/yellow-council/skills/council-patterns/SKILL.md, plugins/yellow-council/agents/review/gemini-reviewer.md, plugins/yellow-council/agents/review/opencode-reviewer.md, plugins/yellow-council/commands/council/council.md, plugins/yellow-council/CLAUDE.md (full content), plugins/yellow-council/README.md (full content)
+- **Tasks:** 2.1, 2.2, 2.3, 2.4, 2.5, 2.6
+- **Depends on:** #1
+
+### 3. agent/feat/yellow-council-polish-and-tests
+- **Type:** feat
+- **Description:** edge cases, partial-result handling, manual e2e tests, docs polish
+- **Scope:** plugins/yellow-council/commands/council/council.md (refinements), plugins/yellow-council/agents/review/*.md (refinements), plugins/yellow-council/skills/council-patterns/SKILL.md (refinements based on smoke tests), README.md (root — plugin count update), plugins/yellow-council/CLAUDE.md (Known Limitations expansion)
+- **Tasks:** 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 4.10
+- **Depends on:** #2

--- a/plans/yellow-council-godmodeskill-integration.md
+++ b/plans/yellow-council-godmodeskill-integration.md
@@ -766,3 +766,10 @@ The brainstorm listed 7 open questions. Research outcomes:
 - **Scope:** plugins/yellow-council/commands/council/council.md (refinements), plugins/yellow-council/agents/review/*.md (refinements), plugins/yellow-council/skills/council-patterns/SKILL.md (refinements based on smoke tests), README.md (root — plugin count update), plugins/yellow-council/CLAUDE.md (Known Limitations expansion)
 - **Tasks:** 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 4.10
 - **Depends on:** #2
+
+## Stack Progress
+
+<!-- Updated by workflows:work. Do not edit manually. -->
+- [x] 1. agent/feat/yellow-council-scaffold-and-spikes (PR #328, completed 2026-05-04)
+- [ ] 2. agent/feat/yellow-council-core-implementation
+- [ ] 3. agent/feat/yellow-council-polish-and-tests

--- a/plugins/yellow-core/commands/setup/all.md
+++ b/plugins/yellow-core/commands/setup/all.md
@@ -175,7 +175,7 @@ for p in sys.argv[1:]:
   fi
   if [ -n "$installed_plugins" ] || command -v python3 >/dev/null 2>&1 || command -v jq >/dev/null 2>&1; then
     # setup-all-dashboard-plugin-loop:start
-    for p in gt-workflow yellow-ruvector yellow-morph yellow-devin yellow-semgrep yellow-research yellow-linear yellow-chatprd yellow-debt yellow-ci yellow-review yellow-browser-test yellow-docs yellow-composio yellow-codex yellow-core; do
+    for p in gt-workflow yellow-ruvector yellow-morph yellow-devin yellow-semgrep yellow-research yellow-linear yellow-chatprd yellow-debt yellow-ci yellow-review yellow-browser-test yellow-docs yellow-composio yellow-codex yellow-council yellow-core; do
       if printf '%s\n' "$installed_plugins" | grep -Fxq "$p"; then
         printf '%-22s installed\n' "$p:"
       else
@@ -361,6 +361,15 @@ Compute bundled source availability out of 6:
 - PARTIAL: `codex` binary found AND version >= 0.118.0, but auth not configured
 - NEEDS SETUP: `codex` binary not found OR version < 0.118.0
 
+**yellow-council:**
+
+- READY: `bash` >= 4.3 AND `timeout` AND `jq` AND
+  (`gemini` >= 0.40 OR `opencode` >= 1.14 OR yellow-codex installed)
+- PARTIAL: required system tools present, but only 0 of 3 reviewer CLIs
+  installed (Gemini, OpenCode, Codex via yellow-codex) — council can run but
+  with degraded coverage
+- NEEDS SETUP: required system tools missing (`bash`, `timeout`, `jq`)
+
 **yellow-core:**
 
 - READY: `python37_check` ok AND `~/.claude/yellow-statusline.py` exists AND
@@ -464,7 +473,8 @@ tool in this fixed order:
 13. `docs:setup`
 14. `composio:setup`
 15. `codex:setup`
-16. `statusline:setup`
+16. `council:setup`
+17. `statusline:setup`
 <!-- setup-all-delegated-commands:end -->
 
 Only invoke setups for plugins the user selected. Use this mapping:
@@ -485,6 +495,7 @@ Only invoke setups for plugins the user selected. Use this mapping:
 - `yellow-docs` → `docs:setup`
 - `yellow-composio` → `composio:setup`
 - `yellow-codex` → `codex:setup`
+- `yellow-council` → `council:setup`
 - `yellow-core` → `statusline:setup`
 <!-- setup-all-plugin-command-map:end -->
 

--- a/plugins/yellow-core/commands/setup/all.md
+++ b/plugins/yellow-core/commands/setup/all.md
@@ -61,6 +61,8 @@ command -v agent-browser >/dev/null 2>&1 && printf 'agent-browser:      OK\n' ||
 [ -n "$_gt" ] && printf 'gt:                 OK (%s)\n' "$("$_gt" --version 2>/dev/null | head -n1)" || printf 'gt:                 NOT FOUND\n'
 command -v ruvector >/dev/null 2>&1 && printf 'ruvector:           OK\n' || printf 'ruvector:           NOT FOUND\n'
 command -v codex >/dev/null 2>&1 && printf 'codex:              OK (%s)\n' "$(codex --version 2>/dev/null | head -n1)" || printf 'codex:              NOT FOUND\n'
+command -v gemini >/dev/null 2>&1 && printf 'gemini:             OK (%s)\n' "$(gemini --version 2>&1 | head -n1)" || printf 'gemini:             NOT FOUND\n'
+command -v opencode >/dev/null 2>&1 && printf 'opencode:           OK (%s)\n' "$(opencode --version 2>&1 | head -n1)" || printf 'opencode:           NOT FOUND\n'
 
 if command -v python3 >/dev/null 2>&1; then
   py_ver=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null)
@@ -365,10 +367,11 @@ Compute bundled source availability out of 6:
 
 - READY: `bash` >= 4.3 AND `timeout` AND `jq` AND
   (`gemini` >= 0.40 OR `opencode` >= 1.14 OR yellow-codex installed)
-- PARTIAL: required system tools present, but only 0 of 3 reviewer CLIs
-  installed (Gemini, OpenCode, Codex via yellow-codex) — council can run but
-  with degraded coverage
-- NEEDS SETUP: required system tools missing (`bash`, `timeout`, `jq`)
+- PARTIAL: required system tools present AND at least 1 of 3 reviewer CLIs
+  installed (Gemini, OpenCode, Codex via yellow-codex) — council can run with
+  reduced coverage
+- NEEDS SETUP: required system tools missing (`bash`, `timeout`, `jq`) OR
+  system tools present but 0 of 3 reviewer CLIs installed
 
 **yellow-core:**
 

--- a/plugins/yellow-council/.claude-plugin/plugin.json
+++ b/plugins/yellow-council/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "yellow-council",
+  "version": "0.1.0",
+  "description": "On-demand cross-lineage code review fanning out to Codex, Gemini, and OpenCode CLIs in parallel for advisory consensus",
+  "author": {
+    "name": "KingInYellows",
+    "url": "https://github.com/KingInYellows"
+  },
+  "homepage": "https://github.com/KingInYellows/yellow-plugins#yellow-council",
+  "repository": "https://github.com/KingInYellows/yellow-plugins",
+  "license": "MIT",
+  "keywords": [
+    "council",
+    "multi-llm",
+    "code-review",
+    "cross-lineage",
+    "gemini",
+    "opencode",
+    "codex",
+    "advisory"
+  ]
+}

--- a/plugins/yellow-council/CHANGELOG.md
+++ b/plugins/yellow-council/CHANGELOG.md
@@ -1,0 +1,7 @@
+# yellow-council
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release: on-demand cross-lineage council command (`/council <mode>`) fanning out to Codex (via yellow-codex), Gemini, and OpenCode CLIs in parallel. Four modes: `plan`, `review`, `debug`, `question`. Synchronous fan-out with 600s per-reviewer timeout and partial-result reporting. Inline synthesis (Headline / Agreement / Disagreement) plus persisted report at `docs/council/<date>-<mode>-<slug>.md`. V1 scaffold + spikes; full implementation lands in subsequent PRs.

--- a/plugins/yellow-council/CLAUDE.md
+++ b/plugins/yellow-council/CLAUDE.md
@@ -1,0 +1,169 @@
+# yellow-council Plugin
+
+On-demand cross-lineage code review plugin. Fans out to Codex (via yellow-codex
+optional dependency), Gemini, and OpenCode CLIs in parallel via subprocess
+spawn-and-wait, synthesizes verdicts inline, and persists the full report to
+`docs/council/<date>-<mode>-<slug>.md`.
+
+## Core Principle
+
+The council is **on-demand and advisory** — never automatic, never blocking.
+It is invoked deliberately when the user wants a heavyweight cross-lineage
+opinion. Output never gates a merge, never triggers an automatic fix pass,
+and never auto-commits. The user decides what to do with the verdicts.
+
+## Required Environment
+
+- **Bash 4.3+** — for `wait "$pid"` per-process exit code capture
+- **GNU coreutils** — `timeout`, `mktemp`, `mv`, `awk`, `sed`, `grep`
+- **`jq`** — required for OpenCode JSON event stream parsing
+- **External CLIs (user-installed; soft-skipped if missing):**
+  - `gemini` — Google Gemini CLI v0.40+ (npm `@google/gemini-cli`)
+  - `opencode` — OpenCode CLI v1.14+ (curl install or npm `opencode-ai`)
+- **Optional cross-plugin dependency:** `yellow-codex` ≥ 0.2.0 — provides the
+  `yellow-codex:review:codex-reviewer` agent. If absent, council runs with
+  2 of 3 reviewers (graceful soft-skip).
+
+## Conventions
+
+- **Synchronous parallel fan-out.** All three reviewers spawned in a single
+  message via Task tool; Claude Code's harness runs them concurrently.
+  council.md collects return values after all three complete.
+- **Per-reviewer timeout: 600 seconds.** Configurable via `COUNCIL_TIMEOUT`.
+  Partial results: timed-out reviewers are excluded from synthesis but the
+  council still produces a report with the remaining verdicts.
+- **Output redaction is mandatory.** Each reviewer's output passes through an
+  11-pattern awk redaction block (sk-, ghp_, AKIA, Bearer, Authorization, PEM,
+  AIza, sk-ant-, ses_) before being included in the report file or surfaced
+  inline.
+- **Injection fencing is mandatory.** All reviewer output is wrapped in
+  `--- begin council-output:<reviewer> (reference only) ---` /
+  `--- end council-output:<reviewer> ---` fences.
+- **Read-only invocation.** Reviewers must NOT use `--yolo` (Gemini),
+  `--dangerously-skip-permissions` (OpenCode), or `--sandbox workspace-write`
+  (Codex). Read-only behavior is enforced via prompt design + safe defaults
+  (Gemini `--approval-mode plan`, OpenCode default permissions, Codex
+  `--sandbox read-only -a never`).
+- **Path validation.** All `--paths` and file inputs validated via SKILL
+  pattern (regex + `..` reject + existence check) before constructing shell
+  args.
+- **Atomic file write via Write tool.** Writes synthesis report directly to
+  `docs/council/<date>-<mode>-<slug>.md` using the Write tool (no temp file
+  staging — matches brainstorm-orchestrator precedent).
+
+## Plugin Components
+
+### Commands (1)
+
+- `/council <mode> [args]` — main entry point with four modes:
+  - `plan <path-or-text>` — council on a planning doc / design proposal
+  - `review [--base <ref>]` — council on the current diff
+  - `debug "<symptom>" [--paths <files>]` — council on a debug investigation
+  - `question "<text>" [--paths <files>]` — open-ended consultation
+- Bare `/council` prints the four-mode help and exits 0.
+- `/council fleet` is reserved for V2 fleet management; prints "fleet management
+  not available in V1 — coming in V2" and exits 0.
+
+### Agents (2)
+
+- `gemini-reviewer` — Gemini CLI wrapper. Invokes
+  `gemini -p "<prompt>" --approval-mode plan --skip-trust -o text`.
+  Spawned via `Task(subagent_type="yellow-council:review:gemini-reviewer")`.
+- `opencode-reviewer` — OpenCode CLI wrapper. Invokes
+  `opencode run --format json --variant high "<prompt>"` plus session cleanup
+  via `opencode session delete <id>`. Spawned via
+  `Task(subagent_type="yellow-council:review:opencode-reviewer")`.
+
+(Codex reviewer is reused from yellow-codex when installed:
+`yellow-codex:review:codex-reviewer`. yellow-council does NOT ship its own
+Codex agent.)
+
+### Skills (1)
+
+- `council-patterns` — canonical reference for CLI invocation conventions,
+  per-mode pack templates, redaction patterns, slug derivation, timeout/exit
+  code handling, and output parsing. Cross-references yellow-codex's
+  `codex-patterns` skill rather than duplicating Codex-specific logic.
+
+## Cross-Plugin Dependencies
+
+| Dependency | Purpose | Required? |
+|---|---|---|
+| yellow-codex | Provides `codex-reviewer` agent for the Codex leg of the council | Optional |
+| yellow-core | None (yellow-council does NOT depend on yellow-core) | — |
+| yellow-review | None (yellow-council is a SEPARATE pipeline; yellow-review's 14-reviewer Claude pipeline runs unchanged) | — |
+
+## When to Use What
+
+| Need | Command | Notes |
+|---|---|---|
+| Cross-lineage opinion on a design doc | `/council plan <path>` | All three reviewers see the doc + repo CLAUDE.md |
+| Cross-lineage code review of current diff | `/council review` | Defaults to upstream-tracking branch's merge-base |
+| Cross-lineage debug investigation | `/council debug "<symptom>" --paths <files>` | Up to 3 files, 8K chars each |
+| Open-ended consultation | `/council question "<text>" [--paths]` | Most flexible; lowest context structure |
+| Standard PR review (Claude only) | Use `/review:pr` from yellow-review | Council is for the heavyweight cross-lineage cases |
+
+## Configuration
+
+| Var | Type | Default | Purpose |
+|-----|------|---------|---------|
+| `COUNCIL_TIMEOUT` | integer seconds | `600` | Per-reviewer timeout passed to GNU `timeout`. Increase for very slow models / very large packs. |
+| `COUNCIL_OPENCODE_VARIANT` | `high \| max \| minimal` | `high` | OpenCode `--variant` reasoning effort. `max` is significantly slower; reserve for explicit override. |
+| `COUNCIL_PATH_CHAR_CAP` | integer chars | `8000` | Per-file content cap for `--paths` injection in `debug`/`question` modes. |
+| `COUNCIL_PATH_MAX_FILES` | integer | `3` | Maximum number of files accepted via `--paths` in any single invocation. |
+
+## Known Limitations
+
+- **OpenCode persistent sessions.** Every `opencode run` creates a SQLite
+  session in `~/.local/share/opencode/`. yellow-council cleans up after each
+  invocation via `opencode session delete <id>`, but if the cleanup itself
+  fails (rare), sessions accumulate. Periodic manual `opencode session list`
+  audit is recommended.
+- **Major OpenCode upgrades trigger SQLite migration.** First invocation after
+  a major version bump (e.g., 1.1.x → 1.14.x) can take 2–5 minutes. Run
+  `opencode run "test"` once interactively after upgrading before invoking
+  `/council`.
+- **Gemini workspace trust.** In untrusted directories, `--approval-mode plan`
+  is overridden to `default` unless `--skip-trust` is also passed.
+  yellow-council always passes `--skip-trust` for non-interactive use.
+- **Gemini `--yolo` is unsafe.** Issue #13561 documents that `--yolo` still
+  prompts in some cases AND auto-approves any write tool the model decides
+  to invoke. yellow-council MUST NOT use `--yolo`.
+- **Codex timeout cap is 300s when reused via yellow-codex.** The existing
+  `codex-reviewer` agent uses a 300s timeout. yellow-council's `COUNCIL_TIMEOUT`
+  affects only Gemini and OpenCode; Codex honors its own agent timeout. If
+  Codex routinely times out at 300s for council use, file a yellow-codex
+  enhancement issue rather than modifying `codex-reviewer.md`.
+- **No fresh-machine install CI.** No automated CI job verifies that Claude
+  Code's runtime accepts the plugin manifest. A manual fresh-install test
+  is required before each release (procedure documented in the implementation
+  plan).
+- **Single-shot V1.** No multi-round iterative review. V2 will add `--round 2`
+  for follow-up consultations and `/council fleet *` subcommands for persistent
+  session management.
+
+## V2 Trajectory
+
+V1 is the on-demand single-shot foundation. V2 evolves toward GodModeSkill's
+native model:
+
+1. **XML evidence contract.** Reviewer output schema tightens from markdown
+   `Verdict:` / `Findings:` to GodModeSkill's `<file-path>` / `<line-number>`
+   / `<quoted-line><![CDATA[...]]></quoted-line>` evidence format.
+2. **Lineage-weighted quorum aggregation.** V1's raw count + verbatim
+   presentation gets replaced with quorum logic (agreement requires ≥1
+   reviewer from each enabled lineage; quote-unverified findings are
+   downgraded).
+3. **Multi-round iterative review.** `/council review --round 2` injects V1
+   output as prior context with round-aware trimming.
+4. **Fleet management subcommand surface.** `/council fleet status`,
+   `/council fleet restart`, persistent tmux-style session management.
+5. **`## DONE` event-driven waiting.** `inotifywait`-equivalent waiting for
+   reviewer output instead of subprocess-blocking timeout.
+
+## Attribution
+
+Algorithmic ideas borrowed from `99xAgency/GodModeSkill` at commit
+`b693d1da498cbcfc2e5cba1f85b3d341205bfeb0`, MIT-licensed. No code copied; if
+verbatim code lift occurs in a future PR, add `third_party/GodModeSkill.LICENSE`
+and per-file attribution headers per MIT requirements.

--- a/plugins/yellow-council/CLAUDE.md
+++ b/plugins/yellow-council/CLAUDE.md
@@ -33,9 +33,10 @@ and never auto-commits. The user decides what to do with the verdicts.
   Partial results: timed-out reviewers are excluded from synthesis but the
   council still produces a report with the remaining verdicts.
 - **Output redaction is mandatory.** Each reviewer's output passes through an
-  11-pattern awk redaction block (sk-, ghp_, AKIA, Bearer, Authorization, PEM,
-  AIza, sk-ant-, ses_) before being included in the report file or surfaced
-  inline.
+  11-pattern awk redaction block (sk-proj-, sk-ant-, sk-, AIza, gh[pous]_,
+  github_pat_, AKIA, Bearer, Authorization, ses_, PEM private key blocks)
+  before being included in the report file or surfaced inline. Canonical
+  list and awk source in `council-patterns` SKILL.md.
 - **Injection fencing is mandatory.** All reviewer output is wrapped in
   `--- begin council-output:<reviewer> (reference only) ---` /
   `--- end council-output:<reviewer> ---` fences.

--- a/plugins/yellow-council/CLAUDE.md
+++ b/plugins/yellow-council/CLAUDE.md
@@ -14,7 +14,7 @@ and never auto-commits. The user decides what to do with the verdicts.
 
 ## Required Environment
 
-- **Bash 4.3+** — for `wait "$pid"` per-process exit code capture
+- **Bash 4.3+** — for associative arrays and `${var^}` case-conversion used in `/council` orchestration
 - **GNU coreutils** — `timeout`, `mktemp`, `mv`, `awk`, `sed`, `grep`
 - **`jq`** — required for OpenCode JSON event stream parsing
 - **External CLIs (user-installed; soft-skipped if missing):**

--- a/plugins/yellow-council/README.md
+++ b/plugins/yellow-council/README.md
@@ -1,0 +1,100 @@
+# yellow-council
+
+On-demand cross-lineage code review for Claude Code. Fans out to three external
+LLM CLIs (Codex, Gemini, OpenCode) in parallel and synthesizes their verdicts
+inline.
+
+## Install
+
+```text
+/plugin marketplace add KingInYellows/yellow-plugins
+/plugin install yellow-council@yellow-plugins
+```
+
+### Required external CLIs
+
+- **Gemini CLI** — `npm install -g @google/gemini-cli` (v0.40+)
+- **OpenCode CLI** — `curl -fsSL https://opencode.ai/install | bash` (v1.14+)
+- **Codex CLI (optional)** — install `yellow-codex` plugin for Codex coverage.
+  Without it, the council runs with 2 of 3 reviewers.
+
+## Usage
+
+The `/council` command takes a mode and arguments:
+
+### `plan` — review a planning doc or design proposal
+
+```text
+/council plan docs/brainstorms/2026-05-04-my-feature-brainstorm.md
+/council plan "Should we replace the auth middleware with a service-layer guard?"
+```
+
+### `review` — council the current diff
+
+```text
+/council review
+/council review --base origin/develop
+```
+
+Defaults to the upstream-tracking branch's merge-base when `--base` is omitted
+(matches yellow-codex's review default).
+
+### `debug` — investigate a symptom
+
+```text
+/council debug "TypeError: cannot read property 'x' of undefined" --paths src/foo.ts,src/bar.ts
+```
+
+### `question` — open-ended consultation
+
+```text
+/council question "What's the right pattern for retrying idempotent HTTP requests in Go?"
+/council question "Is this approach overkill?" --paths plans/my-plan.md
+```
+
+### Bare `/council` — print help
+
+```text
+/council
+```
+
+## Output
+
+Each invocation produces:
+
+- **Inline synthesis** — Headline (verdict count) + Agreement (findings cited
+  by ≥2 reviewers) + Disagreement (unique findings or verdict conflicts).
+- **Persisted report** at `docs/council/<date>-<mode>-<slug>.md` — synthesis
+  plus three labeled raw reviewer outputs (each wrapped in injection fences
+  and credential-redacted).
+
+The user is asked for confirmation (M3 gate) before the report file is written.
+
+## Configuration
+
+| Var | Default | Purpose |
+|---|---|---|
+| `COUNCIL_TIMEOUT` | `600` | Per-reviewer timeout in seconds |
+| `COUNCIL_OPENCODE_VARIANT` | `high` | OpenCode reasoning effort |
+| `COUNCIL_PATH_CHAR_CAP` | `8000` | Per-file content cap for `--paths` |
+| `COUNCIL_PATH_MAX_FILES` | `3` | Max `--paths` files per invocation |
+
+## What yellow-council does NOT do
+
+- It does NOT block merges. Output is advisory.
+- It does NOT modify git state. Read-only file inspection only.
+- It does NOT replace `/review:pr` from yellow-review. The 14-reviewer
+  Claude-only pipeline runs unchanged. Council is for cases where you want
+  cross-lineage input.
+- It does NOT auto-trigger. Always invoked by the user explicitly.
+
+## V1 / V2
+
+V1 is single-shot, synchronous, advisory-only. V2 will add multi-round
+iterative review, lineage-weighted quorum aggregation, quote-backed evidence
+verification, and persistent-session fleet management. See plugin CLAUDE.md
+for the full V2 trajectory.
+
+## License
+
+MIT. Algorithmic ideas borrowed from `99xAgency/GodModeSkill` (also MIT).

--- a/plugins/yellow-council/README.md
+++ b/plugins/yellow-council/README.md
@@ -14,7 +14,13 @@ inline.
 ### Required external CLIs
 
 - **Gemini CLI** — `npm install -g @google/gemini-cli` (v0.40+)
-- **OpenCode CLI** — `curl -fsSL https://opencode.ai/install | bash` (v1.14+)
+- **OpenCode CLI** — download-then-execute (v1.14+):
+  ```bash
+  TMP_INSTALLER="$(mktemp)" && trap 'rm -f "$TMP_INSTALLER"' EXIT
+  curl -fsSL https://opencode.ai/install -o "$TMP_INSTALLER"
+  # Optionally inspect: bat "$TMP_INSTALLER"
+  bash "$TMP_INSTALLER"
+  ```
 - **Codex CLI (optional)** — install `yellow-codex` plugin for Codex coverage.
   Without it, the council runs with 2 of 3 reviewers.
 

--- a/plugins/yellow-council/agents/review/gemini-reviewer.md
+++ b/plugins/yellow-council/agents/review/gemini-reviewer.md
@@ -1,0 +1,72 @@
+---
+name: gemini-reviewer
+description: "Cross-lineage code reviewer that invokes the Google Gemini CLI for an independent verdict. Spawned by /council via Task. PR1 stub — full implementation lands in yellow-council-core-implementation."
+model: inherit
+tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+skills:
+  - council-patterns
+---
+
+# Gemini Reviewer (PR1 Stub)
+
+Spawned by `/council` to invoke Google Gemini CLI for an independent verdict
+on the council pack. Returns structured findings with `Verdict:`,
+`Confidence:`, `Findings:` (P1/P2/P3 with file:line + quoted evidence), and
+`Summary:`.
+
+## Status
+
+This is the PR1 scaffold stub. The full agent body — including the bash
+`timeout 600 gemini -p "$PROMPT" --approval-mode plan --skip-trust -o text`
+invocation, output parsing, redaction, and structured-finding return —
+lands in PR2 (`agent/feat/yellow-council-core-implementation`).
+
+## Tool Surface — Documented Bash Exception
+
+This agent retains `Bash` in its `tools:` list while every other reviewer
+in the marketplace is read-only (`[Read, Grep, Glob]`). This is intentional
+and an explicit exception to the W1.5 read-only-reviewer rule:
+
+- `gemini-reviewer` is fundamentally a CLI-invocation agent — its core
+  responsibility is running `gemini -p "..."` against the council pack and
+  parsing structured output. That requires `Bash` for binary invocation.
+- The "report-only, never edit files" guarantee is enforced by prose
+  discipline in PR2's full agent body, not by the absence of `Bash`.
+- The W1.5 validation rule in `scripts/validate-agent-authoring.js`
+  allowlists this exact path:
+  `plugins/yellow-council/agents/review/gemini-reviewer.md`.
+
+The legitimate Bash surface for this agent in PR2 will cover:
+
+- `gemini -p ... --approval-mode plan --skip-trust -o text` — Gemini CLI
+  invocation (read-only mode, no tool side effects)
+- `mktemp /tmp/council-gemini-XXXXXX.txt` — output capture
+- `timeout --signal=TERM --kill-after=10 ${COUNCIL_TIMEOUT:-600}` — timeout
+  guard
+- `awk '...'` — credential redaction (11-pattern block from
+  `council-patterns` SKILL.md)
+- `command -v gemini` — pre-flight binary check
+- `rm -f` — temp file cleanup
+
+NOT permitted: `git add`, `git commit`, `gt`, `Edit`, `Write`, network
+operations beyond the gemini CLI itself.
+
+## Why This Agent Is in `agents/review/` Despite Bash Access
+
+Per W1.5, agents under `agents/review/` are normally restricted to
+`[Read, Grep, Glob]`. This agent is allowlisted because:
+
+1. Its sole purpose is producing council reviewer output — it belongs
+   logically with `codex-reviewer` (yellow-codex) and `opencode-reviewer`
+   (yellow-council), all of which wrap external CLIs.
+2. The `agents/review/` location signals to /council orchestrator that this
+   is a read-only verdict producer, not a workflow executor.
+3. Moving it elsewhere would obscure the council architecture and require
+   special-casing in council.md routing.
+
+The exception is documented in `scripts/validate-agent-authoring.js`
+`REVIEW_AGENT_ALLOWLIST` with a comment referencing the council plan.

--- a/plugins/yellow-council/agents/review/opencode-reviewer.md
+++ b/plugins/yellow-council/agents/review/opencode-reviewer.md
@@ -1,0 +1,76 @@
+---
+name: opencode-reviewer
+description: "Cross-lineage code reviewer that invokes the OpenCode CLI for an independent verdict. Spawned by /council via Task. PR1 stub — full implementation lands in yellow-council-core-implementation."
+model: inherit
+tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+skills:
+  - council-patterns
+---
+
+# OpenCode Reviewer (PR1 Stub)
+
+Spawned by `/council` to invoke OpenCode CLI for an independent verdict on
+the council pack. Returns structured findings with `Verdict:`,
+`Confidence:`, `Findings:` (P1/P2/P3 with file:line + quoted evidence), and
+`Summary:`.
+
+## Status
+
+This is the PR1 scaffold stub. The full agent body — including the bash
+`timeout 600 opencode run --format json --variant high "$PROMPT"`
+invocation, JSON event stream parsing via jq, session cleanup via
+`opencode session delete`, redaction, and structured-finding return — lands
+in PR2 (`agent/feat/yellow-council-core-implementation`).
+
+## Tool Surface — Documented Bash Exception
+
+This agent retains `Bash` in its `tools:` list while every other reviewer
+in the marketplace is read-only (`[Read, Grep, Glob]`). Same rationale as
+`gemini-reviewer.md`:
+
+- `opencode-reviewer` is fundamentally a CLI-invocation agent.
+- The "report-only, never edit files" guarantee is enforced by prose
+  discipline in PR2's full agent body.
+- The W1.5 validation rule in `scripts/validate-agent-authoring.js`
+  allowlists this exact path:
+  `plugins/yellow-council/agents/review/opencode-reviewer.md`.
+
+The legitimate Bash surface for this agent in PR2 will cover:
+
+- `opencode run --format json --variant high "..."` — OpenCode CLI
+  invocation (read-only via prompt design — no `--dangerously-skip-permissions`)
+- `mktemp /tmp/council-opencode-XXXXXX.json` — JSONL capture
+- `timeout --signal=TERM --kill-after=10 ${COUNCIL_TIMEOUT:-600}` — timeout
+  guard
+- `jq -r '...'` — extract `text` events (assistant message) and
+  `sessionID` for cleanup
+- `awk '...'` — credential redaction (11-pattern block from
+  `council-patterns` SKILL.md, applied to extracted text NOT raw JSONL)
+- `opencode session delete <id>` — REQUIRED post-call cleanup to prevent
+  session accumulation in `~/.local/share/opencode/`
+- `command -v opencode` — pre-flight binary check
+- `rm -f` — temp file cleanup
+
+NOT permitted: `git add`, `git commit`, `gt`, `Edit`, `Write`, network
+operations beyond the opencode CLI itself.
+
+## OpenCode-Specific Concerns
+
+- **Persistent sessions:** every `opencode run` creates a SQLite session in
+  `~/.local/share/opencode/`. Cleanup via `opencode session delete` is
+  REQUIRED.
+- **Tool-use events embed file content:** OpenCode's `--format json` stream
+  may contain `tool_use` events with `part.state.input` and
+  `part.state.output` fields that include full file contents. Apply
+  redaction to the EXTRACTED assistant text only — never write the raw
+  JSONL to `docs/council/` reports.
+- **Major-version upgrades trigger SQLite migration:** first invocation
+  after `opencode upgrade` may take 2–5 minutes due to a one-time database
+  migration. PR2 implementation should detect "sqlite-migration" in stderr
+  and surface a user-facing warning.
+- **`--variant high` is the default; `max` is much slower.** Reserve `max`
+  for explicit `COUNCIL_OPENCODE_VARIANT=max` overrides.

--- a/plugins/yellow-council/commands/council/setup.md
+++ b/plugins/yellow-council/commands/council/setup.md
@@ -29,7 +29,7 @@ done
 printf '[yellow-council] system tools: ok (bash, timeout, jq, mktemp, awk, sed, grep)\n'
 
 # Bash version check (need 4.3+ for wait "$pid" per-process exit codes)
-BASH_VERSION_OK=$(bash -c 'echo "$BASH_VERSINFO[0]"').'$(bash -c 'echo "$BASH_VERSINFO[1]"')'
+BASH_VERSION_OK="${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"
 case "$BASH_VERSION_OK" in
   4.[3-9]*|4.[1-9][0-9]*|[5-9].*|[1-9][0-9].*)
     printf '[yellow-council] bash: ok (%s)\n' "$BASH_VERSION_OK" ;;

--- a/plugins/yellow-council/commands/council/setup.md
+++ b/plugins/yellow-council/commands/council/setup.md
@@ -1,0 +1,153 @@
+---
+name: council:setup
+description: "Detect Gemini and OpenCode CLIs, verify their versions, and report yellow-codex availability for the Codex leg of the council. Run after first install or when /council fails."
+argument-hint: ''
+allowed-tools:
+  - Bash
+  - Read
+  - AskUserQuestion
+---
+
+# Set Up yellow-council
+
+Validate prerequisites, detect external CLIs (Gemini, OpenCode), verify
+versions, and report on yellow-codex availability for the Codex leg of the
+council. yellow-council does not bundle any CLIs; this command verifies the
+user-installed binaries are present and at compatible versions.
+
+## Workflow
+
+### Step 1: Verify required system tools
+
+```bash
+for tool in bash timeout jq mktemp awk sed grep; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    printf '[yellow-council] Error: required system tool "%s" not found\n' "$tool" >&2
+    exit 1
+  fi
+done
+printf '[yellow-council] system tools: ok (bash, timeout, jq, mktemp, awk, sed, grep)\n'
+
+# Bash version check (need 4.3+ for wait "$pid" per-process exit codes)
+BASH_VERSION_OK=$(bash -c 'echo "$BASH_VERSINFO[0]"').'$(bash -c 'echo "$BASH_VERSINFO[1]"')'
+case "$BASH_VERSION_OK" in
+  4.[3-9]*|4.[1-9][0-9]*|[5-9].*|[1-9][0-9].*)
+    printf '[yellow-council] bash: ok (%s)\n' "$BASH_VERSION_OK" ;;
+  *)
+    printf '[yellow-council] Error: bash 4.3+ required, found %s\n' "$BASH_VERSION_OK" >&2
+    exit 1 ;;
+esac
+```
+
+### Step 2: Detect Gemini CLI
+
+```bash
+if command -v gemini >/dev/null 2>&1; then
+  GEMINI_VERSION=$(gemini --version 2>/dev/null | head -1)
+  printf '[yellow-council] gemini: ok (%s)\n' "$GEMINI_VERSION"
+  case "$GEMINI_VERSION" in
+    0.40.*|0.4[1-9].*|0.[5-9][0-9].*|[1-9].*)
+      printf '[yellow-council] gemini version: compatible (>=0.40)\n' ;;
+    *)
+      printf '[yellow-council] gemini version: WARNING — %s may be too old. Recommend v0.40+ for council use.\n' "$GEMINI_VERSION" ;;
+  esac
+else
+  printf '[yellow-council] gemini: NOT INSTALLED\n'
+fi
+```
+
+If gemini is not installed, ask via AskUserQuestion:
+
+> "Gemini CLI not found. Council reviews require gemini for the Gemini leg. Install now?"
+>
+> Options: "Yes, install via npm" / "No, I'll install manually" / "Skip — council will run without Gemini"
+
+If user chooses **Yes, install via npm**:
+
+```bash
+npm install -g @google/gemini-cli@latest
+```
+
+Verify:
+
+```bash
+gemini --version 2>&1 | head -1
+```
+
+If user chooses **No, I'll install manually**: print install instructions and exit:
+
+```text
+[yellow-council] To install Gemini CLI manually:
+  npm install -g @google/gemini-cli            # via npm
+  brew install gemini-cli                      # macOS/Linux Homebrew
+  See: https://google-gemini.github.io/gemini-cli/
+```
+
+### Step 3: Detect OpenCode CLI
+
+```bash
+if command -v opencode >/dev/null 2>&1; then
+  OPENCODE_VERSION=$(opencode --version 2>/dev/null | head -1)
+  printf '[yellow-council] opencode: ok (%s)\n' "$OPENCODE_VERSION"
+  case "$OPENCODE_VERSION" in
+    1.1[4-9].*|1.[2-9][0-9].*|[2-9].*|[1-9][0-9].*)
+      printf '[yellow-council] opencode version: compatible (>=1.14)\n' ;;
+    *)
+      printf '[yellow-council] opencode version: WARNING — %s may be too old. Recommend v1.14+ for council use.\n' "$OPENCODE_VERSION" ;;
+  esac
+else
+  printf '[yellow-council] opencode: NOT INSTALLED\n'
+fi
+```
+
+If opencode is not installed, ask via AskUserQuestion:
+
+> "OpenCode CLI not found. Council reviews require opencode for the OpenCode leg. Install now?"
+>
+> Options: "Yes, install via curl" / "No, I'll install manually" / "Skip — council will run without OpenCode"
+
+If user chooses **Yes, install via curl**:
+
+```bash
+curl -fsSL https://opencode.ai/install | bash
+```
+
+Then prompt the user to source their shell profile or open a new terminal so the binary is on PATH.
+
+### Step 4: Report yellow-codex availability
+
+yellow-codex is an optional cross-plugin dependency. yellow-council reuses its
+`codex-reviewer` agent when present; otherwise the Codex leg is soft-skipped.
+
+```bash
+if [ -d "${HOME}/.claude/plugins/cache/yellow-codex" ] || [ -d "$(git rev-parse --show-toplevel 2>/dev/null)/plugins/yellow-codex" ]; then
+  printf '[yellow-council] yellow-codex: ok (Codex leg available via Task spawn)\n'
+else
+  printf '[yellow-council] yellow-codex: NOT INSTALLED — Codex leg will be skipped.\n'
+  printf '[yellow-council]   Install: /plugin install yellow-codex@yellow-plugins\n'
+fi
+```
+
+### Step 5: Final readiness summary
+
+Print a one-line summary:
+
+```bash
+printf '\n[yellow-council] Setup summary:\n'
+printf '  Required: bash 4.3+, timeout, jq — verified\n'
+printf '  Reviewers: %d of 3 available (Gemini=%s, OpenCode=%s, Codex=%s)\n' \
+  "$READY_COUNT" "$GEMINI_STATUS" "$OPENCODE_STATUS" "$CODEX_STATUS"
+if [ "$READY_COUNT" -eq 0 ]; then
+  printf '  Status: NOT READY — install at least one reviewer CLI before invoking /council\n'
+elif [ "$READY_COUNT" -lt 3 ]; then
+  printf '  Status: PARTIAL — /council will run with %d reviewer(s); install missing CLIs for full council\n' "$READY_COUNT"
+else
+  printf '  Status: READY — /council can run with all three reviewers\n'
+fi
+```
+
+## Notes
+
+- `council:setup` does NOT verify CLI authentication (Gemini OAuth, OpenAI API key, OpenCode provider). Auth verification is the user's responsibility — first invocation of each CLI will prompt for auth if needed.
+- The `--variant` and `--approval-mode` flags used by reviewers are validated at invocation time, not at setup. If a flag is removed in a future CLI version, the corresponding reviewer will fail at runtime with a clear error.
+- This setup is idempotent — running it repeatedly is safe.

--- a/plugins/yellow-council/commands/council/setup.md
+++ b/plugins/yellow-council/commands/council/setup.md
@@ -28,7 +28,7 @@ for tool in bash timeout jq mktemp awk sed grep; do
 done
 printf '[yellow-council] system tools: ok (bash, timeout, jq, mktemp, awk, sed, grep)\n'
 
-# Bash version check (need 4.3+ for wait "$pid" per-process exit codes)
+# Bash version check (need 4.3+ for ${BASH_VERSINFO[N]} array indexing, associative arrays, and ${var^} capitalization used in council.md)
 BASH_VERSION_OK="${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"
 case "$BASH_VERSION_OK" in
   4.[3-9]*|4.[1-9][0-9]*|[5-9].*|[1-9][0-9].*)
@@ -133,6 +133,32 @@ fi
 Print a one-line summary:
 
 ```bash
+# Re-detect each CLI inline — each Bash block is a fresh subprocess so
+# variables from Steps 2-4 do not survive here.
+READY_COUNT=0
+
+if command -v gemini >/dev/null 2>&1; then
+  GEMINI_STATUS="installed"
+  READY_COUNT=$((READY_COUNT + 1))
+else
+  GEMINI_STATUS="missing"
+fi
+
+if command -v opencode >/dev/null 2>&1; then
+  OPENCODE_STATUS="installed"
+  READY_COUNT=$((READY_COUNT + 1))
+else
+  OPENCODE_STATUS="missing"
+fi
+
+if [ -d "${HOME}/.claude/plugins/cache/yellow-codex" ] || \
+   [ -d "$(git rev-parse --show-toplevel 2>/dev/null)/plugins/yellow-codex" ]; then
+  CODEX_STATUS="installed"
+  READY_COUNT=$((READY_COUNT + 1))
+else
+  CODEX_STATUS="missing"
+fi
+
 printf '\n[yellow-council] Setup summary:\n'
 printf '  Required: bash 4.3+, timeout, jq — verified\n'
 printf '  Reviewers: %d of 3 available (Gemini=%s, OpenCode=%s, Codex=%s)\n' \

--- a/plugins/yellow-council/commands/council/setup.md
+++ b/plugins/yellow-council/commands/council/setup.md
@@ -29,12 +29,12 @@ done
 printf '[yellow-council] system tools: ok (bash, timeout, jq, mktemp, awk, sed, grep)\n'
 
 # Bash version check (need 4.3+ for ${BASH_VERSINFO[N]} array indexing, associative arrays, and ${var^} capitalization used in council.md)
-BASH_VERSION_OK="${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"
-case "$BASH_VERSION_OK" in
+BASH_VER="${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"
+case "$BASH_VER" in
   4.[3-9]*|4.[1-9][0-9]*|[5-9].*|[1-9][0-9].*)
-    printf '[yellow-council] bash: ok (%s)\n' "$BASH_VERSION_OK" ;;
+    printf '[yellow-council] bash: ok (%s)\n' "$BASH_VER" ;;
   *)
-    printf '[yellow-council] Error: bash 4.3+ required, found %s\n' "$BASH_VERSION_OK" >&2
+    printf '[yellow-council] Error: bash 4.3+ required, found %s\n' "$BASH_VER" >&2
     exit 1 ;;
 esac
 ```
@@ -43,13 +43,16 @@ esac
 
 ```bash
 if command -v gemini >/dev/null 2>&1; then
-  GEMINI_VERSION=$(gemini --version 2>/dev/null | head -1)
-  printf '[yellow-council] gemini: ok (%s)\n' "$GEMINI_VERSION"
+  # npm-packaged CLIs may prefix output (e.g. `@google/gemini-cli/0.40.1 linux-x64 node-v22.11.0`)
+  # and may emit to stderr; extract bare semver to keep the case match version-format-agnostic.
+  GEMINI_RAW=$(gemini --version 2>&1 | head -1)
+  GEMINI_VERSION=$(printf '%s' "$GEMINI_RAW" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+  printf '[yellow-council] gemini: ok (%s)\n' "${GEMINI_VERSION:-$GEMINI_RAW}"
   case "$GEMINI_VERSION" in
     0.40.*|0.4[1-9].*|0.[5-9][0-9].*|[1-9].*)
       printf '[yellow-council] gemini version: compatible (>=0.40)\n' ;;
     *)
-      printf '[yellow-council] gemini version: WARNING — %s may be too old. Recommend v0.40+ for council use.\n' "$GEMINI_VERSION" ;;
+      printf '[yellow-council] gemini version: WARNING — %s may be too old. Recommend v0.40+ for council use.\n' "${GEMINI_VERSION:-$GEMINI_RAW}" ;;
   esac
 else
   printf '[yellow-council] gemini: NOT INSTALLED\n'
@@ -87,13 +90,15 @@ If user chooses **No, I'll install manually**: print install instructions and ex
 
 ```bash
 if command -v opencode >/dev/null 2>&1; then
-  OPENCODE_VERSION=$(opencode --version 2>/dev/null | head -1)
-  printf '[yellow-council] opencode: ok (%s)\n' "$OPENCODE_VERSION"
+  # Same prefix/stderr robustness as gemini — extract bare semver before case match.
+  OPENCODE_RAW=$(opencode --version 2>&1 | head -1)
+  OPENCODE_VERSION=$(printf '%s' "$OPENCODE_RAW" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+  printf '[yellow-council] opencode: ok (%s)\n' "${OPENCODE_VERSION:-$OPENCODE_RAW}"
   case "$OPENCODE_VERSION" in
     1.1[4-9].*|1.[2-9][0-9].*|[2-9].*|[1-9][0-9].*)
       printf '[yellow-council] opencode version: compatible (>=1.14)\n' ;;
     *)
-      printf '[yellow-council] opencode version: WARNING — %s may be too old. Recommend v1.14+ for council use.\n' "$OPENCODE_VERSION" ;;
+      printf '[yellow-council] opencode version: WARNING — %s may be too old. Recommend v1.14+ for council use.\n' "${OPENCODE_VERSION:-$OPENCODE_RAW}" ;;
   esac
 else
   printf '[yellow-council] opencode: NOT INSTALLED\n'
@@ -109,7 +114,12 @@ If opencode is not installed, ask via AskUserQuestion:
 If user chooses **Yes, install via curl**:
 
 ```bash
-curl -fsSL https://opencode.ai/install | bash
+# Download to a temp file so the user can inspect before execution
+TMP_INSTALLER="$(mktemp)"
+trap 'rm -f "$TMP_INSTALLER"' EXIT
+curl -fsSL https://opencode.ai/install -o "$TMP_INSTALLER"
+printf '[yellow-council] Installer downloaded to %s — inspect with: bat %s\n' "$TMP_INSTALLER" "$TMP_INSTALLER"
+bash "$TMP_INSTALLER"
 ```
 
 Then prompt the user to source their shell profile or open a new terminal so the binary is on PATH.
@@ -120,7 +130,7 @@ yellow-codex is an optional cross-plugin dependency. yellow-council reuses its
 `codex-reviewer` agent when present; otherwise the Codex leg is soft-skipped.
 
 ```bash
-if [ -d "${HOME}/.claude/plugins/cache/yellow-codex" ] || [ -d "$(git rev-parse --show-toplevel 2>/dev/null)/plugins/yellow-codex" ]; then
+if [ -d "${HOME}/.claude/plugins/cache/yellow-codex" ]; then
   printf '[yellow-council] yellow-codex: ok (Codex leg available via Task spawn)\n'
 else
   printf '[yellow-council] yellow-codex: NOT INSTALLED — Codex leg will be skipped.\n'
@@ -151,8 +161,7 @@ else
   OPENCODE_STATUS="missing"
 fi
 
-if [ -d "${HOME}/.claude/plugins/cache/yellow-codex" ] || \
-   [ -d "$(git rev-parse --show-toplevel 2>/dev/null)/plugins/yellow-codex" ]; then
+if [ -d "${HOME}/.claude/plugins/cache/yellow-codex" ]; then
   CODEX_STATUS="installed"
   READY_COUNT=$((READY_COUNT + 1))
 else

--- a/plugins/yellow-council/package.json
+++ b/plugins/yellow-council/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "yellow-council",
+  "version": "0.1.0",
+  "private": true,
+  "description": "On-demand cross-lineage code review fanning out to Codex, Gemini, and OpenCode CLIs in parallel for advisory consensus"
+}

--- a/plugins/yellow-council/skills/council-patterns/SKILL.md
+++ b/plugins/yellow-council/skills/council-patterns/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: council-patterns
+description: "Canonical reference for yellow-council CLI invocation patterns, per-mode pack templates, redaction rules, slug derivation, and timeout/output-capture conventions. Use when authoring or modifying gemini-reviewer, opencode-reviewer, or the /council command. PR1 stub — full content lands in yellow-council-core-implementation."
+---
+
+# council-patterns Skill
+
+## What It Does
+
+Provides shared invocation conventions, per-mode pack templates, credential
+redaction patterns, slug derivation rules, and output-parsing logic for the
+yellow-council plugin's three reviewer surfaces (Codex via yellow-codex,
+Gemini, OpenCode).
+
+## When to Use
+
+- Authoring `gemini-reviewer.md` or `opencode-reviewer.md` — both reference
+  this skill for CLI invocation and output handling
+- Authoring `commands/council/council.md` — pack template structure, slug
+  derivation, atomic file write conventions
+- Modifying any of the above — keep contracts in sync via this single source
+  of truth
+
+## Usage
+
+This is the PR1 scaffold stub. The full skill body — including:
+
+- Per-mode pack templates (plan / review / debug / question)
+- Required reviewer output schema (`Verdict: APPROVE|REVISE|REJECT`,
+  `Confidence: HIGH|MEDIUM|LOW`, `Findings:` with file:line evidence,
+  `Summary:`)
+- 11-pattern credential redaction awk block (sk-, ghp_, AKIA, Bearer,
+  Authorization, PEM, AIza, sk-ant-, ses_, plus sk-proj- and github_pat_)
+- Injection fence format (`--- begin council-output:<reviewer> (reference
+  only) ---` / `--- end council-output:<reviewer> ---`)
+- `timeout --signal=TERM --kill-after=10 ${COUNCIL_TIMEOUT:-600}` pattern
+  with exit-124/137 handling
+- Path validation (regex + `..` reject + existence check)
+- Slug derivation (`LC_ALL=C`, lowercase, alphanum-or-dash, length cap,
+  sha256 fallback for empty slug, same-day collision suffix `-2`...`-10`)
+- Diff truncation algorithm for `review` mode (200K-byte threshold,
+  `git diff --stat` + first 200 lines, per-file 4K cap, total 100K pack
+  budget)
+- UNKNOWN verdict semantics for non-conforming reviewer output
+
+— lands in PR2 (`agent/feat/yellow-council-core-implementation`).
+
+### Cross-References
+
+- `yellow-codex:codex-patterns` — Codex CLI invocation conventions, exit
+  code catalog, sandbox/approval modes. yellow-council reuses these for the
+  Codex reviewer leg via Task spawn — do not duplicate the codex-patterns
+  content here.
+- `gemini-cli-output-format-2026-05-04.md` (in `docs/spikes/`) — verified
+  Gemini CLI v0.40+ invocation: `gemini -p "..." --approval-mode plan
+  --skip-trust -o text`. Do NOT use `--yolo` (issue #13561).
+- `opencode-cli-format-json-2026-05-04.md` (in `docs/spikes/`) — verified
+  OpenCode CLI v1.14+ invocation: `opencode run --format json --variant
+  high "..."` plus `opencode session delete <id>` cleanup.

--- a/plugins/yellow-council/skills/council-patterns/SKILL.md
+++ b/plugins/yellow-council/skills/council-patterns/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: council-patterns
 description: "Canonical reference for yellow-council CLI invocation patterns, per-mode pack templates, redaction rules, slug derivation, and timeout/output-capture conventions. Use when authoring or modifying gemini-reviewer, opencode-reviewer, or the /council command. PR1 stub — full content lands in yellow-council-core-implementation."
+user-invokable: false
 ---
 
 # council-patterns Skill

--- a/scripts/validate-agent-authoring.js
+++ b/scripts/validate-agent-authoring.js
@@ -28,6 +28,13 @@ const REVIEW_AGENT_ALLOWLIST = new Set([
   // only restriction would break the agent. See agent body for rationale.
   // Decision recorded in plans/everyinc-merge.md W1.2 (2026-04-29).
   'yellow-codex/agents/review/codex-reviewer.md',
+  // gemini-reviewer and opencode-reviewer wrap external CLIs (gemini, opencode)
+  // for the on-demand cross-lineage council. Same containment rationale as
+  // codex-reviewer: Bash is required for binary invocation; read-only contract
+  // is enforced via prose discipline + explicit prompt design. See plan
+  // plans/yellow-council-godmodeskill-integration.md (2026-05-04).
+  'yellow-council/agents/review/gemini-reviewer.md',
+  'yellow-council/agents/review/opencode-reviewer.md',
 ]);
 
 const colors = {

--- a/scripts/validate-setup-all.js
+++ b/scripts/validate-setup-all.js
@@ -33,6 +33,7 @@ const COMMAND_PLUGIN_MAP = {
   'docs:setup': 'yellow-docs',
   'composio:setup': 'yellow-composio',
   'codex:setup': 'yellow-codex',
+  'council:setup': 'yellow-council',
   'statusline:setup': 'yellow-core',
 };
 


### PR DESCRIPTION
PR1 of 3 in the yellow-council stack — establishes the new plugin's directory layout, manifests, and CI-passing scaffolding so PR2 can land the SKILL + reviewer agents and PR3 can polish edge cases.

What's in this PR:

- New plugin yellow-council registered at .claude-plugin/marketplace.json
- Plugin manifest, package.json, CHANGELOG.md (pre-populated v0.1.0 per yellow-codex precedent)
- CLAUDE.md and README.md with the full V1 design captured (spikes already validated CLI invocation patterns against current upstream)
- /council:setup command stub that verifies bash 4.3+, timeout, jq, and detects gemini/opencode/yellow-codex availability
- Agent stubs: gemini-reviewer.md and opencode-reviewer.md with proper W1.5-allowlisted Bash exception sections (full bodies land in PR2)
- council-patterns SKILL.md stub cross-referencing yellow-codex codex-patterns
- 2 spike documents in docs/spikes/ verifying gemini v0.40+ and opencode v1.14+ invocation against live CLIs
- Brainstorm + plan + stack decomposition committed under docs/brainstorms/ and plans/

Validation:

- pnpm validate:plugins: PASS (17 plugins all valid)
- pnpm validate:versions: OK (all three-way version sync intact)
- pnpm validate:setup-all: OK (yellow-council added to dashboard / classification / delegated / mapping sections)
- pnpm validate:agent-authoring: PASS (gemini-reviewer + opencode-reviewer added to REVIEW_AGENT_ALLOWLIST with documented exception sections in agent bodies)

Pre-existing error in plugins/yellow-core/agents/workflow/session-historian.md is unrelated to this PR (verified by git stash + re-validation).

Spike findings worth noting:

- Gemini CLI v0.40+ requires -p/--prompt for non-interactive mode (positional prompt now enters TUI). The brainstorm research had cited outdated v0.21-era behavior.
- Gemini --approval-mode plan is the new read-only mode and is what yellow-council will use (NOT --yolo, which has known issue #13561).
- Gemini workspace trust requires --skip-trust for non-interactive use in untrusted dirs.
- OpenCode v1.14+ creates persistent SQLite sessions that require explicit opencode session delete cleanup.
- Major OpenCode upgrades trigger a one-time SQLite migration (2-5 minutes) — documented in CLAUDE.md Known Limitations.

Stack progress: PR2 (yellow-council-core-implementation) lands the full council-patterns SKILL, gemini/opencode reviewer bodies, and /council command. PR3 (yellow-council-polish-and-tests) covers edge cases and manual e2e tests.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the `yellow-council` plugin, enabling on-demand parallel code review via the `/council <mode>` command.
  * Supports four review modes: `plan`, `review`, `debug`, and `question`.
  * Integrates with multiple external reviewers (Codex, Gemini, OpenCode) for advisory consensus.
  * Generates and persists review reports with synthesized findings.

* **Chores**
  * Bumped root package version to 1.2.2.
  * Integrated setup workflow for the new plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is PR1 of a 3-PR stack that establishes the `yellow-council` plugin scaffold — directory layout, manifests, agent stubs, a `council:setup` command, spike documents for Gemini and OpenCode CLI behavior, and the necessary CI validation hooks. No executable council logic ships in this PR; the full reviewer agents and `/council` command land in PR2.

- **Plugin scaffold**: `plugin.json`, `package.json`, `CHANGELOG.md`, `CLAUDE.md`, `README.md`, and stub bodies for `gemini-reviewer`, `opencode-reviewer`, and `council-patterns` SKILL registered with proper marketplace entry and validate-agent-authoring allowlist entries.
- **`all.md` integration**: gemini/opencode binary probes, yellow-council plugin loop entry, classification rule, delegated-command entry, and plugin-command map entry added — the example dashboard table is the one place `yellow-council` is still missing.
- **Spike documentation**: Gemini v0.40+ corrects the brainstorm's outdated positional-prompt assumption (`-p` required, `--approval-mode plan` preferred over `--yolo`); OpenCode v1.14+ documents persistent SQLite sessions requiring explicit cleanup and a one-time migration cost after major upgrades.

<h3>Confidence Score: 4/5</h3>

Safe to merge with the dashboard table fix applied; the missing yellow-council entry in the example table would cause the rendered setup dashboard to silently drop yellow-council status for all users.

The only functional gap is the example dashboard table in all.md that the LLM uses as a formatting template. Every other integration point is wired correctly. Since this is a scaffold-only PR with no live council logic, the real-world blast radius is limited to the misleading setup dashboard output until the table is patched.

plugins/yellow-core/commands/setup/all.md — the example dashboard table (lines 387–411) needs a yellow-council row added between yellow-codex and yellow-core.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/yellow-core/commands/setup/all.md | Adds gemini/opencode detection, yellow-council plugin loop entry, classification rule, delegated command, and plugin-command map entry — but omits yellow-council from the example dashboard table that the LLM uses as a formatting template, meaning yellow-council status will likely be absent from rendered dashboards. |
| plugins/yellow-council/commands/council/setup.md | Well-structured setup command stub with version checks, install-via-npm/curl flows, and a final readiness summary; the yellow-codex detection uses a hardcoded cache-path that may silently misreport plugin availability. |
| docs/spikes/opencode-cli-format-json-2026-05-04.md | Solid spike document for OpenCode CLI v1.14+ invocation; the recommended session-ID jq extraction expression differs from the one given in the implementation plan, which could mislead PR2 implementers. |
| plugins/yellow-council/.claude-plugin/plugin.json | Plugin manifest follows the established schema (repository as string URL, no changelog key, required fields present); version aligned at 0.1.0. |
| scripts/validate-agent-authoring.js | Adds gemini-reviewer and opencode-reviewer to REVIEW_AGENT_ALLOWLIST with a documented rationale comment, consistent with the codex-reviewer precedent. |
| plugins/yellow-council/agents/review/gemini-reviewer.md | PR1 stub correctly declares Bash exception with thorough rationale; permitted/prohibited operations enumerated; full body deferred to PR2. |
| plugins/yellow-council/agents/review/opencode-reviewer.md | PR1 stub mirrors gemini-reviewer structure; OpenCode-specific concerns (persistent sessions, tool-use event redaction, SQLite migration) clearly documented. |
| .claude-plugin/marketplace.json | Appends yellow-council entry following the established marketplace JSON shape; all required fields present. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    User(["/council <mode> [args]"]) --> CMD["council.md\norchestrator\n(PR2)"]
    CMD --> PACK["Build context pack\n(council-patterns SKILL)"]
    PACK --> FAN["Parallel Task fan-out\n(single message)"]
    FAN --> CODEX["Task: yellow-codex\n:review:codex-reviewer\n(optional — soft-skip if absent)"]
    FAN --> GEMINI["Task: yellow-council\n:review:gemini-reviewer\n(PR1 stub)"]
    FAN --> OC["Task: yellow-council\n:review:opencode-reviewer\n(PR1 stub)"]
    CODEX --> WAIT["Collect verdicts"]
    GEMINI --> WAIT
    OC --> WAIT
    WAIT --> SYNTH["Synthesize\nHeadline + Agreement + Disagreement"]
    SYNTH --> M3["AskUserQuestion M3 gate"]
    M3 -- Save --> WRITE["Write → docs/council/DATE-mode-slug.md"]
    M3 -- Cancel --> EXIT["Exit — no file written"]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `plugins/yellow-core/commands/setup/all.md`, line 63 ([link](https://github.com/kinginyellows/yellow-plugins/blob/82e0b72271532c768f7863b143a4d51496440f2a/plugins/yellow-core/commands/setup/all.md#L63)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Missing `gemini` and `opencode` probes in Step 1 dashboard block**

   The yellow-council classification rule added in Step 2 requires `gemini >= 0.40 OR opencode >= 1.14 OR yellow-codex installed`. The `yellow-codex` case is covered by the "=== Installed Plugins ===" section, but there are no `gemini` or `opencode` binary checks anywhere in the Step 1 Bash block. The LLM executing `/setup:all` will have no dashboard data for these two CLIs and will misclassify yellow-council as NEEDS SETUP even when gemini or opencode are properly installed — or silently skip the gem/opencode condition and produce wrong READY/PARTIAL status.

   The `codex` detection pattern just above (line 63) is the right template: add comparable lines for `gemini` and `opencode` with version output so the Step 2 classification has the data it needs.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: plugins/yellow-core/commands/setup/all.md
   Line: 63

   Comment:
   **Missing `gemini` and `opencode` probes in Step 1 dashboard block**

   The yellow-council classification rule added in Step 2 requires `gemini >= 0.40 OR opencode >= 1.14 OR yellow-codex installed`. The `yellow-codex` case is covered by the "=== Installed Plugins ===" section, but there are no `gemini` or `opencode` binary checks anywhere in the Step 1 Bash block. The LLM executing `/setup:all` will have no dashboard data for these two CLIs and will misclassify yellow-council as NEEDS SETUP even when gemini or opencode are properly installed — or silently skip the gem/opencode condition and produce wrong READY/PARTIAL status.

   The `codex` detection pattern just above (line 63) is the right template: add comparable lines for `gemini` and `opencode` with version output so the Step 2 classification has the data it needs.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Fyellow-council-scaffold-and-spikes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Fyellow-council-scaffold-and-spikes%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plugins%2Fyellow-core%2Fcommands%2Fsetup%2Fall.md%0ALine%3A%2063%0A%0AComment%3A%0A**Missing%20%60gemini%60%20and%20%60opencode%60%20probes%20in%20Step%201%20dashboard%20block**%0A%0AThe%20yellow-council%20classification%20rule%20added%20in%20Step%202%20requires%20%60gemini%20%3E%3D%200.40%20OR%20opencode%20%3E%3D%201.14%20OR%20yellow-codex%20installed%60.%20The%20%60yellow-codex%60%20case%20is%20covered%20by%20the%20%22%3D%3D%3D%20Installed%20Plugins%20%3D%3D%3D%22%20section%2C%20but%20there%20are%20no%20%60gemini%60%20or%20%60opencode%60%20binary%20checks%20anywhere%20in%20the%20Step%201%20Bash%20block.%20The%20LLM%20executing%20%60%2Fsetup%3Aall%60%20will%20have%20no%20dashboard%20data%20for%20these%20two%20CLIs%20and%20will%20misclassify%20yellow-council%20as%20NEEDS%20SETUP%20even%20when%20gemini%20or%20opencode%20are%20properly%20installed%20%E2%80%94%20or%20silently%20skip%20the%20gem%2Fopencode%20condition%20and%20produce%20wrong%20READY%2FPARTIAL%20status.%0A%0AThe%20%60codex%60%20detection%20pattern%20just%20above%20%28line%2063%29%20is%20the%20right%20template%3A%20add%20comparable%20lines%20for%20%60gemini%60%20and%20%60opencode%60%20with%20version%20output%20so%20the%20Step%202%20classification%20has%20the%20data%20it%20needs.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

2. `plugins/yellow-core/commands/setup/all.md`, line 387-411 ([link](https://github.com/kinginyellows/yellow-plugins/blob/7b99840d5f54de2c3fab48e66eab545820e01a6e/plugins/yellow-core/commands/setup/all.md#L387-L411)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`yellow-council` missing from example dashboard table**

   The example display table (used by the LLM as a formatting template for output) omits `yellow-council` even though the plugin loop (line 180), the classification block (lines 366–374), the delegated commands list (line 479), and the plugin-command map (line 501) all correctly include it. When an LLM executing `/setup:all` generates the dashboard table it will pattern-match against this example, and because `yellow-council` is absent from the template it is likely to be silently omitted from the actual rendered output — meaning users will never see yellow-council's status even after it is installed.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: plugins/yellow-core/commands/setup/all.md
   Line: 387-411

   Comment:
   **`yellow-council` missing from example dashboard table**

   The example display table (used by the LLM as a formatting template for output) omits `yellow-council` even though the plugin loop (line 180), the classification block (lines 366–374), the delegated commands list (line 479), and the plugin-command map (line 501) all correctly include it. When an LLM executing `/setup:all` generates the dashboard table it will pattern-match against this example, and because `yellow-council` is absent from the template it is likely to be silently omitted from the actual rendered output — meaning users will never see yellow-council's status even after it is installed.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Fyellow-council-scaffold-and-spikes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Fyellow-council-scaffold-and-spikes%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plugins%2Fyellow-core%2Fcommands%2Fsetup%2Fall.md%0ALine%3A%20387-411%0A%0AComment%3A%0A**%60yellow-council%60%20missing%20from%20example%20dashboard%20table**%0A%0AThe%20example%20display%20table%20%28used%20by%20the%20LLM%20as%20a%20formatting%20template%20for%20output%29%20omits%20%60yellow-council%60%20even%20though%20the%20plugin%20loop%20%28line%20180%29%2C%20the%20classification%20block%20%28lines%20366%E2%80%93374%29%2C%20the%20delegated%20commands%20list%20%28line%20479%29%2C%20and%20the%20plugin-command%20map%20%28line%20501%29%20all%20correctly%20include%20it.%20When%20an%20LLM%20executing%20%60%2Fsetup%3Aall%60%20generates%20the%20dashboard%20table%20it%20will%20pattern-match%20against%20this%20example%2C%20and%20because%20%60yellow-council%60%20is%20absent%20from%20the%20template%20it%20is%20likely%20to%20be%20silently%20omitted%20from%20the%20actual%20rendered%20output%20%E2%80%94%20meaning%20users%20will%20never%20see%20yellow-council's%20status%20even%20after%20it%20is%20installed.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

3. `plugins/yellow-core/commands/setup/all.md`, line 387-411 ([link](https://github.com/kinginyellows/yellow-plugins/blob/85a129fc3861f997eec9428151708e790b6dbad7/plugins/yellow-core/commands/setup/all.md#L387-L411)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`yellow-council` missing from the example dashboard table**

   The example display table (lines 387–411) is the LLM's formatting template for producing the dashboard output. `yellow-council` is now correctly listed in the plugin loop, the classification block, the delegated-command list, and the plugin-command map — but it is still absent from this table. An LLM executing `/setup:all` will pattern-match against this example; because `yellow-council` is missing from the template it will likely be silently omitted from the rendered dashboard, meaning users never see its READY/PARTIAL/NEEDS SETUP status even after the plugin is installed.

   The entry should appear between `yellow-codex` and `yellow-core`, following the same format as the other rows.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: plugins/yellow-core/commands/setup/all.md
   Line: 387-411

   Comment:
   **`yellow-council` missing from the example dashboard table**

   The example display table (lines 387–411) is the LLM's formatting template for producing the dashboard output. `yellow-council` is now correctly listed in the plugin loop, the classification block, the delegated-command list, and the plugin-command map — but it is still absent from this table. An LLM executing `/setup:all` will pattern-match against this example; because `yellow-council` is missing from the template it will likely be silently omitted from the rendered dashboard, meaning users never see its READY/PARTIAL/NEEDS SETUP status even after the plugin is installed.

   The entry should appear between `yellow-codex` and `yellow-core`, following the same format as the other rows.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Fyellow-council-scaffold-and-spikes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Fyellow-council-scaffold-and-spikes%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plugins%2Fyellow-core%2Fcommands%2Fsetup%2Fall.md%0ALine%3A%20387-411%0A%0AComment%3A%0A**%60yellow-council%60%20missing%20from%20the%20example%20dashboard%20table**%0A%0AThe%20example%20display%20table%20%28lines%20387%E2%80%93411%29%20is%20the%20LLM's%20formatting%20template%20for%20producing%20the%20dashboard%20output.%20%60yellow-council%60%20is%20now%20correctly%20listed%20in%20the%20plugin%20loop%2C%20the%20classification%20block%2C%20the%20delegated-command%20list%2C%20and%20the%20plugin-command%20map%20%E2%80%94%20but%20it%20is%20still%20absent%20from%20this%20table.%20An%20LLM%20executing%20%60%2Fsetup%3Aall%60%20will%20pattern-match%20against%20this%20example%3B%20because%20%60yellow-council%60%20is%20missing%20from%20the%20template%20it%20will%20likely%20be%20silently%20omitted%20from%20the%20rendered%20dashboard%2C%20meaning%20users%20never%20see%20its%20READY%2FPARTIAL%2FNEEDS%20SETUP%20status%20even%20after%20the%20plugin%20is%20installed.%0A%0AThe%20entry%20should%20appear%20between%20%60yellow-codex%60%20and%20%60yellow-core%60%2C%20following%20the%20same%20format%20as%20the%20other%20rows.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Fyellow-council-scaffold-and-spikes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Fyellow-council-scaffold-and-spikes%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aplugins%2Fyellow-core%2Fcommands%2Fsetup%2Fall.md%3A387-411%0A**%60yellow-council%60%20missing%20from%20the%20example%20dashboard%20table**%0A%0AThe%20example%20display%20table%20%28lines%20387%E2%80%93411%29%20is%20the%20LLM's%20formatting%20template%20for%20producing%20the%20dashboard%20output.%20%60yellow-council%60%20is%20now%20correctly%20listed%20in%20the%20plugin%20loop%2C%20the%20classification%20block%2C%20the%20delegated-command%20list%2C%20and%20the%20plugin-command%20map%20%E2%80%94%20but%20it%20is%20still%20absent%20from%20this%20table.%20An%20LLM%20executing%20%60%2Fsetup%3Aall%60%20will%20pattern-match%20against%20this%20example%3B%20because%20%60yellow-council%60%20is%20missing%20from%20the%20template%20it%20will%20likely%20be%20silently%20omitted%20from%20the%20rendered%20dashboard%2C%20meaning%20users%20never%20see%20its%20READY%2FPARTIAL%2FNEEDS%20SETUP%20status%20even%20after%20the%20plugin%20is%20installed.%0A%0AThe%20entry%20should%20appear%20between%20%60yellow-codex%60%20and%20%60yellow-core%60%2C%20following%20the%20same%20format%20as%20the%20other%20rows.%0A%0A%23%23%23%20Issue%202%20of%203%0Aplugins%2Fyellow-council%2Fcommands%2Fcouncil%2Fsetup.md%3A132-138%0A**Hardcoded%20plugin-cache%20path%20may%20silently%20misreport%20yellow-codex%20status**%0A%0AThe%20check%20%60%5B%20-d%20%22%24%7BHOME%7D%2F.claude%2Fplugins%2Fcache%2Fyellow-codex%22%20%5D%60%20assumes%20a%20specific%20Claude%20Code%20plugin-cache%20layout%20that%20may%20not%20hold%20across%20all%20versions%20or%20OS%20configurations.%20If%20Claude%20Code%20stores%20plugins%20under%20a%20different%20path%2C%20this%20check%20always%20evaluates%20false%20%E2%80%94%20%60council%3Asetup%60%20reports%20%22yellow-codex%3A%20NOT%20INSTALLED%22%20even%20when%20the%20plugin%20is%20fully%20installed%2C%20leading%20users%20to%20believe%20the%20Codex%20reviewer%20is%20unavailable%20when%20it%20isn't.%20The%20%60all.md%60%20Step%201%20block%20detects%20installed%20plugins%20via%20a%20python-based%20%60installed_plugins%60%20variable%20rather%20than%20a%20hardcoded%20path%3B%20a%20similar%20approach%20here%20would%20be%20more%20robust.%0A%0A%23%23%23%20Issue%203%20of%203%0Adocs%2Fspikes%2Fopencode-cli-format-json-2026-05-04.md%3A58-68%0A**Session%20ID%20extraction%20jq%20expression%20is%20inconsistent%20with%20the%20implementation%20plan**%0A%0AThis%20spike%20%28line%2068%29%20uses%20%60jq%20-r%20'first%28.sessionID%20%2F%2F%20empty%29'%60%2C%20accessing%20%60.sessionID%60%20at%20the%20top%20level%20of%20each%20JSONL%20event.%20The%20implementation%20plan%20%28%60plans%2Fyellow-council-godmodeskill-integration.md%60%2C%20task%202.3%29%20instead%20specifies%20%60select%28.part.snapshot.sessionID%29%20%7C%20.part.snapshot.sessionID%60%20%E2%80%94%20a%20different%20object%20path.%20PR2%20implementers%20referencing%20both%20documents%20risk%20picking%20the%20wrong%20expression%2C%20silently%20failing%20to%20extract%20the%20session%20ID%20and%20allowing%20sessions%20to%20accumulate%20in%20%60~%2F.local%2Fshare%2Fopencode%2F%60.%20The%20spike%20is%20labeled%20%22verified%22%20and%20should%20be%20the%20authoritative%20source%3B%20the%20plan's%20expression%20should%20be%20corrected%20to%20match.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
plugins/yellow-core/commands/setup/all.md:387-411
**`yellow-council` missing from the example dashboard table**

The example display table (lines 387–411) is the LLM's formatting template for producing the dashboard output. `yellow-council` is now correctly listed in the plugin loop, the classification block, the delegated-command list, and the plugin-command map — but it is still absent from this table. An LLM executing `/setup:all` will pattern-match against this example; because `yellow-council` is missing from the template it will likely be silently omitted from the rendered dashboard, meaning users never see its READY/PARTIAL/NEEDS SETUP status even after the plugin is installed.

The entry should appear between `yellow-codex` and `yellow-core`, following the same format as the other rows.

### Issue 2 of 3
plugins/yellow-council/commands/council/setup.md:132-138
**Hardcoded plugin-cache path may silently misreport yellow-codex status**

The check `[ -d "${HOME}/.claude/plugins/cache/yellow-codex" ]` assumes a specific Claude Code plugin-cache layout that may not hold across all versions or OS configurations. If Claude Code stores plugins under a different path, this check always evaluates false — `council:setup` reports "yellow-codex: NOT INSTALLED" even when the plugin is fully installed, leading users to believe the Codex reviewer is unavailable when it isn't. The `all.md` Step 1 block detects installed plugins via a python-based `installed_plugins` variable rather than a hardcoded path; a similar approach here would be more robust.

### Issue 3 of 3
docs/spikes/opencode-cli-format-json-2026-05-04.md:58-68
**Session ID extraction jq expression is inconsistent with the implementation plan**

This spike (line 68) uses `jq -r 'first(.sessionID // empty)'`, accessing `.sessionID` at the top level of each JSONL event. The implementation plan (`plans/yellow-council-godmodeskill-integration.md`, task 2.3) instead specifies `select(.part.snapshot.sessionID) | .part.snapshot.sessionID` — a different object path. PR2 implementers referencing both documents risk picking the wrong expression, silently failing to extract the session ID and allowing sessions to accumulate in `~/.local/share/opencode/`. The spike is labeled "verified" and should be the authoritative source; the plan's expression should be corrected to match.


`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(yellow-council): correct jq SESSION\_..."](https://github.com/kinginyellows/yellow-plugins/commit/85a129fc3861f997eec9428151708e790b6dbad7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30734462)</sub>

<!-- /greptile_comment -->