### PR TITLE
docs(yellow-semgrep): close semgrep-mcp-migration plan after runtime tool-list verification

### DIFF
--- a/.changeset/yellow-semgrep-close-mcp-migration.md
+++ b/.changeset/yellow-semgrep-close-mcp-migration.md
@@ -1,0 +1,12 @@
+---
+"yellow-semgrep": patch
+---
+
+Close the semgrep-mcp-migration plan after runtime tool-list verification
+against the built-in `semgrep mcp` server (semgrep v1.154.0): drop
+`semgrep_whoami` from the documented MCP tool surface (it is not exposed by
+the built-in server) and rewrite the stale "whoami does not work with API
+tokens" caveat in `CLAUDE.md` and `README.md` to point at REST `GET
+/api/v1/me` as the authoritative token-validation path. Affects
+`plugins/yellow-semgrep/{CLAUDE.md,README.md,commands/semgrep/setup.md}`.
+Documentation-only — no behavior changes.

--- a/docs/brainstorms/2026-05-04-semgrep-mcp-migration-remaining-brainstorm.md
+++ b/docs/brainstorms/2026-05-04-semgrep-mcp-migration-remaining-brainstorm.md
@@ -1,5 +1,11 @@
 ## What We're Building
 
+> **Historical record (2026-05-04).** This document is the pre-verification
+> audit of the `semgrep-mcp-migration` plan. The runtime verification step
+> (Phase 1.2) has since been completed — see the same PR that introduces
+> this doc for the closing changes. The "1 item genuinely remaining"
+> framing below describes state at audit time, not current state.
+
 A completion audit for the `semgrep-mcp-migration` plan. The migration replaced
 the deprecated `uvx semgrep-mcp` standalone package with the built-in
 `semgrep mcp` subcommand (available in semgrep v1.146.0+). This document
@@ -26,7 +32,10 @@ The plan requires: install semgrep >= 1.146.0 locally, run `semgrep mcp`, and
 confirm that the 8 tool names exposed by the built-in MCP server match the
 names referenced throughout the plugin.
 
-Expected tool names currently hard-coded in commands, agents, and setup.md:
+Expected tool names hard-coded in `setup.md` Step 5 (the only file that
+listed all 8 by name; `CLAUDE.md` listed them in its "Provides:" bullet,
+but `commands/` and `agents/` reference individual tools by their MCP
+prefix at point-of-use rather than via a central list):
 
 - `semgrep_scan`
 - `semgrep_findings`

--- a/docs/brainstorms/2026-05-04-semgrep-mcp-migration-remaining-brainstorm.md
+++ b/docs/brainstorms/2026-05-04-semgrep-mcp-migration-remaining-brainstorm.md
@@ -1,0 +1,109 @@
+## What We're Building
+
+A completion audit for the `semgrep-mcp-migration` plan. The migration replaced
+the deprecated `uvx semgrep-mcp` standalone package with the built-in
+`semgrep mcp` subcommand (available in semgrep v1.146.0+). This document
+captures the true remaining scope after cross-referencing the plan file against
+actual codebase state.
+
+## Why This Approach
+
+The plan banner and checkbox state were significantly out of date. A direct
+codebase audit showed that Phase 2 (version checks in setup.md) and all of
+Phase 4 (documentation updates) are fully implemented despite being marked open
+in the plan. The only remaining work is a single runtime verification step that
+cannot be automated without a live semgrep install.
+
+## Remaining Work
+
+### Punch List (as of 2026-05-04)
+
+**Genuinely remaining: 1 item**
+
+#### 1.2 — Runtime tool name verification (open, cannot be resolved without live semgrep)
+
+The plan requires: install semgrep >= 1.146.0 locally, run `semgrep mcp`, and
+confirm that the 8 tool names exposed by the built-in MCP server match the
+names referenced throughout the plugin.
+
+Expected tool names currently hard-coded in commands, agents, and setup.md:
+
+- `semgrep_scan`
+- `semgrep_findings`
+- `semgrep_scan_with_custom_rule`
+- `get_abstract_syntax_tree`
+- `semgrep_rule_schema`
+- `get_supported_languages`
+- `semgrep_scan_supply_chain`
+- `semgrep_whoami`
+
+If any names differ: update all references in scan.md, fix.md, fix-batch.md,
+finding-fixer.md, scan-verifier.md, setup.md Step 5 expected list, CLAUDE.md
+tool list, and SKILL.md (semgrep-conventions). The grep pattern to find all
+current references:
+
+```
+rg "semgrep_scan|semgrep_findings|semgrep_scan_with_custom|get_abstract_syntax|semgrep_rule_schema|get_supported_languages|semgrep_scan_supply|semgrep_whoami" plugins/yellow-semgrep/
+```
+
+**Verdict:** Until this runtime check is done, all tool-name references are
+assumed correct (no contradicting evidence found). If the built-in server uses
+identical names to the former standalone package, this item closes with no file
+changes.
+
+---
+
+### Items Completed But Marked Open in Plan (plan/code drift)
+
+These were listed as outstanding in the plan banner and Phase 2/4 checkboxes
+but are fully implemented in the codebase:
+
+| Plan Item | Status | Evidence |
+|---|---|---|
+| 2.1 `MIN_SEMGREP_VERSION` constant in setup.md | Done | Line 69 of setup.md: `MIN_SEMGREP_VERSION="1.146.0"` |
+| 2.2 Version comparison after semgrep install | Done | `version_gte()` function + AskUserQuestion branch in Step 0 |
+| 2.3 Step 5 diagnostics (version-aware MCP failure messages) | Done | setup.md lines 228-234 |
+| 4.1 CLAUDE.md MCP Servers section | Done | "Built-in MCP server via `semgrep mcp` (requires v1.146.0+)" |
+| 4.2 README.md prerequisites | Done | Version table present; 1.146.0+ referenced |
+| 4.3 semgrep-conventions SKILL.md | Done | No `uvx` or `semgrep-mcp` references found |
+| 4.4 setup.md Step 5 expected tool list | Done | All 8 tools listed with full MCP prefix |
+| 4.5 CHANGELOG.md migration entry | Done | v2.0.0 entry documents the breaking change |
+
+The plan banner text ("Outstanding work: tool name validation (Phase 1.2) and
+documentation updates (Phase 4)") should be updated to reflect that Phase 4 is
+complete and Phase 2 is complete. Only 1.2 remains.
+
+### Stale References (not bugs, but worth noting)
+
+- CHANGELOG.md has `uvx semgrep-mcp` in the migration description text under
+  v2.0.0 — this is intentional historical context, not a stale active reference.
+- CLAUDE.md line 32 mentions "The standalone `semgrep-mcp` PyPI package was
+  archived Oct 2025" — correct historical note, not a stale active reference.
+
+## Key Decisions
+
+1. **Plan banner update is low priority.** The stale banner is cosmetic. The
+   actual code is correct. Update it when closing 1.2 so both land together.
+
+2. **Tool name verification approach.** Two viable paths:
+   - Run `semgrep mcp --tools` or inspect MCP server JSON schema locally (fast,
+     requires semgrep installed)
+   - Trust that the Semgrep team preserved tool names when moving from standalone
+     to built-in (low risk given active usage, no reported breakage)
+   The pragmatic path is to do the live check once and close 1.2 if names match.
+
+3. **No further code changes needed** unless tool name verification reveals a
+   mismatch. The migration is functionally complete.
+
+## Open Questions
+
+1. **Have any users reported MCP tool failures post-migration?** If not, the
+   tool names are likely correct and 1.2 is a formality.
+
+2. **Does `semgrep mcp` accept a `--list-tools` or `--tools` flag** to enumerate
+   available tools without starting the full MCP server? If not, verification
+   requires actually connecting to the MCP server via Claude Code's tool
+   discovery (ToolSearch in a live session).
+
+3. **Should the plan file checkboxes and banner be updated as a follow-up
+   commit**, or should that be bundled with the 1.2 verification PR?

--- a/plans/semgrep-mcp-migration.md
+++ b/plans/semgrep-mcp-migration.md
@@ -1,6 +1,11 @@
 # Feature: Migrate semgrep MCP from deprecated standalone to built-in subcommand
 
-> **Status**: Phases 1 and 3 complete. Outstanding work: tool name validation (Phase 1.2) and documentation updates (Phase 4).
+> **Status**: ✅ Complete. All phases shipped. Runtime tool name verification
+> against semgrep v1.154.0 confirmed 7 of 8 expected tools match; the
+> built-in MCP server does not expose `semgrep_whoami`, so it has been
+> removed from the expected tool list in `setup.md`, `CLAUDE.md`, and
+> `README.md` (token validation uses REST `GET /api/v1/me`, which already
+> handled this case).
 
 ## Problem Statement
 
@@ -68,26 +73,23 @@ All endpoints (`/api/v1/me`, `/deployments`, `/deployments/{slug}/findings`,
   }
   ```
 
