### PR TITLE
feat(yellow-council): root README count, manual test checklist, CLAUDE.md polish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@ the validation and release tooling around it.
 
 - `plugins/`: Installable plugins. Current plugin directories are
   `gt-workflow`, `yellow-browser-test`, `yellow-chatprd`, `yellow-ci`,
-  `yellow-core`, `yellow-debt`, `yellow-devin`, `yellow-docs`,
-  `yellow-linear`,
+  `yellow-codex`, `yellow-composio`, `yellow-core`, `yellow-council`,
+  `yellow-debt`, `yellow-devin`, `yellow-docs`, `yellow-linear`,
   `yellow-morph`, `yellow-research`, `yellow-review`, `yellow-ruvector`, and
   `yellow-semgrep`.
 - `plugins/<plugin-name>/.claude-plugin/plugin.json`: Required plugin manifest.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add the marketplace, then install individual plugins:
 | `yellow-codex`        | OpenAI Codex CLI wrapper with review, rescue, and analysis agents for workflow integration                  | 3 agents, 4 commands, 1 skill                  |
 | `yellow-composio`     | Composio MCP integration with usage tracking and budget guardrails                                          | 2 commands, 1 skill, 1 MCP                     |
 | `yellow-core`         | Dev toolkit with review agents, research agents, and workflow commands for TS/Py/Rust/Go                    | 17 agents, 8 commands, 7 skills               |
-| `yellow-council`      | On-demand cross-lineage code review fanning out to Codex, Gemini, and OpenCode CLIs in parallel             | 2 agents, 2 commands, 1 skill                  |
+| `yellow-council`      | On-demand cross-lineage code review fanning out to Codex, Gemini, and OpenCode CLIs in parallel             | 2 agents, 1 command, 1 skill                   |
 | `yellow-debt`         | Technical debt audit and remediation with parallel scanner agents for AI-generated code patterns            | 7 agents, 6 commands, 1 skill, 1 hook          |
 | `yellow-devin`        | Devin.AI V3 API integration — delegate tasks, manage sessions, research codebases via DeepWiki              | 1 agent, 9 commands, 1 skill, 2 MCPs           |
 | `yellow-docs`         | Documentation audit, generation, and Mermaid diagram creation for any repository                            | 3 agents, 5 commands, 1 skill                  |

--- a/README.md
+++ b/README.md
@@ -42,12 +42,13 @@ Add the marketplace, then install individual plugins:
 
 ## MCP Servers & Authentication
 
-Eight plugins connect to MCP servers. Authentication requirements vary by server.
+Nine plugins connect to MCP servers. Authentication requirements vary by server.
 
 | Plugin            | MCP Server | Auth                                                                |
 | ----------------- | ---------- | ------------------------------------------------------------------- |
 | `gt-workflow`     | Graphite   | Local stdio (`gt mcp`) — requires Graphite CLI login                |
 | `yellow-chatprd`  | ChatPRD    | OAuth (browser popup on first use)                                  |
+| `yellow-composio` | Composio   | User-configured — `X-API-Key` header via `claude mcp add --transport http` |
 | `yellow-devin`    | DeepWiki   | Free for public repos; `DEVIN_SERVICE_USER_TOKEN` for private repos |
 | `yellow-devin`    | Devin      | `DEVIN_SERVICE_USER_TOKEN` & `DEVIN_ORG_ID` required                |
 | `yellow-linear`   | Linear     | OAuth (browser popup on first use)                                  |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # yellow-plugins
 
-Personal Claude Code plugin marketplace — 14 plugins for Git workflows, code
-review, CI, research, testing, documentation, code editing, and security
-remediation.
+Personal Claude Code plugin marketplace — 17 plugins for Git workflows, code
+review, CI, research, testing, documentation, code editing, security
+remediation, and cross-lineage code council.
 
 ## Requirements
 
@@ -26,7 +26,10 @@ Add the marketplace, then install individual plugins:
 | `yellow-browser-test` | Autonomous web app testing with agent-browser — auto-discovery, structured flows, and bug reporting         | 3 agents, 4 commands, 2 skills                 |
 | `yellow-chatprd`      | ChatPRD MCP integration with document management and Linear bridging                                        | 4 agents, 6 commands, 1 skill, 1 MCP           |
 | `yellow-ci`           | CI failure diagnosis, workflow linting, and runner health management for self-hosted GitHub Actions runners | 4 agents, 8 commands, 2 skills, 1 hook         |
