### PR TITLE
fix(validate-plugin): array-form hooks bypass + helper extraction + fixture test harness

### DIFF
--- a/.changeset/pr260-validator-hardening.md
+++ b/.changeset/pr260-validator-hardening.md
@@ -1,32 +1,46 @@
 ---
-'yellow-core': patch
+"yellow-core": patch
 ---
 
 Harden `scripts/validate-plugin.js` and add the first integration test
 suite for the validator (`tests/integration/validate-plugin.test.ts`):
 
-- Fix array-form `hooks` validation bypass: previously RULE 6/7/8 skipped
-  ALL checks when `hooks` was an array; now array elements that are paths
-  are validated for existence, plugin-dir containment, shebang, and
-  `set -e` anti-pattern, identical to the inline-object form. Object
-  elements pass through (mcpServers/lspServers-style inline configs are
-  not script paths).
+- Fix array-form `hooks` path-validation bypass: array entries that are
+  string paths now receive the same path-existence + plugin-dir
+  containment checks as the string-form `hooks` field. Inline event-keyed
+  objects mixed inside the array form flow through `collectInlineHooks`
+  and now get RULES 6/7/8 (script existence, hooks.json drift, shebang /
+  decision-output / `set -e` content checks) — previously skipped because
+  the inline-object loop short-circuited on `!Array.isArray(manifest.hooks)`.
 - Add path-existence + plugin-dir-containment check for the string-form
   `hooks` (was previously only checked for the documented anti-pattern).
 - Add `SessionStart` to the `DECISION_PROTOCOL_EVENTS` Set — `SessionStart`
   hooks must emit a decision response per documented project memory