-- [ ] **1.2:** Verify tool name compatibility
-  - Install semgrep >= 1.146.0 locally
-  - Run `semgrep mcp` and compare available tool names against expected list
-  - Expected tools in current code:
-    - `semgrep_scan`
-    - `semgrep_findings`
-    - `semgrep_scan_with_custom_rule`
-    - `get_abstract_syntax_tree`
-    - `semgrep_rule_schema`
-    - `get_supported_languages`
-    - `semgrep_scan_supply_chain`
-    - `semgrep_whoami`
-  - If tool names differ, update all references across commands/agents/skills
+- [x] **1.2:** Verify tool name compatibility
+  - ✅ Verified against semgrep v1.154.0 via MCP `tools/list` over stdio
+  - ✅ 7 of 8 expected tools confirmed: `semgrep_scan`, `semgrep_findings`,
+    `semgrep_scan_with_custom_rule`, `get_abstract_syntax_tree`,
+    `semgrep_rule_schema`, `get_supported_languages`, `semgrep_scan_supply_chain`
+  - ✅ `semgrep_whoami` is NOT exposed by the built-in MCP server — removed
+    from expected list in `setup.md` Step 5 and from "Provides:" in `CLAUDE.md`
+  - ✅ Stale `semgrep_whoami does not work with API tokens` bullets in
+    `CLAUDE.md` and `README.md` updated to reflect that the tool no longer
+    exists; REST `GET /api/v1/me` remains the validation path
 