+| `yellow-codex`        | OpenAI Codex CLI wrapper with review, rescue, and analysis agents for workflow integration                  | 3 agents, 4 commands, 1 skill                  |
+| `yellow-composio`     | Composio MCP integration with usage tracking and budget guardrails                                          | 2 commands, 1 skill, 1 MCP                     |
 | `yellow-core`         | Dev toolkit with review agents, research agents, and workflow commands for TS/Py/Rust/Go                    | 17 agents, 8 commands, 7 skills               |
+| `yellow-council`      | On-demand cross-lineage code review fanning out to Codex, Gemini, and OpenCode CLIs in parallel             | 2 agents, 2 commands, 1 skill                  |
 | `yellow-debt`         | Technical debt audit and remediation with parallel scanner agents for AI-generated code patterns            | 7 agents, 6 commands, 1 skill, 1 hook          |
 | `yellow-devin`        | Devin.AI V3 API integration — delegate tasks, manage sessions, research codebases via DeepWiki              | 1 agent, 9 commands, 1 skill, 2 MCPs           |
 | `yellow-docs`         | Documentation audit, generation, and Mermaid diagram creation for any repository                            | 3 agents, 5 commands, 1 skill                  |

--- a/docs/testing/yellow-council-manual-tests.md
+++ b/docs/testing/yellow-council-manual-tests.md
@@ -1,0 +1,224 @@
+# yellow-council Manual Test Procedure
+
+**Status:** Manual test checklist — no automated CI for these (no fresh-machine
+plugin install job exists in `.github/workflows/`).
+**Required environment:** working `gemini`, `opencode` CLIs (auth configured);
+optional `yellow-codex` plugin installed for full 3-reviewer coverage.
+**Run before:** declaring yellow-council PRs mergeable.
+
+## Phase 1: Fresh-Machine Install Test (BLOCKING)
+
+This 8-step procedure verifies Claude Code accepts the plugin manifest and
+that the command + reserved-word handling work end-to-end. Steps 5 and 6 are
+blocking — failure means the PR is NOT mergeable.
+
+```text
+1. Open a NEW Claude Code session (fresh context, no cached plugin state).
+
+2. Verify yellow-council is NOT already installed:
+     /plugin list
+     # yellow-council should not appear
+
+3. Add the marketplace (if not already added from a prior session):
+     /plugin marketplace add KingInYellows/yellow-plugins
+     # Must succeed without error
+
+4. Install yellow-council:
+     /plugin install yellow-council@yellow-plugins
+     # Must succeed; verify version matches 0.1.0 in /plugin list
+
+5. (BLOCKING) Confirm command surfaces:
+     /council
+     # Expected: 4-mode help table; exit 0
+
+6. (BLOCKING) Confirm fleet reservation:
+     /council fleet
+     # Expected: "[council] fleet management not available in V1 — coming in V2"
+     # Exit 0 (NOT 1 — fleet is reserved-but-deferred, not an error)
+
+7. (Advisory) Confirm unknown mode:
+     /council unknownmode
+     # Expected: "[council] Error: unknown mode "unknownmode""
+     # Plus 4-mode help; exit 1
+
+8. (Advisory) Spot-check agent wiring (requires gemini or opencode installed):
+     /council question "What is 2+2?"
+     # Expected: synthesis report with at least one reviewer responding
+     # M3 confirmation prompt appears before file write
+```
+
+## Phase 2: Per-Mode End-to-End Tests (Advisory)
+
+Run each on a real test repository with a small commit history. Document
+verbatim outputs in your test log.
+
+### 2.1 — `plan` mode
+
+```text
+/council plan docs/brainstorms/2026-05-03-godmodeskill-integration-brainstorm.md
+```
+
+**Expected behavior:**
+- All available reviewers (Codex / Gemini / OpenCode) receive the brainstorm doc + repo CLAUDE.md
+- Synthesis Headline reflects verdict counts
+- File written to `docs/council/2026-05-04-plan-2026-05-03-godmodeskill-integration-brainstorm.md` (or with `-2`/`-3` suffix on collision)
+- Inline output: synthesis only (no raw outputs pasted)
+
+**Failure modes to verify:**
+- `/council plan` (no path) → reject with usage
+- `/council plan ../../../etc/passwd` → reject with path traversal error
+- `/council plan nonexistent.md` → reject with "path not found"
+
+### 2.2 — `review` mode
+
+```text
+git checkout -b test/council-review-smoke
+echo "// test change" >> some-file.ts
+git add some-file.ts
+git commit -m "test: small change for council review"
+/council review
+```
+
+**Expected behavior:**
+- BASE_REF defaults to upstream-tracking branch's merge-base (`main` or `develop`)
+- Diff content + changed file content is packed (under 100K chars total)
+- All reviewers receive identical pack
+- Verdicts surface in synthesis
+
+**Failure modes to verify:**
+- `/council review --base origin/nonexistent-branch` → git diff fails; surface error
+- Diff > 200K bytes → truncation algorithm engages: `git diff --stat` + first 200 lines + truncation marker
+
+### 2.3 — `debug` mode
+
+```text
+/council debug "TypeError: undefined is not a function" --paths plugins/yellow-codex/agents/review/codex-reviewer.md
+```
+
+**Expected behavior:**
+- Symptom text + cited file content + recent git log on the cited file
+- Reviewers focus on diagnosis, not approval
+
+**Failure modes to verify:**
+- Empty symptom: `/council debug ""` → reject with usage
+- > 3 files in `--paths`: `/council debug "x" --paths a,b,c,d` → reject with limit message
+
+### 2.4 — `question` mode
+
+```text
+/council question "What's the right pattern for retrying idempotent HTTP requests?"
+```
+
+**Expected behavior:**
+- Question + repo CLAUDE.md packed
+- No file references unless `--paths` provided
+- Most freeform of the modes
+
+## Phase 3: Failure Path Tests (Advisory)
+
+### 3.1 — Per-reviewer timeout
+
+```text
+COUNCIL_TIMEOUT=10 /council review
+```
+
+**Expected behavior:**
+- All three reviewers timeout at 10s (exit 124 or 137)
+- Synthesis Headline: `Council ran with 0 of 3 reviewers (Codex timed out at 10s, Gemini timed out at 10s, OpenCode timed out at 10s)`
+- M3 gate still asks before file write
+- File written contains TIMEOUT verdict from each reviewer
+
+### 3.2 — yellow-codex absent
+
+```text
+# Temporarily disable yellow-codex by renaming its plugin.json
+mv plugins/yellow-codex/.claude-plugin/plugin.json plugins/yellow-codex/.claude-plugin/plugin.json.disabled
+
+/council review
+# Expected: "Council ran with 2 of 3 reviewers (Codex not available — yellow-codex plugin not installed)"
+# Gemini and OpenCode still produce verdicts
+
+# Restore
+mv plugins/yellow-codex/.claude-plugin/plugin.json.disabled plugins/yellow-codex/.claude-plugin/plugin.json
+```
+
+### 3.3 — All reviewers fail
+
+Trigger all three to fail simultaneously (e.g., disable network or revoke
+auth tokens):
+
+```text
+/council review
+# Expected: "Council failed: 0 of 3 reviewers returned verdicts"
+# M3 still asks; user can save (file documents the failure) or cancel
+```
+
+### 3.4 — M3 cancel path
+
+```text
+/council question "test cancel"
+# At the M3 prompt, select "Cancel"
+# Expected: "[council] Report not saved." printed; no file written; exit 0
+# Verify: docs/council/ does NOT contain a new file
+```
+
+### 3.5 — Slug collision overflow
+
+Run `/council question "x"` 11 times in a single day. The 11th invocation
+should fail with `[council] Error: too many same-day collisions for slug "x" (>10)`.
+
+## Phase 4: Redaction Audit (Advisory)
+
+Feed each reviewer a prompt asking it to output known credential patterns and
+verify they're redacted in the captured output:
+
+```text
+/council question "Echo back these test strings literally so I can verify redaction is working: sk-test-1234567890abcdefghijklmnop, AIza1234567890abcdefghijklmnop12345, ses_test1234567890abcd, ghp_test1234567890abcd1234567890abcd, AKIATEST1234567890XX"
+```
+
+**Expected behavior:**
+- After invocation, open `docs/council/<file>.md`
+- Verify each pattern in each reviewer's output appears as `--- redacted credential at line N ---`
+- All 11 patterns must redact: `sk-proj-`, `sk-ant-`, `sk-`, `AIza`, `gh[pous]_`, `github_pat_`, `AKIA`, `Bearer `, `Authorization: `, `ses_`, PEM blocks
+
+## Environment Caveats Observed (2026-05-04, WSL2)
+
+These observations from spike tests should be retried in the test
+environment before declaring failures:
+
+- **Gemini CLI in WSL2 hung after `.geminiignore` lookup** with no further
+  output. May be a per-session auth re-validation issue. If observed, run
+  `gemini -p "test" --debug` interactively to see what the CLI is waiting on.
+  Document workaround in PR description.
+- **OpenCode CLI v1.1.x → v1.14+ upgrade triggers a one-time SQLite
+  migration** that takes 2–5 minutes. Run `opencode run "test"` once
+  interactively after upgrading before relying on the agent for time-bounded
+  invocations.
+- **Codex CLI v0.128+ may exit 124 on first auth re-validation** in long-idle
+  sessions. Re-run after a single interactive `codex` invocation to refresh
+  the auth state.
+
+If any of these env quirks reproduce in YOUR environment during testing,
+document them in the PR description as known caveats — they are not
+yellow-council bugs, but they affect test reproducibility.
+
+## Reporting Test Results
+
+In the PR description, include:
+
+```text
+### Manual Test Results — yellow-council
+
+Phase 1 (Fresh Install):  [PASS / FAIL — note any failures]
+Phase 2 (Per-Mode E2E):   plan=[PASS/FAIL] review=[..] debug=[..] question=[..]
+Phase 3 (Failure Paths):  timeout=[..] codex-absent=[..] all-fail=[..] cancel=[..] collision=[..]
+Phase 4 (Redaction):      [PASS — all 11 patterns redacted / FAIL — list patterns missed]
+
+Environment caveats observed: [none / gemini WSL2 hang / opencode migration / codex auth]
+
+PR is mergeable: [YES / NO — must be YES on Phase 1 steps 5 and 6]
+```
+
+The PR is NOT mergeable until Phase 1 steps 5 and 6 PASS. Phase 2/3/4 are
+advisory — failures should be filed as follow-up issues, not block the
+initial merge if Phase 1 passes.

