### PR TITLE
docs(reference): subagent frontmatter field catalog (verified 2026-05-04)

### DIFF
--- a/docs/research/all-possible-subagent-frontmatter-config.md
+++ b/docs/research/all-possible-subagent-frontmatter-config.md
@@ -1,0 +1,725 @@
+# Subagent Frontmatter Reference (Claude Code, as of 2026-05-04)
+
+**Date:** 2026-05-04
+**Sources:** Official Anthropic docs (code.claude.com, docs.anthropic.com), Claude Code TypeScript SDK reference, official changelog, GitHub issues on anthropics/claude-code, real-world plugin repos
+
+## Summary
+
+Subagent `.md` files in Claude Code use a YAML frontmatter block (delimited by `---`) to declare identity, capabilities, model selection, permissions, and runtime behavior. The Markdown body below the frontmatter becomes the subagent's system prompt verbatim. The frontmatter parser is strict about field names: only recognized keys are acted upon; unknown keys are silently ignored unless they conflict with YAML parsing itself. Only `name` and `description` are required; all other fields are optional. Invalid YAML (malformed scalars, bad indentation) prevents the file from loading; invalid field _values_ typically cause the field to be ignored or the agent to fail to spawn.
+
+---
+
+## Required Fields
+
+### `name`
+
+| Attribute | Value |
+|-----------|-------|
+| Type | `string` |
+| Required | Yes |
+| Pattern | Lowercase letters (`a-z`), digits (`0-9`), and hyphens (`-`) only. No spaces, no uppercase, no underscores. |
+| Max length | Not officially stated; community convention and examples use 1–64 characters. |
+| Uniqueness | Must be unique within its discovery scope. Name collisions across scopes are resolved by precedence (see Precedence section). |
+| Reserved words | Cannot start with a reserved prefix (exact list not published, but avoid `anthropic`, `claude`). |
+
+**Runtime behavior:** The name is the identifier used in the `/agents` UI, in Task tool `subagent_type` references, in `--agent <name>` CLI invocations, and in `@mention` typeahead (introduced April 2026, v2.1.90+). The filename of the `.md` file does not need to match the `name` field, but by strong convention it should (e.g., `name: code-reviewer` in `code-reviewer.md`).
+
+**Plugin namespacing:** When a plugin ships an agent, the agent is accessible in the Task tool as `plugin:<plugin-dir>:<name>` (qualified form) or as just `<name>` if unambiguous. Bare `<name>` resolves using scope precedence; specify the qualified form in command files where ambiguity is possible to ensure the correct agent is invoked.
+
+---
+
+### `description`
+
+| Attribute | Value |
+|-----------|-------|
+| Type | `string` (single-line) |
+| Required | Yes |
+| Format | Must be a single-line string. Do NOT use YAML folded scalars (`description: >`) or YAML literal block scalars (`description: \|`) or multi-line single-quoted strings. |
+| Length | No official hard limit; community practice keeps it under ~300 characters for automatic routing accuracy. |
+
+**Runtime behavior:** The description serves two purposes simultaneously:
+
+1. **Delegation routing:** Claude reads the description to decide whether to delegate a task to this subagent. Descriptions that include explicit trigger conditions ("Use when the user asks to…", "Delegate here for all X tasks") produce more reliable automatic invocation than vague descriptions.
+2. **UI display:** Shown in the `/agents` list and in the task list alongside the agent's color.
+
+**The "Use when..." trigger clause convention:** Although not enforced by the parser, the community has converged on a convention of beginning or ending the description with a trigger clause: `"Use when the user asks to review code for security vulnerabilities"`. This maximizes correct automatic delegation. The description is matched semantically (not lexically) against the task at hand.
+
+**Why folded scalars silently truncate:** Claude Code's frontmatter parser reads only the first line of the scalar value when a YAML folded (`>`) or literal block (`|`) scalar is encountered. The continuation lines are discarded without warning, producing a truncated description. This is a known parser limitation documented in multiple GitHub issues (anthropics/claude-code #10504). The same truncation occurs with multi-line single-quoted strings that wrap to the next line. Always keep `description:` on a single line with the value inline.
+
+**Examples block convention (observed in real-world agents):** Some description strings embed XML-style `<example>` blocks directly inline to improve automatic routing. This is observed practice (see home-assistant/core agents), not an officially documented feature. These examples are part of the description string and contribute to routing context.
+
+```yaml
+# Good — single line with trigger clause
+description: Reviews code changes for security vulnerabilities. Use when the user asks to audit, scan, or review code for security issues.
+
+# Bad — folded scalar, silently truncates to "Reviews code changes"
+description: >
+  Reviews code changes for security vulnerabilities.
+  Use when the user asks to audit code.
+
+# Bad — literal block, same truncation problem
+description: |
+  Reviews code changes.
+  Use when: code review requested.
+```
+
+---
+
+## Optional Fields
+
+### `tools`
+
+| Attribute | Value |
+|-----------|-------|
+| Type | Comma-separated string OR YAML list |
+| Default | All tools inherited from the parent session if omitted |
+| Format | `tools: Read, Grep, Glob, Bash` OR YAML list form `tools:\n  - Read\n  - Grep` |
+
+**Semantics:** When specified, this is an explicit **allowlist** — the subagent can only use the listed tools. Tools not in the list are unavailable, even if the parent session has them. When omitted, all tools available to the parent conversation are available.
+
+**MCP tool naming:** MCP tools follow the pattern `mcp__plugin_<pluginName>_<serverName>__<toolName>`. For example: `mcp__plugin_yellow-research_perplexity__perplexity_research`. The double underscore (`__`) separates the server prefix from the tool name. In frontmatter you must use the exact fully-qualified MCP tool name:
+
+```yaml
+tools: mcp__meigen__generate_image, Read, Grep
+```
+
+**Built-in tool names (as of May 2026):** `Read`, `Write`, `Edit`, `MultiEdit`, `Bash`, `Grep`, `Glob`, `WebFetch`, `WebSearch`, `Task`, `TodoRead`, `TodoWrite`, `NotebookRead`, `NotebookEdit`, `exit_plan_mode`, `AskUserQuestion`. Note: on native macOS/Linux builds (v2.1.113+), `Glob` and `Grep` are provided as `bfs`/`ugrep` through `Bash` rather than standalone tools, but you can still reference them by name in `tools` — the backend substitution is transparent.
+
+**Bash specifiers for fine-grained tool control:** You can restrict Bash to specific command prefixes: `Bash(git *)`, `Bash(npm:*)`, `Bash(test:*)`. This allows a subagent to run `git` commands but not arbitrary shell.
+
+**`ToolSearch` deferred-tool pattern:** Commands and agents that use MCP tools must include `ToolSearch` in their `tools` (or `allowed-tools` for SKILL.md files) so that the tool schemas can be resolved at runtime. Without `ToolSearch`, calling a deferred tool fails with `InputValidationError`.
+
+**Subagents cannot spawn subagents:** Do NOT include `Task` in a subagent's `tools` array. Subagents cannot invoke other subagents via the Task tool. Only the main conversation (or a command) can spawn subagents. Attempting to include `Task` will either be silently ignored or cause the spawn to fail.
+
+---
+
+### `disallowedTools`
+
+| Attribute | Value |
+|-----------|-------|
+| Type | Comma-separated string OR YAML list |
+| Default | None (no tools denied beyond what `tools` already restricts) |
+
+**Semantics:** A denylist. Removes specific tools from the agent's effective tool set. Applied after the `tools` allowlist is computed. Useful when you want to inherit all tools but deny a specific few:
+
+```yaml
+# Inherit everything except Write and Edit (read-only agent)
+disallowedTools: Write, Edit
+
+# Deny specific Bash patterns
+disallowedTools:
+  - "Bash(rm -rf*)"
+  - "Bash(git push*)"
+```
+
+When both `tools` and `disallowedTools` are specified, `tools` sets the allowlist and `disallowedTools` further removes from it.
+
+---
+
+### `model`
+
+| Attribute | Value |
+|-----------|-------|
+| Type | `string` (enum alias or full model ID) |
+| Default | `inherit` (uses the parent session's active model) |
+
+**Valid values:**
+
+| Value | Meaning |
+|-------|---------|
+| `sonnet` | Latest Claude Sonnet model (currently maps to `claude-sonnet-4-6`) |
+| `opus` | Latest Claude Opus model (currently maps to `claude-opus-4-7` or similar) |
+| `haiku` | Latest Claude Haiku model (currently maps to `claude-haiku-4-5-20251001` or similar) |
+| `inherit` | Use the same model as the parent conversation (default behavior; explicit `inherit` and omitting the field are equivalent) |
+| Full model ID | Any concrete Anthropic API model ID, e.g., `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001` |
+
+**Override precedence:** The `model` field in frontmatter can be overridden by:
+1. The environment variable `CLAUDE_CODE_SUBAGENT_MODEL` (takes precedence over frontmatter)
+2. The parent session's `--model` CLI flag (behavior depends on version; in recent versions `CLAUDE_CODE_SUBAGENT_MODEL` is the authoritative override)
+3. Frontmatter `model` field
+4. Default: `inherit`
+
+**Plugin subagents:** The `model` field is honored for plugin-shipped agents (added in the same release as `effort`, `maxTurns`, and `disallowedTools` for plugin agents, v2.0.x).
+
+**Note on alias-to-ID mapping:** The concrete model IDs that aliases like `sonnet`, `opus`, `haiku` resolve to are updated as new model releases occur. The aliases always point to the latest recommended model in that family. For reproducible behavior in production, use full model IDs rather than aliases.
+
+---
+
+### `permissionMode`
+
+| Attribute | Value |
+|-----------|-------|
+| Type | `string` (enum) |
+| Default | Inherits from parent session |
+| Plugin agents | Ignored for plugin subagents |
+
+**Valid values:**
+
+| Value | Behavior |
+|-------|----------|
+| `default` | Standard permission checking — prompts for approval before risky actions |
+| `acceptEdits` | Auto-accepts file edits and common filesystem commands (`mkdir`, `touch`, `mv`, `cp`) for paths in working directory or `additionalDirectories` |
+| `auto` | Background classifier reviews commands; auto-approves most, prompts on risky ones |
+| `dontAsk` | Auto-denies permission prompts; only pre-approved (explicitly allowed) tools run |
+| `bypassPermissions` | Skips all permission prompts. Protected paths (`.git`, `.claude`, `.vscode`, `.idea`, `.husky`) still prompt, except `.claude/commands`, `.claude/agents`, `.claude/skills` |
+| `plan` | Read-only exploration mode; no file edits or command execution |
+
+**Inheritance rules:**
+- If the parent uses `bypassPermissions` or `acceptEdits`, that takes precedence and the subagent's `permissionMode` is ignored.
+- If the parent uses `auto`, the subagent inherits `auto` and its `permissionMode` frontmatter is ignored.
+- In all other cases, the subagent's `permissionMode` frontmatter overrides the parent's mode.
+
+**Added:** v2.0.43 (November 18, 2025)
+
+---
+
+### `maxTurns`
+
+| Attribute | Value |
+|-----------|-------|
+| Type | `number` (positive integer) |
+| Default | No limit (or session default) |
+
+**Semantics:** Caps the number of agentic turns (API round-trips) the subagent may take before stopping. Prevents runaway agents. A value of `0` or omitting the field means no explicit cap is imposed beyond session defaults.
+
+Real-world examples: `maxTurns: 25` (game prototyper), `maxTurns: 30` (typical complex agent), `maxTurns: 500` (rulecheck-agent designed for extended autonomous operation).
+
+---
+
+### `skills`
+
+| Attribute | Value |
+|-----------|-------|
+| Type | YAML list of skill names OR comma-separated string |
+| Default | No preloaded skills |
+
+**Semantics:** Declares a list of skill names (from `skills/` directories) to preload into the subagent's context. Skills inject additional instructions or knowledge into the system prompt. The skill name is the short name matching the skill's `name:` frontmatter field.
+
+```yaml
+skills:
+  - code-review-standards
+  - security-patterns
+  - nw-design-patterns
+```
+
+**Added:** `skills` frontmatter field for subagents added in v2.0.43 (November 18, 2025).
+
+---
+
+### `mcpServers`
+
+| Attribute | Value |
+|-----------|-------|
+| Type | YAML list of server name strings OR inline MCP server configs |
+| Default | Inherits MCP servers from session |
+
+**Semantics:** Specifies which MCP servers the subagent can access. Can be provided as a list of named servers (by their registered name) or as inline config objects for servers not registered globally.
+
+**Format — named server:**
+```yaml
+mcpServers:
+  - sentry
+  - github
+```
+
+**Format — inline config (HTTP):**
+```yaml
+mcpServers:
+  notion:
+    type: http
+    url: https://mcp.notion.com/mcp
+  github:
+    type: http
+    url: https://api.githubcopilot.com/mcp
+```
+
+**Honored in main-thread mode:** `mcpServers` in frontmatter is honored when the agent is invoked as a main-thread agent via `claude --agent <name>` (added v2.1.117+).
+
+**Note:** MCP tool names available to the subagent via `mcpServers` follow the naming pattern `mcp__<serverName>__<toolName>`. The server name in the prefix matches the key used to register the server.
+
+---
+
+### `hooks`
+
+| Attribute | Value |
+|-----------|-------|
+| Type | YAML mapping (event name → hook definition) |
+| Default | No subagent-scoped hooks |
+
+**Semantics:** Allows lifecycle hooks scoped to this specific subagent definition. Hook events available for subagents include `PreToolUse` and `PostToolUse`. At session level, `SubagentStart` and `SubagentStop` fire for any subagent spawn/completion.
+
+```yaml
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: /path/to/validate-bash.sh
+```
+
+**SubagentStart hook output:** A `SubagentStart` hook can inject additional context into the subagent by returning `{"hookSpecificOutput": {"hookEventName": "SubagentStart", "additionalContext": "..."}}`. SubagentStart hooks cannot block subagent creation.
+
+**SubagentStop hook:** Fires when the subagent finishes. Receives `agent_id` and `agent_transcript_path` fields in its input (added v2.0.42, November 15, 2025).
+
+---
+
+### `memory`
+
+| Attribute | Value |
+|-----------|-------|
+| Type | `string` (enum) |
+| Default | No persistent memory |
+| Valid values | `user`, `project`, `local` |
+
+**Semantics:** Enables persistent memory for the subagent across sessions. A `MEMORY.md` file is maintained in the corresponding directory.
+
+| Value | Storage Location | VCS-trackable |
+|-------|-----------------|---------------|
+| `user` | `~/.claude/agent-memory/<name>/` | No |
+| `project` | `.claude/agent-memory/<name>/` | Yes |
+| `local` | `.claude/agent-memory-local/<name>/` | No |
+
+When `memory` is set, the subagent reads and updates its `MEMORY.md` file automatically, allowing it to accumulate knowledge across separate sessions.
+
+---
+
+### `background`
+
+| Attribute | Value |
+|-----------|-------|
+| Type | `boolean` |
+| Default | `false` |
+| Valid values | `true`, `false` |
+
+**Semantics:** When `true`, the subagent runs as a non-blocking background task when invoked. The main conversation does not wait for the subagent to complete before continuing. Useful for fire-and-forget operations like logging, notifications, or parallel analysis.
+
+---
+
+### `effort`
+
+| Attribute | Value |
+|-----------|-------|
+| Type | `string` (enum) OR `number` (integer) |
+| Default | Inherits from session |
+| Valid string values | `low`, `medium`, `high`, `xhigh`, `max` |
+
+**Semantics:** Sets the reasoning effort level for this subagent when it runs. Overrides the session-level effort setting. Available levels depend on the model — not all models support all effort levels. Numeric values are also accepted by the SDK (maps to internal token budget).
+
+| Value | Effect |
+|-------|--------|
+| `low` | Minimal thinking tokens, fastest response, lowest cost |
+| `medium` | Balanced reasoning (typical default) |
+| `high` | More extended thinking, better on complex problems |
+| `xhigh` | Extended high reasoning |
+| `max` | Maximum thinking tokens available for the model |
+
+**Added:** `effort` frontmatter support added in the same batch as `maxTurns` and `disallowedTools` for plugin agents.
+
+---
+
+### `isolation`
+
+| Attribute | Value |
+|-----------|-------|
+| Type | `string` (enum) |
+| Default | No isolation (shares working directory with main session) |
+| Valid values | `worktree` |
+
+**Semantics:** `isolation: worktree` runs the subagent in a temporary git worktree — an isolated copy of the repository. The worktree is created before the subagent starts and automatically cleaned up if the subagent makes no changes. If changes are made, the worktree branch can be reviewed and merged.
+
+Use cases: safe parallel code changes, prototype work that may be discarded, preventing the subagent from affecting main working tree state.
+
+**Added:** v2.1.49 (`isolation: worktree` support). Documented in changelog and GitHub issue #27023.
+
+**Note on undocumented variants:** The EXA deep research report mentions `strict`, `shared`, and `fork` as isolation values. These do NOT appear in the official Anthropic docs or the TypeScript SDK reference as of May 2026. Only `worktree` is officially documented. Do not use other values.
+
+---
+
+### `color`
+
+| Attribute | Value |
+|-----------|-------|
+| Type | `string` (named color enum) |
+| Default | No color (uses system default in UI) |
+| Valid values | `red`, `blue`, `green`, `yellow`, `purple`, `orange`, `pink`, `cyan` |
+
+**Semantics:** Sets the display color for the subagent in the task list and transcript UI. Used purely for visual distinction — has no effect on behavior.
+
+**Format:** Named color strings only. Hex codes (e.g., `#00ccff`) appear in community examples and the SDK documentation but are NOT listed in the official frontmatter reference table. The official docs list exactly 8 named colors: `red`, `blue`, `green`, `yellow`, `purple`, `orange`, `pink`, `cyan`. The GitHub issue #19292 also proposes adding `magenta` (not in the official table as of May 2026). The community issue report notes that `color` was undocumented for an extended period and was only added to the official docs table after a user bug report. Treat hex codes as "observed but unofficially documented" — they may work but are not in the official spec.
+
+**UI surface:** Appears in the agent icon/badge in the task list, the subagent transcript header, and the `/agents` management UI.
+
+---
+
+### `initialPrompt`
+
+| Attribute | Value |
+|-----------|-------|
+| Type | `string` |
+| Default | None |
+
+**Semantics:** A string that is automatically submitted as the first user turn when the subagent starts. Allows pre-seeding the subagent's first action without requiring the caller to pass an initial message. Only relevant when invoking the agent via `claude --agent <name>` (main-thread mode).
+
+---
+
+## Fields Documented Only in the TypeScript SDK (`AgentDefinition`)
+
+These fields appear in the official TypeScript SDK `AgentDefinition` type and/or the `--agents` JSON flag documentation. They are supported in programmatic/SDK agent definitions and via the `--agents` CLI flag. Their behavior in file-based YAML frontmatter is either confirmed or likely — the `--agents` flag docs explicitly state it "accepts JSON with the same frontmatter fields."
+
+### `criticalSystemReminder_EXPERIMENTAL`
+
+| Attribute | Value |
+|-----------|-------|
+| Type | `string` |
+| Status | Experimental — name contains `_EXPERIMENTAL` suffix |
+
+**Semantics:** A critical reminder string appended to the subagent's system prompt. The `_EXPERIMENTAL` suffix signals that this API may change or be removed. Use with caution and avoid relying on it in production.
+
+---
+
+## Advanced / Observed-but-Unofficial Fields
+
+The following fields have been observed in real-world public repositories but do NOT appear in the official Anthropic documentation's frontmatter table. They are annotated accordingly.
+
+### `priority` — observed but unofficial
+
+Seen in a small number of community agents. Suggested semantics: integer controlling routing precedence when multiple agents match a task. Not in official docs as of May 2026. Do not rely on it.
+
+### `linked-from-skills` — observed but unofficial
+
+Seen in `popup-studio-ai/bkit-claude-code` agents. Appears to be a plugin-internal cross-reference metadata field, not parsed by Claude Code's core runtime. Community/plugin convention only.
+
+### `imports` — observed but unofficial
+
+Seen in `popup-studio-ai/bkit-claude-code` design-validator.md. Appears to be a plugin framework extension to inline-include content from other files. Not in official spec.
+
+### `context: fork` — observed but unofficial
+
+Seen alongside `mergeResult: false` in bkit-claude-code plugin agents. Appears to be a plugin-level extension, not an official Claude Code frontmatter field.
+
+### `readonly: true` — observed but unofficial
+
+Seen in `streamlit/streamlit` reviewing-local-changes.md. Appears to be a semantic shorthand for read-only mode. Not in official docs — when read-only behavior is needed, use `disallowedTools: Write, Edit` or `permissionMode: plan` instead.
+
+### `voiceId`, `voice:` mapping — observed but unofficial
+
+Seen in `danielmiessler/Personal_AI_Infrastructure` agents. Custom extension for voice/TTS integration. Not parsed by Claude Code's core runtime.
+
+### `version`, `author`, `license`, `metadata` — observed but unofficial
+
+Seen in various plugin and community agents (e.g., NousResearch/hermes-agent). These are informational metadata fields. The Claude Code runtime ignores them. The plugin manifest (`plugin.json`) uses `version`, `author`, `license` but these are separate from the agent frontmatter spec.
+
+---
+
+## Format and Parsing Rules
+
+### File structure
+
+```
+---
+name: agent-name
+description: Single-line description of what this agent does and when to use it.
+tools: Read, Grep, Glob
+model: sonnet
+color: blue
+---
+
+# Agent Name (this heading is optional — the whole body is the system prompt)
+
+Your system prompt goes here. This Markdown content is passed verbatim
+to the subagent as its system prompt.
+```
+
+### YAML delimiters
+
+The frontmatter block must begin and end with `---` on their own lines. The opening `---` must be the very first line of the file (no BOM, no blank lines before it).
+
+### Comma-separated vs YAML list for `tools` and `disallowedTools`
+
+Both forms are accepted. The comma-separated string form is more common in documentation examples:
+
+```yaml
+tools: Read, Grep, Glob, Bash
+```
+
+The YAML list form also works and is more readable for long lists:
+
+```yaml
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+```
+
+Do not mix forms in the same field.
+
+### Single-line description requirement
+
+The `description` field must be a single inline YAML string. The following patterns silently truncate the description:
+
+```yaml
+# WRONG — folded scalar, truncates to first line
+description: >
+  Use when the user asks about security.
+  Also handles vulnerability scanning.
+
+# WRONG — literal block scalar, same problem
+description: |
+  Use when security review needed.
+
+# WRONG — multi-line single-quoted string that wraps
+description: 'Use when the user asks about security
+  and vulnerability scanning.'
+
+# CORRECT — inline single line (quotes optional unless special chars)
+description: Use when the user asks about security or needs vulnerability scanning.
+
+# CORRECT — double-quoted for strings with colons or special chars
+description: "Use when: security review, audit, or vulnerability scan is requested."
+```
+
+### LF line endings
+
+All agent `.md` files must use LF line endings, not CRLF. On WSL2 or Windows environments where the Write tool creates files with CRLF, run `sed -i 's/\r$//' <file>` after creating the file to normalize endings. CRLF can cause frontmatter parsing failures.
+
+### Naming rules for `name`
+
+- Lowercase letters (`a-z`), digits (`0-9`), hyphens (`-`) only
+- No spaces, no underscores, no uppercase letters
+- Should not start or end with a hyphen
+- Must be unique within its scope (project, user, plugin)
+- Convention: use kebab-case matching the filename minus `.md`
+
+### File location and filename
+
+The filename does not need to match the `name` field, but must end in `.md`. By convention, `name: code-reviewer` lives in `code-reviewer.md`. The file must be placed in an `agents/` directory within the appropriate scope location.
+
+### System prompt (body)
+
+Everything after the closing `---` of the frontmatter is the system prompt. This is passed verbatim to the subagent — it does not receive the full Claude Code system prompt, only this body plus basic environment details (working directory). The body can be any Markdown: headings, lists, code blocks are all valid and render as part of the instructions.
+
+---
+
+## Triggering and Discovery
+
+### Automatic delegation
+
+When Claude is handling a task, it evaluates all loaded subagent descriptions to determine if any match the current task. Matching is semantic (not literal keyword matching). A subagent is selected when its description accurately captures the task type and the task would benefit from delegation (context isolation, specialized behavior).
+
+### Manual invocation
+
+Subagents can always be invoked explicitly:
+- `@agent-name` in chat (@ mention typeahead, added April 2026 v2.1.90+)
+- `claude --agent <name>` CLI (runs agent as main-thread, not subagent)
+- Via the Task tool: `subagent_type: "agent-name"` or `subagent_type: "plugin:plugin-dir:agent-name"`
+
+### Loading and refresh
+
+Subagents are loaded at session start. If you add or modify a `.md` file while a session is running:
+- Run `/agents` command to reload immediately, OR
+- Restart the session
+
+### `proactive` / auto-invocation description keywords
+
+The word "Proactively" in the description is a documented pattern that signals the agent should be considered for automatic invocation after relevant operations (e.g., "Proactively review JS/TS files and offer fixes before committing"). This is a prompt-level convention — there is no `proactive:` boolean frontmatter field in the official spec as of May 2026. The EXA research report mentions a `proactive` field — this is not confirmed in official docs and should be treated as unverified.
+
+### `initialPrompt` and main-thread invocation
+
+When using `claude --agent <name>`, the `initialPrompt` frontmatter field auto-submits a first turn. In subagent (Task tool) mode, the initial message is supplied by the parent.
+
+---
+
+## Precedence and Namespacing
+
+### Scope hierarchy
+
+Definitions are loaded from all applicable scopes. When multiple definitions share the same `name`, the following precedence applies (highest to lowest):
+
+| Priority | Scope | Location |
+|----------|-------|----------|
+| 1 (highest) | Managed (organization admin) | Managed settings directory / `.claude/agents/` in managed settings |
+| 2 | CLI-defined | `--agents` JSON flag (session-only, not persisted) |
+| 3 | Project | `.claude/agents/` in current project or ancestor directories |
+| 4 | User | `~/.claude/agents/` |
+| 5 (lowest) | Plugin | `plugins/<name>/agents/` or plugin-installed agents |
+
+**Programmatic vs filesystem:** Agents defined programmatically (SDK `agents` parameter or `--agents` flag) take precedence over filesystem-based agents with the same name.
+
+**Plugin agents:** Plugin agents appear in `/agents` alongside custom agents but have the lowest precedence. Plugin agents can be referenced by unqualified name (if unique) or qualified name `plugin:<plugin-dir>:<name>`.
+
+### Qualified `subagent_type` in command files
+
+When spawning agents from command files or other agents using the Task tool, always use the fully-qualified form when there is any risk of name collision:
+
+```
+subagent_type: "plugin:yellow-research:ceramic-researcher"
+subagent_type: "code-reviewer"  # unqualified — OK only if unique in scope
+```
+
+The fully-qualified form is `plugin:<plugin-directory-name>:<agent-name>` where `plugin-directory-name` is the directory name of the plugin (e.g., `yellow-research`), not the plugin's `name` field. This distinction matters: using the wrong identifier causes silent invocation failure or invocation of the wrong agent.
+
+### Managed agents
+
+Administrators deploy managed subagents by placing `.md` files in `.claude/agents/` inside the managed settings directory. Managed agents use identical frontmatter format and override project/user agents with the same name. The `permissionMode` field is honored for managed agents (unlike plugin agents, where it is ignored).
+
+---
+
+## Examples
+
+### Example 1 — Minimal valid agent
+
+```yaml
+---
+name: code-reviewer
+description: Reviews code for quality, security, and best practices. Use when the user asks for a code review or wants feedback on their implementation.
+tools: Read, Glob, Grep
+model: sonnet
+---
+
+You are a code reviewer. When invoked, analyze the provided code and return
+specific, actionable feedback on quality, security, and best practices.
+Focus on:
+- Security vulnerabilities (injection, auth, secrets in code)
+- Performance issues
+- Maintainability and readability
+
+Return your findings as a numbered list with file:line references.
+```
+
+### Example 2 — Full-featured agent with isolation and persistent memory
+
+```yaml
+---
+name: rulecheck-agent
+description: Autonomous code quality agent that scans for rule violations, fixes them in an isolated worktree, creates a PR, and updates memory with findings. Use when a systematic compliance check is needed.
+model: sonnet
+permissionMode: acceptEdits
+maxTurns: 500
+isolation: worktree
+memory: project
+color: purple
+effort: high
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
+skills:
+  - coding-standards
+  - security-patterns
+---
+
+You are an autonomous code quality agent. Your working directory MUST
+contain `.claude/worktrees/` in the path — if it does not, stop immediately.
+
+[...system prompt continues...]
+```
+
+### Example 3 — Plugin agent with MCP server access
+
+```yaml
+---
+name: sentry-mcp
+description: Sentry error tracking and performance monitoring agent. Use when the user asks about errors, exceptions, issues, stack traces, performance, traces, releases, or provides a Sentry URL.
+mcpServers:
+  - sentry
+model: haiku
+color: cyan
+---
+
+You are a Sentry specialist. Use the Sentry MCP tools to search for issues,
+analyze stack traces, and provide actionable debugging recommendations.
+```
+
+### Example 4 — Background agent with explicit effort
+
+```yaml
+---
+name: dependency-scanner
+description: Scans project dependencies for known vulnerabilities in the background. Use when the user adds new dependencies or asks about security of dependencies.
+model: haiku
+background: true
+effort: low
+maxTurns: 10
+tools: Read, Bash(npm audit:*), Glob
+color: yellow
+---
+
+Scan the project's dependencies for known security vulnerabilities.
+Run `npm audit` or equivalent for the detected package manager.
+Return a summary of critical and high-severity findings only.
+```
+
+---
+
+## Field Quick-Reference Table
+
+| Field | Required | Type | Default | Official? |
+|-------|----------|------|---------|-----------|
+| `name` | Yes | `string` (kebab-case) | — | Official |
+| `description` | Yes | `string` (single-line) | — | Official |
+| `tools` | No | comma-string or list | inherit all | Official |
+| `disallowedTools` | No | comma-string or list | none | Official |
+| `model` | No | string enum or model ID | `inherit` | Official |
+| `permissionMode` | No | string enum | inherit from parent | Official |
+| `maxTurns` | No | integer | no limit | Official |
+| `skills` | No | list of skill names | none | Official |
+| `mcpServers` | No | list or mapping | none | Official |
+| `hooks` | No | event → handler mapping | none | Official |
+| `memory` | No | `user`/`project`/`local` | none | Official |
+| `background` | No | `boolean` | `false` | Official |
+| `effort` | No | `low`/`medium`/`high`/`xhigh`/`max` or integer | inherit | Official |
+| `isolation` | No | `worktree` (only valid value) | none | Official |
+| `color` | No | `red`/`blue`/`green`/`yellow`/`purple`/`orange`/`pink`/`cyan` | none | Official |
+| `initialPrompt` | No | `string` | none | Official |
+| `criticalSystemReminder_EXPERIMENTAL` | No | `string` | none | Official (experimental) |
+| `priority` | No | integer | — | Observed, unofficial |
+| `version`, `author`, `license` | No | string | — | Ignored (plugin manifest fields) |
+
+---
+
+## Changelog: Recently Added and Removed Fields
+
+| Version | Date | Change |
+|---------|------|--------|
+| v2.0.28 | October 27, 2025 | Subagents introduced; `model` dynamic selection added |
+| v2.0.42 | November 15, 2025 | `agent_id` and `agent_transcript_path` added to `SubagentStop` hook input |
+| v2.0.43 | November 18, 2025 | `permissionMode` field added; `skills` frontmatter field added; `SubagentStart` hook event added |
+| v2.0.x  | Late 2025 | `effort`, `maxTurns`, `disallowedTools` frontmatter support added for plugin-shipped agents |
+| v2.1.49 | Early 2026 | `isolation: worktree` added |
+| v2.1.90+ | April 2026 | `@mention` typeahead for agents; `mcpServers` in frontmatter honored when using `claude --agent <name>` (v2.1.117+); `permissionMode` honored for built-in agents via `--agent <name>` (v2.1.119+) |
+
+**Fields with no deprecation history found** as of May 4, 2026 in official sources. The EXA report mentions `deny-tools` (deprecated v2.1.110), `auto-invoke` (deprecated v2.1.112, replaced by `proactive`), and `extends` (removed v2.1.115) — these could not be confirmed against the official changelog and should be treated as unverified. The official docs do not mention any deprecated frontmatter fields.
+
+---
+
+## Sources
+
+1. [Create custom subagents — code.claude.com](https://code.claude.com/docs/en/subagents) — Primary official reference for all frontmatter fields including the complete field table, color values, effort values, permissionMode values, and isolation. Accessed 2026-05-04.
+
+2. [Create custom subagents — docs.anthropic.com](https://docs.anthropic.com/en/docs/claude-code/sub-agents) — Anthropic-hosted mirror of official docs. Confirms `--agents` JSON field list. Accessed 2026-05-04.
+
+3. [Subagents in the SDK — code.claude.com](https://code.claude.com/docs/en/agent-sdk/subagents) — SDK programmatic agent fields including `memory`, `skills`, `cleanupPeriodDays`. Accessed 2026-05-04.
+
+4. [Agent SDK reference — TypeScript — code.claude.com](https://code.claude.com/docs/en/agent-sdk/typescript) — Authoritative `AgentDefinition` TypeScript type confirming all SDK-level fields including `criticalSystemReminder_EXPERIMENTAL`. Accessed 2026-05-04.
+
+5. [Hooks reference — code.claude.com](https://code.claude.com/docs/en/hooks) — SubagentStart/SubagentStop hook events, hook input/output schemas, `additionalContext` field. Accessed 2026-05-04.
+
+6. [Changelog — code.claude.com](https://code.claude.com/docs/en/changelog) — Version history confirming when `permissionMode`, `skills`, `effort`, `maxTurns`, `isolation` were added. Accessed 2026-05-04.
+
+7. [Choose a permission mode — code.claude.com](https://code.claude.com/docs/en/permission-modes) — Full permissionMode enum values and inheritance semantics. Accessed 2026-05-04.
+
+8. [GitHub issue #19292 — anthropics/claude-code](https://github.com/anthropics/claude-code/issues/19292) — `color` field undocumented bug report; reveals accepted color values `blue`, `cyan`, `green`, `yellow`, `magenta`, `red`. Accessed 2026-05-04.
+
+9. [GitHub issue #27023 — anthropics/claude-code](https://github.com/anthropics/claude-code/issues/27023) — `isolation: worktree` missing from docs; confirms v2.1.49 introduction. Accessed 2026-05-04.
+
+10. [GitHub issue #10504 — anthropics/claude-code](https://github.com/anthropics/claude-code/issues/10504) — Description field YAML parsing issues; confirms folded scalar truncation behavior. Accessed 2026-05-04.
+
+11. [claude-howto/04-subagents — luongnv89/claude-howto](https://github.com/luongnv89/claude-howto/blob/main/04-subagents/README.md) — Community reference showing full frontmatter including `background`, `effort`, `isolation`, `initialPrompt`, and `hooks` syntax with version annotations. Accessed 2026-05-04.
+
+12. Real-world agent examples from: [home-assistant/core](https://github.com/home-assistant/core/tree/dev/.claude/agents), [n8n-io/n8n](https://github.com/n8n-io/n8n/tree/master/.claude/plugins/n8n/agents), [streamlit/streamlit](https://github.com/streamlit/streamlit/tree/develop/.claude/agents), [coleam00/Archon](https://github.com/coleam00/Archon/tree/dev/.claude/agents), [getsentry/sentry-mcp](https://github.com/getsentry/sentry-mcp/tree/main/plugins/sentry-mcp/agents), [danielmiessler/Personal_AI_Infrastructure](https://github.com/danielmiessler/Personal_AI_Infrastructure/tree/main/Releases/v4.0.3/.claude/agents). Accessed 2026-05-04.
+
+13. [perplexity_research] — Source skipped (unavailable — API quota exceeded).

--- a/docs/solutions/code-quality/subagent-frontmatter-field-catalog.md
+++ b/docs/solutions/code-quality/subagent-frontmatter-field-catalog.md
@@ -1,0 +1,257 @@
+---
+title: 'Subagent Frontmatter Field Catalog'
+date: 2026-05-04
+category: code-quality
+track: knowledge
+problem: Claude Code subagent .md frontmatter fields — required, optional, version history, scope precedence
+tags: [subagents, frontmatter, agents, permissionMode, isolation, effort, disallowedTools, skills, mcpServers, memory]
+components: [agents, plugin-authoring, frontmatter-parser]
+---
+
+## Context
+
+Subagent `.md` files in Claude Code use a YAML frontmatter block to declare
+identity, capabilities, model, permissions, and runtime behavior. The body
+below the frontmatter becomes the subagent's system prompt verbatim. Only
+`name` and `description` are required. Unknown keys are silently ignored;
+invalid values typically cause the field to be ignored or the agent to fail to
+spawn.
+
+Sources: [docs.anthropic.com/en/docs/claude-code/sub-agents](https://docs.anthropic.com/en/docs/claude-code/sub-agents) (primary, verified 2026-05-04 via Perplexity),
+[code.claude.com/docs/en/subagents](https://code.claude.com/docs/en/subagents),
+[/agent-sdk/typescript](https://code.claude.com/docs/en/agent-sdk/typescript),
+[/changelog](https://code.claude.com/docs/en/changelog),
+[/hooks](https://code.claude.com/docs/en/hooks),
+[/permission-modes](https://code.claude.com/docs/en/permission-modes).
+
+---
+
+## Guidance
+
+### Required fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | `string` | Lowercase `a-z`, digits, hyphens only. No spaces, underscores, uppercase. Convention: matches filename minus `.md`. |
+| `description` | `string` (single-line) | **Must be single-line inline.** Folded scalars (`>`) and literal blocks (`|`) silently truncate to first line (parser bug, GH #10504). Include a "Use when…" trigger clause for reliable automatic delegation. |
+
+### Optional fields — behavioral
+
+| Field | Type | Default | Added |
+|---|---|---|---|
+| `tools` | comma-string or list | inherit all | v2.0.28 |
+| `disallowedTools` | comma-string or list | none | v2.0.x late 2025 |
+| `model` | enum alias or full model ID | `inherit` | v2.0.28 |
+| `permissionMode` | enum (see below) | inherit from parent | v2.0.43 |
+| `effort` | `low`/`medium`/`high`/`xhigh`/`max` or integer | inherit | v2.0.x late 2025 |
+| `maxTurns` | positive integer | no limit | v2.0.x late 2025 |
+| `isolation` | `worktree` (only valid value) | none | v2.1.49 |
+| `background` | boolean | `false` | v2.0.x |
+| `skills` | list of skill names | none | v2.0.43 |
+| `mcpServers` | list or inline mapping | inherit from session | v2.1.117+ (main-thread) |
+| `memory` | `user`/`project`/`local` | none | SDK-level |
+| `hooks` | event → handler mapping | none | v2.0.42 |
+| `initialPrompt` | string | none | SDK-level |
+| `color` | `red`/`blue`/`green`/`yellow`/`purple`/`orange`/`pink`/`cyan` | none | undocumented until GH #19292 |
+
+### `permissionMode` enum and inheritance
+
+| Value | Behavior |
+|---|---|
+| `default` | Standard — prompts for approval before risky actions |
+| `acceptEdits` | Auto-accepts file edits + common filesystem commands in working dir |
+| `auto` | Background classifier auto-approves most commands, prompts on risky |
+| `dontAsk` | Auto-denies permission prompts; only pre-approved tools run |
+| `bypassPermissions` | Skips all prompts except protected paths (`.git`, `.claude`, `.vscode`, `.husky`) |
+| `plan` | Read-only exploration; no edits or command execution |
+
+**Inheritance rules:**
+- Parent uses `bypassPermissions` or `acceptEdits` → subagent `permissionMode` is **ignored**; parent mode takes precedence.
+- Parent uses `auto` → subagent inherits `auto`; frontmatter ignored.
+- All other cases → subagent frontmatter overrides parent.
+- Plugin agents: `permissionMode` is **always silently dropped** for plugin-shipped subagents (security boundary). Same for `hooks` and `mcpServers` — see "Plugin subagent restrictions" below.
+
+### `tools` and `disallowedTools` semantics
+
+`tools` is an explicit allowlist — omitting it inherits all parent tools; specifying it restricts to exactly those listed. `disallowedTools` is a denylist applied after the allowlist. Both accept comma-separated strings or YAML list form.
+
+Bash can be restricted to command prefixes: `Bash(git *)`, `Bash(npm:*)`. The `tools` allowlist also supports `Agent(<subagent-name>)` to restrict which subagents can be spawned.
+
+Do NOT include `Task` in a subagent's `tools` — subagents cannot spawn other subagents.
+
+MCP tool naming: `mcp__plugin_<pluginName>_<serverName>__<toolName>`.
+
+### `isolation: worktree`
+
+Runs the subagent in a temporary git worktree (isolated repository copy). The worktree is created before the subagent starts and auto-cleaned up if no changes are made. Useful for parallel code changes or prototype work that may be discarded.
+
+Only `worktree` is officially documented as of May 2026. Values like `strict`, `shared`, `fork` appear in third-party research but are not in official docs — do not use them.
+
+### `memory` storage locations
+
+| Value | Path | VCS-trackable |
+|---|---|---|
+| `user` | `~/.claude/agent-memory/<name>/` | No |
+| `project` | `.claude/agent-memory/<name>/` | Yes |
+| `local` | `.claude/agent-memory-local/<name>/` | No |
+
+**`memory: true` (boolean form) is invalid** — silently ignored. Must use the string scopes `user`/`project`/`local`. Any pre-existing agent with `memory: true` predates the scope-string spec and is doing nothing until corrected.
+
+**`memory:` is a tool expansion**, not just a storage flag. Setting any scope auto-grants `Read`, `Write`, and `Edit` to the subagent **regardless of its `tools:` allowlist**. For agents documented as read-only (e.g., review agents that "report findings, do NOT edit"), the read-only contract becomes prompt-level only — the runtime permission is full read/write. Validate at PR-review time: when an author adds `memory:`, re-check the agent's tool-allowlist semantics still match its documented contract.
+
+`memory:` also injects the first ~200 lines of the agent's `MEMORY.md` index into context at startup.
+
+### `skills` preloading
+
+Lists skill names (from `skills/` directories) to inject into the subagent's context. Skill name must match the `name:` frontmatter field of the skill file, not the filename. **Subagents do NOT inherit skills from their parent** — the `skills:` list must be explicit. Skills configured with `disable-model-invocation: true` cannot be preloaded.
+
+### `background: true` requires both halves
+
+The `background: true` frontmatter flag declares the agent is concurrent-eligible, but the spawning Task call must also pass `run_in_background: true` to actually run in parallel. One without the other still serializes — the spawn call is the deciding factor. Subagents always run as concurrent tasks within the parent's session regardless of this flag; the flag only affects whether the parent waits for completion.
+
+### `mcpServers` inline config
+
+Named servers or inline HTTP config:
+
+```yaml
+mcpServers:
+  notion:
+    type: http
+    url: https://mcp.notion.com/mcp
+```
+
+Honored when agent is invoked via `claude --agent <name>` (added v2.1.117+). In subagent (Task tool) mode, the parent session's MCP servers are inherited.
+
+### `hooks` event mapping
+
+Lifecycle hooks scoped to a subagent. The `Stop` event auto-converts to `SubagentStop` when scoped to a subagent definition. `PreToolUse` and `PostToolUse` work as in session-level hooks; `SubagentStart` cannot block creation.
+
+---
+
+## Plugin subagent restrictions (security boundary)
+
+Three frontmatter fields are **silently dropped** when the agent comes from a plugin (not user/project/managed scope):
+
+- `permissionMode`
+- `mcpServers`
+- `hooks`
+
+Plugin-shipped agents cannot escalate their own permissions, register their own MCP servers, or attach lifecycle hooks. The fields parse without error but have zero runtime effect. To use them, copy the agent file into `.claude/agents/` (project) or `~/.claude/agents/` (user).
+
+Detection: when reviewing a plugin PR that adds any of these three fields to a `plugins/<name>/agents/*.md` file, flag as a no-op.
+
+---
+
+## Scope Precedence (highest → lowest)
+
+| Priority | Scope | Location |
+|---|---|---|
+| 1 | Managed (org admin) | Managed settings `.claude/agents/` |
+| 2 | CLI-defined | `--agents` JSON flag (session-only) |
+| 3 | Project | `.claude/agents/` in project or ancestor |
+| 4 | User | `~/.claude/agents/` |
+| 5 | Plugin | `plugins/<name>/agents/` |
+
+Name collisions are resolved by precedence. To guarantee the correct agent is invoked from a command file, use the fully-qualified form:
+
+```
+subagent_type: "plugin:<plugin-directory-name>:<agent-name>"
+```
+
+The `plugin-directory-name` is the directory name (e.g., `yellow-research`), NOT the plugin's `name` field value. Confusing these causes silent invocation failure.
+
+---
+
+## Why This Matters
+
+- **`description` single-line rule:** Folded scalars silently truncate — the parser reads only the first line. This is confirmed parser behavior (GH #10504), not a subtle edge case. Every folded-scalar description passes YAML validation but delivers a broken routing signal.
+- **Plugin subagents silently drop three fields:** `permissionMode`, `mcpServers`, and `hooks` are no-ops when shipped from a plugin. Reviewing a plugin PR that adds any of these is reviewing dead frontmatter unless the agent is later moved to user/project scope.
+- **`memory:` is a tool expansion:** Adding `memory: project` to an agent advertised as read-only silently grants Read/Write/Edit. The "read-only contract" exists only in the system prompt — the runtime grant is real.
+- **`memory: true` is invalid:** Boolean form silently does nothing. Use `user`/`project`/`local` strings.
+- **`background: true` requires `run_in_background: true` on the spawn call:** Frontmatter alone does not parallelize — the Task call is the deciding factor.
+- **`disallowedTools` composability:** Prefer `disallowedTools` to restrict a single tool rather than enumerating an entire `tools` allowlist when the goal is "everything except Write/Edit."
+- **`isolation: worktree` cleanup:** Worktrees with no changes are cleaned up automatically. Worktrees with changes are left for review — callers must account for this in their orchestration.
+- **Scope precedence affects plugin QA:** A project-level `.claude/agents/same-name.md` silently overrides a plugin agent with the same name. Always use qualified `subagent_type` in plugin command files.
+
+---
+
+## When to Apply
+
+- Authoring a new agent `.md` file in any scope.
+- Reviewing a PR that adds `memory:`, `background:`, `permissionMode:`, `mcpServers:`, or `hooks:` to a plugin agent — verify the value is in spec AND the field is honored at the agent's scope (not silently dropped).
+- Debugging silent delegation failures (wrong agent invoked, routing never fires).
+- Choosing between `permissionMode` values for an autonomous agent.
+- Adding `isolation: worktree` to agents that must not affect main working tree state.
+- Setting `effort` and `maxTurns` to control cost/quality tradeoffs for long-running autonomous agents.
+
+---
+
+## Examples
+
+Minimal agent with explicit tool allowlist:
+
+```yaml
+---
+name: code-reviewer
+description: Reviews code for quality, security, and best practices. Use when the user asks for a code review or wants feedback on their implementation.
+tools: Read, Glob, Grep
+model: sonnet
+---
+```
+
+Autonomous agent with isolation, memory, and effort:
+
+```yaml
+---
+name: rulecheck-agent
+description: Runs systematic compliance checks in an isolated worktree. Use when a full codebase scan for rule violations is needed.
+model: sonnet
+permissionMode: acceptEdits
+maxTurns: 500
+isolation: worktree
+memory: project
+effort: high
+color: purple
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
+skills:
+  - coding-standards
+---
+```
+
+Background scanner with denylist:
+
+```yaml
+---
+name: dependency-scanner
+description: Scans project dependencies for known vulnerabilities. Use when new dependencies are added or a security check is requested.
+model: haiku
+background: true
+effort: low
+maxTurns: 10
+disallowedTools: Write, Edit
+tools: Read, Bash, Glob
+---
+```
+
+---
+
+## Version Changelog
+
+| Version | Date | Change |
+|---|---|---|
+| v2.0.28 | 2025-10-27 | Subagents introduced; `model` dynamic selection added |
+| v2.0.42 | 2025-11-15 | `agent_id` + `agent_transcript_path` added to SubagentStop hook input |
+| v2.0.43 | 2025-11-18 | `permissionMode`, `skills` fields added; SubagentStart hook event added |
+| v2.0.x | Late 2025 | `effort`, `maxTurns`, `disallowedTools` added for plugin-shipped agents |
+| v2.1.49 | Early 2026 | `isolation: worktree` added |
+| v2.1.90+ | 2026-04 | `@mention` typeahead for agents added |
+| v2.1.117+ | 2026-04 | `mcpServers` frontmatter honored in `claude --agent <name>` main-thread mode |
+| v2.1.119+ | 2026-04 | `permissionMode` honored for built-in agents via `--agent <name>` |
+
+Fields with no deprecation history as of 2026-05-04. Reports of deprecated `deny-tools`, `auto-invoke`, and `extends` fields could not be confirmed against the official changelog — treat as unverified.


### PR DESCRIPTION
## Summary

Adds two compounded reference docs for Claude Code subagent `.md` frontmatter, distilled from official Anthropic docs (sub-agents, agent-sdk/typescript, changelog, hooks, permission-modes) verified 2026-05-04 via Perplexity, plus real-world plugin examples.

- `docs/solutions/code-quality/subagent-frontmatter-field-catalog.md` — action-guiding reference. Required + optional fields with defaults and added-in version. Documents the three plugin-subagent silent drops (`permissionMode`, `mcpServers`, `hooks`), the `memory:` tool-expansion side effect (auto-grants Read/Write/Edit regardless of `tools:` allowlist), the `memory: true` boolean-form invalidity, the `background: true` two-halves rule, `permissionMode` inheritance, `isolation: worktree` lifecycle, scope precedence (managed > CLI > project > user > plugin), and v2.0.28 → v2.1.119+ changelog.
- `docs/research/all-possible-subagent-frontmatter-config.md` — full long-form research snapshot. Catalogs every observed field including SDK-only `criticalSystemReminder_EXPERIMENTAL` and observed-but-unofficial fields (`priority`, `readonly`, `voiceId`, etc.) with explicit non-spec annotation.

No plugin code changed; docs-only — no changeset required.

## Why this matters

These two docs prevent re-derivation work for future agent authors and PR reviewers. The catalog flags three high-impact silent failure modes that the existing `MEMORY.md` did not previously cover:

1. **`memory:` is a tool expansion** — adding it to a "read-only" review agent silently grants Write/Edit at runtime; the read-only contract becomes prompt-level only.
2. **`memory: true` (boolean) is invalid** — silently does nothing; must be `user`/`project`/`local`.
3. **`hooks` / `mcpServers` / `permissionMode` are silently dropped for plugin subagents** — fields parse without error but have zero runtime effect when shipped from a plugin.

## Test plan

- [x] LF line endings verified (`file` + `sed -i 's/\r$//'`)
- [x] Both files render in GitHub markdown preview
- [x] Sources cross-checked against `docs.anthropic.com/en/docs/claude-code/sub-agents` (verified 2026-05-04)
- [ ] Merge queue CI passes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This docs-only PR adds two new reference documents covering Claude Code subagent `.md` frontmatter: an action-guiding field catalog and a comprehensive research snapshot. The documents are well-structured and cover a wide range of fields, but three P1 content inconsistencies between the two files need resolution before they can serve as a reliable single source of truth.

- **`background: true` contract**: the research doc says the parent won't wait, but the catalog says `run_in_background: true` on the Task call is also required — only one can be correct from a practitioner's perspective.
- **MCP tool naming**: the catalog uses `mcp__plugin_<pluginName>_<serverName>__<toolName>` while the research doc uses `mcp__<serverName>__<toolName>`; the difference is unexplained.
- **`bypassPermissions` path list**: the catalog omits `.idea` and the `.claude/commands`, `.claude/agents`, `.claude/skills` exceptions that appear in the research doc.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until the three cross-document factual contradictions are resolved — they will mislead developers using either doc as a reference.

Three P1 content conflicts exist between the two files (background two-halves rule, MCP tool naming pattern, bypassPermissions path list). Merging contradictory reference docs is worse than merging no docs, since practitioners will cite whichever version supports their current assumption. Score is pulled below the P1 ceiling of 4 because all three P1s affect the same two files and compound each other's confusion risk.

Both files require attention: the `background`, `bypassPermissions`, and MCP naming sections need to be reconciled so the two documents agree.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/solutions/code-quality/subagent-frontmatter-field-catalog.md | Action-guiding reference for subagent frontmatter; `bypassPermissions` protected-paths list is missing `.idea` and the `.claude/*` sub-path exceptions present in the companion research doc; MCP tool naming pattern (`mcp__plugin_…`) conflicts with the shorter pattern in the other file. |
| docs/research/all-possible-subagent-frontmatter-config.md | Comprehensive research snapshot; `background` section omits the critical `run_in_background: true` spawn-call requirement; `memory` section omits the tool-expansion side-effect; Source #8 color list contradicts the color enum table within the same file. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Subagent .md file] --> B{Scope?}
    B -->|Plugin| C[plugin/agents/*.md]
    B -->|Project| D[.claude/agents/*.md]
    B -->|User| E[~/.claude/agents/*.md]
    B -->|Managed| F[managed/.claude/agents/*.md]

    C --> G[permissionMode DROPPED
mcpServers DROPPED
hooks DROPPED]
    D --> H[All fields honored]
    E --> H
    F --> H

    H --> I{Parent permissionMode?}
    I -->|bypassPermissions / acceptEdits / auto| J[Parent mode wins
frontmatter ignored]
    I -->|default / plan / dontAsk| K[Subagent frontmatter overrides]

    K --> L{background: true?}
    L -->|frontmatter only| M[Parent still waits
serializes]
    L -->|frontmatter + run_in_background: true on Task call| N[Truly parallel]

    H --> O{memory: set?}
    O -->|user/project/local| P[Read+Write+Edit granted
regardless of tools: list]
    O -->|true boolean| Q[Silently ignored — no-op]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22docs%2Fsubagent-frontmatter-reference%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fsubagent-frontmatter-reference%22.%0A%0AFix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Adocs%2Fresearch%2Fall-possible-subagent-frontmatter-config.md%3A294-295%0A**%60background%3A%20true%60%20missing%20the%20required%20%60run_in_background%3A%20true%60%20spawn-call%20condition**%0A%0AThe%20companion%20field-catalog%20doc%20%28%60subagent-frontmatter-field-catalog.md%60%2C%20lines%20108%E2%80%93111%29%20explicitly%20states%20that%20%60background%3A%20true%60%20in%20frontmatter%20does%20*not*%20by%20itself%20parallelize%20execution%20%E2%80%94%20the%20caller's%20Task%20invocation%20must%20also%20pass%20%60run_in_background%3A%20true%60%2C%20otherwise%20the%20parent%20still%20serializes.%20This%20research%20doc's%20description%20says%20%22The%20main%20conversation%20does%20not%20wait%20for%20the%20subagent%20to%20complete%20before%20continuing%2C%22%20which%20contradicts%20that%20rule%20and%20will%20mislead%20anyone%20using%20only%20this%20document%20as%20their%20reference.%0A%0A%23%23%23%20Issue%202%20of%205%0Adocs%2Fsolutions%2Fcode-quality%2Fsubagent-frontmatter-field-catalog.md%3A65%0A**%60bypassPermissions%60%20protected-paths%20list%20is%20incomplete%20vs.%20the%20research%20doc**%0A%0AThe%20research%20doc%20%28%60all-possible-subagent-frontmatter-config.md%60%2C%20line%20164%29%20lists%20%60.idea%60%20as%20an%20additional%20protected%20path%20and%20also%20notes%20that%20%60.claude%2Fcommands%60%2C%20%60.claude%2Fagents%60%2C%20and%20%60.claude%2Fskills%60%20are%20*exceptions*%20that%20still%20allow%20writes.%20The%20catalog%20entry%20omits%20%60.idea%60%20and%20the%20sub-path%20exceptions%20entirely%2C%20leaving%20the%20permission%20boundary%20described%20here%20narrower%20than%20what%20is%20actually%20enforced.%0A%0A%23%23%23%20Issue%203%20of%205%0Adocs%2Fsolutions%2Fcode-quality%2Fsubagent-frontmatter-field-catalog.md%3A82%0A**MCP%20tool-name%20pattern%20conflicts%20between%20the%20two%20documents**%0A%0AThis%20line%20uses%20%60mcp__plugin_%3CpluginName%3E_%3CserverName%3E__%3CtoolName%3E%60%20%28with%20a%20%60plugin_%60%20infix%29%2C%20but%20the%20research%20doc%20%28%60all-possible-subagent-frontmatter-config.md%60%2C%20line%20238%29%20uses%20%60mcp__%3CserverName%3E__%3CtoolName%3E%60%20%28no%20infix%29.%20Both%20patterns%20appear%20in%20the%20same%20PR%3B%20exactly%20one%20can%20be%20correct%20for%20a%20given%20context.%20If%20the%20longer%20form%20is%20specific%20to%20plugin-registered%20servers%20and%20the%20short%20form%20applies%20to%20globally-registered%20MCP%20servers%2C%20that%20distinction%20is%20not%20explained%20in%20either%20document%2C%20making%20the%20%60tools%3A%60%20frontmatter%20unreliable%20to%20author%20without%20knowing%20which%20pattern%20applies.%0A%0A%23%23%23%20Issue%204%20of%205%0Adocs%2Fresearch%2Fall-possible-subagent-frontmatter-config.md%3A266-284%0A**%60memory%3A%60%20tool-expansion%20side-effect%20omitted%20from%20research%20doc**%0A%0AThe%20field-catalog%20doc%20%28lines%20100%E2%80%93102%29%20calls%20out%20a%20critical%20behavioral%20consequence%3A%20any%20%60memory%3A%60%20scope%20value%20auto-grants%20%60Read%60%2C%20%60Write%60%2C%20and%20%60Edit%60%20to%20the%20subagent%20*regardless*%20of%20its%20%60tools%3A%60%20allowlist%2C%20and%20also%20injects%20~200%20lines%20of%20%60MEMORY.md%60%20into%20context%20at%20startup.%20The%20catalog%20flags%20this%20as%20a%20security-relevant%20concern%20when%20an%20agent%20is%20documented%20as%20read-only.%20This%20research%20doc's%20%60memory%60%20section%20describes%20only%20the%20storage%20locations%20and%20%60MEMORY.md%60%20persistence%2C%20omitting%20both%20the%20tool-grant%20side-effect%20and%20the%20%60memory%3A%20true%60%20boolean%20invalidity%20warning%20that%20the%20catalog%20covers.%0A%0A%23%23%23%20Issue%205%20of%205%0Adocs%2Fresearch%2Fall-possible-subagent-frontmatter-config.md%3A715%0A**Source%20%238%20citation%20contradicts%20the%20color%20enum%20table%20in%20the%20same%20document**%0A%0ASource%20%238%20records%20that%20GH%20%2319292%20%22reveals%20accepted%20color%20values%20%60blue%60%2C%20%60cyan%60%2C%20%60green%60%2C%20%60yellow%60%2C%20%60magenta%60%2C%20%60red%60%22%20%E2%80%94%20a%20set%20of%206%20values%20that%20excludes%20%60orange%60%2C%20%60pink%60%2C%20and%20%60purple%60%2C%20and%20instead%20includes%20%60magenta%60.%20The%20field%20quick-reference%20table%20%28line%20676%29%20and%20the%20%60color%60%20section%20%28line%20344%29%20both%20list%208%20named%20colors%3A%20%60red%60%2C%20%60blue%60%2C%20%60green%60%2C%20%60yellow%60%2C%20%60purple%60%2C%20%60orange%60%2C%20%60pink%60%2C%20%60cyan%60%20%E2%80%94%20no%20%60magenta%60.%20The%20two%20parts%20of%20this%20document%20tell%20different%20stories%20about%20which%20values%20are%20accepted%3B%20at%20minimum%20the%20source%20citation%20should%20clarify%20that%20the%20GH%20issue%20list%20is%20not%20the%20same%20as%20the%20official%20table.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 5 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 5
docs/research/all-possible-subagent-frontmatter-config.md:294-295
**`background: true` missing the required `run_in_background: true` spawn-call condition**

The companion field-catalog doc (`subagent-frontmatter-field-catalog.md`, lines 108–111) explicitly states that `background: true` in frontmatter does *not* by itself parallelize execution — the caller's Task invocation must also pass `run_in_background: true`, otherwise the parent still serializes. This research doc's description says "The main conversation does not wait for the subagent to complete before continuing," which contradicts that rule and will mislead anyone using only this document as their reference.

### Issue 2 of 5
docs/solutions/code-quality/subagent-frontmatter-field-catalog.md:65
**`bypassPermissions` protected-paths list is incomplete vs. the research doc**

The research doc (`all-possible-subagent-frontmatter-config.md`, line 164) lists `.idea` as an additional protected path and also notes that `.claude/commands`, `.claude/agents`, and `.claude/skills` are *exceptions* that still allow writes. The catalog entry omits `.idea` and the sub-path exceptions entirely, leaving the permission boundary described here narrower than what is actually enforced.

### Issue 3 of 5
docs/solutions/code-quality/subagent-frontmatter-field-catalog.md:82
**MCP tool-name pattern conflicts between the two documents**

This line uses `mcp__plugin_<pluginName>_<serverName>__<toolName>` (with a `plugin_` infix), but the research doc (`all-possible-subagent-frontmatter-config.md`, line 238) uses `mcp__<serverName>__<toolName>` (no infix). Both patterns appear in the same PR; exactly one can be correct for a given context. If the longer form is specific to plugin-registered servers and the short form applies to globally-registered MCP servers, that distinction is not explained in either document, making the `tools:` frontmatter unreliable to author without knowing which pattern applies.

### Issue 4 of 5
docs/research/all-possible-subagent-frontmatter-config.md:266-284
**`memory:` tool-expansion side-effect omitted from research doc**

The field-catalog doc (lines 100–102) calls out a critical behavioral consequence: any `memory:` scope value auto-grants `Read`, `Write`, and `Edit` to the subagent *regardless* of its `tools:` allowlist, and also injects ~200 lines of `MEMORY.md` into context at startup. The catalog flags this as a security-relevant concern when an agent is documented as read-only. This research doc's `memory` section describes only the storage locations and `MEMORY.md` persistence, omitting both the tool-grant side-effect and the `memory: true` boolean invalidity warning that the catalog covers.

### Issue 5 of 5
docs/research/all-possible-subagent-frontmatter-config.md:715
**Source #8 citation contradicts the color enum table in the same document**

Source #8 records that GH #19292 "reveals accepted color values `blue`, `cyan`, `green`, `yellow`, `magenta`, `red`" — a set of 6 values that excludes `orange`, `pink`, and `purple`, and instead includes `magenta`. The field quick-reference table (line 676) and the `color` section (line 344) both list 8 named colors: `red`, `blue`, `green`, `yellow`, `purple`, `orange`, `pink`, `cyan` — no `magenta`. The two parts of this document tell different stories about which values are accepted; at minimum the source citation should clarify that the GH issue list is not the same as the official table.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(reference): subagent frontmatter fi..."](https://github.com/kinginyellows/yellow-plugins/commit/ede5046dd51fc4910ef582479fd2f00c290dd337) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30722870)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->