-### Phase 2: Setup Command — Version Check & MCP Verification
+### Phase 2: Setup Command — Version Check & MCP Verification ✅ COMPLETE
 
-- [ ] **2.1:** Add minimum version constant to setup.md
-  - `MIN_SEMGREP_VERSION="1.146.0"` (required for `semgrep mcp` subcommand)
+- [x] **2.1:** Add minimum version constant to setup.md
+  - ✅ `MIN_SEMGREP_VERSION="1.146.0"` present in `setup.md` Step 0
 
-- [ ] **2.2:** Add version comparison after semgrep install/detection (between
+- [x] **2.2:** Add version comparison after semgrep install/detection (between
   current Step 0 and Step 1)
   ```bash
   installed=$(semgrep --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
@@ -104,11 +106,10 @@ All endpoints (`/api/v1/me`, `/deployments`, `/deployments/{slug}/findings`,
   - If version is below minimum: warn that MCP tools won't work, suggest upgrade
   - If version is at/above minimum: proceed normally
 
-- [ ] **2.3:** Update Step 5 (Verify MCP Tools) to give better diagnostics
-  - If MCP tools not found AND semgrep version < minimum: "Upgrade semgrep to
-    v1.146.0+ for MCP support: `pipx upgrade semgrep`"
-  - If MCP tools not found AND semgrep version >= minimum: "MCP server failed
-    to start. Check SEMGREP_APP_TOKEN and try restarting Claude Code."
+- [x] **2.3:** Update Step 5 (Verify MCP Tools) to give better diagnostics
+  - ✅ Step 5 routes diagnostics by version: < 1.146.0 → suggest upgrade;
+    >= 1.146.0 → check `SEMGREP_APP_TOKEN` and restart; not installed →
+    re-run `/semgrep:setup`
 
 ### Phase 3: Install Script — Minimum Version ✅ COMPLETE
 
@@ -124,19 +125,23 @@ All endpoints (`/api/v1/me`, `/deployments`, `/deployments/{slug}/findings`,
   - ✅ If installed but below `MIN_VERSION`, offers to upgrade
   - ✅ Early exit only if version is >= minimum
 
-### Phase 4: Documentation & Conventions
+### Phase 4: Documentation & Conventions ✅ COMPLETE
 
-- [ ] **4.1:** Update `CLAUDE.md` MCP Servers section
-  - Change "Local stdio server via `uvx semgrep-mcp`" to
-    "Built-in MCP server via `semgrep mcp` (requires v1.146.0+)"
+- [x] **4.1:** Update `CLAUDE.md` MCP Servers section
+  - ✅ Now reads "Built-in MCP server via `semgrep mcp` (requires v1.146.0+)"
+  - ✅ "Provides:" tool list updated to drop `semgrep_whoami`
 
-- [ ] **4.2:** Update `README.md` prerequisites/setup section
+- [x] **4.2:** Update `README.md` prerequisites/setup section
+  - ✅ Stale `semgrep_whoami` limitation bullet replaced with REST validation note
 
-- [ ] **4.3:** Update `semgrep-conventions` SKILL.md if any tool names changed
+- [x] **4.3:** Update `semgrep-conventions` SKILL.md if any tool names changed
+  - ✅ No `semgrep_whoami` references in SKILL.md — no edit needed
 
-- [ ] **4.4:** Update setup.md Step 5 expected tool list if names differ
+- [x] **4.4:** Update setup.md Step 5 expected tool list if names differ
+  - ✅ `semgrep_whoami` removed from the expected MCP tool list
 
-- [ ] **4.5:** Update CHANGELOG.md with migration entry
+- [x] **4.5:** Update CHANGELOG.md with migration entry
+  - ✅ "yellow-semgrep MCP migration" entry already present
 
 ## Technical Details
 

--- a/plans/semgrep-mcp-migration.md
+++ b/plans/semgrep-mcp-migration.md
@@ -2,10 +2,14 @@
 
 > **Status**: ✅ Complete. All phases shipped. Runtime tool name verification
 > against semgrep v1.154.0 confirmed 7 of 8 expected tools match; the
-> built-in MCP server does not expose `semgrep_whoami`, so it has been
-> removed from the expected tool list in `setup.md`, `CLAUDE.md`, and
-> `README.md` (token validation uses REST `GET /api/v1/me`, which already
-> handled this case).
+> built-in MCP server does not expose `semgrep_whoami`. The expected tool
+> list (which only existed in `setup.md` Step 5 and `CLAUDE.md`'s
+> "Provides:" bullet) has been pruned to 7 tools. `README.md` and
+> `CLAUDE.md` "Known Limitations" entries that referenced the now-absent
+> `whoami` tool were rewritten to point to REST `GET /api/v1/me`, which
+> already handled token validation. Note: `plans/yellow-semgrep-plugin.md`
+> contains a sibling stale `semgrep_whoami` reference (line 657) — left
+> for cleanup in the parent plan-status-updates PR.
 
 ## Problem Statement
 

--- a/plugins/yellow-semgrep/CLAUDE.md
+++ b/plugins/yellow-semgrep/CLAUDE.md
@@ -38,7 +38,7 @@ hybrid MCP + REST API architecture.
 - **semgrep** — Built-in MCP server via `semgrep mcp` (requires v1.146.0+)
   - Provides: `semgrep_scan`, `semgrep_findings`, `get_abstract_syntax_tree`,
     `semgrep_scan_with_custom_rule`, `semgrep_rule_schema`,
-    `get_supported_languages`, `semgrep_scan_supply_chain`, `semgrep_whoami`
+    `get_supported_languages`, `semgrep_scan_supply_chain`
   - Auth: `userConfig.semgrep_app_token` is the source of truth — Claude
     Code injects it into the MCP process environment via
     `${user_config.semgrep_app_token}` in `plugin.json`. The shell
@@ -145,8 +145,8 @@ Layer 3: LIFECYCLE (write state)  → REST API for triage mutations
 - **SAST only** — SCA/dependency findings not supported in v1 (different fix
   strategy needed)
 - **REST API rate limit** — ~60 requests/minute; batch operations add 1s delays
-- **`semgrep_whoami` does not work with API tokens** — only OAuth JWTs; use
-  REST `GET /api/v1/me` for token validation
+- **Token validation uses REST `GET /api/v1/me`** — the built-in MCP server
+  does not expose a `whoami` tool; REST is authoritative for token status
 - **MCP tool names must be verified** — actual names may differ from expected;
   `/semgrep:setup` verifies them via ToolSearch
 - **No webhook/push support** — finding status is polled, not pushed

--- a/plugins/yellow-semgrep/CLAUDE.md
+++ b/plugins/yellow-semgrep/CLAUDE.md
@@ -147,8 +147,8 @@ Layer 3: LIFECYCLE (write state)  → REST API for triage mutations
 - **REST API rate limit** — ~60 requests/minute; batch operations add 1s delays
 - **Token validation uses REST `GET /api/v1/me`** — the built-in MCP server
   does not expose a `whoami` tool; REST is authoritative for token status
-- **MCP tool names must be verified** — actual names may differ from expected;
-  `/semgrep:setup` verifies them via ToolSearch
+- **MCP tool names verified against semgrep v1.154.0** — 7 tools confirmed
+  match expected; `/semgrep:setup` re-verifies at install time via ToolSearch
 - **No webhook/push support** — finding status is polled, not pushed
 - **Pagination limit** — REST API defaults to `page_size=100`; large finding
   sets require multiple requests

--- a/plugins/yellow-semgrep/README.md
+++ b/plugins/yellow-semgrep/README.md
@@ -113,8 +113,8 @@ all platform interactions (better pagination, dedup, triage mutations).
 - **REST API rate limit** — ~60 requests/minute; batch operations add 1s delays
 - **Token validation uses REST `GET /api/v1/me`** — the built-in MCP server
   does not expose a `whoami` tool; REST is authoritative for token status
-- **MCP tool names must be verified** — actual names may differ; `/semgrep:setup`
-  verifies them
+- **MCP tool names verified against semgrep v1.154.0** — 7 tools confirmed
+  match expected; `/semgrep:setup` re-verifies at install time
 - **No webhook/push support** — finding status is polled, not pushed
 - **Pagination limit** — REST API defaults to `page_size=100`
 

--- a/plugins/yellow-semgrep/README.md
+++ b/plugins/yellow-semgrep/README.md
@@ -111,8 +111,8 @@ all platform interactions (better pagination, dedup, triage mutations).
 
 - **SAST only** — SCA/dependency findings not supported in v1
 - **REST API rate limit** — ~60 requests/minute; batch operations add 1s delays
-- **`semgrep_whoami` does not work with API tokens** — only OAuth JWTs; plugin
-  uses REST `GET /api/v1/me` for validation
+- **Token validation uses REST `GET /api/v1/me`** — the built-in MCP server
+  does not expose a `whoami` tool; REST is authoritative for token status
 - **MCP tool names must be verified** — actual names may differ; `/semgrep:setup`
   verifies them
 - **No webhook/push support** — finding status is polled, not pushed

--- a/plugins/yellow-semgrep/commands/semgrep/setup.md
+++ b/plugins/yellow-semgrep/commands/semgrep/setup.md
@@ -353,7 +353,6 @@ Expected tools (fully qualified):
 - `mcp__plugin_yellow-semgrep_semgrep__semgrep_rule_schema`
 - `mcp__plugin_yellow-semgrep_semgrep__get_supported_languages`
 - `mcp__plugin_yellow-semgrep_semgrep__semgrep_scan_supply_chain`
-- `mcp__plugin_yellow-semgrep_semgrep__semgrep_whoami`
 
 Count discovered tools. If fewer than 2 core tools
 (`mcp__plugin_yellow-semgrep_semgrep__semgrep_scan`,


### PR DESCRIPTION
Probed the built-in `semgrep mcp` server (semgrep v1.154.0) over stdio
with an MCP `tools/list` request. Result: 7 of 8 expected tools match;
`semgrep_whoami` is NOT exposed by the built-in server.

Plugin updates:
- setup.md: drop semgrep_whoami from the expected MCP tool list (Step 5)
- CLAUDE.md: drop semgrep_whoami from the "Provides:" tool list and
  rewrite the stale "whoami does not work with API tokens" limitation
  to note that REST GET /api/v1/me is the validation path (the tool
  no longer exists in the built-in server, so the old caveat is moot)
- README.md: same rewrite as CLAUDE.md for the Limitations section

Plan updates (plans/semgrep-mcp-migration.md):
- Banner flipped to ✅ Complete with verification details
- Phase 1.2 ticked with the verification result and removed-tool note
- Phase 2 ticked (version checks already shipped in setup.md)
- Phase 4 ticked (CLAUDE.md / README.md / setup.md / CHANGELOG already
  updated; SKILL.md needed no changes — no whoami references there)

Audit context: docs/brainstorms/2026-05-04-semgrep-mcp-migration-remaining-brainstorm.md

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a documentation-only PR that closes the `semgrep-mcp-migration` plan after runtime verification of the built-in `semgrep mcp` server (v1.154.0): 7 of 8 expected tools confirmed; `semgrep_whoami` is absent from the built-in server.

- Removes `semgrep_whoami` from the expected MCP tool list in `setup.md` Step 5 and from the \"Provides:\" list in `CLAUDE.md`
- Rewrites the stale `semgrep_whoami` limitation bullets in `CLAUDE.md` and `README.md` to point to REST `GET /api/v1/me` as the authoritative token-validation path
- Flips all open plan checkboxes to complete in `plans/semgrep-mcp-migration.md` and adds an audit brainstorm doc for historical context

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no runtime behavior modifications — safe to merge.

All edits are confined to markdown docs and a plan file. The tool-list pruning in setup.md only removes a line from a bullet list; the diagnostic threshold of 2 core tools is unchanged. The stale limitation bullets in CLAUDE.md and README.md are accurately rewritten. No code paths are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .changeset/yellow-semgrep-close-mcp-migration.md | New patch changeset documenting the documentation-only closure of the MCP migration — accurately scopes the affected files and notes no behavior changes. |
| docs/brainstorms/2026-05-04-semgrep-mcp-migration-remaining-brainstorm.md | New historical audit doc with a clear pre-verification banner; provides traceability for the tool-name verification decision without affecting runtime behavior. |
| plans/semgrep-mcp-migration.md | All open checkboxes ticked; banner updated to Complete with verification details; stale sibling-file reference in plans/yellow-semgrep-plugin.md is acknowledged as a follow-up item. |
| plugins/yellow-semgrep/CLAUDE.md | semgrep_whoami dropped from Provides list; stale limitations bullets correctly rewritten to reflect REST-only token validation path. |
| plugins/yellow-semgrep/README.md | Limitations section updated in lockstep with CLAUDE.md; stale whoami caveat replaced with REST validation note. |
| plugins/yellow-semgrep/commands/semgrep/setup.md | semgrep_whoami removed from expected MCP tool list in Step 5; the 2-core-tool threshold check is unaffected by the count change from 8 to 7. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[semgrep v1.154.0 MCP tools/list over stdio] --> B{8 expected tools verified?}
    B -->|7 match| C[semgrep_scan, semgrep_findings, semgrep_scan_with_custom_rule, get_abstract_syntax_tree, semgrep_rule_schema, get_supported_languages, semgrep_scan_supply_chain]
    B -->|NOT exposed| D[semgrep_whoami]
    C --> E[setup.md Step 5 7-tool list]
    C --> F[CLAUDE.md Provides 7-tool list]
    D --> G[Remove from setup.md + CLAUDE.md]
    D --> H[Rewrite limitations: REST GET /api/v1/me is validation path]
    E --> I[Migration Plan Closed]
    F --> I
    G --> I
    H --> I
```

<sub>Reviews (5): Last reviewed commit: ["chore(yellow-semgrep): add patch changes..."](https://github.com/kinginyellows/yellow-plugins/commit/be6790976de177221db56cd00ddb83cfd9b72bec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30734685)</sub>

<!-- /greptile_comment -->