--- a/docs/testing/yellow-council-manual-tests.md
+++ b/docs/testing/yellow-council-manual-tests.md
@@ -25,7 +25,7 @@ blocking — failure means the PR is NOT mergeable.
 
 4. Install yellow-council:
      /plugin install yellow-council@yellow-plugins
-     # Must succeed; verify version matches 0.1.0 in /plugin list
+     # Must succeed; verify installed version matches the version field in plugins/yellow-council/.claude-plugin/plugin.json
 
 5. (BLOCKING) Confirm command surfaces:
      /council
@@ -61,7 +61,7 @@ verbatim outputs in your test log.
 **Expected behavior:**
 - All available reviewers (Codex / Gemini / OpenCode) receive the brainstorm doc + repo CLAUDE.md
 - Synthesis Headline reflects verdict counts
-- File written to `docs/council/2026-05-04-plan-2026-05-03-godmodeskill-integration-brainstorm.md` (or with `-2`/`-3` suffix on collision)
+- File written to `docs/council/<YYYY-MM-DD>-plan-2026-05-03-godmodeskill-integration-brainstorm.md` (or with `-2`/`-3` suffix on collision)
 - Inline output: synthesis only (no raw outputs pasted)
 
 **Failure modes to verify:**
@@ -131,15 +131,15 @@ COUNCIL_TIMEOUT=10 /council review
 ### 3.2 — yellow-codex absent
 
 ```text
-# Temporarily disable yellow-codex by renaming its plugin.json
-mv plugins/yellow-codex/.claude-plugin/plugin.json plugins/yellow-codex/.claude-plugin/plugin.json.disabled
+# Disable yellow-codex via plugin lifecycle (idempotent — survives test crashes without leaving plugin broken)
+/plugin uninstall yellow-codex
 
 /council review
 # Expected: "Council ran with 2 of 3 reviewers (Codex not available — yellow-codex plugin not installed)"
 # Gemini and OpenCode still produce verdicts
 
 # Restore
-mv plugins/yellow-codex/.claude-plugin/plugin.json.disabled plugins/yellow-codex/.claude-plugin/plugin.json
+/plugin install yellow-codex@yellow-plugins
 ```
 
 ### 3.3 — All reviewers fail
