### PR TITLE
chore(docs): compound 8 learnings from yellow-council Wave-2 review (PRs #328-#330)

### DIFF
--- a/docs/solutions/code-quality/bash-block-subshell-isolation-in-command-files.md
+++ b/docs/solutions/code-quality/bash-block-subshell-isolation-in-command-files.md
@@ -191,3 +191,95 @@ Add to command file review checklist:
 - `docs/solutions/code-quality/claude-code-command-authoring-anti-patterns.md` — Section 15
   covers the variable-survival angle of this same root cause (PR #74)
 - MEMORY.md: "**$VAR in bash code blocks (from PR #74)**" entry in Command File Anti-Patterns
+
+---
+
+## Update — 2026-05-04
+
+### Status / Summary Blocks Are the Most Common Site of Cross-Block Variable Loss (PRs #328–#330)
+
+Yellow-council's `setup.md` (Step 5 summary block) referenced
+`$READY_COUNT`, `$GEMINI_STATUS`, `$OPENCODE_STATUS`, and `$CODEX_STATUS` —
+all of which were meant to be assigned in Steps 2–4. Because each step runs
+as a separate Bash tool call (a fresh subprocess), all four variables are
+unset in Step 5. The summary block silently printed "0 of 3 reviewers ready /
+NOT READY" regardless of actual install state.
+
+Five reviewers flagged this in the same wave. It is the single most common
+concretization of the cross-block isolation bug: **setup/install command files
+almost always have a final summary step that consolidates status across prior
+steps, and that summary step always runs in a fresh subprocess.**
+
+#### Concretization: the setup summary anti-pattern
+
+```bash
+# Step 2 — fresh subprocess
+GEMINI_STATUS="ok"
+echo "gemini: $GEMINI_STATUS"
+
+# Step 3 — fresh subprocess
+OPENCODE_STATUS="ok"
+echo "opencode: $OPENCODE_STATUS"
+
+# Step 5 — DIFFERENT fresh subprocess; $GEMINI_STATUS and $OPENCODE_STATUS are unset
+READY_COUNT=0
+[ "$GEMINI_STATUS"  = "ok" ] && READY_COUNT=$((READY_COUNT + 1))   # always false
+[ "$OPENCODE_STATUS" = "ok" ] && READY_COUNT=$((READY_COUNT + 1))  # always false
+printf '%d of 3 reviewers ready\n' "$READY_COUNT"                   # always "0 of 3"
+```
+
+#### Three fixes, in order of preference
+
+**Fix A: Re-derive inline in the summary block**
+
+Each prior step writes a sentinel file (e.g., `touch /tmp/gemini-ok`) and the
+summary block checks for the files' existence:
+
+```bash
+# Step 2
+command -v gemini >/dev/null 2>&1 && touch /tmp/.council-gemini-ok || rm -f /tmp/.council-gemini-ok
+
+# Step 5 — re-derive from sentinel files
+READY_COUNT=0
+GEMINI_STATUS="NOT READY";  [ -f /tmp/.council-gemini-ok  ] && { GEMINI_STATUS="ok";  READY_COUNT=$((READY_COUNT + 1)); }
+OPENCODE_STATUS="NOT READY"; [ -f /tmp/.council-opencode-ok ] && { OPENCODE_STATUS="ok"; READY_COUNT=$((READY_COUNT + 1)); }
+printf 'gemini:   %s\nopencode:  %s\n%d of 3 ready\n' \
+  "$GEMINI_STATUS" "$OPENCODE_STATUS" "$READY_COUNT"
+```
+
+**Fix B: Persist to a state file and source it**
+
+```bash
+# Step 2
+STATE_FILE="/tmp/.council-setup-state.env"
+GEMINI_STATUS="ok"
+printf 'GEMINI_STATUS=%s\n' "$GEMINI_STATUS" >> "$STATE_FILE"
+
+# Step 5
+STATE_FILE="/tmp/.council-setup-state.env"
+[ -f "$STATE_FILE" ] && . "$STATE_FILE"
+# $GEMINI_STATUS, $OPENCODE_STATUS now available
+```
+
+**Fix C: Consolidate all steps into one Bash block**
+
+If the steps are fast and do not require separate user interaction between
+them, merge Steps 2–5 into a single Bash block. This is the simplest fix when
+the intermediate steps produce no output the user needs to act on.
+
+#### Detection
+
+When reviewing a multi-step setup or install command file, run:
+
+```bash
+# Find variables used in a later bash block that are set in an earlier one
+# (heuristic: look for variables referenced in "summary" or "Step N" blocks
+# where N > the step that sets them)
+rg 'READY_COUNT|_STATUS|INSTALLED_COUNT' plugins/ --include='*.md'
+```
+
+Checklist question: "Does any bash block in this file reference a variable
+that was only assigned in a prior code block (not the current one)?"
+
+If yes: apply Fix A (sentinel files), Fix B (state file), or Fix C (merge
+blocks) as appropriate.

--- a/docs/solutions/code-quality/bash-block-subshell-isolation-in-command-files.md
+++ b/docs/solutions/code-quality/bash-block-subshell-isolation-in-command-files.md
@@ -237,7 +237,11 @@ summary block checks for the files' existence:
 
 ```bash
 # Step 2
-command -v gemini >/dev/null 2>&1 && touch /tmp/.council-gemini-ok || rm -f /tmp/.council-gemini-ok
+if command -v gemini >/dev/null 2>&1; then
+  touch /tmp/.council-gemini-ok
+else
+  rm -f /tmp/.council-gemini-ok
+fi
 
 # Step 5 — re-derive from sentinel files
 READY_COUNT=0

--- a/docs/solutions/code-quality/bash-block-subshell-isolation-in-command-files.md
+++ b/docs/solutions/code-quality/bash-block-subshell-isolation-in-command-files.md
@@ -230,7 +230,7 @@ printf '%d of 3 reviewers ready\n' "$READY_COUNT"                   # always "0 
 
 #### Three fixes, in order of preference
 
-**Fix A: Re-derive inline in the summary block**
+##### Fix A: Re-derive inline in the summary block
 
 Each prior step writes a sentinel file (e.g., `touch /tmp/gemini-ok`) and the
 summary block checks for the files' existence:
@@ -251,7 +251,7 @@ printf 'gemini:   %s\nopencode:  %s\n%d of 3 ready\n' \
   "$GEMINI_STATUS" "$OPENCODE_STATUS" "$READY_COUNT"
 ```
 
-**Fix B: Persist to a state file and source it**
+##### Fix B: Persist to a state file and source it
 
 ```bash
 # Step 2
@@ -265,7 +265,7 @@ STATE_FILE="/tmp/.council-setup-state.env"
 # $GEMINI_STATUS, $OPENCODE_STATUS now available
 ```
 
-**Fix C: Consolidate all steps into one Bash block**
+##### Fix C: Consolidate all steps into one Bash block
 
 If the steps are fast and do not require separate user interaction between
 them, merge Steps 2–5 into a single Bash block. This is the simplest fix when

--- a/docs/solutions/code-quality/cat-file-argmax-inline-substitution-antipattern.md
+++ b/docs/solutions/code-quality/cat-file-argmax-inline-substitution-antipattern.md
@@ -1,0 +1,132 @@
+---
+title: "$(cat large-file)" Defeats Its Own ARG_MAX Safety Comment
+date: 2026-05-04
+category: code-quality
+track: bug
+problem: Inline $(cat "$FILE") as a shell argument is subject to ARG_MAX (~128KB per argument on Linux) — the very limit the pattern claims to avoid
+tags: [argmax, shell, cat, inline-substitution, command-authoring, large-file, reliability]
+components:
+  - plugins/yellow-council/agents/review/gemini-reviewer.md
+  - plugins/yellow-council/agents/review/opencode-reviewer.md
+---
+
+# `$(cat large-file)` Defeats Its Own ARG_MAX Safety Comment
+
+## Problem
+
+Two yellow-council reviewer agents contained this pattern:
+
+```bash
+# Pass file content — avoids shell argument size limits
+cat "$PACK_FILE" | timeout 120 gemini -p "$(cat "$PACK_FILE")"
+```
+
+This has two independent bugs:
+
+### Bug 1: Dead-code `cat |` pipe
+
+The `cat "$PACK_FILE" |` on the left feeds stdin to `gemini`. But `gemini`
+reads its prompt from the `-p` flag, not from stdin. The stdin pipe is
+completely ignored. The comment "avoids shell argument size limits" implicitly
+justifies the pipe (as if stdin avoids ARG_MAX) — but the actual argument
+delivery is through `-p "$(cat "$PACK_FILE")"`, not stdin.
+
+### Bug 2: `$(cat large-file)` IS subject to ARG_MAX
+
+`$(cat "$PACK_FILE")` is a command substitution. The result is passed as a
+single shell argument to `gemini -p`. On Linux, the kernel enforces a per-
+argument limit of approximately 128KB (`MAX_ARG_STRLEN`, not just total
+`ARG_MAX`). The agents set a pack budget of 100K characters — which approaches
+this limit and will silently truncate or fail when the pack is near-full.
+
+The comment claiming this pattern "avoids shell argument size limits" is wrong.
+Command substitution in `$(...)` constructs the value in memory and passes it
+as a single argument — fully subject to the per-argument limit.
+
+Five reviewers flagged this in the same review wave (correctness, reliability,
+comment-analyzer, security, adversarial roles).
+
+## Why This Matters
+
+Agents that review large pack files (diffs, concatenated source) approach the
+100K budget by design. Any pack over ~128KB will either:
+- Silently truncate the argument (kernel clips at `MAX_ARG_STRLEN`)
+- Cause `E2BIG` / argument-too-long error, crashing the review step
+
+Because the failure mode is silent truncation, the reviewer may produce a
+result that covers only part of the pack without any error surfacing.
+
+## Key Insight
+
+**Stdin redirection (`cmd < "$FILE"`) is the correct way to pass large file
+content.** It avoids argument limits entirely because the data goes through the
+file descriptor, not the argument vector. `$(cat "$FILE")` is identical to
+reading the file path directly — both are subject to the same limits.
+
+## Fix
+
+### Option A: stdin redirection (preferred when the tool supports it)
+
+```bash
+timeout 120 gemini < "$PACK_FILE"
+```
+
+If the tool reads prompt from stdin by default, this is the cleanest fix.
+
+### Option B: `--prompt-file` flag (preferred when the tool offers it)
+
+```bash
+timeout 120 gemini --prompt-file "$PACK_FILE"
+```
+
+File-path flags pass the path as an argument (a few hundred bytes) and the
+tool reads the file internally — no argument size limit applies.
+
+### Option C: process substitution with explicit stdin flag
+
+```bash
+timeout 120 gemini -p "$(cat "$PACK_FILE")"   # WRONG — still hits limit
+
+# If -p must be used and the tool doesn't have --prompt-file:
+# split: write prompt to temp file, then pass path
+PROMPT_TMP=$(mktemp)
+printf '%s\n%s' "$SYSTEM_PROMPT" "$(cat "$PACK_FILE")" > "$PROMPT_TMP"
+timeout 120 gemini --prompt-file "$PROMPT_TMP"
+rm -f "$PROMPT_TMP"
+```
+
+### Remove the misleading comment
+
+Any comment claiming `$(cat "$FILE")` avoids argument limits must be removed
+or corrected. The safe pattern is stdin or a file-path flag; document that
+instead.
+
+## Detection
+
+```bash
+# Find inline $(cat ...) passed as a command argument (not in assignments)
+rg '\$\(cat ' plugins/ --include='*.md' \
+  | grep -v '^\s*[A-Z_]*=' \
+  | grep -v '# .*read from'
+```
+
+When reviewing shell code that passes large file content:
+1. Check whether the delivery path is stdin (`< file`), file-path flag
+   (`--file`), or inline substitution (`$(cat file)`)
+2. If inline substitution: check the budget comments — any claim that it
+   "avoids ARG_MAX" is incorrect and must be removed
+
+## Prevention
+
+- [ ] Never use `$(cat "$LARGE_FILE")` as an inline argument when file content
+      may approach 64KB — use `< "$FILE"` or a `--prompt-file` flag
+- [ ] When a tool has both stdin and a `-p` flag, prefer stdin for large inputs
+- [ ] Delete or correct any comment claiming `$(cat ...)` avoids argument limits
+- [ ] Pack budget constants (e.g., 100K chars) should be compared against
+      the target tool's actual input method to confirm the budget is safe
+
+## Related Documentation
+
+- MEMORY.md: "Command File Anti-Patterns" section — `$VAR in bash code blocks`
+- `docs/solutions/code-quality/bash-block-subshell-isolation-in-command-files.md`
+  — related shell execution model issues in command files

--- a/docs/solutions/code-quality/cat-file-argmax-inline-substitution-antipattern.md
+++ b/docs/solutions/code-quality/cat-file-argmax-inline-substitution-antipattern.md
@@ -124,6 +124,7 @@ rg '\$\(cat ' plugins/ --include='*.md' \
 ```
 
 When reviewing shell code that passes large file content:
+
 1. Check whether the delivery path is stdin (`< file`), file-path flag
    (`--file`), or inline substitution (`$(cat file)`)
 2. If inline substitution: check the budget comments — any claim that it

--- a/docs/solutions/code-quality/cat-file-argmax-inline-substitution-antipattern.md
+++ b/docs/solutions/code-quality/cat-file-argmax-inline-substitution-antipattern.md
@@ -49,12 +49,11 @@ comment-analyzer, security, adversarial roles).
 ## Why This Matters
 
 Agents that review large pack files (diffs, concatenated source) approach the
-100K budget by design. Any pack over ~128KB will either:
-- Silently truncate the argument (kernel clips at `MAX_ARG_STRLEN`)
-- Cause `E2BIG` / argument-too-long error, crashing the review step
+100K budget by design. Any pack over ~128KB will exceed kernel limits and cause
+`execve` to fail with `E2BIG` (argument-too-long), crashing the review step.
 
-Because the failure mode is silent truncation, the reviewer may produce a
-result that covers only part of the pack without any error surfacing.
+Because the failure surfaces as a hard error rather than a graceful fallback,
+the review step aborts entirely — no partial result is returned.
 
 ## Key Insight
 
@@ -82,18 +81,32 @@ timeout 120 gemini --prompt-file "$PACK_FILE"
 File-path flags pass the path as an argument (a few hundred bytes) and the
 tool reads the file internally — no argument size limit applies.
 
-### Option C: process substitution with explicit stdin flag
+### Option C: build a temp file safely when `--prompt-file` is available
+
+When the tool supports `--prompt-file` and a system prompt must be prepended,
+write the combined content to the temp file without any command substitution.
+Use a process group to stream both parts directly — no `$(cat ...)` in
+argument position:
 
 ```bash
 timeout 120 gemini -p "$(cat "$PACK_FILE")"   # WRONG — still hits limit
 
-# If -p must be used and the tool doesn't have --prompt-file:
-# split: write prompt to temp file, then pass path
+# RIGHT — process group streams both parts into the temp file;
+# $(cat ...) never appears as a shell argument
 PROMPT_TMP=$(mktemp)
-printf '%s\n%s' "$SYSTEM_PROMPT" "$(cat "$PACK_FILE")" > "$PROMPT_TMP"
+{
+  printf '%s\n' "$SYSTEM_PROMPT"
+  cat "$PACK_FILE"
+} > "$PROMPT_TMP"
 timeout 120 gemini --prompt-file "$PROMPT_TMP"
 rm -f "$PROMPT_TMP"
 ```
+
+Note: `printf` is a bash builtin and is not subject to the kernel-level
+`execve` `MAX_ARG_STRLEN` limit for the system prompt string alone. The
+problem arises when `$(cat "$PACK_FILE")` is expanded as an argument —
+avoid that regardless of which command receives it, because future refactors
+may replace the builtin with an external command.
 
 ### Remove the misleading comment
 
@@ -106,7 +119,7 @@ instead.
 ```bash
 # Find inline $(cat ...) passed as a command argument (not in assignments)
 rg '\$\(cat ' plugins/ --include='*.md' \
-  | grep -v '^\s*[A-Z_]*=' \
+  | grep -Ev '^[[:space:]]*[A-Z_]*=' \
   | grep -v '# .*read from'
 ```
 

--- a/docs/solutions/code-quality/jq-select-filter-over-first-empty-for-jsonl.md
+++ b/docs/solutions/code-quality/jq-select-filter-over-first-empty-for-jsonl.md
@@ -1,0 +1,123 @@
+---
+title: Use jq select() Not first(expr // empty) for JSONL Field Extraction
+date: 2026-05-04
+category: code-quality
+track: bug
+problem: jq first(.field // empty) emits per-line errors on JSONL streams where most lines lack the field, producing unpredictable output even with 2>/dev/null
+tags: [jq, jsonl, select, first, shell, command-authoring, silent-failure, extraction]
+components:
+  - plugins/yellow-council/agents/review/opencode-reviewer.md
+---
+
+# Use `jq select()` Not `first(expr // empty)` for JSONL Field Extraction
+
+## Problem
+
+Yellow-council's opencode reviewer extracted a session ID from a JSONL output
+file using:
+
+```bash
+SESSION_ID=$(jq -r 'first(.part.snapshot.sessionID // empty)' "$OUTPUT_FILE" 2>/dev/null)
+```
+
+On a real JSONL stream, most lines are progress events, log entries, or other
+structured objects that do not have `.part.snapshot.sessionID`. For each such
+line, jq processes the expression `.part.snapshot.sessionID // empty` and
+finds the field absent. `first(... // empty)` emits no output for those lines
+but also generates a jq-internal error per line. The `2>/dev/null` suppresses
+all errors — including genuine parse failures — making the failure invisible.
+
+When many lines lack the field, jq's behavior under `first()` with an empty
+generator becomes implementation-dependent. In practice the result is either:
+- An empty string (session ID appears unset even when it exists later in the file)
+- Partial output from a line where the field exists but error recovery is off
+
+The `2>/dev/null` then guarantees no diagnostic is surfaced when things go
+wrong. The command silently returns empty and the session cleanup / session
+reference step silently no-ops.
+
+## Key Insight
+
+**`select(.field != null)` omits non-matching lines cleanly without erroring.**
+Pair it with `| head -1` to take the first match. This is the idiomatic jq
+pattern for "find the first line in a JSONL stream that has a field."
+
+`first(expr // empty)` is designed for in-memory JSON arrays, not streaming
+JSONL. On JSONL input it processes the entire file as a sequence of values and
+the `first()` semantics interact poorly with a generator that produces zero
+outputs on most inputs.
+
+## Fix
+
+```bash
+# WRONG: first() + empty on JSONL — per-line errors, unpredictable output
+SESSION_ID=$(jq -r 'first(.part.snapshot.sessionID // empty)' "$OUTPUT_FILE" 2>/dev/null)
+
+# CORRECT: select() filter skips non-matching lines without error
+SESSION_ID=$(jq -r 'select(.part.snapshot.sessionID != null) | .part.snapshot.sessionID' \
+  "$OUTPUT_FILE" 2>/dev/null | head -1)
+```
+
+The `select()` version:
+- Emits zero output for lines that lack the field (no error)
+- Emits the field value for lines that have it
+- `head -1` takes the first match, consistent with the original intent
+- `2>/dev/null` is still appropriate to suppress genuine parse errors on
+  malformed lines, but it no longer suppresses structural field-absence errors
+
+### Nested field path variant
+
+For deeply nested paths, the same pattern applies:
+
+```bash
+# Extract first occurrence of a nested field from JSONL
+VALUE=$(jq -r 'select(.a.b.c != null) | .a.b.c' "$FILE" 2>/dev/null | head -1)
+```
+
+### With a fallback
+
+If no matching line exists and a fallback is needed:
+
+```bash
+SESSION_ID=$(jq -r 'select(.part.snapshot.sessionID != null) | .part.snapshot.sessionID' \
+  "$OUTPUT_FILE" 2>/dev/null | head -1)
+SESSION_ID="${SESSION_ID:-}"   # explicit empty-string fallback
+```
+
+## Detection
+
+```bash
+# Find first(...// empty) patterns applied to file inputs (JSONL risk)
+rg "first\(.*//\s*empty\)" plugins/ --include='*.md'
+
+# Find jq invocations with 2>/dev/null that extract nested fields from files
+# (candidates for the suppressed-error pattern)
+rg "jq.*2>/dev/null.*\\.\\w+\\.\\w+" plugins/ --include='*.md'
+```
+
+When reviewing jq expressions that read JSONL files:
+1. If the expression uses `first()`: verify the input is a JSON array, not a
+   JSONL stream. For JSONL, use `select()` + `head -1` instead.
+2. If `2>/dev/null` is present: confirm that the suppressed errors are only
+   line-parse failures, not field-absence errors from `// empty` on mismatched
+   lines.
+
+## Prevention
+
+- [ ] JSONL field extraction always uses `select(.field != null) | .field` +
+      `head -1`, never `first(.field // empty)` on streaming input
+- [ ] `2>/dev/null` on jq commands is documented with a comment explaining
+      what errors are expected and why suppression is acceptable
+- [ ] When adding a new field extraction from a JSONL output file, prototype
+      the jq expression against a real sample file with mixed-schema lines
+      before adding to a command file
+
+## Related Documentation
+
+- MEMORY.md: "jq pipelines: always capture exit code" (GitHub GraphQL Shell
+  Patterns section) — complementary: always check exit code even when using
+  `2>/dev/null`
+- `docs/solutions/code-quality/claude-code-command-authoring-anti-patterns.md`
+  — broader shell anti-patterns in command files
+- `docs/solutions/integration-issues/gh-api-graphql-plugin-command-template.md`
+  — jq null guard patterns for GraphQL responses (analogous `select` usage)

--- a/docs/solutions/code-quality/jq-select-filter-over-first-empty-for-jsonl.md
+++ b/docs/solutions/code-quality/jq-select-filter-over-first-empty-for-jsonl.md
@@ -3,7 +3,7 @@ title: Use jq select() Not first(expr // empty) for JSONL Field Extraction
 date: 2026-05-04
 category: code-quality
 track: bug
-problem: jq first(.field // empty) emits per-line errors on JSONL streams where most lines lack the field, producing unpredictable output even with 2>/dev/null
+problem: jq first(.field // empty) on a JSONL stream errors when no line contains the field (empty generator), and 2>/dev/null silences genuine parse errors alongside it, producing unpredictable silent failures
 tags: [jq, jsonl, select, first, shell, command-authoring, silent-failure, extraction]
 components:
   - plugins/yellow-council/agents/review/opencode-reviewer.md
@@ -22,35 +22,40 @@ SESSION_ID=$(jq -r 'first(.part.snapshot.sessionID // empty)' "$OUTPUT_FILE" 2>/
 
 On a real JSONL stream, most lines are progress events, log entries, or other
 structured objects that do not have `.part.snapshot.sessionID`. For each such
-line, jq processes the expression `.part.snapshot.sessionID // empty` and
-finds the field absent. `first(... // empty)` emits no output for those lines
-but also generates a jq-internal error per line. The `2>/dev/null` suppresses
-all errors — including genuine parse failures — making the failure invisible.
+line, jq evaluates `.part.snapshot.sessionID` as `null`, and `// empty`
+converts that to `empty` — cleanly, without error. So the expression is
+not error-prone per line.
 
-When many lines lack the field, jq's behavior under `first()` with an empty
-generator becomes implementation-dependent. In practice the result is either:
-- An empty string (session ID appears unset even when it exists later in the file)
-- Partial output from a line where the field exists but error recovery is off
+The actual failure mode is different: if **no** line in the file contains the
+field, the generator inside `first()` produces zero outputs. `first()` with an
+empty generator emits a jq error (`null (null) has no keys` or similar, depending
+on jq version) and exits non-zero. The `2>/dev/null` suppresses that error
+alongside genuine JSONL parse failures on malformed lines, making both failure
+modes invisible. `SESSION_ID` is silently set to empty even when the field does
+exist further in the file or when the file itself is corrupt.
 
-The `2>/dev/null` then guarantees no diagnostic is surfaced when things go
-wrong. The command silently returns empty and the session cleanup / session
-reference step silently no-ops.
+A second, subtler problem: `first()` returns only one value. If the caller
+later needs all matching session IDs (e.g., for multi-session cleanup), the
+pattern silently drops all but the first without any indication that more
+matches were available.
 
 ## Key Insight
 
-**`select(.field != null)` omits non-matching lines cleanly without erroring.**
-Pair it with `| head -1` to take the first match. This is the idiomatic jq
-pattern for "find the first line in a JSONL stream that has a field."
+**`select(.field != null)` omits non-matching lines cleanly and emits the
+field value for every matching line.** Pair it with `| head -1` to take the
+first match, or omit `head -1` to collect all matches. This is the idiomatic
+jq pattern for "find lines in a JSONL stream that have a field."
 
-`first(expr // empty)` is designed for in-memory JSON arrays, not streaming
-JSONL. On JSONL input it processes the entire file as a sequence of values and
-the `first()` semantics interact poorly with a generator that produces zero
-outputs on most inputs.
+`first(expr // empty)` works correctly when at least one line matches, but
+errors when zero lines match (empty generator). It also returns only one value,
+hiding the availability of additional matches. `select()` avoids both problems:
+it never errors on field absence and naturally produces all matches, letting
+the caller decide how many to consume.
 
 ## Fix
 
 ```bash
-# WRONG: first() + empty on JSONL — per-line errors, unpredictable output
+# WRONG: first() + empty on JSONL — errors when no line matches, hides all-matches case
 SESSION_ID=$(jq -r 'first(.part.snapshot.sessionID // empty)' "$OUTPUT_FILE" 2>/dev/null)
 
 # CORRECT: select() filter skips non-matching lines without error
@@ -59,11 +64,11 @@ SESSION_ID=$(jq -r 'select(.part.snapshot.sessionID != null) | .part.snapshot.se
 ```
 
 The `select()` version:
-- Emits zero output for lines that lack the field (no error)
-- Emits the field value for lines that have it
-- `head -1` takes the first match, consistent with the original intent
+- Emits zero output for lines that lack the field (no error — field absence evaluates to `null` then filters out cleanly)
+- Emits the field value for every line that has it
+- `head -1` takes the first match, consistent with the original intent; omit it to collect all matches
 - `2>/dev/null` is still appropriate to suppress genuine parse errors on
-  malformed lines, but it no longer suppresses structural field-absence errors
+  malformed JSONL lines; unlike the `first()` pattern, there are no empty-generator errors for it to accidentally hide
 
 ### Nested field path variant
 
@@ -97,10 +102,12 @@ rg "jq.*2>/dev/null.*\\.\\w+\\.\\w+" plugins/ --include='*.md'
 
 When reviewing jq expressions that read JSONL files:
 1. If the expression uses `first()`: verify the input is a JSON array, not a
-   JSONL stream. For JSONL, use `select()` + `head -1` instead.
-2. If `2>/dev/null` is present: confirm that the suppressed errors are only
-   line-parse failures, not field-absence errors from `// empty` on mismatched
-   lines.
+   JSONL stream. For JSONL, use `select()` + `head -1` instead. `first()` errors
+   when zero lines match — which is a silent failure when `2>/dev/null` is also
+   present.
+2. If `2>/dev/null` is present: confirm it is only suppressing genuine JSONL
+   parse errors (malformed JSON lines). If `first(... // empty)` is also present,
+   it may also be silencing the empty-generator error, masking a real failure.
 
 ## Prevention
 

--- a/docs/solutions/code-quality/jq-select-filter-over-first-empty-for-jsonl.md
+++ b/docs/solutions/code-quality/jq-select-filter-over-first-empty-for-jsonl.md
@@ -64,6 +64,7 @@ SESSION_ID=$(jq -r 'select(.part.snapshot.sessionID != null) | .part.snapshot.se
 ```
 
 The `select()` version:
+
 - Emits zero output for lines that lack the field (no error — field absence evaluates to `null` then filters out cleanly)
 - Emits the field value for every line that has it
 - `head -1` takes the first match, consistent with the original intent; omit it to collect all matches
@@ -101,6 +102,7 @@ rg "jq.*2>/dev/null.*\\.\\w+\\.\\w+" plugins/ --include='*.md'
 ```
 
 When reviewing jq expressions that read JSONL files:
+
 1. If the expression uses `first()`: verify the input is a JSON array, not a
    JSONL stream. For JSONL, use `select()` + `head -1` instead. `first()` errors
    when zero lines match — which is a silent failure when `2>/dev/null` is also

--- a/docs/solutions/code-quality/shell-and-or-chain-operator-precedence-bugs.md
+++ b/docs/solutions/code-quality/shell-and-or-chain-operator-precedence-bugs.md
@@ -1,0 +1,125 @@
+---
+title: Shell && / || Chain Operator-Precedence Bugs in Guard-Then-Act Patterns
+date: 2026-05-04
+category: code-quality
+track: bug
+problem: "[ -n \"$VAR\" ] && cmd 2>/dev/null || warn fires the warning when $VAR is empty AND silently swallows cmd failures when $VAR is set"
+tags: [shell, operator-precedence, bash, guard, error-handling, silent-failure, command-authoring]
+components:
+  - plugins/yellow-council/agents/review/opencode-reviewer.md
+---
+
+# Shell `&&` / `||` Chain Operator-Precedence Bugs in Guard-Then-Act Patterns
+
+## Problem
+
+Yellow-council's opencode reviewer used this inline chain for session cleanup:
+
+```bash
+[ -n "$SESSION_ID" ] && opencode session delete "$SESSION_ID" 2>/dev/null || warn "cleanup failed"
+```
+
+This chain has two independent failure modes:
+
+### Failure mode 1: Warning fires on empty `$SESSION_ID`
+
+Shell operator precedence: `&&` and `||` are left-associative and equal
+precedence. The chain parses as:
+
+```
+( [ -n "$SESSION_ID" ] && opencode session delete "$SESSION_ID" 2>/dev/null ) || warn "..."
+```
+
+When `$SESSION_ID` is empty, `[ -n "" ]` exits 1. The `&&` short-circuits —
+`opencode session delete` does not run. The `||` then fires because the left
+side exited non-zero. `warn "cleanup failed"` runs with an empty session ID,
+producing a misleading warning that implies a delete attempt was made and
+failed.
+
+### Failure mode 2: `2>/dev/null` swallows delete errors before `||` sees them
+
+When `$SESSION_ID` is set and `opencode session delete` fails (e.g., session
+already gone, network error), the failure's stderr is silenced by
+`2>/dev/null`. The `||` is triggered by the non-zero exit code — so the
+warning *does* fire, but the original error message is gone. The operator
+can only see "cleanup failed" with no diagnostic information.
+
+Combined effect: the chain misreports in both the "empty variable" and "actual
+error" cases, and the two cases are indistinguishable from the warning message.
+
+## Key Insight
+
+**Never write `[ -n "$VAR" ] && cmd || handler` when the handler is intended
+only for cmd failure.** The `||` binds to the entire left side, not just `cmd`.
+
+The `&&`/`||` inline chain is safe only when:
+1. The guard condition is the first thing that can fail, AND
+2. Either branch of `||` is the correct response to ANY left-side failure,
+   including guard failures
+
+For guard-then-act-then-handle patterns, use `if/then/fi` which has explicit
+branch semantics.
+
+## Fix
+
+```bash
+# WRONG: || fires on empty $SESSION_ID too
+[ -n "$SESSION_ID" ] && opencode session delete "$SESSION_ID" 2>/dev/null || warn "cleanup failed"
+
+# CORRECT: explicit if guard separates "not set" from "delete failed"
+if [ -n "$SESSION_ID" ]; then
+  if ! opencode session delete "$SESSION_ID" 2>/dev/null; then
+    printf '[opencode-reviewer] Warning: session cleanup failed for %s\n' "$SESSION_ID" >&2
+  fi
+fi
+```
+
+If stderr from the delete command is useful for diagnosis, remove the
+`2>/dev/null` and redirect to stderr instead:
+
+```bash
+if [ -n "$SESSION_ID" ]; then
+  opencode session delete "$SESSION_ID" 2>&1 \
+    || printf '[opencode-reviewer] Warning: session cleanup failed for %s\n' "$SESSION_ID" >&2
+fi
+```
+
+## Detection
+
+```bash
+# Find inline && / || chains with a guard condition as the first element
+# These are candidates for the misfiring-on-empty-var pattern
+rg '\[ -[nz] "\$\w+"\s*\]\s*&&.*\|\|' plugins/ --include='*.md'
+
+# Broader: any && ... || chain (any of them may have this precedence issue)
+rg '&&.*2>/dev/null.*\|\|' plugins/ --include='*.md'
+```
+
+Checklist question when reviewing shell guards:
+
+1. Can the expression before `&&` fail for a reason OTHER than cmd failure?
+   (e.g., empty variable, missing file, unset env var)
+2. If yes: does the `||` handler make sense for that non-cmd-failure case?
+3. If no: refactor to `if/then/fi`
+
+## Prevention
+
+- [ ] Guard-then-act-then-warn patterns always use `if [ ... ]; then cmd; else warn; fi`
+      — never inline `[ ... ] && cmd || warn`
+- [ ] `2>/dev/null` is never placed between the action and its `||` error
+      handler — if stderr is suppressed, the handler must not claim it observed
+      an error
+- [ ] When reviewing cleanup/teardown code: trace every `||` back to its left
+      side and confirm the handler is appropriate for ALL ways the left side
+      can fail, not just the primary intended failure
+- [ ] Linter note: ShellCheck SC2015 flags `A && B || C` as potentially
+      unintended — enable SC2015 in CI for command files that contain shell code
+
+## Related Documentation
+
+- MEMORY.md: "Command File Anti-Patterns" section — existing `&&`/`||` entries
+  cover curl split and flag parsing; this extends to guard-condition misfiring
+- `docs/solutions/code-quality/bash-block-subshell-isolation-in-command-files.md`
+  — related shell execution pitfalls in command files
+- `docs/solutions/code-quality/claude-code-command-authoring-anti-patterns.md`
+  — broader command anti-patterns catalogue

--- a/docs/solutions/code-quality/shell-and-or-chain-operator-precedence-bugs.md
+++ b/docs/solutions/code-quality/shell-and-or-chain-operator-precedence-bugs.md
@@ -3,7 +3,7 @@ title: Shell && / || Chain Operator-Precedence Bugs in Guard-Then-Act Patterns
 date: 2026-05-04
 category: code-quality
 track: bug
-problem: "[ -n \"$VAR\" ] && cmd 2>/dev/null || warn fires the warning when $VAR is empty AND silently swallows cmd failures when $VAR is set"
+problem: "Guard-then-act && / || chains misfire on empty guards and silence errors"
 tags: [shell, operator-precedence, bash, guard, error-handling, silent-failure, command-authoring]
 components:
   - plugins/yellow-council/agents/review/opencode-reviewer.md
@@ -16,7 +16,9 @@ components:
 Yellow-council's opencode reviewer used this inline chain for session cleanup:
 
 ```bash
-[ -n "$SESSION_ID" ] && opencode session delete "$SESSION_ID" 2>/dev/null || warn "cleanup failed"
+[ -n "$SESSION_ID" ] && \
+  opencode session delete "$SESSION_ID" 2>/dev/null || \
+  warn "cleanup failed"
 ```
 
 This chain has two independent failure modes:
@@ -26,7 +28,7 @@ This chain has two independent failure modes:
 Shell operator precedence: `&&` and `||` are left-associative and equal
 precedence. The chain parses as:
 
-```
+```bash
 ( [ -n "$SESSION_ID" ] && opencode session delete "$SESSION_ID" 2>/dev/null ) || warn "..."
 ```
 
@@ -53,6 +55,7 @@ error" cases, and the two cases are indistinguishable from the warning message.
 only for cmd failure.** The `||` binds to the entire left side, not just `cmd`.
 
 The `&&`/`||` inline chain is safe only when:
+
 1. The guard condition is the first thing that can fail, AND
 2. Either branch of `||` is the correct response to ANY left-side failure,
    including guard failures
@@ -69,7 +72,8 @@ branch semantics.
 # CORRECT: explicit if guard separates "not set" from "delete failed"
 if [ -n "$SESSION_ID" ]; then
   if ! opencode session delete "$SESSION_ID" 2>/dev/null; then
-    printf '[opencode-reviewer] Warning: session cleanup failed for %s\n' "$SESSION_ID" >&2
+    printf '[opencode-reviewer] Warning: session cleanup failed for %s\n' \
+      "$SESSION_ID" >&2
   fi
 fi
 ```
@@ -104,8 +108,9 @@ Checklist question when reviewing shell guards:
 
 ## Prevention
 
-- [ ] Guard-then-act-then-warn patterns always use `if [ ... ]; then cmd; else warn; fi`
-      — never inline `[ ... ] && cmd || warn`
+- [ ] Guard-then-act-then-warn patterns use `if guard; then cmd || warn; fi`
+      — warn only when the command fails, not when the guard is empty/unset;
+      never inline `[ ... ] && cmd || warn`
 - [ ] `2>/dev/null` is never placed between the action and its `||` error
       handler — if stderr is suppressed, the handler must not claim it observed
       an error

--- a/docs/solutions/code-quality/shell-and-or-chain-operator-precedence-bugs.md
+++ b/docs/solutions/code-quality/shell-and-or-chain-operator-precedence-bugs.md
@@ -43,7 +43,7 @@ failed.
 When `$SESSION_ID` is set and `opencode session delete` fails (e.g., session
 already gone, network error), the failure's stderr is silenced by
 `2>/dev/null`. The `||` is triggered by the non-zero exit code — so the
-warning *does* fire, but the original error message is gone. The operator
+warning _does_ fire, but the original error message is gone. The operator
 can only see "cleanup failed" with no diagnostic information.
 
 Combined effect: the chain misreports in both the "empty variable" and "actual

--- a/docs/solutions/code-quality/skill-frontmatter-attribute-and-format-requirements.md
+++ b/docs/solutions/code-quality/skill-frontmatter-attribute-and-format-requirements.md
@@ -293,3 +293,50 @@ special characters predictably.
 - `docs/solutions/code-quality/automated-bot-review-false-positives.md`:
   Bot false positives on frontmatter patterns
 - Memory: `Plugin Authoring Quality Rules` section updated with new rules
+
+---
+
+## Update — 2026-05-04
+
+### `user-invokable: false` Must Be Present, Not Just Correctly Spelled (PRs #328–#330)
+
+Five reviewers across PRs #328–#330 (yellow-council Wave-2 review) flagged a
+skill missing the `user-invokable: false` field entirely. Prior MEMORY.md and
+this doc documented the correct spelling (`user-invokable` with **k**), but
+not the requirement that the field must be present for internal skills.
+
+**The gap:** The peer pattern — `codex-patterns`, `pr-review-workflow`,
+`debt-conventions` — all carry `user-invokable: false` for internal skills.
+Without the field, Claude Code's frontmatter parser applies an undefined
+default, and CI tooling (including automated reviewers) flags the omission.
+
+**Rule:** Every internal SKILL.md (one not intended for direct user invocation)
+MUST include `user-invokable: false` in its frontmatter, regardless of whether
+the skill has any other frontmatter.
+
+**Minimum valid frontmatter for an internal skill:**
+
+```yaml
+---
+name: council-patterns
+description: "Shared redaction and pack conventions for council reviewers. Use when authoring or updating a council reviewer agent."
+user-invokable: false
+---
+```
+
+**Detection:**
+
+```bash
+GIT_ROOT="$(git rev-parse --show-toplevel)"
+# List internal skills missing the user-invokable field entirely
+grep -rL 'user-invokable' "$GIT_ROOT/plugins/"*/skills/*/SKILL.md
+```
+
+Any file returned by this command is missing the field and should be audited:
+if it is an internal skill, add `user-invokable: false`; if it is intended for
+user invocation, add `user-invokable: true` explicitly for clarity.
+
+**On-touch rule extension:** When any SKILL.md is modified (even for unrelated
+changes), confirm `user-invokable:` is present AND correctly spelled. The
+existing on-touch check for description format now has a sibling check for
+field presence.

--- a/docs/solutions/code-quality/stale-env-var-docs-and-prose-count-drift.md
+++ b/docs/solutions/code-quality/stale-env-var-docs-and-prose-count-drift.md
@@ -201,3 +201,111 @@ means the LLM has no probe result to evaluate at classification time — the
 criterion silently misfires on every run. See
 [setup-classification-probe-coupling.md](./setup-classification-probe-coupling.md)
 for the full pattern.
+
+---
+
+## Update — 2026-05-04
+
+### Plugin Count, Command Count, and Directory Tree Drift (PRs #328–#330)
+
+The entire yellow-council PR stack (3 PRs) carried a consistent internal
+contradiction: the README Plugins table claimed "2 commands" for
+yellow-council while `plugins/yellow-council/CLAUDE.md` reported
+"Commands (1)". Separately, the Project Structure directory tree in the root
+README was never updated when yellow-council was added to `marketplace.json`
+and the Plugins table.
+
+This is a distinct failure mode from the MCP-count drift documented above.
+MCP counts are per-plugin server enumerations; this is about:
+
+1. **Plugins table row counts** (agents/commands/skills per plugin row)
+   drifting from actual filesystem contents
+2. **Project Structure directory tree** not gaining new entries when plugins
+   are added to the marketplace table
+
+Both fail silently — no CI check enforces consistency between prose counts
+and the filesystem.
+
+#### Why This Recurs
+
+When a plugin is scaffolded and added to the marketplace table, the author
+updates:
+- `marketplace.json` (required for install to work)
+- The Plugins table in README (usually done)
+
+But commonly misses:
+- The Project Structure tree block (visual directory listing)
+- Per-row counts (commands, agents, skills) which must match `ls plugins/<name>/commands/ | wc -l`
+
+The tree and the counts have no single source of truth and no CI enforcement,
+so they lag indefinitely.
+
+#### Rule: Treat Every Plugin Add or Command/Agent/Skill Add as a README Operation
+
+Any PR that adds a plugin OR adds/removes a command, agent, or skill inside
+an existing plugin must run the following before opening for review:
+
+```bash
+GIT_ROOT="$(git rev-parse --show-toplevel)"
+PLUGIN="yellow-council"   # substitute affected plugin name
+
+# Check Plugins table row for this plugin
+grep -A3 "$PLUGIN" "$GIT_ROOT/README.md" | grep -E 'commands|agents|skills'
+
+# Check filesystem counts
+echo "commands: $(ls "$GIT_ROOT/plugins/$PLUGIN/commands/" 2>/dev/null | wc -l)"
+echo "agents:   $(ls "$GIT_ROOT/plugins/$PLUGIN/agents/"   2>/dev/null | wc -l)"
+echo "skills:   $(ls "$GIT_ROOT/plugins/$PLUGIN/skills/"   2>/dev/null | wc -l)"
+
+# Check that Project Structure tree mentions the plugin
+grep "$PLUGIN" "$GIT_ROOT/README.md"
+```
+
+Any mismatch between the filesystem counts and the table counts is a required
+fix before the PR is merged.
+
+#### CI Enforcement Script Skeleton
+
+Add `scripts/check-readme-count.js` to enforce this automatically:
+
+```js
+// scripts/check-readme-count.js
+// Asserts: (1) README plugin count matches plugins/ directory count
+// (2) Every Plugins table row has a Project Structure tree entry
+// (3) Per-plugin row counts match filesystem
+
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+const ROOT = new URL('..', import.meta.url).pathname;
+const readme = readFileSync(join(ROOT, 'README.md'), 'utf8');
+const pluginDirs = readdirSync(join(ROOT, 'plugins'), { withFileTypes: true })
+  .filter(d => d.isDirectory())
+  .map(d => d.name);
+
+let failed = false;
+
+for (const plugin of pluginDirs) {
+  // Check that Project Structure section mentions the plugin
+  if (!readme.includes(plugin)) {
+    console.error(`[check-readme-count] Project Structure tree missing: ${plugin}`);
+    failed = true;
+  }
+  // Per-subdir count check (commands, agents, skills)
+  for (const subdir of ['commands', 'agents', 'skills']) {
+    let count = 0;
+    try { count = readdirSync(join(ROOT, 'plugins', plugin, subdir)).length; } catch {}
+    // Extract claimed count from Plugins table row (heuristic — adapt to actual table format)
+    const rowMatch = readme.match(new RegExp(`${plugin}[^\\n]*\\b(\\d+)\\s+${subdir}`));
+    if (rowMatch && parseInt(rowMatch[1], 10) !== count) {
+      console.error(`[check-readme-count] ${plugin}: README claims ${rowMatch[1]} ${subdir}, found ${count}`);
+      failed = true;
+    }
+  }
+}
+
+if (failed) process.exit(1);
+console.log('[check-readme-count] ok');
+```
+
+Add to `package.json` scripts: `"check:readme": "node scripts/check-readme-count.js"` and invoke in CI alongside `validate:schemas`.

--- a/docs/solutions/code-quality/stale-env-var-docs-and-prose-count-drift.md
+++ b/docs/solutions/code-quality/stale-env-var-docs-and-prose-count-drift.md
@@ -230,10 +230,12 @@ and the filesystem.
 
 When a plugin is scaffolded and added to the marketplace table, the author
 updates:
+
 - `marketplace.json` (required for install to work)
 - The Plugins table in README (usually done)
 
 But commonly misses:
+
 - The Project Structure tree block (visual directory listing)
 - Per-row counts (commands, agents, skills) which must match `ls plugins/<name>/commands/ | wc -l`
 
@@ -277,7 +279,8 @@ Add `scripts/check-readme-count.js` to enforce this automatically:
 import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 
-const ROOT = new URL('..', import.meta.url).pathname;
+// Node 22+ — import.meta.dirname is the script's own directory, cross-platform safe
+const ROOT = join(import.meta.dirname, '..');
 const readme = readFileSync(join(ROOT, 'README.md'), 'utf8');
 const pluginDirs = readdirSync(join(ROOT, 'plugins'), { withFileTypes: true })
   .filter(d => d.isDirectory())
@@ -294,13 +297,24 @@ for (const plugin of pluginDirs) {
   // Per-subdir count check (commands, agents, skills)
   for (const subdir of ['commands', 'agents', 'skills']) {
     let count = 0;
-    try { count = readdirSync(join(ROOT, 'plugins', plugin, subdir)).length; } catch {}
+    try { count = readdirSync(join(ROOT, 'plugins', plugin, subdir)).filter(f => f.endsWith('.md')).length; } catch {}
     // Extract claimed count from Plugins table row (heuristic — adapt to actual table format)
     const rowMatch = readme.match(new RegExp(`${plugin}[^\\n]*\\b(\\d+)\\s+${subdir}`));
     if (rowMatch && parseInt(rowMatch[1], 10) !== count) {
       console.error(`[check-readme-count] ${plugin}: README claims ${rowMatch[1]} ${subdir}, found ${count}`);
       failed = true;
     }
+  }
+}
+
+// Inverse check: every plugin row in the README Plugins table must have a real directory
+const tablePluginRegex = /^\|\s*`([^`]+)`\s*\|/gm;
+let tableMatch;
+while ((tableMatch = tablePluginRegex.exec(readme)) !== null) {
+  const tablePlugin = tableMatch[1];
+  if (!pluginDirs.includes(tablePlugin)) {
+    console.error(`[check-readme-count] README lists missing plugin directory: ${tablePlugin}`);
+    failed = true;
   }
 }
 

--- a/docs/solutions/code-quality/stale-env-var-docs-and-prose-count-drift.md
+++ b/docs/solutions/code-quality/stale-env-var-docs-and-prose-count-drift.md
@@ -121,6 +121,7 @@ the table rows. Do not trust a count written in a previous version of the file.
 ### resolve-pr-parallel File Grouping
 
 Before spawning agents, always run file-ownership analysis:
+
 - Map each comment to its target file(s)
 - Group comments sharing any file into the same agent
 - Only parallelize across non-overlapping file sets

--- a/docs/solutions/security-issues/awk-pem-state-machine-variable-mutation.md
+++ b/docs/solutions/security-issues/awk-pem-state-machine-variable-mutation.md
@@ -1,0 +1,121 @@
+---
+title: awk PEM State Machine Breaks When Testing Mutated Variable
+date: 2026-05-04
+category: security-issues
+track: bug
+problem: awk redaction state machine tests the already-overwritten line variable for END-marker, so in_pem never resets and all subsequent output is silently redacted
+tags: [awk, redaction, pem, state-machine, silent-failure, security-sentinel]
+components:
+  - plugins/yellow-council/skills/council-patterns/SKILL.md
+  - plugins/yellow-council/agents/review/gemini-reviewer.md
+  - plugins/yellow-council/agents/review/opencode-reviewer.md
+---
+
+# awk PEM State Machine Breaks When Testing Mutated Variable
+
+## Problem
+
+A PEM private-key redaction state machine in three yellow-council files used
+this pattern:
+
+```awk
+{
+  line = $0
+  if (line ~ /^-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----/) in_pem = 1
+  if (in_pem) line = "[REDACTED PEM BLOCK]"
+  if (line ~ /^-----END (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----/)  in_pem = 0
+  print line
+}
+```
+
+The END-marker test on line 5 runs against `line` — but `line` was already
+overwritten to `"[REDACTED PEM BLOCK]"` on line 4. The literal string
+`"[REDACTED PEM BLOCK]"` never matches `-----END ... PRIVATE KEY-----`, so
+`in_pem` is never reset to 0. Every line after the first PEM block is
+silently redacted, even when no PEM material is present.
+
+## Why This Matters
+
+The failure has two independent security consequences:
+
+1. **Data loss:** All content after the first PEM block is replaced with the
+   redaction marker. If the reviewed file or diff contains a PEM block followed
+   by normal code, the entire subsequent section is lost — reviewer sees only
+   `[REDACTED PEM BLOCK]` for everything.
+
+2. **Bypass via single-line PEM:** An adversarial or malformed PEM block on a
+   single line (BEGIN and END on the same line) sets `in_pem = 1` but the
+   END-marker test also fails for the same mutation reason. The attacker embeds
+   a single-line fake PEM header and every subsequent line is redacted,
+   effectively blinding the reviewer.
+
+Five reviewers flagged this across correctness, security-sentinel, and
+silent-failure-hunter roles in the same review wave.
+
+## Key Insight
+
+**Always test original `$0` — never the variable that may have been mutated by
+an earlier branch in the same awk block.**
+
+State-transition tests (BEGIN/END markers, delimiter detection, boundary
+matching) must evaluate the unmodified input line. Assign to a working variable
+only for the output value, not for the guard condition itself.
+
+## Fix
+
+```awk
+{
+  if ($0 ~ /^-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----/) in_pem = 1
+  line = in_pem ? "[REDACTED PEM BLOCK]" : $0
+  if ($0 ~ /^-----END (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----/)   in_pem = 0
+  print line
+}
+```
+
+Key changes:
+- All state-transition tests use `$0` directly, not `line`
+- The END-marker test now correctly sees the original input and resets `in_pem`
+- `line` is derived from `in_pem` after it may have changed, covering
+  the edge case where BEGIN and END markers appear on the same line
+  (single-line PEM block): that line is redacted, but `in_pem` resets
+  immediately so the next line is not redacted
+
+## Severity
+
+P0. Silent data-loss for all content after the first PEM block. Bypass-capable
+via single-line PEM injection. Three separate file copies meant the bug was
+present in the gemini, opencode, and council-patterns skill paths
+simultaneously.
+
+## Detection
+
+```bash
+# Find awk blocks where a variable is overwritten then tested for END-marker
+# against the same variable — the classic mutation-before-test pattern
+rg -n 'in_pem\b' plugins/ --include='*.md' | grep -v 'in_pem = 0' | head -20
+
+# Structural check: any awk block where line= appears before if (line ~
+grep -n 'line = ' plugins/*/skills/*/SKILL.md plugins/*/agents/**/*.md 2>/dev/null \
+  | grep -A2 'in_pem\|redact'
+```
+
+When reviewing any multi-line redaction state machine in awk:
+- Confirm every state-transition condition uses `$0`, not a derived variable
+- Confirm the END-marker test can never match the redaction placeholder string
+
+## Prevention
+
+- [ ] In every awk redaction block: state transitions test `$0`, not `line`
+- [ ] Derived output variable (`line`) is assigned AFTER the state update
+      (or derived from the current state rather than tested for transitions)
+- [ ] When copying a PEM redaction snippet, run a mental trace: what is
+      `line`'s value when the END-marker `if` executes?
+- [ ] Add a one-line unit test: pipe a 3-line PEM block followed by a normal
+      line through the awk and assert the normal line is not redacted
+
+## Related Documentation
+
+- `docs/solutions/security-issues/heredoc-delimiter-collision.md` — adjacent
+  pattern: delimiter/marker matching bugs in shell redaction pipelines
+- `docs/solutions/security-issues/prompt-injection-defense-layering-2026.md`
+  — broader context on output-filtering as load-bearing security control

--- a/docs/solutions/security-issues/awk-pem-state-machine-variable-mutation.md
+++ b/docs/solutions/security-issues/awk-pem-state-machine-variable-mutation.md
@@ -73,6 +73,7 @@ only for the output value, not for the guard condition itself.
 ```
 
 Key changes:
+
 - All state-transition tests use `$0` directly, not `line`
 - The END-marker test now correctly sees the original input and resets `in_pem`
 - `line` is derived from `in_pem` after it may have changed, covering
@@ -101,6 +102,7 @@ rg -n --glob 'plugins/*/skills/*/SKILL.md' --glob 'plugins/*/agents/**/*.md' \
 ```
 
 When reviewing any multi-line redaction state machine in awk:
+
 - Confirm every state-transition condition uses `$0`, not a derived variable
 - Confirm the END-marker test can never match the redaction placeholder string
 

--- a/docs/solutions/security-issues/awk-pem-state-machine-variable-mutation.md
+++ b/docs/solutions/security-issues/awk-pem-state-machine-variable-mutation.md
@@ -95,7 +95,8 @@ simultaneously.
 rg -n 'in_pem\b' plugins/ --include='*.md' | grep -v 'in_pem = 0' | head -20
 
 # Structural check: any awk block where line= appears before if (line ~
-grep -n 'line = ' plugins/*/skills/*/SKILL.md plugins/*/agents/**/*.md 2>/dev/null \
+rg -n --glob 'plugins/*/skills/*/SKILL.md' --glob 'plugins/*/agents/**/*.md' \
+  'line = ' \
   | grep -A2 'in_pem\|redact'
 ```
 

--- a/docs/solutions/security-issues/prompt-injection-fence-delimiter-escape.md
+++ b/docs/solutions/security-issues/prompt-injection-fence-delimiter-escape.md
@@ -1,0 +1,161 @@
+---
+title: Prompt Injection Fence Escape via Literal Delimiter Match in Reviewer Output
+date: 2026-05-04
+category: security-issues
+track: bug
+problem: Per-invocation fence tags like "--- end council-output:gemini ---" can be emitted verbatim by the fenced model, breaking the reference-only advisory boundary
+tags: [prompt-injection, fence, delimiter, escape, security, council, nonce, agentic]
+components:
+  - plugins/yellow-council/skills/council-patterns/SKILL.md
+  - plugins/yellow-council/agents/review/gemini-reviewer.md
+  - plugins/yellow-council/agents/review/opencode-reviewer.md
+---
+
+# Prompt Injection Fence Escape via Literal Delimiter Match in Reviewer Output
+
+## Problem
+
+Yellow-council wraps each reviewer's output in named fence tags before
+presenting it to the orchestrator:
+
+```
+--- begin council-output:gemini ---
+[reviewer output here]
+--- end council-output:gemini ---
+```
+
+A "treat as reference only" advisory accompanies the fenced section. The
+intent is to isolate reviewer output so the orchestrator treats it as
+untrusted data, not instructions.
+
+The vulnerability: neither the gemini-reviewer nor the opencode-reviewer
+strips or escapes lines in their output that match the fence-close delimiter.
+If the reviewed diff, the reviewed codebase, or an adversarial prompt
+embedded in those sources causes the reviewer model to emit the literal
+string `--- end council-output:gemini ---`, the fence closes prematurely.
+Any content the reviewer emits after that line is outside the fenced region
+and the reference-only advisory no longer applies to it.
+
+An attacker who can influence the content passed to the reviewer (via a
+PR diff, commit message, file content, or issue body) can craft a payload
+that escapes the fence and appears to the orchestrator as trusted
+orchestrator-level content.
+
+## Why This Matters
+
+The fence is the primary isolation boundary between untrusted reviewer output
+and the orchestrator's instruction context. A bypass collapses this boundary:
+
+- Post-escape content appears at the same trust level as orchestrator prose
+- The reference-only advisory explicitly does NOT cover post-escape content
+- The orchestrator may follow injected instructions (tool calls, file writes,
+  git operations) it would have blocked if the content stayed inside the fence
+- The attacker does not need code execution — only the ability to influence
+  the text of a diff or file that enters the review pipeline
+
+## Key Insight
+
+**Fence tags with static, predictable delimiters are only as strong as the
+guarantee that fenced content cannot reproduce the closing delimiter.**
+
+When fenced content is untrusted LLM output (not raw file bytes), that
+guarantee does not hold: any model can be prompted to reproduce an exact
+string, and adversarial input can steer it to do so.
+
+## Fix Options
+
+Three independently sufficient mitigations, in order of robustness:
+
+### Option A: Per-invocation nonce (recommended)
+
+Generate a random suffix at invocation time and embed it in both the
+open and close tags:
+
+```bash
+FENCE_NONCE="$(openssl rand -hex 8)"
+OPEN_TAG="--- begin council-output:gemini:${FENCE_NONCE} ---"
+CLOSE_TAG="--- end council-output:gemini:${FENCE_NONCE} ---"
+```
+
+The nonce is not known to the reviewed content at the time it was authored,
+so a pre-planted payload cannot predict the closing tag. The orchestrator
+receives the nonce and knows which tag to look for.
+
+**Caveat:** This prevents pre-planted attacks but not attacks where the
+reviewed content can observe the nonce at review time (e.g., if the diff
+includes a script that reads the nonce from the environment). For most PR
+review pipelines this is an acceptable residual risk.
+
+### Option B: Post-redaction sweep before fencing
+
+After receiving the reviewer's raw output and before wrapping it in fence
+tags, strip or escape any line that matches the closing delimiter pattern:
+
+```bash
+# Escape any line that would close the fence prematurely
+SAFE_OUTPUT=$(printf '%s\n' "$RAW_OUTPUT" \
+  | sed 's/^--- end council-output:/<!-- redacted fence-close: /')
+```
+
+Then wrap `$SAFE_OUTPUT` in the fence tags. This is deterministic and does
+not require nonces, but requires the orchestration layer to perform the sweep
+before fencing — it cannot be delegated to the reviewer itself.
+
+### Option C: Base64-armor the entire fenced section
+
+Encode the reviewer output as base64 before fencing:
+
+```bash
+ENCODED=$(printf '%s' "$RAW_OUTPUT" | base64)
+printf '--- begin council-output:gemini ---\n%s\n--- end council-output:gemini ---\n' \
+  "$ENCODED"
+```
+
+The orchestrator decodes before processing. Base64 output contains only
+`[A-Za-z0-9+/=\n]` — it structurally cannot contain the fence-close pattern.
+The tradeoff: the orchestrator must decode before it can read finding content,
+which adds implementation complexity and breaks human readability of logs.
+
+## Severity
+
+P0. Escape from the reference-only safety boundary. The attack surface includes
+any PR diff, commit message, or file content that enters the review pipeline.
+Exploitable without access to infrastructure — only requires ability to open a
+PR or push a commit.
+
+## Detection
+
+```bash
+# Check that fence tags include a nonce or that reviewer output is swept
+# before fencing — static tags with no sweep are vulnerable
+rg 'begin council-output|end council-output' plugins/ --include='*.md' \
+  | grep -v 'nonce\|NONCE\|FENCE_NONCE\|base64\|sed.*fence'
+```
+
+When reviewing any agent that wraps untrusted LLM output in named delimiters:
+1. Confirm the delimiter cannot be reproduced verbatim by the fenced model
+2. If the delimiter is static and human-readable: flag as vulnerable to
+   pre-plant and require one of the three mitigations above
+
+## Prevention
+
+- [ ] All fence tags that wrap untrusted LLM output include a per-invocation
+      nonce OR the output is swept for close-delimiter matches before fencing
+- [ ] Fence-close delimiter patterns are not predictable from the reviewed
+      content alone (static reviewer names like `:gemini` are predictable)
+- [ ] Orchestrators that parse fenced output validate that open and close
+      tags are balanced and that no unbalanced close tags appear inside the fence
+- [ ] Reviewed content (diffs, file content, issue bodies) is treated as
+      fully adversarial — assume it can steer the reviewer to emit any string
+
+## Related Documentation
+
+- `docs/solutions/security-issues/prompt-injection-defense-layering-2026.md`
+  — broader model-level vs application-layer defense hierarchy; fence bypass
+  is the specific structural failure that application-layer filtering must
+  catch before output reaches sensitive sinks
+- `docs/solutions/security-issues/heredoc-delimiter-collision.md` — analogous
+  pattern in shell: user-supplied content closing a heredoc prematurely
+- MEMORY.md: "Prompt injection fencing: Wrap untrusted content in begin/end
+  delimiters + treat as reference only advisory" — this doc establishes that
+  static fences alone are insufficient; add nonce or sweep

--- a/docs/solutions/security-issues/prompt-injection-fence-delimiter-escape.md
+++ b/docs/solutions/security-issues/prompt-injection-fence-delimiter-escape.md
@@ -18,7 +18,7 @@ components:
 Yellow-council wraps each reviewer's output in named fence tags before
 presenting it to the orchestrator:
 
-```
+```text
 --- begin council-output:gemini ---
 [reviewer output here]
 --- end council-output:gemini ---
@@ -94,7 +94,7 @@ tags, strip or escape any line that matches the closing delimiter pattern:
 ```bash
 # Escape any line that would close the fence prematurely
 SAFE_OUTPUT=$(printf '%s\n' "$RAW_OUTPUT" \
-  | sed 's/^--- end council-output:/<!-- redacted fence-close: /')
+  | sed 's/^--- end council-output:.*$/[redacted: fence-close tag removed]/')
 ```
 
 Then wrap `$SAFE_OUTPUT` in the fence tags. This is deterministic and does
@@ -133,6 +133,7 @@ rg 'begin council-output|end council-output' plugins/ --include='*.md' \
 ```
 
 When reviewing any agent that wraps untrusted LLM output in named delimiters:
+
 1. Confirm the delimiter cannot be reproduced verbatim by the fenced model
 2. If the delimiter is static and human-readable: flag as vulnerable to
    pre-plant and require one of the three mitigations above


### PR DESCRIPTION
5 new solution docs + 3 amendments + MEMORY.md pointers covering: awk PEM state machine variable mutation, $(cat $FILE) ARG_MAX antipattern, prompt-injection fence delimiter escape, shell &&/|| operator precedence bugs, jq select filter for JSONL, SKILL user-invokable presence rule, README plugin count drift, bash-block status/summary variable scope.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guides addressing code-quality anti-patterns: bash subprocess isolation, command substitution size limits, jq JSONL filtering, and shell operator precedence.
  * Added security documentation covering PEM redaction state machine failures and prompt-injection fence delimiter vulnerabilities.
  * Enhanced documentation for frontmatter and README validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR compounds eight engineering learnings from yellow-council Wave-2 review (PRs #328–#330) into the `docs/solutions` knowledge base: five new solution docs and three amendments to existing ones, covering correctness, reliability, and security patterns in shell/awk/jq command-file authoring.

- **5 new docs** added: `$(cat)` ARG_MAX antipattern, `jq select()` vs `first(expr // empty)` for JSONL, `&&`/`||` operator-precedence guard bugs, awk PEM state-machine variable-mutation (security), and prompt-injection fence-delimiter escape (security).
- **3 amendments** added to existing docs: bash subshell isolation (status/summary block concretization), skill frontmatter `user-invokable` presence rule, and README plugin-count / directory-tree drift (including a CI enforcement script skeleton).

<h3>Confidence Score: 5/5</h3>

All changes are documentation only; no production code is modified.

Every changed file is a Markdown solution doc or amendment. The technical analysis across all new docs is accurate. The two findings are both minor issues confined to the CI example script within one doc and affect no running code.

docs/solutions/code-quality/stale-env-var-docs-and-prose-count-drift.md — the bash quick-check and the CI script skeleton use different counting methods for plugin components.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/solutions/code-quality/bash-block-subshell-isolation-in-command-files.md | Amendment: adds Status/Summary Blocks concretization of cross-block variable loss with sentinel-file, state-file, and merge-block fixes; technically accurate. |
| docs/solutions/code-quality/cat-file-argmax-inline-substitution-antipattern.md | New doc: documents the $(cat FILE) ARG_MAX antipattern with two independent bugs (dead stdin pipe, per-argument kernel limit); fixes and detection are correct. |
| docs/solutions/code-quality/jq-select-filter-over-first-empty-for-jsonl.md | New doc: accurately describes the first(expr // empty) empty-generator error on JSONL streams and the select() replacement pattern; examples are correct. |
| docs/solutions/code-quality/shell-and-or-chain-operator-precedence-bugs.md | New doc: correctly documents the left-associative && / || precedence hazard in guard-then-act-then-warn chains and provides the if/then/fi fix. |
| docs/solutions/code-quality/skill-frontmatter-attribute-and-format-requirements.md | Amendment: adds rule requiring user-invokable field presence for internal skills, with detection script and on-touch extension; no issues. |
| docs/solutions/code-quality/stale-env-var-docs-and-prose-count-drift.md | Amendment: adds plugin-count drift rule with bash quick-check and JS CI skeleton; bash uses ls | wc -l (counts subdirs/non-md files) while CI script filters to .md only — inconsistent counts across the same doc. |
| docs/solutions/security-issues/awk-pem-state-machine-variable-mutation.md | New doc: correctly identifies the mutate-before-test bug in the PEM awk state machine and the fix (test $0, derive line after state update); single-line PEM edge case handled correctly. |
| docs/solutions/security-issues/prompt-injection-fence-delimiter-escape.md | New doc: accurately documents the static-fence-close-tag escape vulnerability and three mitigations (nonce, pre-fencing sweep, base64-armor); caveats for Option A are correctly noted. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[yellow-council Wave-2 PRs 328-330] --> B[5 new solution docs]
    A --> C[3 doc amendments]
    B --> D[cat-file-argmax antipattern]
    B --> E[jq-select-filter for JSONL]
    B --> F[shell and-or chain precedence bugs]
    B --> G[awk-pem state machine]
    B --> H[prompt-injection fence escape]
    C --> I[bash-block subshell isolation]
    C --> J[skill-frontmatter requirements]
    C --> K[stale docs and count drift]
    G --> L[Fix: test $0 not mutated variable]
    H --> M[Fix: nonce or sweep or base64]
    E --> N[Fix: select plus head -1]
    F --> O[Fix: if/then/fi explicit branch]
    K --> P[Fix: scripts/check-readme-count.js]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22chore%2Fcompound-yellow-council-learnings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Fcompound-yellow-council-learnings%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Adocs%2Fsolutions%2Fcode-quality%2Fstale-env-var-docs-and-prose-count-drift.md%3A258-261%0AThe%20bash%20quick-check%20uses%20plain%20%60ls%20%7C%20wc%20-l%60%2C%20which%20counts%20every%20entry%20in%20the%20directory%20%E2%80%94%20including%20subdirectories%20and%20non-Markdown%20files%20%E2%80%94%20while%20the%20CI%20skeleton%20immediately%20below%20it%20filters%20to%20%60.endsWith%28'.md'%29%60.%20A%20%60commands%2F%60%20directory%20containing%20a%20subdirectory%20will%20produce%20a%20higher%20count%20here%20than%20CI%20does%2C%20generating%20a%20false%20mismatch%20that%20the%20doc%20itself%20calls%20a%20required%20fix%20before%20merging.%20Aligning%20the%20bash%20check%20to%20the%20same%20%60.md%60-only%20criterion%20avoids%20confusion.%0A%0A%60%60%60suggestion%0A%23%20Check%20filesystem%20counts%20%28.md%20files%20only%20%E2%80%94%20matches%20CI%20script%20and%20README%20table%29%0Aecho%20%22commands%3A%20%24%28ls%20%22%24GIT_ROOT%2Fplugins%2F%24PLUGIN%2Fcommands%2F%22*.md%202%3E%2Fdev%2Fnull%20%7C%20wc%20-l%29%22%0Aecho%20%22agents%3A%20%20%20%24%28ls%20%22%24GIT_ROOT%2Fplugins%2F%24PLUGIN%2Fagents%2F%22*.md%20%20%202%3E%2Fdev%2Fnull%20%7C%20wc%20-l%29%22%0Aecho%20%22skills%3A%20%20%20%24%28ls%20%22%24GIT_ROOT%2Fplugins%2F%24PLUGIN%2Fskills%2F%22*.md%20%20%202%3E%2Fdev%2Fnull%20%7C%20wc%20-l%29%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Adocs%2Fsolutions%2Fcode-quality%2Fstale-env-var-docs-and-prose-count-drift.md%3A303%0APlugin%20names%20are%20interpolated%20directly%20into%20a%20%60RegExp%60%20constructor%20without%20escaping.%20Kebab-case%20names%20like%20%60yellow-browser-test%60%20are%20safe%20today%2C%20but%20a%20name%20containing%20%60.%60%20would%20make%20it%20match%20any%20character%20and%20potentially%20report%20a%20false%20count%20against%20the%20wrong%20row.%20Since%20this%20is%20a%20CI%20skeleton%20intended%20for%20future%20adaptation%2C%20escaping%20%60plugin%60%20before%20constructing%20the%20regex%20guards%20against%20silent%20mismatches.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20escapedPlugin%20%3D%20plugin.replace%28%2F%5B.*%2B%3F%5E%24%7B%7D%28%29%7C%5B%5C%5D%5C%5C%5D%2Fg%2C%20'%5C%5C%24%26'%29%3B%0A%20%20%20%20const%20rowMatch%20%3D%20readme.match%28new%20RegExp%28%60%24%7BescapedPlugin%7D%5B%5E%5C%5Cn%5D*%5C%5Cb%28%5C%5Cd%2B%29%5C%5Cs%2B%24%7Bsubdir%7D%60%29%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
docs/solutions/code-quality/stale-env-var-docs-and-prose-count-drift.md:258-261
The bash quick-check uses plain `ls | wc -l`, which counts every entry in the directory — including subdirectories and non-Markdown files — while the CI skeleton immediately below it filters to `.endsWith('.md')`. A `commands/` directory containing a subdirectory will produce a higher count here than CI does, generating a false mismatch that the doc itself calls a required fix before merging. Aligning the bash check to the same `.md`-only criterion avoids confusion.

```suggestion
# Check filesystem counts (.md files only — matches CI script and README table)
echo "commands: $(ls "$GIT_ROOT/plugins/$PLUGIN/commands/"*.md 2>/dev/null | wc -l)"
echo "agents:   $(ls "$GIT_ROOT/plugins/$PLUGIN/agents/"*.md   2>/dev/null | wc -l)"
echo "skills:   $(ls "$GIT_ROOT/plugins/$PLUGIN/skills/"*.md   2>/dev/null | wc -l)"
```

### Issue 2 of 2
docs/solutions/code-quality/stale-env-var-docs-and-prose-count-drift.md:303
Plugin names are interpolated directly into a `RegExp` constructor without escaping. Kebab-case names like `yellow-browser-test` are safe today, but a name containing `.` would make it match any character and potentially report a false count against the wrong row. Since this is a CI skeleton intended for future adaptation, escaping `plugin` before constructing the regex guards against silent mismatches.

```suggestion
    const escapedPlugin = plugin.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
    const rowMatch = readme.match(new RegExp(`${escapedPlugin}[^\\n]*\\b(\\d+)\\s+${subdir}`));
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(docs): clear PR-introduced markdownl..."](https://github.com/kinginyellows/yellow-plugins/commit/d23eb315cdb08620283451ef66061f7d70330710) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30734451)</sub>

<!-- /greptile_comment -->