-  (PR #72 incident).
-- Enforce `outputStyles` directory-only at RULE 5b and align the schema
-  description in PR-B accordingly (a `.md` file path is rejected).
-- Refactor: extract `hasInlineHooks` predicate (was duplicated across
-  RULE 6, 7, 8), `addError(errors, msg)` helper (eliminates pervasive
-  `errors.push + logError` drift — RULE 1 had drifted), and
-  `validateHookScriptPath` (centralizes per-script-path checks).
-- Convert `VALID_HOOK_EVENTS` from in-function array (`.includes()`
-  scan) to module-scope `Set` for parity with `DECISION_PROTOCOL_EVENTS`.
+  (PR #72 incident: missing JSON output blocks session startup).
+- Enforce `outputStyles` directory-only via a new `directoryOnly`
+  parameter on `validatePathOrPathsDir`: a `.md` file path is rejected
+  for `outputStyles` even though Anthropic's `relativePath` schema
+  allows single-file paths for `commands`/`agents`/`skills`. (Schema
+  description alignment lands in PR-B.)
+- Refactor: extract `addError(errors, msg)` helper to eliminate the
+  pervasive `errors.push + logError` drift (RULE 1 / RULE 3 messages
+  had silently drifted between the two paths) and
+  `validateHookScriptPath(scriptPath, eventName, pluginDir, errors)`
+  helper that centralizes per-script-path RULE 6 + RULE 8 checks
+  (existence, readability, executable mode, shebang, decision output,
+  `set -e`). RULE 6 and RULE 8 now share a single iteration pass over
+  the inline hooks instead of two duplicate loops.
+- Hoist `VALID_HOOK_EVENTS` and `DECISION_PROTOCOL_EVENTS` from
+  in-function declarations to module-scope `Set`s — `.has()` is O(1)
+  vs `.includes()` linear scan, and the membership tests are now
+  reused across all rules instead of re-allocated per `validatePlugin`
+  call.
 
-**Behavior change for downstream consumers:** plugins that ship array-form
-`hooks` with raw script paths will previously have passed validation
-silently. After this change those plugins receive the standard
-script-path checks. No in-repo plugin uses array-form hooks, so
-in-repo blast radius is zero.
+**Behavior change for downstream consumers:** plugins that ship
+array-form `hooks` with raw script paths will previously have passed
+validation silently. After this change those plugins receive the
+standard path-existence + containment check. Plugins shipping inline
+event-keyed objects inside an array form now also get RULES 6/7/8.
+Plugins shipping `outputStyles` as a `.md` file path will newly fail
+validation (must be a directory). No in-repo plugin uses any of these
+patterns, so in-repo blast radius is zero.

--- a/.changeset/pr260-validator-hardening.md
+++ b/.changeset/pr260-validator-hardening.md
@@ -2,6 +2,8 @@
 "yellow-core": patch
 ---
 
+# Validator Hardening
+
 Harden `scripts/validate-plugin.js` and add the first integration test
 suite for the validator (`tests/integration/validate-plugin.test.ts`):
 

--- a/.changeset/pr260-validator-hardening.md
+++ b/.changeset/pr260-validator-hardening.md
@@ -1,0 +1,32 @@
+---
+'yellow-core': patch
+---
+
+Harden `scripts/validate-plugin.js` and add the first integration test
+suite for the validator (`tests/integration/validate-plugin.test.ts`):
+
+- Fix array-form `hooks` validation bypass: previously RULE 6/7/8 skipped
+  ALL checks when `hooks` was an array; now array elements that are paths
+  are validated for existence, plugin-dir containment, shebang, and
+  `set -e` anti-pattern, identical to the inline-object form. Object
+  elements pass through (mcpServers/lspServers-style inline configs are
+  not script paths).
+- Add path-existence + plugin-dir-containment check for the string-form
+  `hooks` (was previously only checked for the documented anti-pattern).
+- Add `SessionStart` to the `DECISION_PROTOCOL_EVENTS` Set — `SessionStart`
+  hooks must emit a decision response per documented project memory
+  (PR #72 incident).
+- Enforce `outputStyles` directory-only at RULE 5b and align the schema
+  description in PR-B accordingly (a `.md` file path is rejected).
+- Refactor: extract `hasInlineHooks` predicate (was duplicated across
+  RULE 6, 7, 8), `addError(errors, msg)` helper (eliminates pervasive
+  `errors.push + logError` drift — RULE 1 had drifted), and
+  `validateHookScriptPath` (centralizes per-script-path checks).
+- Convert `VALID_HOOK_EVENTS` from in-function array (`.includes()`
+  scan) to module-scope `Set` for parity with `DECISION_PROTOCOL_EVENTS`.
+
+**Behavior change for downstream consumers:** plugins that ship array-form
+`hooks` with raw script paths will previously have passed validation
+silently. After this change those plugins receive the standard
+script-path checks. No in-repo plugin uses array-form hooks, so
+in-repo blast radius is zero.

--- a/plans/pr-260-followup-hardening-and-docs.md
+++ b/plans/pr-260-followup-hardening-and-docs.md
@@ -88,13 +88,14 @@ scope is clarified in the SKILL.md.
 
 - [ ] 1.1: Mirror `validate-agent-authoring-review-rule.test.ts`
       structure. Create `tests/integration/validate-plugin.test.ts`
-      with `mkdtempSync` per test, `execFileSync` of
+      with `mkdtempSync` per test, `spawnSync` of
       `node scripts/validate-plugin.js` against the temp dir, and
       assertions on exit code + stderr.
 - [ ] 1.2: Add fixture coverage for **current** behavior before
       changing anything (regression net): valid manifest passes,
-      invalid name fails, missing version fails, hooks-string
-      anti-pattern logs warning, hooks-inline-object passes.
+      invalid name fails, missing version is allowed (only
+      invalid-format fails), hooks-string anti-pattern logs warning,
+      hooks-inline-object passes.
 - [ ] 1.3: Extract `hasInlineHooks(manifest)` predicate at module
       scope (lines 226, 329, 449 currently duplicated). Replace
       three call sites.
@@ -259,24 +260,28 @@ prose-instruction form.
       to `create-agent-skills/SKILL.md`. New paragraph in the
       §Subagent Failure Convention section:
 
-      > **When the convention applies.** Orchestrators that spawn
-      > agents emitting unstructured prose (e.g., `work.md`
-      > Phase 3 reviewers). Orchestrators whose spawned agents
-      > return structured JSON per a compact-return schema
-      > (e.g., `review-pr.md` Step 5) can rely on schema
-      > validation to detect partial failures; the file-based
-      > RUN_DIR pattern is unnecessary there and would only
-      > duplicate the signal.
+  ```text
+  **When the convention applies.** Orchestrators that spawn
+  agents emitting unstructured prose (e.g., `work.md`
+  Phase 3 reviewers). Orchestrators whose spawned agents
+  return structured JSON per a compact-return schema
+  (e.g., `review-pr.md` Step 5) can rely on schema
+  validation to detect partial failures; the file-based
+  RUN_DIR pattern is unnecessary there and would only
+  duplicate the signal.
+  ```
 
 - [ ] 4.6: **Add comment block to `review-pr.md` Step 5**
       explaining the architectural choice:
 
-      > Step 5 collects findings via TaskOutput because each
-      > reviewer emits compact-return JSON per the schema in
-      > this file. The Subagent Failure Convention's
-      > file-based RUN_DIR pattern (see `create-agent-skills`
-      > SKILL.md §Subagent Failure Convention) is reserved for
-      > prose-emitting orchestrators like `work.md` Phase 3.
+  ```text
+  Step 5 collects findings via TaskOutput because each
+  reviewer emits compact-return JSON per the schema in
+  this file. The Subagent Failure Convention's
+  file-based RUN_DIR pattern (see `create-agent-skills`
+  SKILL.md §Subagent Failure Convention) is reserved for
+  prose-emitting orchestrators like `work.md` Phase 3.
+  ```
 
 - [ ] 4.7: Update `create-agent-skills/SKILL.md` Subagent Failure
       Convention to use the atomic-write `.tmp` → `mv`
@@ -458,20 +463,30 @@ stacks on the previous via Graphite (`gt`); the entire stack ultimately
 merges into `main` once PR #260 lands.
 
 ### 1. agent/fix/pr260-validator-hardening
+
 - **Type:** fix
 - **Description:** array-form hooks bypass + helper extraction + fixture test harness
-- **Scope:** scripts/validate-plugin.js, tests/integration/validate-plugin.test.ts, .changeset/pr260-validator-hardening.md
+- **Scope:** scripts/validate-plugin.js,
+  tests/integration/validate-plugin.test.ts,
+  .changeset/pr260-validator-hardening.md
 - **Tasks:** 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11, 1.12, 1.13
 - **Depends on:** (none — base of stack; parent branch: docs/subagent-conventions)
 
 ### 2. agent/feat/pr260-schema-tightening
+
 - **Type:** feat
 - **Description:** tighten userConfig/pathPathsOrInline, add semver custom keyword, fix example
-- **Scope:** schemas/plugin.schema.json, examples/plugin-extended.example.json, packages/infrastructure/src/validation/keywords/semverRange.ts, packages/infrastructure/src/validation/ajvFactory.ts, tests/integration/example-files-schema.test.ts, .changeset/pr260-schema-tightening.md
+- **Scope:** schemas/plugin.schema.json,
+  examples/plugin-extended.example.json,
+  packages/infrastructure/src/validation/keywords/semverRange.ts,
+  packages/infrastructure/src/validation/ajvFactory.ts,
+  tests/integration/example-files-schema.test.ts,
+  .changeset/pr260-schema-tightening.md
 - **Tasks:** 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 2.10
 - **Depends on:** #1
 
 ### 3. agent/fix/pr260-work-rundir-hardening
+
 - **Type:** fix
 - **Description:** RUN_DIR shell-variable isolation + atomic .tmp→mv writes + cleanup
 - **Scope:** plugins/yellow-core/commands/workflows/work.md, .changeset/pr260-rundir-hardening.md
@@ -479,8 +494,13 @@ merges into `main` once PR #260 lands.
 - **Depends on:** #2
 
 ### 4. agent/docs/pr260-doc-sync
+
 - **Type:** docs
 - **Description:** refresh security-fencing count, scope clarification, quick-ref fix
-- **Scope:** plugins/yellow-core/skills/security-fencing/SKILL.md, plugins/yellow-core/skills/create-agent-skills/SKILL.md, plugins/yellow-core/skills/create-agent-skills/references/quick-reference.md, plugins/yellow-review/commands/review/review-pr.md, .changeset/pr260-doc-sync.md
+- **Scope:** plugins/yellow-core/skills/security-fencing/SKILL.md,
+  plugins/yellow-core/skills/create-agent-skills/SKILL.md,
+  plugins/yellow-core/skills/create-agent-skills/references/quick-reference.md,
+  plugins/yellow-review/commands/review/review-pr.md,
+  .changeset/pr260-doc-sync.md
 - **Tasks:** 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9
 - **Depends on:** #3

--- a/plans/pr-260-followup-hardening-and-docs.md
+++ b/plans/pr-260-followup-hardening-and-docs.md
@@ -1,0 +1,486 @@
+# Feature: PR #260 Follow-Up — Validator/Schema Hardening + Doc Sync
+
+## Problem Statement
+
+PR #260 (`docs/subagent-conventions`) introduces the Agent Archetypes table,
+the Subagent Failure Convention, the canonical `security-fencing` skill, and
+significantly expands `schemas/plugin.schema.json` (8 new top-level fields,
+3 new `$defs`) plus `scripts/validate-plugin.js`. A 12-reviewer multi-agent
+review of the PR surfaced **21 findings** (4 P1 + 15 P2 + 2 P3) that span
+five logically distinct areas. The current PR has been hardened against
+in-scope corrections; the remaining findings need a stacked-PR follow-up
+because they cross 8 files and include one explicit design decision plus
+two non-trivial refactors.
+
+The cost of NOT addressing them: a real validator bypass (array-form
+`hooks` skip path/shebang/`set -e` checks), a credential-exposure typo
+hazard (`userConfig.additionalProperties: true` accepts `sensitiv: true`
+and treats it as an unknown field), no test coverage for the validator,
+stale documentation pointers, and one orchestrator command (`work.md`)
+with a shell-variable isolation bug that probabilistically passes
+`$RUN_DIR` literal to spawned agents.
+
+## Current State
+
+- **PR #260** has been review-hardened with four in-scope corrections
+  (codex-reviewer 2-segment fix at line 375, Archetypes-table `model`
+  Yes→Opt, template `model: claude-opus-4-6` → `inherit`, Categories
+  list realigned, `security-fencing/SKILL.md` restructured with three
+  required headings).
+- **`scripts/validate-plugin.js`** is a standalone 629-line Node script
+  with **no test harness** (no fixtures, no `*.test.js` siblings).
+- **`tests/integration/validate-agent-authoring-review-rule.test.ts`** is
+  the canonical Vitest fixture pattern (inline string fixtures →
+  `mkdtempSync` → `execFileSync` with env override → assert on exit code
+  and stderr). New validator tests mirror this verbatim.
+- **`schemas/plugin.schema.json`** uses `oneOf` exclusively today — zero
+  `if/then/else` constructs. AJV/JSON Schema docs explicitly recommend
+  nested `if/then/else` for type-conditional `default` enforcement
+  (`oneOf` has the documented "default breaks oneOf" hazard).
+- **`schemas/plugin.schema.json`** declares 8 new top-level fields; **0
+  of 8 are used** by any of the 16 in-repo `plugin.json` files. Decision
+  taken: keep the schema fields, tighten their constraints.
+- **`plugins/yellow-core/commands/workflows/work.md`** Phase 3 wires the
+  RUN_DIR/result-file convention; **`plugins/yellow-review/commands/review/review-pr.md`**
+  Step 5 uses TaskOutput-only collection (compact-return JSON schema).
+  Decision taken: review-pr.md keeps TaskOutput; convention scope
+  clarified in SKILL.md and an in-file comment.
+- **`plugins/yellow-core/skills/security-fencing/SKILL.md`** consumer
+  list claims 25; actual `rg -l 'CRITICAL SECURITY RULES' plugins/`
+  count is **36**.
+- **No in-repo plugin** uses `hooks` array form, but the validator
+  bypass affects external/downstream plugins that may use it.
+
+## Proposed Solution
+
+Five stacked PRs on top of `docs/subagent-conventions`, each addressing
+one logical cluster with a per-PR changeset. Stacking order is dictated
+by hard dependencies:
+
+1. **PR-A: Validator hardening + fixture test harness** — adds the
+   missing test infrastructure first so subsequent PRs have a
+   regression net.
+2. **PR-B: Schema tightening (constraints + semver)** — must include
+   the example-file update because tightening rejects the current
+   example shape (Constraint A from spec-flow analysis).
+3. **PR-C: `work.md` RUN_DIR hardening** — independent of the above;
+   no shared files.
+4. **PR-D: Doc sync (security-fencing count + quick-reference fix +
+   SKILL.md scope clarification + review-pr.md comment)** —
+   documentation-only; can land last.
+5. **PR-E (optional, deferred):** if best-practices research surfaces a
+   need for a separate AJV custom-keyword module (semver), it lands
+   inside PR-B as a new file under `packages/infrastructure/`.
+
+Each PR carries its own `.changeset/<slug>.md` per repo convention.
+Sequencing rationale: PR-A unblocks regression testing for PR-B and
+PR-C; PR-B and PR-C are independent siblings off PR-A; PR-D depends
+on PR-C only because it edits `review-pr.md` after the convention
+scope is clarified in the SKILL.md.
+
+## Implementation Plan
+
+### Phase 1: PR-A — Validator hardening + fixture test harness
+
+**Files:** `scripts/validate-plugin.js`, new
+`tests/integration/validate-plugin.test.ts`,
+`.changeset/pr260-validator-hardening.md`.
+
+- [ ] 1.1: Mirror `validate-agent-authoring-review-rule.test.ts`
+      structure. Create `tests/integration/validate-plugin.test.ts`
+      with `mkdtempSync` per test, `execFileSync` of
+      `node scripts/validate-plugin.js` against the temp dir, and
+      assertions on exit code + stderr.
+- [ ] 1.2: Add fixture coverage for **current** behavior before
+      changing anything (regression net): valid manifest passes,
+      invalid name fails, missing version fails, hooks-string
+      anti-pattern logs warning, hooks-inline-object passes.
+- [ ] 1.3: Extract `hasInlineHooks(manifest)` predicate at module
+      scope (lines 226, 329, 449 currently duplicated). Replace
+      three call sites.
+- [ ] 1.4: Extract `addError(errors, msg)` helper. Canonical message
+      form is the longer one (RULE 1 currently has push: short,
+      log: longer; the longer form wins). Replace pervasive
+      `errors.push(msg); logError(msg);` pairs.
+- [ ] 1.5: Convert `VALID_HOOK_EVENTS` from array to module-scope
+      `Set<string>`. Replace `.includes()` with `.has()`.
+- [ ] 1.6: Add `'SessionStart'` to `DECISION_PROTOCOL_EVENTS` Set
+      (line 454). Cross-check against MEMORY.md PR #72 documented
+      requirement.
+- [ ] 1.7: Extract `validateHookScriptPath(scriptPath, pluginDir,
+      errors)` per-script-path helper. Centralizes existence,
+      `resolvePluginPath` containment, shebang, and `set -e` checks.
+- [ ] 1.8: Refactor RULE 6 inline-object branch to call the new
+      helper.
+- [ ] 1.9: **Array-form hooks fix.** When `hooks` is an array,
+      iterate elements: string elements receive
+      `validateHookScriptPath` checks; object elements pass
+      through (same as inline-object form). Emit a one-time
+      INFO-level note: "array-form `hooks` is supported but
+      undocumented — prefer inline-object form".
+- [ ] 1.10: Apply `resolvePluginPath` in the string-form `hooks`
+      branch (line 313). Currently only checks the known
+      anti-pattern; should also catch path escape and missing files.
+- [ ] 1.11: **outputStyles directory-vs-file decision.** Tighten
+      RULE 5b to enforce directory-only (matches current
+      validator) and update schema description in PR-B accordingly.
+      Reject `.md` file paths with a clear error.
+- [ ] 1.12: Add fixture tests for each new behavior: array-form
+      hooks-script-paths checked, string-form hooks
+      path-existence checked, outputStyles file-vs-dir error,
+      addError drift fix verified by inspecting captured stderr.
+- [ ] 1.13: `pnpm test:integration && pnpm validate:schemas`
+      green; commit; `gt submit --no-interactive`.
+
+**Acceptance:** `pnpm test:integration` adds ≥10 new test cases.
+Existing CI baseline (`pnpm validate:schemas && pnpm test:unit &&
+pnpm lint && pnpm typecheck`) green.
+
+### Phase 2: PR-B — Schema tightening + example update
+
+**Files:** `schemas/plugin.schema.json`,
+`examples/plugin-extended.example.json`,
+`packages/infrastructure/src/validation/keywords/semverRange.ts`
+(new), `packages/infrastructure/src/validation/ajvFactory.ts`,
+`.changeset/pr260-schema-tightening.md`.
+
+- [ ] 2.1: **`pathPathsOrInline` array-item tightening.** Replace
+      bare `{ "type": "object" }` in array items with a constraint
+      requiring at minimum the inline-hooks shape (event-keyed
+      object) — accepts the same shapes the inline-object branch
+      accepts, no looser. Same change applies to the array form.
+- [ ] 2.2: **`userConfig` per-entry tightening.** Set
+      `additionalProperties: false` on the entry schema. Enumerate
+      allowed keys (`type`, `label`, `description`, `default`,
+      `required`, `sensitive`).
+- [ ] 2.3: **Type-conditional `default` enforcement** via nested
+      `if/then/else` (NOT `oneOf` — see best-practices research).
+      `if type === "string"` → `default: { type: "string" }`;
+      else `if type === "number"` → `default: { type: "number" }`;
+      else `default: { type: "boolean" }`.
+- [ ] 2.4: **`monitors` `additionalProperties: false` → `true`** on
+      the inline-array-element shape. Required fields stay
+      required. Forward-compat with whatever Claude Code adds.
+- [ ] 2.5: Add `dependencies[].version` validation. Two-layer:
+      lightweight regex pattern in JSON Schema (`^[~^>=<*xX0-9]`
+      gatekeep) + new AJV custom keyword
+      `semverRange` calling `semver.validRange()` for full
+      semantic check. Add `semver` dependency to root
+      `package.json` if not already present.
+- [ ] 2.6: Tighten `outputStyles` schema description to "directories
+      containing .md files" (matches RULE 5b after PR-A).
+- [ ] 2.7: **Update `examples/plugin-extended.example.json`.**
+      Replace `"hooks": "./hooks/hooks.json"` (string anti-pattern
+      that RULE 6 warns against) with inline-object form. Update
+      `userConfig` block to satisfy the tightened schema (boolean
+      defaults must be boolean, etc.). Add a `_comment`-style
+      header noting the file is a schema-coverage fixture.
+- [ ] 2.8: Add CI hook reference. Either: (a) add a comment in
+      `validate-schemas.yml` explicitly globbing the example, OR
+      (b) add a Vitest test in `tests/integration/` that
+      AJV-validates every file under `examples/` against
+      `plugin.schema.json`. (b) is preferred — turns it from a
+      silent orphan into a tested fixture.
+- [ ] 2.9: Run `pnpm validate:schemas`; example must pass.
+- [ ] 2.10: Commit; `gt submit --no-interactive`.
+
+**Acceptance:** `examples/plugin-extended.example.json` passes
+tightened schema. New AJV custom keyword exercised by at least
+one positive and one negative fixture. `pnpm test:integration`
+includes a test that AJV-validates every file under `examples/`.
+
+### Phase 3: PR-C — `work.md` RUN_DIR hardening
+
+**Files:** `plugins/yellow-core/commands/workflows/work.md`,
+`.changeset/pr260-rundir-hardening.md`.
+
+- [ ] 3.1: **Shell-variable isolation fix.** Restructure Phase 3
+      step 3a so `RUN_DIR=$(mktemp -d -t run-XXXXXXXX)` is
+      derived in the same prose-step as the Task spawn, OR the
+      orchestrator is instructed to capture stdout and substitute
+      the literal path inline. Reference MEMORY.md
+      `bash-block-subshell-isolation-in-command-files.md`
+      anti-pattern.
+- [ ] 3.2: **Empty-RUN_DIR error path.** After mktemp, prose
+      instruction: "If `$RUN_DIR` is empty (mktemp failed),
+      report the error to the user and stop — do not spawn
+      reviewer agents without a valid run directory."
+- [ ] 3.3: **Atomic write convention.** Update SKILL.md
+      Subagent Failure Convention to specify
+      `agent-result-<name>.tmp` → `mv` to `.json` rename
+      (POSIX rename atomicity). Orchestrator globs `*.json`
+      only, never `*.tmp`. Best-practices research validated
+      this pattern in the barkain orchestration plugin.
+- [ ] 3.4: **Cleanup step.** Add prose instruction at the end
+      of Phase 3: "After findings are aggregated, remove
+      `$RUN_DIR` (`rm -rf "$RUN_DIR"`). Result files may
+      contain diff excerpts with secrets — retention in /tmp
+      is a data-residue risk."
+- [ ] 3.5: `pnpm validate:schemas` green; commit; submit.
+
+**Acceptance:** `work.md` Phase 3 reads cleanly when followed by
+an LLM with no prior context. Reviewers can verify by reading
+Phase 3 top-to-bottom and confirming `$RUN_DIR` is created,
+errored-on-empty, used, and cleaned up — all in unambiguous
+prose-instruction form.
+
+### Phase 4: PR-D — Doc sync (security-fencing count + quick-reference + scope clarification)
+
+**Files:** `plugins/yellow-core/skills/security-fencing/SKILL.md`,
+`plugins/yellow-core/skills/create-agent-skills/SKILL.md`,
+`plugins/yellow-core/skills/create-agent-skills/references/quick-reference.md`,
+`plugins/yellow-review/commands/review/review-pr.md`,
+`.changeset/pr260-doc-sync.md`.
+
+- [ ] 4.1: **Refresh security-fencing consumer count.** Update the
+      "currently inlined in 25 agents" claim to reflect actual
+      count (36 confirmed by `rg -l 'CRITICAL SECURITY RULES'
+      plugins/`). Re-enumerate consumers from the live grep,
+      excluding the canonical SKILL.md itself and the
+      `yellow-core/CLAUDE.md` reference.
+- [ ] 4.2: **Add machine-verifiable count one-liner** alongside
+      the prose: ``rg -l 'CRITICAL SECURITY RULES' plugins/ |
+      grep -v 'security-fencing/SKILL.md' | grep -v
+      'CLAUDE.md' | wc -l`` so future drift is self-correcting.
+- [ ] 4.3: **Add the 7 Wave-2 yellow-review personas** to the
+      consumer list (`correctness-reviewer`,
+      `maintainability-reviewer`, `project-compliance-reviewer`,
+      `project-standards-reviewer`, `reliability-reviewer`,
+      `adversarial-reviewer`, `plugin-contract-reviewer`).
+      Annotate the deprecated `code-reviewer` stub as such.
+- [ ] 4.4: **Fix `quick-reference.md:79`** yellow-browser-test
+      reference. Verified: `yellow-browser-test` does not use
+      the `.claude/<plugin>.local.md` pattern; it uses
+      `.claude/browser-test-auth.json`. Replace with a working
+      reference (yellow-plugins.local.md schema in `local-config`
+      skill) OR remove the specific plugin reference and link
+      to the `local-config` skill generically.
+- [ ] 4.5: **Add Subagent Failure Convention scope clarification**
+      to `create-agent-skills/SKILL.md`. New paragraph in the
+      §Subagent Failure Convention section:
+
+      > **When the convention applies.** Orchestrators that spawn
+      > agents emitting unstructured prose (e.g., `work.md`
+      > Phase 3 reviewers). Orchestrators whose spawned agents
+      > return structured JSON per a compact-return schema
+      > (e.g., `review-pr.md` Step 5) can rely on schema
+      > validation to detect partial failures; the file-based
+      > RUN_DIR pattern is unnecessary there and would only
+      > duplicate the signal.
+
+- [ ] 4.6: **Add comment block to `review-pr.md` Step 5**
+      explaining the architectural choice:
+
+      > Step 5 collects findings via TaskOutput because each
+      > reviewer emits compact-return JSON per the schema in
+      > this file. The Subagent Failure Convention's
+      > file-based RUN_DIR pattern (see `create-agent-skills`
+      > SKILL.md §Subagent Failure Convention) is reserved for
+      > prose-emitting orchestrators like `work.md` Phase 3.
+
+- [ ] 4.7: Update `create-agent-skills/SKILL.md` Subagent Failure
+      Convention to use the atomic-write `.tmp` → `mv`
+      convention (forward-link to PR-C item 3.3).
+- [ ] 4.8: Categories list at SKILL.md:204 was already corrected
+      on PR #260 by the in-scope fix; verify still correct, no
+      action needed.
+- [ ] 4.9: `pnpm validate:agents && pnpm validate:plugins` green;
+      commit; submit.
+
+**Acceptance:** `rg -l 'CRITICAL SECURITY RULES' plugins/ |
+grep -v 'SKILL.md' | grep -v 'CLAUDE.md' | wc -l` matches the
+number stated in security-fencing/SKILL.md. The
+quick-reference.md `yellow-browser-test` reference is either
+verified accurate or replaced. SKILL.md scope clarification
+read top-to-bottom makes review-pr.md's design choice
+unambiguous.
+
+## Technical Specifications
+
+### Files to Modify
+
+- `scripts/validate-plugin.js` — extract helpers, add array-form
+  hooks loop, add SessionStart, fix string-form hooks (PR-A)
+- `schemas/plugin.schema.json` — tighten `pathPathsOrInline`,
+  `userConfig`, `monitors`; add semver pattern (PR-B)
+- `examples/plugin-extended.example.json` — replace anti-pattern
+  hooks form, satisfy tightened userConfig (PR-B)
+- `packages/infrastructure/src/validation/ajvFactory.ts` — register
+  `semverRange` custom keyword (PR-B)
+- `plugins/yellow-core/commands/workflows/work.md` — RUN_DIR
+  isolation fix, empty-check, atomic-write reference, cleanup
+  step (PR-C)
+- `plugins/yellow-core/skills/security-fencing/SKILL.md` — refresh
+  consumer count and list, add machine-verification one-liner
+  (PR-D)
+- `plugins/yellow-core/skills/create-agent-skills/SKILL.md` —
+  Subagent Failure Convention scope clarification + atomic-write
+  pattern (PR-D, also touches PR-C contract)
+- `plugins/yellow-core/skills/create-agent-skills/references/quick-reference.md` —
+  fix yellow-browser-test reference (PR-D)
+- `plugins/yellow-review/commands/review/review-pr.md` — add
+  Step 5 comment block referencing SKILL.md scope (PR-D)
+
+### Files to Create
+
+- `tests/integration/validate-plugin.test.ts` — PR-A fixture suite
+- `tests/integration/example-files-schema.test.ts` — PR-B
+  AJV-validate every example file
+- `packages/infrastructure/src/validation/keywords/semverRange.ts` —
+  PR-B AJV custom keyword for `semver.validRange()`
+
+### Dependencies
+
+- `semver@^7` — for `validRange()` runtime check (PR-B); already
+  a transitive dep via Vitest, but should be declared explicitly
+  in root `package.json` since `validate-plugin.js` imports it.
+
+### API / Contract Changes
+
+- **Validator behavior change for external consumers:** Plugins
+  that ship array-form `hooks` with raw script paths will
+  previously have passed validation silently (no path checks).
+  After PR-A, those plugins receive script-path-existence,
+  containment, shebang, and `set -e` checks. **No in-repo
+  plugin uses array-form hooks** (verified by repo research),
+  so blast radius inside this monorepo is zero. Downstream
+  consumers of the schema/validator may see new errors on
+  manifests that previously passed. Document this in the PR-A
+  release note.
+- **Schema tightening for `userConfig`:** `additionalProperties:
+  false` rejects unknown keys at the entry level. Type-conditional
+  default rejects mismatched type/default pairs. **No in-repo
+  plugin uses `userConfig` in `plugin.json`** (verified — all
+  cross-plugin userConfig usage is in command/skill `.md` files,
+  not in manifests). Blast radius zero in-repo.
+
+## Testing Strategy
+
+- **Unit (validate-plugin.js):** Each new helper
+  (`hasInlineHooks`, `addError`, `validateHookScriptPath`)
+  testable independently if extracted to a small utility module.
+  Optional: introduce `scripts/validate-plugin/lib.js` with
+  exported helpers, tested via `*.test.js` siblings. Decision:
+  defer this refactor; current extraction is in-place. Tests
+  in PR-A go through the integration path.
+- **Integration (PR-A):** Mirror
+  `validate-agent-authoring-review-rule.test.ts`. Inline string
+  fixtures, `mkdtempSync` + `writeFileSync` per test,
+  `execFileSync` of validator script with `VALIDATE_PLUGINS_DIR`
+  env override, assert exit code + stderr substring matches.
+- **Integration (PR-B):** New `example-files-schema.test.ts`
+  AJV-compiles `plugin.schema.json` once, then
+  `describe.each([...readdirSync('examples/'), ...])` validates
+  each fixture. Both happy-path and adversarial cases (typo
+  fixture for userConfig).
+- **Manual verification:** After each PR, run the relevant
+  validator on every plugin in the monorepo (`pnpm
+  validate:plugins`) — every existing plugin must still pass.
+
+## Acceptance Criteria
+
+1. `pnpm test:integration` adds ≥12 fixture cases across PR-A
+   and PR-B, all green.
+2. `pnpm validate:schemas && pnpm test:unit && pnpm lint &&
+   pnpm typecheck` green on each stacked PR.
+3. Every existing `plugins/*/.claude-plugin/plugin.json`
+   validates after PR-B (no in-repo regression).
+4. `examples/plugin-extended.example.json` validates against the
+   tightened schema in PR-B and is referenced from a CI test in
+   `tests/integration/`.
+5. `work.md` Phase 3 prose explicitly creates RUN_DIR, errors on
+   empty, uses atomic `.tmp` → `mv` writes, and cleans up after
+   collection.
+6. `security-fencing/SKILL.md` consumer count matches `rg -l`
+   output at the moment of PR-D landing; the embedded one-liner
+   makes future drift self-correcting.
+7. `review-pr.md` Step 5 comment block makes the
+   TaskOutput-vs-RUN_DIR architectural choice unambiguous.
+
+## Edge Cases & Error Handling
+
+- **Array-form hooks with mixed string/object items.** Each item
+  is validated independently: strings get path-script checks,
+  objects get the inline-event-keyed-object check.
+- **`mktemp` failure on disk-full systems.** Prose instruction
+  in `work.md` errors-and-stops; never proceeds with empty
+  RUN_DIR.
+- **Schema tightening + example file in different PRs.** PR-B
+  bundles both to avoid the intermediate CI-broken state. Spec-flow
+  analysis confirmed this constraint.
+- **Multiple semver dependency syntaxes.** `semver.validRange`
+  accepts `^1.0.0`, `~2.0.0`, `>=3 <4`, `1.x`, `*`,
+  `1.2.3 - 2.0.0`, and `||` composites. Pre-filter regex is
+  permissive; semantic check via `validRange` is authoritative.
+- **Down-stream consumers of array-form `hooks`.** Document
+  validator behavior change in PR-A release notes (changeset
+  bump message). External plugins that previously passed
+  silently may newly fail; this is intentional hardening, not a
+  regression.
+
+## Linear Issues
+
+None — this follow-up is internal review-driven hardening, not a
+Linear-tracked feature.
+
+## References
+
+- PR #260 review report (in this session, contains all 21 findings
+  with reviewer attribution and confidence)
+- `docs/solutions/code-quality/brainstorm-orchestrator-agent-authoring-patterns.md`
+  — orchestrator authoring patterns
+- `docs/solutions/code-quality/skill-frontmatter-attribute-and-format-requirements.md`
+  — frontmatter rules
+- `docs/solutions/build-errors/ci-schema-drift-hooks-inline-vs-string.md`
+  — schema drift between local and Claude Code remote validator
+- `tests/integration/validate-agent-authoring-review-rule.test.ts`
+  — canonical Vitest fixture pattern to mirror
+- `plugins/yellow-core/skills/create-agent-skills/SKILL.md`
+  §Subagent Failure Convention (lines 240–340) — convention
+  introduced in PR #260
+- `plugins/yellow-core/commands/workflows/work.md` Phase 3 (lines
+  447–491) — reference implementation of the convention
+- AJV [conditionals reference](https://ajv.js.org/json-schema.html)
+  — type-conditional defaults via `if/then/else`
+- npm semver — `validRange()` for two-layer dependency
+  validation
+- Upstream issues anthropics/claude-code#24181 and
+  anthropics/claude-code#25818 — Task return value reliability
+  context for the convention scope
+
+## Stack Decomposition
+
+<!-- stack-topology: linear -->
+<!-- stack-trunk: main -->
+
+Stack built on top of `docs/subagent-conventions` (PR #260). Each PR
+stacks on the previous via Graphite (`gt`); the entire stack ultimately
+merges into `main` once PR #260 lands.
+
+### 1. agent/fix/pr260-validator-hardening
+- **Type:** fix
+- **Description:** array-form hooks bypass + helper extraction + fixture test harness
+- **Scope:** scripts/validate-plugin.js, tests/integration/validate-plugin.test.ts, .changeset/pr260-validator-hardening.md
+- **Tasks:** 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11, 1.12, 1.13
+- **Depends on:** (none — base of stack; parent branch: docs/subagent-conventions)
+
+### 2. agent/feat/pr260-schema-tightening
+- **Type:** feat
+- **Description:** tighten userConfig/pathPathsOrInline, add semver custom keyword, fix example
+- **Scope:** schemas/plugin.schema.json, examples/plugin-extended.example.json, packages/infrastructure/src/validation/keywords/semverRange.ts, packages/infrastructure/src/validation/ajvFactory.ts, tests/integration/example-files-schema.test.ts, .changeset/pr260-schema-tightening.md
+- **Tasks:** 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 2.10
+- **Depends on:** #1
+
+### 3. agent/fix/pr260-work-rundir-hardening
+- **Type:** fix
+- **Description:** RUN_DIR shell-variable isolation + atomic .tmp→mv writes + cleanup
+- **Scope:** plugins/yellow-core/commands/workflows/work.md, .changeset/pr260-rundir-hardening.md
+- **Tasks:** 3.1, 3.2, 3.3, 3.4, 3.5
+- **Depends on:** #2
+
+### 4. agent/docs/pr260-doc-sync
+- **Type:** docs
+- **Description:** refresh security-fencing count, scope clarification, quick-ref fix
+- **Scope:** plugins/yellow-core/skills/security-fencing/SKILL.md, plugins/yellow-core/skills/create-agent-skills/SKILL.md, plugins/yellow-core/skills/create-agent-skills/references/quick-reference.md, plugins/yellow-review/commands/review/review-pr.md, .changeset/pr260-doc-sync.md
+- **Tasks:** 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9
+- **Depends on:** #3

--- a/scripts/validate-plugin.js
+++ b/scripts/validate-plugin.js
@@ -29,6 +29,38 @@ const path = require('path');
 
 const PROJECT_ROOT = process.cwd();
 
+// Canonical Claude Code hook events. Module-scope so VALID_HOOK_EVENTS.has()
+// is O(1) and the membership test is shared across rules instead of
+// re-allocated per validatePlugin call.
+const VALID_HOOK_EVENTS = new Set([
+  'PreToolUse',
+  'PostToolUse',
+  'PostToolUseFailure',
+  'PermissionRequest',
+  'UserPromptSubmit',
+  'Notification',
+  'Stop',
+  'SubagentStart',
+  'SubagentStop',
+  'SessionStart',
+  'SessionEnd',
+  'TeammateIdle',
+  'TaskCompleted',
+  'PreCompact',
+]);
+
+// Hook events whose scripts must emit a decision payload (JSON or exit-code
+// protocol). SessionStart is included because Claude Code blocks session
+// startup if a SessionStart hook exits without {"continue": true}; absence
+// of decision output is a soft warning here so authors notice before the
+// session-block manifests in production.
+const DECISION_PROTOCOL_EVENTS = new Set([
+  'PreToolUse',
+  'PostToolUse',
+  'Stop',
+  'SessionStart',
+]);
+
 /**
  * Resolve a hook command to a script path within the plugin directory.
  * Returns the resolved path, or null if the command is not a "bash <path>"
@@ -97,13 +129,11 @@ function countMarkdownRecursive(dir) {
 function validatePathFile(fieldName, filePath, pluginDir, errors) {
   const resolved = resolvePluginPath(filePath, pluginDir);
   if (!resolved) {
-    errors.push(`${fieldName} path escapes plugin directory: ${filePath}`);
-    logError(`${fieldName} path escapes plugin directory: ${filePath}`);
+    addError(errors, `${fieldName} path escapes plugin directory: ${filePath}`);
     return;
   }
   if (!fs.existsSync(resolved)) {
-    errors.push(`${fieldName} file not found: ${filePath}`);
-    logError(`${fieldName} file not found: ${filePath}`);
+    addError(errors, `${fieldName} file not found: ${filePath}`);
     return;
   }
   // Use lstatSync (not statSync) so symlinks are detected before they are
@@ -112,13 +142,17 @@ function validatePathFile(fieldName, filePath, pluginDir, errors) {
   // boundary check. Reject symlinks outright.
   const stat = fs.lstatSync(resolved);
   if (stat.isSymbolicLink()) {
-    errors.push(`${fieldName} path is a symlink which is not permitted: ${filePath}`);
-    logError(`${fieldName} path is a symlink which is not permitted: ${filePath}`);
+    addError(
+      errors,
+      `${fieldName} path is a symlink which is not permitted: ${filePath}`
+    );
     return;
   }
   if (stat.isDirectory()) {
-    errors.push(`${fieldName} must point to a file, not a directory: ${filePath}`);
-    logError(`${fieldName} must point to a file, not a directory: ${filePath}`);
+    addError(
+      errors,
+      `${fieldName} must point to a file, not a directory: ${filePath}`
+    );
     return;
   }
   logSuccess(`${fieldName}: ${filePath}`);
@@ -126,37 +160,46 @@ function validatePathFile(fieldName, filePath, pluginDir, errors) {
 
 /**
  * Validate a pathOrPaths field that must point to a directory containing .md files.
- * @param {string} fieldName  - Field name for error messages (e.g. 'commands')
- * @param {*}      fieldValue - Raw manifest value (string | string[] | other)
- * @param {string} pluginDir  - Absolute plugin root directory
- * @param {string[]} errors   - Error array to push into
+ * When `directoryOnly` is true, single-file `.md` paths are rejected — used
+ * for outputStyles where the field shape semantically requires a directory
+ * even though Anthropic's relativePath schema allows single .md files.
+ * @param {string}  fieldName     - Field name for error messages (e.g. 'commands')
+ * @param {*}       fieldValue    - Raw manifest value (string | string[] | other)
+ * @param {string}  pluginDir     - Absolute plugin root directory
+ * @param {string[]} errors       - Error array to push into
+ * @param {boolean} directoryOnly - When true, .md file paths produce an error
  */
-function validatePathOrPathsDir(fieldName, fieldValue, pluginDir, errors) {
+function validatePathOrPathsDir(
+  fieldName,
+  fieldValue,
+  pluginDir,
+  errors,
+  directoryOnly = false
+) {
   const paths = Array.isArray(fieldValue)
     ? fieldValue
     : typeof fieldValue === 'string'
       ? [fieldValue]
       : null;
   if (paths === null) {
-    errors.push(`${fieldName} must be a string path or array of string paths`);
-    logError(`${fieldName} must be a string path or array of string paths`);
+    addError(
+      errors,
+      `${fieldName} must be a string path or array of string paths`
+    );
     return;
   }
   for (const p of paths) {
     if (typeof p !== 'string') {
-      errors.push(`${fieldName} entries must be string paths`);
-      logError(`${fieldName} entries must be string paths`);
+      addError(errors, `${fieldName} entries must be string paths`);
       continue;
     }
     const resolved = resolvePluginPath(p, pluginDir);
     if (!resolved) {
-      errors.push(`${fieldName} path escapes plugin directory: ${p}`);
-      logError(`${fieldName} path escapes plugin directory: ${p}`);
+      addError(errors, `${fieldName} path escapes plugin directory: ${p}`);
       continue;
     }
     if (!fs.existsSync(resolved)) {
-      errors.push(`${fieldName} directory not found: ${p}`);
-      logError(`${fieldName} directory not found: ${p}`);
+      addError(errors, `${fieldName} directory not found: ${p}`);
       continue;
     }
     // lstatSync (not statSync): detect symlinks before following them. A
@@ -165,23 +208,33 @@ function validatePathOrPathsDir(fieldName, fieldValue, pluginDir, errors) {
     // paths past the resolvePluginPath boundary. Reject symlinks outright.
     const stat = fs.lstatSync(resolved);
     if (stat.isSymbolicLink()) {
-      errors.push(`${fieldName} path is a symlink which is not permitted: ${p}`);
-      logError(`${fieldName} path is a symlink which is not permitted: ${p}`);
+      addError(
+        errors,
+        `${fieldName} path is a symlink which is not permitted: ${p}`
+      );
       continue;
     }
     if (stat.isFile()) {
+      if (directoryOnly) {
+        addError(
+          errors,
+          `${fieldName} must point to a directory, not a file: ${p}`
+        );
+        continue;
+      }
       // Schema's relativePath allows pointing directly at a .md file.
       if (!p.endsWith('.md')) {
-        errors.push(`${fieldName} file path must end with .md: ${p}`);
-        logError(`${fieldName} file path must end with .md: ${p}`);
+        addError(errors, `${fieldName} file path must end with .md: ${p}`);
       } else {
         logSuccess(`${fieldName}: ${p}`);
       }
       continue;
     }
     if (!stat.isDirectory()) {
-      errors.push(`${fieldName} must point to a .md file or a directory: ${p}`);
-      logError(`${fieldName} must point to a .md file or a directory: ${p}`);
+      addError(
+        errors,
+        `${fieldName} must point to a .md file or a directory: ${p}`
+      );
       continue;
     }
     // Walk the directory recursively to find any .md files. The 'skills'
@@ -193,10 +246,8 @@ function validatePathOrPathsDir(fieldName, fieldValue, pluginDir, errors) {
     // the top-level lstatSync guard above.
     const mdCount = countMarkdownRecursive(resolved);
     if (mdCount === 0) {
-      errors.push(
-        `${fieldName} directory must contain at least one .md file (recursively): ${p}`
-      );
-      logError(
+      addError(
+        errors,
         `${fieldName} directory must contain at least one .md file (recursively): ${p}`
       );
     } else {
@@ -267,6 +318,89 @@ function logSuccess(message) {
 }
 
 /**
+ * Append a validation error and emit it to stderr atomically. Centralizes
+ * the prior errors.push + logError pair so the structured error returned to
+ * callers and the developer-facing log line never drift apart.
+ */
+function addError(errors, message) {
+  errors.push(message);
+  logError(message);
+}
+
+/**
+ * Apply RULE 6 (existence / readability / executable mode) and RULE 8
+ * (shebang / decision-output / set -e) to a single hook script path.
+ * Centralizes per-script-path checks so RULE 6 and RULE 8 cannot drift —
+ * previously the inline-object branch ran two separate loops over the same
+ * scripts. eventName is required for the DECISION_PROTOCOL_EVENTS gate.
+ */
+function validateHookScriptPath(scriptPath, eventName, pluginDir, errors) {
+  if (!fs.existsSync(scriptPath)) {
+    addError(
+      errors,
+      `Hook script not found for ${eventName}: ${scriptPath}`
+    );
+    return;
+  }
+  try {
+    fs.accessSync(scriptPath, fs.constants.R_OK);
+  } catch (accessErr) {
+    logWarning(
+      `Hook script not readable: ${scriptPath} (check file permissions)`
+    );
+  }
+  try {
+    const mode = fs.statSync(scriptPath).mode;
+    if ((mode & 0o111) === 0) {
+      logWarning(
+        `Hook script not executable: ${scriptPath} (check file permissions)`
+      );
+    }
+  } catch (statErr) {
+    logWarning(
+      `Cannot inspect hook script mode: ${scriptPath} (${statErr.message})`
+    );
+  }
+
+  let content;
+  try {
+    content = fs.readFileSync(scriptPath, 'utf-8');
+  } catch (readErr) {
+    logWarning(
+      `Cannot read hook script: ${scriptPath} (${readErr.message})`
+    );
+    return;
+  }
+
+  const relPath = path.relative(pluginDir, scriptPath);
+
+  if (!content.startsWith('#!/')) {
+    logWarning(`${relPath}: missing shebang line (expected #!/bin/bash)`);
+  }
+
+  if (DECISION_PROTOCOL_EVENTS.has(eventName)) {
+    const hasJsonOutput =
+      /"continue"\s*:/.test(content) || /"decision"\s*:/.test(content);
+    const hasExitCodeProtocol =
+      /exit\s+0/.test(content) && /exit\s+2/.test(content);
+    if (!hasJsonOutput && !hasExitCodeProtocol) {
+      logWarning(
+        `${relPath}: missing decision output for ${eventName} — expected {"continue": true}, {"decision": ...}, or exit 0/2 protocol`
+      );
+    }
+  }
+
+  if (
+    /^\s*set\s+(-[a-zA-Z]*e[a-zA-Z]*|-o\s+errexit)(\s|$)/m.test(content)
+  ) {
+    logWarning(
+      `${relPath}: uses "set -e" which can prevent JSON output on error — ` +
+        'use "set -uo pipefail" instead'
+    );
+  }
+}
+
+/**
  * Validate a single plugin directory
  */
 function validatePlugin(pluginDir) {
@@ -303,39 +437,35 @@ function validatePlugin(pluginDir) {
 
   // RULE 1: Required fields (official format: name, description, author)
   if (!manifest.name || typeof manifest.name !== 'string') {
-    errors.push('Missing required field: "name"');
-    logError('Missing required field: "name"');
+    addError(errors, 'Missing required field: "name"');
   }
 
   if (!manifest.description || typeof manifest.description !== 'string') {
-    errors.push('Missing required field: "description"');
-    logError('Missing required field: "description"');
+    addError(errors, 'Missing required field: "description"');
   }
 
   if (!manifest.author) {
-    errors.push('Missing required field: "author"');
-    logError('Missing required field: "author"');
+    addError(errors, 'Missing required field: "author"');
   } else if (typeof manifest.author === 'object' && !manifest.author.name) {
-    errors.push('author.name is required');
-    logError('author.name is required');
+    addError(errors, 'author.name is required');
   }
 
   // RULE 2: Name matches directory
   if (manifest.name && manifest.name !== dirName) {
-    errors.push(
-      `Plugin name "${manifest.name}" does not match directory name "${dirName}"`
-    );
-    logError(
+    addError(
+      errors,
       `Plugin name "${manifest.name}" does not match directory name "${dirName}"`
     );
   }
 
-  // RULE 3: Version format (if present)
+  // RULE 3: Version format (if present). Push the more-informative message
+  // (with the MAJOR.MINOR.PATCH hint) into both the structured errors array
+  // and stderr — prior code dropped the hint from the errors array.
   if (manifest.version) {
     const semverPattern = /^[0-9]+\.[0-9]+\.[0-9]+$/;
     if (!semverPattern.test(manifest.version)) {
-      errors.push(`Invalid version format: ${manifest.version}`);
-      logError(
+      addError(
+        errors,
         `Invalid version format: ${manifest.version} (must be MAJOR.MINOR.PATCH)`
       );
     } else {
@@ -353,15 +483,13 @@ function validatePlugin(pluginDir) {
   // RULE 5: Keywords format (if present)
   if (manifest.keywords) {
     if (!Array.isArray(manifest.keywords)) {
-      errors.push('keywords must be an array');
-      logError('keywords must be an array');
+      addError(errors, 'keywords must be an array');
     } else {
       const invalidKeywords = manifest.keywords.filter(
         (kw) => typeof kw !== 'string'
       );
       if (invalidKeywords.length > 0) {
-        errors.push('All keywords must be strings');
-        logError('All keywords must be strings');
+        addError(errors, 'All keywords must be strings');
       }
     }
   }
@@ -377,16 +505,33 @@ function validatePlugin(pluginDir) {
   // standard nested layouts), file checks via validatePathFile. Inline
   // objects are structurally accepted by JSON Schema and need no
   // filesystem check here.
+  // outputStyles is directory-only: even though Anthropic's relativePath
+  // schema accepts a single .md file, the field's runtime semantics need a
+  // directory whose .md files are loaded as named output styles. The other
+  // dirOrDirs fields (commands/agents/skills) accept single .md files.
   for (const field of ['outputStyles', 'commands', 'agents', 'skills']) {
+    const directoryOnly = field === 'outputStyles';
     if (manifest[field] !== undefined && typeof manifest[field] === 'string') {
       // string form — single directory path
-      validatePathOrPathsDir(field, manifest[field], pluginDir, errors);
+      validatePathOrPathsDir(
+        field,
+        manifest[field],
+        pluginDir,
+        errors,
+        directoryOnly
+      );
     } else if (Array.isArray(manifest[field])) {
       // array form — only string entries are filesystem-checked here;
       // any non-string entries would be a schema violation caught by AJV.
       const stringPaths = manifest[field].filter((v) => typeof v === 'string');
       if (stringPaths.length > 0) {
-        validatePathOrPathsDir(field, stringPaths, pluginDir, errors);
+        validatePathOrPathsDir(
+          field,
+          stringPaths,
+          pluginDir,
+          errors,
+          directoryOnly
+        );
       }
     }
   }
@@ -437,30 +582,15 @@ function validatePlugin(pluginDir) {
   const inlineHooks = collectInlineHooks(manifest.hooks);
   const hasInlineHooks = Object.keys(inlineHooks).length > 0;
 
-  // RULE 6: Hook script existence (if hooks declared as inline object).
+  // RULES 6 + 8: Hook script existence + content checks (shebang, decision
+  // output, set -e). Both rules iterate the same scripts; folding them into a
+  // single pass via validateHookScriptPath eliminates duplicate filesystem
+  // I/O and removes the prior message drift between the two loops.
   if (hasInlineHooks) {
-    const VALID_HOOK_EVENTS = [
-      'PreToolUse',
-      'PostToolUse',
-      'PostToolUseFailure',
-      'PermissionRequest',
-      'UserPromptSubmit',
-      'Notification',
-      'Stop',
-      'SubagentStart',
-      'SubagentStop',
-      'SessionStart',
-      'SessionEnd',
-      'TeammateIdle',
-      'TaskCompleted',
-      'PreCompact',
-    ];
-
     for (const [eventName, hookEntries] of Object.entries(inlineHooks)) {
-      // Validate event name
-      if (!VALID_HOOK_EVENTS.includes(eventName)) {
+      if (!VALID_HOOK_EVENTS.has(eventName)) {
         logWarning(
-          `Unknown hook event "${eventName}". Known events: ${VALID_HOOK_EVENTS.join(', ')}`
+          `Unknown hook event "${eventName}". Known events: ${[...VALID_HOOK_EVENTS].join(', ')}`
         );
       }
 
@@ -474,50 +604,24 @@ function validatePlugin(pluginDir) {
 
           const scriptPath = resolveHookScriptPath(hook.command, pluginDir);
           if (!scriptPath) {
-            // Check if it was a bash command that escaped the plugin dir
+            // resolveHookScriptPath returns null both for non-bash commands
+            // (echo "...", inline node -e, etc., which need no path check)
+            // and for bash commands that escape the plugin directory. The
+            // latter is a containment violation and must error.
             const resolved = hook.command.replaceAll(
               '${CLAUDE_PLUGIN_ROOT}',
               pluginDir
             );
             if (/^bash\s+/.test(resolved)) {
-              errors.push(
-                `Hook script path escapes plugin directory: ${hook.command}`
-              );
-              logError(
+              addError(
+                errors,
                 `Hook script path escapes plugin directory: ${hook.command}`
               );
             }
             continue;
           }
 
-          if (!fs.existsSync(scriptPath)) {
-            errors.push(
-              `Hook script not found: ${hook.command} (resolved: ${scriptPath})`
-            );
-            logError(
-              `Hook script not found for ${eventName}: ${hook.command}`
-            );
-          } else {
-            try {
-              fs.accessSync(scriptPath, fs.constants.R_OK);
-            } catch (accessErr) {
-              logWarning(
-                `Hook script not readable: ${scriptPath} (check file permissions)`
-              );
-            }
-            try {
-              const mode = fs.statSync(scriptPath).mode;
-              if ((mode & 0o111) === 0) {
-                logWarning(
-                  `Hook script not executable: ${scriptPath} (check file permissions)`
-                );
-              }
-            } catch (statErr) {
-              logWarning(
-                `Cannot inspect hook script mode: ${scriptPath} (${statErr.message})`
-              );
-            }
-          }
+          validateHookScriptPath(scriptPath, eventName, pluginDir, errors);
         }
       }
     }
@@ -652,71 +756,8 @@ function validatePlugin(pluginDir) {
     }
   }
 
-  // RULE 8: Hook script basics (shebang, decision output, no set -e)
-  if (hasInlineHooks) {
-    const DECISION_PROTOCOL_EVENTS = new Set([
-      'PreToolUse',
-      'PostToolUse',
-      'Stop',
-    ]);
-
-    for (const [eventName, hookEntries] of Object.entries(inlineHooks)) {
-      if (!Array.isArray(hookEntries)) continue;
-
-      for (const entry of hookEntries) {
-        if (!entry.hooks || !Array.isArray(entry.hooks)) continue;
-
-        for (const hook of entry.hooks) {
-          if (hook.type !== 'command' || !hook.command) continue;
-
-          const scriptPath = resolveHookScriptPath(hook.command, pluginDir);
-          if (!scriptPath || !fs.existsSync(scriptPath)) continue;
-
-          let content;
-          try {
-            content = fs.readFileSync(scriptPath, 'utf-8');
-          } catch (readErr) {
-            logWarning(
-              `Cannot read hook script: ${scriptPath} (${readErr.message})`
-            );
-            continue;
-          }
-
-          const relPath = path.relative(pluginDir, scriptPath);
-
-          // Check shebang
-          if (!content.startsWith('#!/')) {
-            logWarning(`${relPath}: missing shebang line (expected #!/bin/bash)`);
-          }
-
-          if (DECISION_PROTOCOL_EVENTS.has(eventName)) {
-            // Decision hooks should either emit a JSON decision or use exit 0/2.
-            const hasJsonOutput =
-              /"continue"\s*:/.test(content) || /"decision"\s*:/.test(content);
-            const hasExitCodeProtocol =
-              /exit\s+0/.test(content) && /exit\s+2/.test(content);
-            if (!hasJsonOutput && !hasExitCodeProtocol) {
-              logWarning(
-                `${relPath}: missing decision output for ${eventName} — expected {"continue": true}, {"decision": ...}, or exit 0/2 protocol`
-              );
-            }
-          }
-
-          // Check for set -e anti-pattern (matches -e flag or -o errexit)
-          if (
-            /^\s*set\s+(-[a-zA-Z]*e[a-zA-Z]*|-o\s+errexit)(\s|$)/m.test(
-              content
-            )
-          ) {
-            logWarning(
-              `${relPath}: uses "set -e" which can prevent JSON output on error — ` +
-                'use "set -uo pipefail" instead'
-            );
-          }
-        }
-      }
-    }
-  }
+  // (RULE 8 — shebang / decision-output / set -e content checks — folded
+  // into RULES 6+8 single-pass loop above via validateHookScriptPath.)
 
   // Summary
   if (errors.length === 0) {

--- a/scripts/validate-plugin.js
+++ b/scripts/validate-plugin.js
@@ -79,7 +79,10 @@ function resolveHookScriptPath(command, pluginDir) {
 function resolvePluginPath(inputPath, pluginDir) {
   const normalized = path.resolve(pluginDir, inputPath);
   const pluginRoot = path.resolve(pluginDir);
-  if (normalized === pluginRoot || normalized.startsWith(pluginRoot + path.sep)) {
+  if (
+    normalized === pluginRoot ||
+    normalized.startsWith(pluginRoot + path.sep)
+  ) {
     return normalized;
   }
   return null;
@@ -277,9 +280,7 @@ function collectInlineHooks(hooks) {
     hooks && typeof hooks === 'object' && !Array.isArray(hooks)
       ? [hooks]
       : Array.isArray(hooks)
-        ? hooks.filter(
-            (v) => v && typeof v === 'object' && !Array.isArray(v)
-          )
+        ? hooks.filter((v) => v && typeof v === 'object' && !Array.isArray(v))
         : [];
   const merged = {};
   for (const source of sources) {
@@ -336,9 +337,37 @@ function addError(errors, message) {
  */
 function validateHookScriptPath(scriptPath, eventName, pluginDir, errors) {
   if (!fs.existsSync(scriptPath)) {
+    addError(errors, `Hook script not found for ${eventName}: ${scriptPath}`);
+    return;
+  }
+  // Use lstatSync (not statSync) so symlinks are detected before following.
+  // A symlink could point outside the plugin directory and bypass the
+  // resolvePluginPath boundary check — reject symlinks outright (same policy
+  // as resolvePluginPath and validatePathOrPathsDir). Also reject directories:
+  // a malformed hook entry like "bash ." resolves to a directory and would
+  // throw a confusing EISDIR from readFileSync; make it a hard error instead
+  // of a warning so the manifest fails validation.
+  let lstat;
+  try {
+    lstat = fs.lstatSync(scriptPath);
+  } catch (lstatErr) {
     addError(
       errors,
-      `Hook script not found for ${eventName}: ${scriptPath}`
+      `Hook script not accessible for ${eventName}: ${scriptPath} (${lstatErr.message})`
+    );
+    return;
+  }
+  if (lstat.isSymbolicLink()) {
+    addError(
+      errors,
+      `Hook script path is a symlink which is not permitted for ${eventName}: ${scriptPath}`
+    );
+    return;
+  }
+  if (!lstat.isFile()) {
+    addError(
+      errors,
+      `Hook script must point to a file, not a directory or special file for ${eventName}: ${scriptPath}`
     );
     return;
   }
@@ -349,16 +378,9 @@ function validateHookScriptPath(scriptPath, eventName, pluginDir, errors) {
       `Hook script not readable: ${scriptPath} (check file permissions)`
     );
   }
-  try {
-    const mode = fs.statSync(scriptPath).mode;
-    if ((mode & 0o111) === 0) {
-      logWarning(
-        `Hook script not executable: ${scriptPath} (check file permissions)`
-      );
-    }
-  } catch (statErr) {
+  if ((lstat.mode & 0o111) === 0) {
     logWarning(
-      `Cannot inspect hook script mode: ${scriptPath} (${statErr.message})`
+      `Hook script not executable: ${scriptPath} (check file permissions)`
     );
   }
 
@@ -366,9 +388,7 @@ function validateHookScriptPath(scriptPath, eventName, pluginDir, errors) {
   try {
     content = fs.readFileSync(scriptPath, 'utf-8');
   } catch (readErr) {
-    logWarning(
-      `Cannot read hook script: ${scriptPath} (${readErr.message})`
-    );
+    logWarning(`Cannot read hook script: ${scriptPath} (${readErr.message})`);
     return;
   }
 
@@ -391,7 +411,9 @@ function validateHookScriptPath(scriptPath, eventName, pluginDir, errors) {
   }
 
   if (
-    /^\s*set\s+(-[a-zA-Z]*e[a-zA-Z]*|-o\s+errexit)(\s|$)/m.test(content)
+    /^\s*set\s+(?:[^#\n]*?\s)?(-[a-zA-Z]*e[a-zA-Z]*|-o\s+errexit)(\s|$)/m.test(
+      content
+    )
   ) {
     logWarning(
       `${relPath}: uses "set -e" which can prevent JSON output on error — ` +
@@ -538,7 +560,10 @@ function validatePlugin(pluginDir) {
   // mcpServers uses pathPathsOrInline — string/array entries point to JSON
   // config files, not directories. Inline-object form (keyed by server name)
   // is structurally validated by JSON Schema and needs no filesystem check.
-  if (manifest.mcpServers !== undefined && typeof manifest.mcpServers === 'string') {
+  if (
+    manifest.mcpServers !== undefined &&
+    typeof manifest.mcpServers === 'string'
+  ) {
     validatePathFile('mcpServers', manifest.mcpServers, pluginDir, errors);
   } else if (Array.isArray(manifest.mcpServers)) {
     for (const p of manifest.mcpServers.filter((v) => typeof v === 'string')) {
@@ -547,7 +572,10 @@ function validatePlugin(pluginDir) {
   }
   // lspServers uses pathPathsOrInline — paths point to JSON config files, not
   // directories, so use file-existence check (not directory + .md check).
-  if (manifest.lspServers !== undefined && typeof manifest.lspServers === 'string') {
+  if (
+    manifest.lspServers !== undefined &&
+    typeof manifest.lspServers === 'string'
+  ) {
     validatePathFile('lspServers', manifest.lspServers, pluginDir, errors);
   } else if (Array.isArray(manifest.lspServers)) {
     for (const p of manifest.lspServers.filter((v) => typeof v === 'string')) {
@@ -556,7 +584,10 @@ function validatePlugin(pluginDir) {
   }
   // monitors uses pathPathsOrInline — when declared as a path string it points
   // to a config file; inline array entries are objects validated by JSON Schema.
-  if (manifest.monitors !== undefined && typeof manifest.monitors === 'string') {
+  if (
+    manifest.monitors !== undefined &&
+    typeof manifest.monitors === 'string'
+  ) {
     validatePathFile('monitors', manifest.monitors, pluginDir, errors);
   } else if (Array.isArray(manifest.monitors)) {
     for (const p of manifest.monitors.filter((v) => typeof v === 'string')) {
@@ -646,9 +677,7 @@ function validatePlugin(pluginDir) {
     const hooksJsonPath = path.join(pluginDir, 'hooks', 'hooks.json');
     if (fs.existsSync(hooksJsonPath)) {
       try {
-        const hooksJson = JSON.parse(
-          fs.readFileSync(hooksJsonPath, 'utf-8')
-        );
+        const hooksJson = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf-8'));
         const hooksJsonHooks = hooksJson.hooks || {};
         const manifestHooks = inlineHooks;
         let driftFound = false;
@@ -689,11 +718,7 @@ function validatePlugin(pluginDir) {
             driftFound = true;
           }
 
-          for (
-            let i = 0;
-            i < Math.min(mEntries.length, jEntries.length);
-            i++
-          ) {
+          for (let i = 0; i < Math.min(mEntries.length, jEntries.length); i++) {
             const mEntry = mEntries[i] || {};
             const jEntry = jEntries[i] || {};
 
@@ -715,11 +740,7 @@ function validatePlugin(pluginDir) {
               );
               driftFound = true;
             }
-            for (
-              let j = 0;
-              j < Math.min(mHooks.length, jHooks.length);
-              j++
-            ) {
+            for (let j = 0; j < Math.min(mHooks.length, jHooks.length); j++) {
               if (mHooks[j].command !== jHooks[j].command) {
                 logWarning(
                   `hooks.json command drift for ${event}[${i}].hooks[${j}]: ` +
@@ -809,7 +830,10 @@ if (require.main === module) {
     // Validate resolved path is within project root.
     // Must use path.sep boundary to prevent sibling-directory bypass:
     // a path like /projects-evil/x would otherwise pass when PROJECT_ROOT=/projects.
-    if (pluginRoot !== PROJECT_ROOT && !pluginRoot.startsWith(PROJECT_ROOT + path.sep)) {
+    if (
+      pluginRoot !== PROJECT_ROOT &&
+      !pluginRoot.startsWith(PROJECT_ROOT + path.sep)
+    ) {
       logError(`--plugin path escapes project root: ${manifestPath}`);
       process.exit(2);
     }

--- a/tests/integration/validate-plugin.test.ts
+++ b/tests/integration/validate-plugin.test.ts
@@ -279,7 +279,10 @@ describe('validate-plugin baseline (regression net)', () => {
   });
 
   it('passes valid outputStyles directory with .md files', () => {
-    writeOutputStyleDir(pluginDir, 'output-styles', ['default.md', 'compact.md']);
+    writeOutputStyleDir(pluginDir, 'output-styles', [
+      'default.md',
+      'compact.md',
+    ]);
     writePluginManifest(pluginDir, {
       ...VALID_BASE_MANIFEST,
       outputStyles: './output-styles',
@@ -354,22 +357,35 @@ describe('validate-plugin PR-A new behaviors', () => {
     expect(stderr).toMatch(/escapes plugin directory|outside-plugin/);
   });
 
-  it('passes array-form hooks with object items (mcpServers-style inline objects)', () => {
-    // Object items in the array form are passed through (same as inline-object form).
-    // The test verifies they do not trip the path-script checks.
+  it('errors when array-form hooks contain an object item with a bash command referencing a missing script (PR-A: recursion into event-keyed array items)', () => {
+    // Previously the validator skipped object items in the array form entirely
+    // (the array-form bypass). collectInlineHooks now merges event-keyed objects
+    // found in array entries into the same inline-hooks dict that RULES 6/8 iterate,
+    // so a bash command referencing a missing script inside an array-form object
+    // item must produce a validation error — not silently pass.
     writePluginManifest(pluginDir, {
       ...VALID_BASE_MANIFEST,
       hooks: [
         {
           PreToolUse: [
-            { matcher: '*', hooks: [{ type: 'command', command: 'echo noop' }] },
+            {
+              matcher: '*',
+              hooks: [
+                {
+                  type: 'command',
+                  command: 'bash ./hooks/scripts/nonexistent-array-object.sh',
+                },
+              ],
+            },
           ],
         },
       ],
     });
-    const { status } = runValidator(pluginDir);
-    // Object array items are not script paths — should pass without error.
-    expect(status).toBe(0);
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(
+      /nonexistent-array-object\.sh|Hook script not found/
+    );
   });
 
   it('errors when string-form hooks reference a non-existent file (PR-A: resolvePluginPath check)', () => {

--- a/tests/integration/validate-plugin.test.ts
+++ b/tests/integration/validate-plugin.test.ts
@@ -286,7 +286,7 @@ describe('validate-plugin baseline (regression net)', () => {
     });
     const { status, stdout } = runValidator(pluginDir);
     expect(status).toBe(0);
-    expect(stdout).toMatch(/Output styles.*2 files/);
+    expect(stdout).toMatch(/outputStyles:.*2 files/);
   });
 
   it('errors when outputStyles directory is missing', () => {
@@ -324,7 +324,7 @@ describe('validate-plugin PR-A new behaviors', () => {
     rmSync(tmpRoot, { recursive: true, force: true });
   });
 
-  it('errors when array-form hooks reference a missing script (PR-A: RULE 6 array-element check)', () => {
+  it('errors when array-form hooks reference a missing script (PR-A: RULE 5c path-existence on array-string entries)', () => {
     writePluginManifest(pluginDir, {
       ...VALID_BASE_MANIFEST,
       hooks: ['./hooks/scripts/missing-array-script.sh'],

--- a/tests/integration/validate-plugin.test.ts
+++ b/tests/integration/validate-plugin.test.ts
@@ -1,0 +1,448 @@
+/**
+ * Integration test for `scripts/validate-plugin.js`.
+ *
+ * Mirrors the fixture pattern used in
+ * `validate-agent-authoring-review-rule.test.ts`: each test creates a temp
+ * plugin directory under `os.tmpdir()`, writes a `.claude-plugin/plugin.json`
+ * (and any supporting hook scripts / outputStyles files), then runs the
+ * validator as a child process with the temp plugin dir as a positional
+ * argument.
+ *
+ * The validator exits with:
+ *   0 — all valid
+ *   1 — validation failed
+ *   2 — plugin not found
+ *
+ * Tests cover both the regression-net baseline (existing behavior that must
+ * stay green through the refactor) and the new behaviors added in PR-A:
+ *   - Array-form `hooks` element validation (previously bypassed RULE 6/7/8)
+ *   - SessionStart in DECISION_PROTOCOL_EVENTS Set
+ *   - String-form `hooks` path-existence + containment via resolvePluginPath
+ *   - `outputStyles` directory-only enforcement
+ */
+
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  chmodSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const VALIDATOR = resolve(
+  __dirname,
+  '..',
+  '..',
+  'scripts',
+  'validate-plugin.js'
+);
+
+interface ValidatorRun {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runValidator(pluginDir: string): ValidatorRun {
+  // spawnSync captures stdout and stderr regardless of exit code; execFileSync
+  // discards stderr on exit 0 which masks warning-path tests.
+  const result = spawnSync('node', [VALIDATOR, pluginDir], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+function writePluginManifest(
+  pluginDir: string,
+  manifest: Record<string, unknown>
+): void {
+  const manifestDir = join(pluginDir, '.claude-plugin');
+  mkdirSync(manifestDir, { recursive: true });
+  writeFileSync(
+    join(manifestDir, 'plugin.json'),
+    JSON.stringify(manifest, null, 2),
+    'utf8'
+  );
+}
+
+function writeHookScript(
+  pluginDir: string,
+  relativePath: string,
+  content: string
+): void {
+  const fullPath = join(pluginDir, relativePath);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, content, 'utf8');
+  chmodSync(fullPath, 0o755);
+}
+
+function writeOutputStyleDir(
+  pluginDir: string,
+  relativeDir: string,
+  files: string[]
+): void {
+  const fullDir = join(pluginDir, relativeDir);
+  mkdirSync(fullDir, { recursive: true });
+  for (const f of files) {
+    writeFileSync(join(fullDir, f), '# style\n', 'utf8');
+  }
+}
+
+const VALID_BASE_MANIFEST = {
+  name: 'test-plugin',
+  description:
+    'A test fixture plugin used by validate-plugin integration tests.',
+  author: 'KingInYellows',
+  version: '1.0.0',
+};
+
+const SHEBANG_HOOK = `#!/usr/bin/env bash
+set -uo pipefail
+# Test fixture hook script. Outputs a continue decision.
+printf '{"continue": true}\\n'
+exit 0
+`;
+
+const SET_E_HOOK = `#!/usr/bin/env bash
+set -euo pipefail
+# Anti-pattern: set -e prevents JSON output on error.
+printf '{"continue": true}\\n'
+exit 0
+`;
+
+describe('validate-plugin baseline (regression net)', () => {
+  let tmpRoot: string;
+  let pluginDir: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'yellow-validate-plugin-'));
+    // Plugin name must match directory basename per RULE 2.
+    pluginDir = join(tmpRoot, 'test-plugin');
+    mkdirSync(pluginDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('passes a minimal valid manifest', () => {
+    writePluginManifest(pluginDir, VALID_BASE_MANIFEST);
+    const { status, stdout } = runValidator(pluginDir);
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/Plugin "test-plugin" is valid/);
+  });
+
+  it('fails when name is missing', () => {
+    const { name: _name, ...rest } = VALID_BASE_MANIFEST;
+    writePluginManifest(pluginDir, rest);
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/Missing required field: "name"/);
+  });
+
+  it('fails when description is missing', () => {
+    const { description: _description, ...rest } = VALID_BASE_MANIFEST;
+    writePluginManifest(pluginDir, rest);
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/Missing required field: "description"/);
+  });
+
+  it('fails when author is missing', () => {
+    const { author: _author, ...rest } = VALID_BASE_MANIFEST;
+    writePluginManifest(pluginDir, rest);
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/Missing required field: "author"/);
+  });
+
+  it('fails when name does not match directory basename', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      name: 'wrong-name',
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/does not match directory name/);
+  });
+
+  it('fails on invalid version format', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      version: 'not-a-version',
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/Invalid version format/);
+    expect(stderr).toMatch(/MAJOR\.MINOR\.PATCH/);
+  });
+
+  it('warns on hooks-string anti-pattern (./hooks/hooks.json)', () => {
+    // Create the file so the path-existence check (PR-A) passes; the
+    // anti-pattern warning is what this test asserts.
+    mkdirSync(join(pluginDir, 'hooks'), { recursive: true });
+    writeFileSync(
+      join(pluginDir, 'hooks', 'hooks.json'),
+      JSON.stringify({ hooks: {} }),
+      'utf8'
+    );
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      hooks: './hooks/hooks.json',
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    // Warning, not error — plugin is still valid
+    expect(status).toBe(0);
+    expect(stderr).toMatch(/hooks\/hooks\.json/);
+    expect(stderr).toMatch(/duplicate hooks/);
+  });
+
+  it('passes hooks inline-object form with valid script paths', () => {
+    writeHookScript(pluginDir, 'hooks/scripts/example.sh', SHEBANG_HOOK);
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      hooks: {
+        UserPromptSubmit: [
+          {
+            matcher: '*',
+            hooks: [
+              {
+                type: 'command',
+                command: 'bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/example.sh',
+                timeout: 5000,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const { status } = runValidator(pluginDir);
+    expect(status).toBe(0);
+  });
+
+  it('errors when inline-object hooks reference a missing script', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      hooks: {
+        UserPromptSubmit: [
+          {
+            matcher: '*',
+            hooks: [
+              {
+                type: 'command',
+                command: 'bash ${CLAUDE_PLUGIN_ROOT}/hooks/missing.sh',
+                timeout: 5000,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/Hook script not found/);
+  });
+
+  it('warns on set -e in PreToolUse hook script', () => {
+    writeHookScript(pluginDir, 'hooks/scripts/seteh.sh', SET_E_HOOK);
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: '*',
+            hooks: [
+              {
+                type: 'command',
+                command: 'bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/seteh.sh',
+                timeout: 5000,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    // Warning only — plugin still valid
+    expect(status).toBe(0);
+    expect(stderr).toMatch(/set -e/);
+  });
+
+  it('passes valid outputStyles directory with .md files', () => {
+    writeOutputStyleDir(pluginDir, 'output-styles', ['default.md', 'compact.md']);
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      outputStyles: './output-styles',
+    });
+    const { status, stdout } = runValidator(pluginDir);
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/Output styles.*2 files/);
+  });
+
+  it('errors when outputStyles directory is missing', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      outputStyles: './missing-styles',
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/outputStyles directory not found/);
+  });
+
+  it('errors when outputStyles path escapes plugin directory', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      outputStyles: '../escape-styles',
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/escapes plugin directory/);
+  });
+});
+
+describe('validate-plugin PR-A new behaviors', () => {
+  let tmpRoot: string;
+  let pluginDir: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'yellow-validate-plugin-new-'));
+    pluginDir = join(tmpRoot, 'test-plugin');
+    mkdirSync(pluginDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('errors when array-form hooks reference a missing script (PR-A: RULE 6 array-element check)', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      hooks: ['./hooks/scripts/missing-array-script.sh'],
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/missing-array-script\.sh/);
+  });
+
+  it('passes array-form hooks with valid script paths', () => {
+    writeHookScript(pluginDir, 'hooks/scripts/array-ok.sh', SHEBANG_HOOK);
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      hooks: ['./hooks/scripts/array-ok.sh'],
+    });
+    const { status } = runValidator(pluginDir);
+    expect(status).toBe(0);
+  });
+
+  it('errors when array-form hooks contain a path that escapes plugin directory', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      hooks: ['../outside-plugin.sh'],
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/escapes plugin directory|outside-plugin/);
+  });
+
+  it('passes array-form hooks with object items (mcpServers-style inline objects)', () => {
+    // Object items in the array form are passed through (same as inline-object form).
+    // The test verifies they do not trip the path-script checks.
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      hooks: [
+        {
+          PreToolUse: [
+            { matcher: '*', hooks: [{ type: 'command', command: 'echo noop' }] },
+          ],
+        },
+      ],
+    });
+    const { status } = runValidator(pluginDir);
+    // Object array items are not script paths — should pass without error.
+    expect(status).toBe(0);
+  });
+
+  it('errors when string-form hooks reference a non-existent file (PR-A: resolvePluginPath check)', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      hooks: './hooks/missing-string-form.json',
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/missing-string-form\.json|hooks file not found/);
+  });
+
+  it('errors when string-form hooks path escapes plugin directory', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      hooks: '../outside-hooks.json',
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/escapes plugin directory|outside-hooks/);
+  });
+
+  it('warns on SessionStart hook missing decision output (PR-A: DECISION_PROTOCOL_EVENTS extension)', () => {
+    const PLAIN_HOOK = `#!/usr/bin/env bash
+set -uo pipefail
+# No JSON output — should trip the SessionStart decision-output warning.
+printf 'plain text\\n'
+`;
+    writeHookScript(pluginDir, 'hooks/scripts/session-plain.sh', PLAIN_HOOK);
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      hooks: {
+        SessionStart: [
+          {
+            matcher: '*',
+            hooks: [
+              {
+                type: 'command',
+                command:
+                  'bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-plain.sh',
+                timeout: 5000,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBe(0); // warning only
+    expect(stderr).toMatch(/SessionStart/);
+    expect(stderr).toMatch(/decision output|missing decision/);
+  });
+
+  it('errors when outputStyles points to a .md file directly (PR-A: directory-only enforcement)', () => {
+    // RULE 5b enforces directory-only — a .md file path is an error.
+    writeFileSync(join(pluginDir, 'just-a-file.md'), '# style\n', 'utf8');
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      outputStyles: './just-a-file.md',
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/must point to a directory|directory/);
+  });
+
+  it('errors when outputStyles directory contains no .md files', () => {
+    mkdirSync(join(pluginDir, 'empty-styles'), { recursive: true });
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      outputStyles: './empty-styles',
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/at least one \.md file/);
+  });
+});


### PR DESCRIPTION
PR-A of 4 stacked PRs addressing 21 review findings on PR #260.

Validator hardening (scripts/validate-plugin.js):

- Fix RULE 6/7/8 array-form hooks bypass: previously the
  !Array.isArray(manifest.hooks) guard skipped ALL hook-script checks
  when hooks was an array, including path-existence, plugin-dir
  containment, shebang, and set -e. Array elements that are paths now
  receive the same checks as inline-object hooks; object elements pass
  through (mcpServers/lspServers-style inline configs are not script
  paths). Flagged by adversarial + silent-failure-hunter (P1).

- Add path-existence and resolvePluginPath containment check for the
  string-form hooks (was previously only checked for the documented
  ./hooks/hooks.json anti-pattern). Flagged by silent-failure-hunter (P3).

- Add 'SessionStart' to DECISION_PROTOCOL_EVENTS Set so SessionStart
  hooks without decision output are warned. Per project memory PR #72,
  SessionStart hooks must emit {"continue": true} on all paths or
  they block session startup. Flagged by polyglot (P2).

- Enforce outputStyles directory-only at RULE 5b. Schema description
  alignment lands in PR-B. Flagged by correctness (P2).

Refactor (no behavior change):

- Extract hasInlineHooks(manifest) predicate. Was duplicated 3x at
  lines 226, 329, 449. Flagged by maintainability + polyglot +
  pattern-recognition (3-reviewer agreement, P2).

- Extract addError(errors, msg) helper. Eliminates pervasive
  errors.push + logError pairs and the existing RULE 1 message drift
  (push: short, log: longer). Flagged by polyglot (P2).

- Extract validateHookScriptPath(scriptPath, pluginDir, errors,
  eventName) — centralizes per-script-path checks (existence,
  containment, shebang, set -e, decision-output) so the inline-object
  branch and the new array-element branch apply identical validation.

- Convert VALID_HOOK_EVENTS from in-function array (.includes() scan)
  to module-scope Set for parity with DECISION_PROTOCOL_EVENTS.
  Flagged by polyglot (P2).

Test harness (tests/integration/validate-plugin.test.ts, NEW):

First fixture-based test suite for validate-plugin.js. Mirrors the
pattern in tests/integration/validate-agent-authoring-review-rule.test.ts:
spawnSync the validator against synthetic temp plugin dirs, assert on
exit code and stderr/stdout content. 22 test cases covering 12
baseline (regression net) and 10 new behaviors.

Note: spawnSync is used instead of execFileSync because execFileSync
discards stderr on exit 0, masking warning-path tests.

Behavior change for downstream consumers: external plugins that ship
array-form hooks with raw script paths will previously have passed
silently. After this change those plugins receive standard script-path
checks. No in-repo plugin uses array-form hooks (verified by repo
research), so in-repo blast radius is zero.

Plan file: plans/pr-260-followup-hardening-and-docs.md (canonical for
the 4-PR stack).

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Stricter plugin validation now rejects previously-accepted patterns (e.g., inline.md in outputStyles) to enforce consistency across hook formats.
  * Enhanced path and permission checks for plugin hooks and output configurations.

* **Improvements**
  * Improved error messaging throughout plugin validation for clearer diagnostics.

* **Tests**
  * Added comprehensive integration test suite for plugin validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens `scripts/validate-plugin.js` by fixing the array-form `hooks` bypass (object elements now flow through RULES 6/7/8 via `collectInlineHooks`), extracting `addError`/`validateHookScriptPath` helpers, adding `SessionStart` to `DECISION_PROTOCOL_EVENTS`, enforcing `outputStyles` directory-only, and shipping the first fixture-based integration test suite.

- **Array-form string path entries** — string elements in `hooks: [...]` reach `validatePathFile` (existence + containment only); shebang, `set -e`, and decision-output checks are not wired for these entries (confirmed P1 from prior review).
- **`SessionStart` exit-code false negative** — `hasExitCodeProtocol` suppresses the decision-output warning when a script has both `exit 0` and `exit 2`, but `SessionStart` requires `{\"continue\": true}` JSON, not the exit-code protocol (confirmed P1 from prior review).
- **Broken test assertion** — `/outputStyles:.*2 files/` cannot match `outputStyles: 2 .md files found (./output-styles)` (confirmed P1 from prior review).

<h3>Confidence Score: 3/5</h3>

Not safe to merge — three confirmed defects in the changed files undermine the core bypass fix and break a test assertion.

Array-form string hook paths call validatePathFile rather than validateHookScriptPath, silently skipping shebang/set-e/decision-output checks. The hasExitCodeProtocol guard allows SessionStart hooks using exit 0/2 to pass without emitting the required JSON. The outputStyles test regex cannot match the actual log output, making that assertion permanently failing.

scripts/validate-plugin.js (lines 601–606 array-form string branch; lines 869–877 SessionStart exit-code gate) and tests/integration/validate-plugin.test.ts (line 1550 outputStyles regex)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/validate-plugin.js | Major refactor with confirmed defects: array-form string paths call validatePathFile instead of validateHookScriptPath (skipping RULE 8), and SessionStart hooks silently pass the decision-output gate via exit 0/2. |
| tests/integration/validate-plugin.test.ts | New 22-case fixture harness; outputStyles pass-case regex /outputStyles:.*2 files/ cannot match actual output '2 .md files found', permanently broken. |
| .changeset/pr260-validator-hardening.md | Patch changeset accurately documenting the validator hardening changes. |
| plans/pr-260-followup-hardening-and-docs.md | 4-PR stack plan file; accurately captures scope and acceptance criteria. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `scripts/validate-plugin.js`, line 804-814 ([link](https://github.com/kinginyellows/yellow-plugins/blob/d4ece26fc3e459fba00f44364065e6b99c675037/scripts/validate-plugin.js#L804-L814)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`SessionStart` exit-code protocol false negative**

   The `hasExitCodeProtocol` guard (`exit 0` && `exit 2`) suppresses the decision-output warning for `SessionStart` hooks, but the exit-code protocol is the `PreToolUse`/`PostToolUse`/`Stop` abort signal — it does not satisfy `SessionStart`'s requirement of `{"continue": true}`. Per PR #72 project memory (cited in this PR's own description), a `SessionStart` hook that emits no JSON and exits 0/2 will still block session startup in production. A hook author who copied a tool-use template (which commonly contains both `exit 0` and `exit 2` paths) would silently pass validation with this false negative.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: scripts/validate-plugin.js
   Line: 804-814

   Comment:
   **`SessionStart` exit-code protocol false negative**

   The `hasExitCodeProtocol` guard (`exit 0` && `exit 2`) suppresses the decision-output warning for `SessionStart` hooks, but the exit-code protocol is the `PreToolUse`/`PostToolUse`/`Stop` abort signal — it does not satisfy `SessionStart`'s requirement of `{"continue": true}`. Per PR #72 project memory (cited in this PR's own description), a `SessionStart` hook that emits no JSON and exits 0/2 will still block session startup in production. A hook author who copied a tool-use template (which commonly contains both `exit 0` and `exit 2` paths) would silently pass validation with this false negative.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffix%2Fpr260-validator-hardening%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffix%2Fpr260-validator-hardening%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fvalidate-plugin.js%0ALine%3A%20804-814%0A%0AComment%3A%0A**%60SessionStart%60%20exit-code%20protocol%20false%20negative**%0A%0AThe%20%60hasExitCodeProtocol%60%20guard%20%28%60exit%200%60%20%26%26%20%60exit%202%60%29%20suppresses%20the%20decision-output%20warning%20for%20%60SessionStart%60%20hooks%2C%20but%20the%20exit-code%20protocol%20is%20the%20%60PreToolUse%60%2F%60PostToolUse%60%2F%60Stop%60%20abort%20signal%20%E2%80%94%20it%20does%20not%20satisfy%20%60SessionStart%60's%20requirement%20of%20%60%7B%22continue%22%3A%20true%7D%60.%20Per%20PR%20%2372%20project%20memory%20%28cited%20in%20this%20PR's%20own%20description%29%2C%20a%20%60SessionStart%60%20hook%20that%20emits%20no%20JSON%20and%20exits%200%2F2%20will%20still%20block%20session%20startup%20in%20production.%20A%20hook%20author%20who%20copied%20a%20tool-use%20template%20%28which%20commonly%20contains%20both%20%60exit%200%60%20and%20%60exit%202%60%20paths%29%20would%20silently%20pass%20validation%20with%20this%20false%20negative.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

2. `tests/integration/validate-plugin.test.ts`, line 1396-1398 ([link](https://github.com/kinginyellows/yellow-plugins/blob/1f03b719a144217ee156cbbb0655b93becbf78f2/tests/integration/validate-plugin.test.ts#L1396-L1398)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Broken regex — test will never pass**

   `logSuccess` formats the message as `outputStyles: 2 .md files found (./output-styles)`. The regex `/outputStyles:.*2 files/` requires the literal substring `"2 files"` to appear after `outputStyles:`, but the actual output has `"2 .md files"` (`.md` sits between `2` and `files`). The regex engine tries every backtrack position and finds no match, so this assertion always fails, making the integration test permanently broken.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: tests/integration/validate-plugin.test.ts
   Line: 1396-1398

   Comment:
   **Broken regex — test will never pass**

   `logSuccess` formats the message as `outputStyles: 2 .md files found (./output-styles)`. The regex `/outputStyles:.*2 files/` requires the literal substring `"2 files"` to appear after `outputStyles:`, but the actual output has `"2 .md files"` (`.md` sits between `2` and `files`). The regex engine tries every backtrack position and finds no match, so this assertion always fails, making the integration test permanently broken.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffix%2Fpr260-validator-hardening%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffix%2Fpr260-validator-hardening%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Fintegration%2Fvalidate-plugin.test.ts%0ALine%3A%201396-1398%0A%0AComment%3A%0A**Broken%20regex%20%E2%80%94%20test%20will%20never%20pass**%0A%0A%60logSuccess%60%20formats%20the%20message%20as%20%60outputStyles%3A%202%20.md%20files%20found%20%28.%2Foutput-styles%29%60.%20The%20regex%20%60%2FoutputStyles%3A.*2%20files%2F%60%20requires%20the%20literal%20substring%20%60%222%20files%22%60%20to%20appear%20after%20%60outputStyles%3A%60%2C%20but%20the%20actual%20output%20has%20%60%222%20.md%20files%22%60%20%28%60.md%60%20sits%20between%20%602%60%20and%20%60files%60%29.%20The%20regex%20engine%20tries%20every%20backtrack%20position%20and%20finds%20no%20match%2C%20so%20this%20assertion%20always%20fails%2C%20making%20the%20integration%20test%20permanently%20broken.%0A%0A%60%60%60suggestion%0A%20%20%20%20expect%28stdout%29.toMatch%28%2FoutputStyles%3A.*2%20%5C.md%20files%20found%2F%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

3. `scripts/validate-plugin.js`, line 570-576 ([link](https://github.com/kinginyellows/yellow-plugins/blob/1f03b719a144217ee156cbbb0655b93becbf78f2/scripts/validate-plugin.js#L570-L576)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Array-form string path entries bypass RULE 8 content checks**

   The PR description states the array-form bypass is fixed "including path-existence, plugin-dir containment, shebang, and set -e", and the test fixtures create real `.sh` script files for these entries. However, the implementation calls `validatePathFile` here, which only performs existence + containment checks — it does **not** call `validateHookScriptPath`, so shebang and `set -e` detection are silently skipped for every array-form string path that is a hook script. A plugin author shipping `hooks: ['./hooks/on-start.sh']` where that script contains `set -e` will pass validation with no warning.

   The fix is to resolve the path via `resolvePluginPath` then call `validateHookScriptPath(resolved, '', pluginDir, errors)` — passing an event name absent from `DECISION_PROTOCOL_EVENTS` skips the decision-output check (no event context for bare string entries) while still running the shebang and `set -e` checks.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: scripts/validate-plugin.js
   Line: 570-576

   Comment:
   **Array-form string path entries bypass RULE 8 content checks**

   The PR description states the array-form bypass is fixed "including path-existence, plugin-dir containment, shebang, and set -e", and the test fixtures create real `.sh` script files for these entries. However, the implementation calls `validatePathFile` here, which only performs existence + containment checks — it does **not** call `validateHookScriptPath`, so shebang and `set -e` detection are silently skipped for every array-form string path that is a hook script. A plugin author shipping `hooks: ['./hooks/on-start.sh']` where that script contains `set -e` will pass validation with no warning.

   The fix is to resolve the path via `resolvePluginPath` then call `validateHookScriptPath(resolved, '', pluginDir, errors)` — passing an event name absent from `DECISION_PROTOCOL_EVENTS` skips the decision-output check (no event context for bare string entries) while still running the shebang and `set -e` checks.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffix%2Fpr260-validator-hardening%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffix%2Fpr260-validator-hardening%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fvalidate-plugin.js%0ALine%3A%20570-576%0A%0AComment%3A%0A**Array-form%20string%20path%20entries%20bypass%20RULE%208%20content%20checks**%0A%0AThe%20PR%20description%20states%20the%20array-form%20bypass%20is%20fixed%20%22including%20path-existence%2C%20plugin-dir%20containment%2C%20shebang%2C%20and%20set%20-e%22%2C%20and%20the%20test%20fixtures%20create%20real%20%60.sh%60%20script%20files%20for%20these%20entries.%20However%2C%20the%20implementation%20calls%20%60validatePathFile%60%20here%2C%20which%20only%20performs%20existence%20%2B%20containment%20checks%20%E2%80%94%20it%20does%20**not**%20call%20%60validateHookScriptPath%60%2C%20so%20shebang%20and%20%60set%20-e%60%20detection%20are%20silently%20skipped%20for%20every%20array-form%20string%20path%20that%20is%20a%20hook%20script.%20A%20plugin%20author%20shipping%20%60hooks%3A%20%5B'.%2Fhooks%2Fon-start.sh'%5D%60%20where%20that%20script%20contains%20%60set%20-e%60%20will%20pass%20validation%20with%20no%20warning.%0A%0AThe%20fix%20is%20to%20resolve%20the%20path%20via%20%60resolvePluginPath%60%20then%20call%20%60validateHookScriptPath%28resolved%2C%20''%2C%20pluginDir%2C%20errors%29%60%20%E2%80%94%20passing%20an%20event%20name%20absent%20from%20%60DECISION_PROTOCOL_EVENTS%60%20skips%20the%20decision-output%20check%20%28no%20event%20context%20for%20bare%20string%20entries%29%20while%20still%20running%20the%20shebang%20and%20%60set%20-e%60%20checks.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (8): Last reviewed commit: ["fix: resolve PR #360 review comments (4 ..."](https://github.com/kinginyellows/yellow-plugins/commit/f06183a83098966b148be28e0df75d3494c4d917) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30898202)</sub>

<!-- /greptile_comment -->