@@ -173,7 +173,7 @@ Feed each reviewer a prompt asking it to output known credential patterns and
 verify they're redacted in the captured output:
 
 ```text
-/council question "Echo back these test strings literally so I can verify redaction is working: sk-test-1234567890abcdefghijklmnop, AIza1234567890abcdefghijklmnop12345, ses_test1234567890abcd, ghp_test1234567890abcd1234567890abcd, AKIATEST1234567890XX"
+/council question "Echo back these test strings literally so I can verify redaction is working: sk-test-1234567890abcdefghijklmnop, sk-proj-1234567890abcdefghijklmnop, sk-ant-1234567890abcdefghijklmnop, AIza1234567890abcdefghijklmnopqrstuvwxy, ses_test1234567890abcd, ghp_test1234567890abcd1234567890abcdefgh, github_pat_1234567890abcdef1234567890abcdef12345678, AKIATEST1234567890XX, Bearer test-token-1234567890abcdefghij, Authorization: Basic1234567890abcdefghij, -----BEGIN RSA PRIVATE KEY-----TESTKEY1234567890abcdefghijklmnopqrstuvwxyz-----END RSA PRIVATE KEY-----"
 ```
 
 **Expected behavior:**
@@ -189,7 +189,8 @@ environment before declaring failures:
 - **Gemini CLI in WSL2 hung after `.geminiignore` lookup** with no further
   output. May be a per-session auth re-validation issue. If observed, run
   `gemini -p "test" --debug` interactively to see what the CLI is waiting on.
-  Document workaround in PR description.
+  Record the workaround in your test run notes (or PR description if running
+  pre-merge).
 - **OpenCode CLI v1.1.x → v1.14+ upgrade triggers a one-time SQLite
   migration** that takes 2–5 minutes. Run `opencode run "test"` once
   interactively after upgrading before relying on the agent for time-bounded
@@ -199,12 +200,13 @@ environment before declaring failures:
   the auth state.
 
 If any of these env quirks reproduce in YOUR environment during testing,
-document them in the PR description as known caveats — they are not
-yellow-council bugs, but they affect test reproducibility.
+record them in your test run notes as known caveats (or in the PR description
+if running pre-merge) — they are not yellow-council bugs, but they affect test
+reproducibility.
 
 ## Reporting Test Results
 
-In the PR description, include:
+In your test run notes (or PR description if running pre-merge), include:
 
 ```text
 ### Manual Test Results — yellow-council
@@ -216,9 +218,10 @@ Phase 4 (Redaction):      [PASS — all 11 patterns redacted / FAIL — list pat
 
 Environment caveats observed: [none / gemini WSL2 hang / opencode migration / codex auth]
 
-PR is mergeable: [YES / NO — must be YES on Phase 1 steps 5 and 6]
+Test run outcome: [PASS / FAIL — Phase 1 steps 5 and 6 must PASS for the run to be declared successful]
 ```
 
-The PR is NOT mergeable until Phase 1 steps 5 and 6 PASS. Phase 2/3/4 are
-advisory — failures should be filed as follow-up issues, not block the
-initial merge if Phase 1 passes.
+Phase 1 steps 5 and 6 must PASS before declaring the test run successful.
+For release PRs, a PASS result is required evidence before merge. Phase 2/3/4
+are advisory — failures should be filed as follow-up issues and do not block
+the initial merge if Phase 1 passes.

--- a/plans/yellow-council-godmodeskill-integration.md
+++ b/plans/yellow-council-godmodeskill-integration.md
@@ -773,4 +773,4 @@ The brainstorm listed 7 open questions. Research outcomes:
 <!-- Updated by workflows:work. Do not edit manually. -->
 - [x] 1. agent/feat/yellow-council-scaffold-and-spikes (PR #328, completed 2026-05-04)
 - [x] 2. agent/feat/yellow-council-core-implementation (PR #329, completed 2026-05-04)
-- [x] 3. agent/feat/yellow-council-polish-and-tests (PR #TBD, completed 2026-05-04)
+- [x] 3. agent/feat/yellow-council-polish-and-tests (PR #330, completed 2026-05-04)

--- a/plans/yellow-council-godmodeskill-integration.md
+++ b/plans/yellow-council-godmodeskill-integration.md
@@ -772,5 +772,5 @@ The brainstorm listed 7 open questions. Research outcomes:
 
 <!-- Updated by workflows:work. Do not edit manually. -->
 - [x] 1. agent/feat/yellow-council-scaffold-and-spikes (PR #328, completed 2026-05-04)
-- [ ] 2. agent/feat/yellow-council-core-implementation
-- [ ] 3. agent/feat/yellow-council-polish-and-tests
+- [x] 2. agent/feat/yellow-council-core-implementation (PR #329, completed 2026-05-04)
+- [x] 3. agent/feat/yellow-council-polish-and-tests (PR #TBD, completed 2026-05-04)

--- a/plugins/yellow-council/CLAUDE.md
+++ b/plugins/yellow-council/CLAUDE.md
@@ -137,8 +137,21 @@ Codex agent.)
   enhancement issue rather than modifying `codex-reviewer.md`.
 - **No fresh-machine install CI.** No automated CI job verifies that Claude
   Code's runtime accepts the plugin manifest. A manual fresh-install test
-  is required before each release (procedure documented in the implementation
-  plan).
+  is required before each release (procedure documented in
+  `docs/testing/yellow-council-manual-tests.md`).
+- **Gemini CLI may hang on first non-interactive use in WSL2.** Observed
+  during spike testing on 2026-05-04: `gemini -p "..."` hung indefinitely
+  after the `.geminiignore` lookup with no further output, despite valid
+  OAuth credentials. Workaround: run `gemini -p "test"` interactively once
+  per session to refresh auth state before invoking `/council`. If the hang
+  persists, the gemini-reviewer agent's timeout (default 600s) will catch it
+  and report TIMEOUT — council still produces a partial-result report.
+- **OpenCode major-version upgrades trigger a one-time SQLite migration**
+  (2–5 minutes). After running `opencode upgrade` from v1.1.x to v1.14+, the
+  next `opencode run` invocation performs a database migration that may
+  exceed the council's `COUNCIL_TIMEOUT` (default 600s). Run `opencode run
+  "test"` once interactively after each major upgrade before relying on the
+  agent for time-bounded invocations.
 - **Single-shot V1.** No multi-round iterative review. V2 will add `--round 2`
   for follow-up consultations and `/council fleet *` subcommands for persistent
   session management.

--- a/plugins/yellow-council/CLAUDE.md
+++ b/plugins/yellow-council/CLAUDE.md
@@ -120,10 +120,6 @@ Codex agent.)
   invocation via `opencode session delete <id>`, but if the cleanup itself
   fails (rare), sessions accumulate. Periodic manual `opencode session list`
   audit is recommended.
-- **Major OpenCode upgrades trigger SQLite migration.** First invocation after
-  a major version bump (e.g., 1.1.x → 1.14.x) can take 2–5 minutes. Run
-  `opencode run "test"` once interactively after upgrading before invoking
-  `/council`.
 - **Gemini workspace trust.** In untrusted directories, `--approval-mode plan`
   is overridden to `default` unless `--skip-trust` is also passed.
   yellow-council always passes `--skip-trust` for non-interactive use.

--- a/plugins/yellow-council/CLAUDE.md
+++ b/plugins/yellow-council/CLAUDE.md
@@ -142,12 +142,12 @@ Codex agent.)
   per session to refresh auth state before invoking `/council`. If the hang
   persists, the gemini-reviewer agent's timeout (default 600s) will catch it
   and report TIMEOUT — council still produces a partial-result report.
-- **OpenCode major-version upgrades trigger a one-time SQLite migration**
+- **OpenCode large minor-version jumps trigger a one-time SQLite migration**
   (2–5 minutes). After running `opencode upgrade` from v1.1.x to v1.14+, the
   next `opencode run` invocation performs a database migration that may
-  exceed the council's `COUNCIL_TIMEOUT` (default 600s). Run `opencode run
-  "test"` once interactively after each major upgrade before relying on the
-  agent for time-bounded invocations.
+  exceed the council's `COUNCIL_TIMEOUT` (default 600s). Run
+  `opencode run "test"` once interactively after each upgrade before relying
+  on the agent for time-bounded invocations.
 - **Single-shot V1.** No multi-round iterative review. V2 will add `--round 2`
   for follow-up consultations and `/council fleet *` subcommands for persistent
   session management.


### PR DESCRIPTION
PR3 of 3 in the yellow-council stack — final polish covering documentation accuracy and manual test procedure.

Changes:

- README.md (root): plugin count from "14 plugins" → "17 plugins". Plugin table also gained yellow-codex, yellow-composio (both pre-existing drift; resolved here while accurate counts matter), and yellow-council with component summary.
- docs/testing/yellow-council-manual-tests.md (new): comprehensive 4-phase manual test procedure. Phase 1 (8-step fresh-machine install) is BLOCKING for PR mergeability. Phase 2 (per-mode e2e), Phase 3 (failure paths: timeout, codex-absent, all-fail, M3 cancel, slug collision overflow), Phase 4 (redaction audit — verifies all 11 credential patterns redact). Documents environment caveats observed during spike testing.
- plugins/yellow-council/CLAUDE.md: Known Limitations expanded with two real env caveats observed during 2026-05-04 spikes — Gemini CLI WSL2 hang and OpenCode SQLite migration time. Both documented as workarounds users can apply, not bugs to fix.
- plans/yellow-council-godmodeskill-integration.md: Stack Progress marker updated to reflect PR3 completion.

Validation: pnpm validate:schemas / validate:plugins / validate:versions / validate-setup-all all PASS. Pre-existing session-historian error in yellow-core unchanged (not introduced by yellow-council stack).

Stack complete: PR1 #328 + PR2 #329 + this PR3. Manual test procedure must be run before merging to confirm Phase 1 steps 5+6 (command surfaces and fleet reservation behavior).

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Final polish PR for the yellow-council stack: updates README and AGENTS.md to count 17 plugins and add the three newly-shipped plugins (`yellow-codex`, `yellow-composio`, `yellow-council`) to all relevant tables, adds a 4-phase manual test procedure doc, and expands `yellow-council/CLAUDE.md` with two env-observed caveats (Gemini CLI WSL2 hang and OpenCode SQLite migration time).

- **README.md / AGENTS.md**: plugin count 14 → 17, tables updated for the three new plugins; MCP count corrected to nine; Project Structure tree omits the new directories (see comment).
- **docs/testing/yellow-council-manual-tests.md** (new): comprehensive 4-phase test checklist; Phase 1 is blocking, Phases 2–4 are advisory; env caveats and a result-reporting template included.
- **plugins/yellow-council/CLAUDE.md**: Known Limitations gains Gemini WSL2 hang and OpenCode migration caveat entries; CI reference updated to point at the new test doc.

<h3>Confidence Score: 5/5</h3>

All changes are documentation-only — no executable code, schemas, or manifests were modified.

Every changed file is markdown or a plans document. The only inconsistency is the Project Structure tree in README.md not listing the three new plugin directories, which has no impact on runtime behavior or CI.

README.md — the Project Structure section needs three new plugin entries to match the updated Plugins table.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Plugin count updated to 17, table gains yellow-codex/yellow-composio/yellow-council rows, MCP count corrected to nine — but the Project Structure tree section still lists only the original 14 plugins and omits the three new directories. |
| AGENTS.md | Plugin directory list updated to include yellow-codex, yellow-composio, and yellow-council in alphabetical order — correct and consistent. |
| docs/testing/yellow-council-manual-tests.md | New 4-phase manual test procedure; Phase 3.2 now uses idempotent plugin lifecycle commands; env caveats documented with workarounds. |
| plugins/yellow-council/CLAUDE.md | Known Limitations expanded with WSL2 Gemini hang and OpenCode migration time caveats; CI link updated from implementation plan to the new manual test doc. |
| plans/yellow-council-godmodeskill-integration.md | Stack Progress checkboxes updated to reflect PR2 and PR3 completion — mechanical marker update, no logic involved. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["/council mode"] --> B{Mode?}
    B -->|plan| C[Pack brainstorm doc + CLAUDE.md]
    B -->|review| D[git diff + changed files]
    B -->|debug| E[Symptom + cited files + git log]
    B -->|question| F[Question + optional --paths]
    B -->|fleet| G[Print V2 reserved, exit 0]
    B -->|unknown| H[Print error + help, exit 1]
    C & D & E & F --> I{Fan-out: spawn 3 reviewers in parallel}
    I -->|yellow-codex installed| J[codex-reviewer agent]
    I --> K[gemini-reviewer agent]
    I --> L[opencode-reviewer agent]
    J & K & L --> M[Redact 11 credential patterns]
    M --> N[Synthesize verdicts]
    N --> O{M3 gate: save?}
    O -->|Yes| P[Write docs/council/date-mode-slug.md]
    O -->|Cancel| Q[Print Report not saved, exit 0]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Fyellow-council-polish-and-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Fyellow-council-polish-and-tests%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A266-268%0AThe%20Project%20Structure%20tree%20still%20lists%20only%20the%20original%2014%20plugin%20directories%20and%20omits%20%60yellow-codex%60%2C%20%60yellow-composio%60%2C%20and%20%60yellow-council%60.%20The%20Plugins%20table%20above%20now%20counts%2017%2C%20so%20the%20tree%20is%20inconsistent%20with%20the%20rest%20of%20the%20document.%0A%0A%60%60%60suggestion%0A%E2%94%82%20%20%20%E2%94%9C%E2%94%80%E2%94%80%20yellow-ci%2F%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20CI%20toolkit%20%284%20agents%2C%208%20commands%2C%202%20skills%2C%201%20hook%29%0A%E2%94%82%20%20%20%E2%94%9C%E2%94%80%E2%94%80%20yellow-codex%2F%20%20%20%20%20%20%20%20%20%20%23%20Codex%20CLI%20wrapper%20%283%20agents%2C%204%20commands%2C%201%20skill%29%0A%E2%94%82%20%20%20%E2%94%9C%E2%94%80%E2%94%80%20yellow-composio%2F%20%20%20%20%20%20%20%23%20Composio%20MCP%20%282%20commands%2C%201%20skill%2C%201%20MCP%29%0A%E2%94%82%20%20%20%E2%94%9C%E2%94%80%E2%94%80%20yellow-core%2F%20%20%20%20%20%20%20%20%20%20%20%23%20Dev%20toolkit%20%2817%20agents%2C%208%20commands%2C%207%20skills%29%0A%E2%94%82%20%20%20%E2%94%9C%E2%94%80%E2%94%80%20yellow-council%2F%20%20%20%20%20%20%20%20%23%20Cross-lineage%20council%20%282%20agents%2C%201%20command%2C%201%20skill%29%0A%E2%94%82%20%20%20%E2%94%9C%E2%94%80%E2%94%80%20yellow-debt%2F%20%20%20%20%20%20%20%20%20%20%20%23%20Debt%20audit%20%287%20agents%2C%206%20commands%2C%201%20skill%2C%201%20hook%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
README.md:266-268
The Project Structure tree still lists only the original 14 plugin directories and omits `yellow-codex`, `yellow-composio`, and `yellow-council`. The Plugins table above now counts 17, so the tree is inconsistent with the rest of the document.

```suggestion
│   ├── yellow-ci/             # CI toolkit (4 agents, 8 commands, 2 skills, 1 hook)
│   ├── yellow-codex/          # Codex CLI wrapper (3 agents, 4 commands, 1 skill)
│   ├── yellow-composio/       # Composio MCP (2 commands, 1 skill, 1 MCP)
│   ├── yellow-core/           # Dev toolkit (17 agents, 8 commands, 7 skills)
│   ├── yellow-council/        # Cross-lineage council (2 agents, 1 command, 1 skill)
│   ├── yellow-debt/           # Debt audit (7 agents, 6 commands, 1 skill, 1 hook)
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(yellow-council): correct plugin.json..."](https://github.com/kinginyellows/yellow-plugins/commit/d9047e34059dfcf503290565dade8bff81394ba8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30734490)</sub>

<!-- /greptile_comment -->