### PR TITLE
fix(workflows-work): RUN_DIR shell-variable isolation + atomic .tmp→mv writes + cleanup

### DIFF
--- a/.changeset/pr260-rundir-hardening.md
+++ b/.changeset/pr260-rundir-hardening.md
@@ -1,0 +1,50 @@
+---
+'yellow-core': patch
+---
+
+Harden the RUN_DIR / result-file convention introduced in PR #260
+against the bash-block subshell isolation anti-pattern (per
+`docs/solutions/code-quality/bash-block-subshell-isolation-in-command-files.md`)
+and add atomic-write semantics + cleanup.
+
+`plugins/yellow-core/commands/workflows/work.md` Phase 3:
+
+- **Shell-variable isolation fix.** The previous step 3a captured
+  `RUN_DIR=$(mktemp …)` in one Bash call and referenced `$RUN_DIR` in
+  later Task input prompts as if the variable persisted. Bash variables
+  do not survive across separate Bash tool calls — each call is a
+  fresh subprocess. Step 3a now instructs the orchestrator to capture
+  the printed path and substitute the **literal value** into Task
+  input prompts (not the variable name `$RUN_DIR`). Flagged by
+  adversarial (P1) and matches the documented anti-pattern in MEMORY.md.
+- **Empty-RUN_DIR error path.** If `mktemp -d` fails (disk full,
+  permission denied) the captured path is empty. Step 3a now requires
+  reporting the failure and skipping parallel review rather than
+  spawning agents with an empty `run_dir`. Flagged by correctness +
+  silent-failure-hunter (P3).
+- **Cleanup step.** New step after collection: `rm -rf "<literal mktemp
+  path>"`. Result files may contain diff excerpts including secrets;
+  retention in `/tmp` is a data-residue risk on multi-user or
+  long-lived machines. Skip-cleanup is allowed only with explicit
+  user-visible documentation. Flagged by adversarial (P2).
+
+`plugins/yellow-core/skills/create-agent-skills/SKILL.md` §Subagent
+Failure Convention:
+
+- **Atomic write `.tmp` → `mv` to `.json`.** Agents now MUST write to
+  a `.tmp` file first then `mv` to `.json` (POSIX rename atomicity).
+  The orchestrator globs only `*.json`, never `*.tmp` — partial writes
+  are invisible. Lock files remain unnecessary because each agent
+  owns a unique filename. Pattern validated against community
+  conventions (barkain claude-code-workflow-orchestration).
+- **Orchestrator example refresh.** Re-frames the `mktemp` capture so
+  the variable-substitution requirement is explicit at the canonical
+  source, alongside the empty-path error advice and the data-residue
+  cleanup rationale.
+
+No code changes — all updates are prose-instruction edits to two
+authoring docs. The downstream effect is that `/workflows:work` Phase 3
+becomes correctness-readable (an LLM following the steps top-to-bottom
+no longer carries a phantom `$RUN_DIR` shell variable across Bash calls)
+and parallel-orchestrator authors get the atomic-write convention
+documented at the canonical source.

--- a/.changeset/pr260-rundir-hardening.md
+++ b/.changeset/pr260-rundir-hardening.md
@@ -2,6 +2,8 @@
 'yellow-core': patch
 ---
 
+# RUN_DIR Hardening
+
 Harden the RUN_DIR / result-file convention introduced in PR #260
 against the bash-block subshell isolation anti-pattern (per
 `docs/solutions/code-quality/bash-block-subshell-isolation-in-command-files.md`)
@@ -16,7 +18,8 @@ and add atomic-write semantics + cleanup.
   fresh subprocess. Step 3a now instructs the orchestrator to capture
   the printed path and substitute the **literal value** into Task
   input prompts (not the variable name `$RUN_DIR`). Flagged by
-  adversarial (P1) and matches the documented anti-pattern in MEMORY.md.
+  adversarial (P1) and matches the documented anti-pattern in
+  `docs/solutions/code-quality/bash-block-subshell-isolation-in-command-files.md`.
 - **Empty-RUN_DIR error path.** If `mktemp -d` fails (disk full,
   permission denied) the captured path is empty. Step 3a now requires
   reporting the failure and skipping parallel review rather than

--- a/plans/pr-260-followup-hardening-and-docs.md
+++ b/plans/pr-260-followup-hardening-and-docs.md
@@ -509,6 +509,6 @@ merges into `main` once PR #260 lands.
 
 <!-- Updated by workflows:work. Do not edit manually. -->
 - [x] 1. agent/fix/pr260-validator-hardening (PR #360, completed 2026-05-05)
-- [x] 2. agent/feat/pr260-schema-tightening (completed 2026-05-05)
-- [ ] 3. agent/fix/pr260-work-rundir-hardening
+- [x] 2. agent/feat/pr260-schema-tightening (PR #362, completed 2026-05-05)
+- [x] 3. agent/fix/pr260-work-rundir-hardening (completed 2026-05-05)
 - [ ] 4. agent/docs/pr260-doc-sync

--- a/plugins/yellow-core/commands/workflows/work.md
+++ b/plugins/yellow-core/commands/workflows/work.md
@@ -446,27 +446,43 @@ it at a Phase 1b checkpoint.
    tweak, rename only), skip this step and proceed to Step 4.** For complex
    changes, run reviewer agents in parallel using Task tool.
 
-   **3a. Create the per-run directory FIRST (before any Task spawn)** so
-   each agent receives a path to write its result file to. The directory
-   prevents collisions between concurrent workflow sessions:
+   **3a. Create the per-run directory FIRST (before any Task spawn).**
+   Bash variables do NOT survive across separate Bash tool calls — each
+   call is a fresh subprocess. To make `$RUN_DIR` reach the Task input
+   prompts in step 3b, run mktemp and immediately capture the absolute
+   path the command printed; substitute that literal path value inline
+   into each Task prompt below. Do not reference the variable name
+   `$RUN_DIR` in the Task input — the spawned agent receives the value
+   you substitute, not a shell-variable expansion.
 
    ```bash
-   RUN_DIR=$(mktemp -d -t run-XXXXXXXX)
+   RUN_DIR=$(mktemp -d -t run-XXXXXXXX) && printf '%s\n' "$RUN_DIR"
    ```
 
-   **3b. Spawn agents in parallel.** **Issue all four Task invocations in a
-   single response** so they execute concurrently. **Each Task invocation
+   **Empty-RUN_DIR error path.** If `mktemp -d` fails (disk full,
+   permission denied) the command produces empty output. If the captured
+   path is empty, do NOT spawn reviewer agents — report the failure to
+   the user ("[/workflows:work] Could not create run directory; skipping
+   parallel review (run mktemp -d manually to diagnose)") and proceed to
+   step 5 with an empty findings set, marked as "no parallel review
+   coverage". Continuing with empty `$RUN_DIR` would cause every agent
+   to write to a non-existent path and silently appear "failed".
+
+   **3b. Spawn agents in parallel.** **Issue all four Task invocations in
+   a single response** so they execute concurrently. **Each Task invocation
    MUST set `run_in_background: true`** — the review agents declare
    `background: true` in their frontmatter, but true parallelism also
-   requires the spawning call to run in the background. Pass `$RUN_DIR` to
-   each agent so it can write `$RUN_DIR/agent-result-<agent-name>.json`
-   (see `create-agent-skills` skill §Subagent Failure Convention). Wait
+   requires the spawning call to run in the background. Pass the
+   **literal path** captured from step 3a to each agent so it can write
+   `<run_dir>/agent-result-<agent-name>.tmp` then atomically rename to
+   `<run_dir>/agent-result-<agent-name>.json` (POSIX rename atomicity;
+   see `create-agent-skills` skill §Subagent Failure Convention). Wait
    for all agents via TaskOutput before aggregating findings.
 
    ```text
    Task: code-simplicity-reviewer
    subagent_type: "yellow-core:review:code-simplicity-reviewer"
-   Input: {changed_files, diff, run_dir: $RUN_DIR}
+   Input: {changed_files, diff, run_dir: <literal mktemp path>}
    Goal: Identify overly complex code, suggest simplifications
    run_in_background: true
    ```
@@ -474,7 +490,7 @@ it at a Phase 1b checkpoint.
    ```text
    Task: security-sentinel
    subagent_type: "yellow-core:review:security-sentinel"
-   Input: {changed_files, diff, run_dir: $RUN_DIR}
+   Input: {changed_files, diff, run_dir: <literal mktemp path>}
    Goal: Find security vulnerabilities, unsafe patterns
    run_in_background: true
    ```
@@ -482,7 +498,7 @@ it at a Phase 1b checkpoint.
    ```text
    Task: performance-oracle
    subagent_type: "yellow-core:review:performance-oracle"
-   Input: {changed_files, diff, run_dir: $RUN_DIR}
+   Input: {changed_files, diff, run_dir: <literal mktemp path>}
    Goal: Identify performance issues, optimization opportunities
    run_in_background: true
    ```
@@ -490,16 +506,18 @@ it at a Phase 1b checkpoint.
    ```text
    Task: polyglot-reviewer
    subagent_type: "yellow-core:review:polyglot-reviewer"
-   Input: {changed_files, diff, run_dir: $RUN_DIR}
+   Input: {changed_files, diff, run_dir: <literal mktemp path>}
    Goal: Check language-specific best practices, idioms
    run_in_background: true
    ```
 
-4. Collect agent findings from `$RUN_DIR/agent-result-<agent-name>.json`
-   files. Each agent writes its result with a `status` and `findings`
-   before exiting. After TaskOutput completes, read each file. Agents with
-   missing files, invalid JSON, or `status != "success"` are logged as
-   failed and surfaced in the summary — not silently dropped.
+4. Collect agent findings. The orchestrator globs only `*.json` files
+   (never `.tmp` — partial writes are invisible). Read each
+   `<run_dir>/agent-result-<agent-name>.json`. Each agent writes its
+   result with a `status` and `findings` before exiting. After
+   TaskOutput completes, read each file. Agents with missing `.json`
+   files, invalid JSON, or `status != "success"` are logged as failed
+   and surfaced in the summary — not silently dropped.
 
    Present the consolidated agent findings:
    - Critical issues (P1): Must fix before merge
@@ -507,6 +525,21 @@ it at a Phase 1b checkpoint.
    - Nice-to-have (P3): Optional improvements
    - Failed agents (if any): agent name + failure reason, so the user knows
      which concerns were NOT evaluated
+
+   **Cleanup the run directory** after findings have been read.
+   Reviewer result files may contain diff excerpts including secrets or
+   credentials; retention in `/tmp` is a data-residue risk. Run:
+
+   ```bash
+   rm -rf "<literal mktemp path>"
+   ```
+
+   Substitute the same literal path captured in step 3a (do not
+   reference `$RUN_DIR` — it does not survive across Bash calls). On
+   any error path that exits before this step (mktemp failure, agent
+   spawn error), there is nothing to clean up because the directory
+   was either never created or contains only the agent stub files;
+   in that case skip the cleanup and continue.
 
 5. Address critical and important issues:
    - Fix P1 issues immediately

--- a/plugins/yellow-core/commands/workflows/work.md
+++ b/plugins/yellow-core/commands/workflows/work.md
@@ -535,11 +535,16 @@ it at a Phase 1b checkpoint.
    ```
 
    Substitute the same literal path captured in step 3a (do not
-   reference `$RUN_DIR` — it does not survive across Bash calls). On
-   any error path that exits before this step (mktemp failure, agent
-   spawn error), there is nothing to clean up because the directory
-   was either never created or contains only the agent stub files;
-   in that case skip the cleanup and continue.
+   reference `$RUN_DIR` — it does not survive across Bash calls).
+   **If the run directory was successfully created in step 3a, you
+   MUST clean it up even if the workflow exits early** (agent spawn
+   error, TaskOutput failure, conflict reconciliation rollback,
+   user-initiated cancel) — the directory may already contain agent
+   result files with diff excerpts, secrets, or credentials, and
+   leaving them in `/tmp` is the exact data-residue risk this step
+   exists to prevent. The ONLY skip case is when `mktemp -d` itself
+   failed and no directory was created (the empty-RUN_DIR error path
+   from step 3a).
 
 5. Address critical and important issues:
    - Fix P1 issues immediately

--- a/plugins/yellow-core/skills/create-agent-skills/SKILL.md
+++ b/plugins/yellow-core/skills/create-agent-skills/SKILL.md
@@ -291,6 +291,23 @@ where `$RUN_DIR` is a unique directory the orchestrator creates at the
 start of the run (see orchestrator example below) and passes to each agent
 via the spawn prompt.
 
+**Atomic write semantics.** Agents MUST write to a `.tmp` filename first,
+then `mv` to the final `.json` filename. POSIX rename is atomic with
+respect to concurrent readers on the same filesystem, so the orchestrator
+sees either the complete result file or no file at all — never a partial
+write. The orchestrator MUST glob only `*.json`, never `*.tmp`. Sequence:
+
+```bash
+RESULT_TMP="$RUN_DIR/agent-result-${AGENT_NAME}.tmp"
+RESULT_FINAL="$RUN_DIR/agent-result-${AGENT_NAME}.json"
+printf '%s\n' "$JSON_PAYLOAD" > "$RESULT_TMP" && mv "$RESULT_TMP" "$RESULT_FINAL"
+```
+
+If the agent crashes between the `>` and the `mv`, the orchestrator finds
+no `.json` file and treats the agent as failed — the partial `.tmp` is
+invisible. Lock files are unnecessary because each agent owns a unique
+filename.
+
 ### For orchestrator authors
 
 1. Create a unique run directory at the start of the workflow:
@@ -298,11 +315,23 @@ via the spawn prompt.
    ```bash
    # Uses $TMPDIR (or /tmp). Avoids CLAUDE_PLUGIN_DATA — not a
    # documented Claude Code runtime env var; rely on the OS tempdir instead.
-   RUN_DIR=$(mktemp -d -t run-XXXXXXXX)
+   RUN_DIR=$(mktemp -d -t run-XXXXXXXX) && printf '%s\n' "$RUN_DIR"
    ```
 
-2. Pass `$RUN_DIR` to each spawned agent so the agent writes to
-   `$RUN_DIR/agent-result-<agent-name>.json`.
+   Capture the printed path. Bash variables do NOT survive across
+   separate Bash tool calls in command files (each call is a fresh
+   subprocess), so the orchestrator must substitute the literal path
+   value into subsequent Task input prompts rather than referencing
+   `$RUN_DIR` by name. If `mktemp` fails (disk full, permission
+   denied) the captured path is empty — error out before spawning
+   agents; an empty `run_dir` causes every agent to write to a
+   non-existent path and silently appear "failed".
+
+2. Pass the **literal path** (not the variable name) to each spawned
+   agent so the agent writes to
+   `<run_dir>/agent-result-<agent-name>.tmp` then atomically renames
+   to `<run_dir>/agent-result-<agent-name>.json`. The agent owns the
+   `.tmp` → `.json` rename; the orchestrator only reads `.json`.
 
 3. After the Task call returns, read the result file rather than relying on
    the Task return value. Treat `status: "success"` as the only signal that
@@ -341,8 +370,13 @@ The two-stage check (`jq -e .` for JSON validity, then `jq -er .status` for
 field presence) avoids the misleading "not valid JSON" diagnosis when the
 file parses correctly but `.status` is null or absent.
 
-1. Clean up `$RUN_DIR` at the end of the workflow, or leave it in place
-   when retaining result files aids post-run debugging.
+1. Clean up the run directory at the end of the workflow:
+   `rm -rf "<literal mktemp path>"`. Result files may contain diff
+   excerpts including secrets or credentials; retention in `/tmp` is a
+   data-residue risk on multi-user or long-lived machines. Skip cleanup
+   only when explicitly retaining files for post-run debugging, and
+   document the retention in the orchestrator's user-visible output
+   (so the user knows where the residue lives).
 
 ### Why files and not stdout
 

--- a/plugins/yellow-core/skills/create-agent-skills/SKILL.md
+++ b/plugins/yellow-core/skills/create-agent-skills/SKILL.md
@@ -289,7 +289,9 @@ $RUN_DIR/agent-result-<agent-name>.json
 
 where `$RUN_DIR` is a unique directory the orchestrator creates at the
 start of the run (see orchestrator example below) and passes to each agent
-via the spawn prompt.
+via the spawn prompt. The spawned agent receives the literal directory path
+in its prompt; it cannot inherit a shell variable from the orchestrator's
+process.
 
 **Atomic write semantics.** Agents MUST write to a `.tmp` filename first,
 then `mv` to the final `.json` filename. POSIX rename is atomic with
@@ -298,6 +300,7 @@ sees either the complete result file or no file at all — never a partial
 write. The orchestrator MUST glob only `*.json`, never `*.tmp`. Sequence:
 
 ```bash
+RUN_DIR="/tmp/yellow-work-abc123"
 RESULT_TMP="$RUN_DIR/agent-result-${AGENT_NAME}.tmp"
 RESULT_FINAL="$RUN_DIR/agent-result-${AGENT_NAME}.json"
 printf '%s\n' "$JSON_PAYLOAD" > "$RESULT_TMP" && mv "$RESULT_TMP" "$RESULT_FINAL"


### PR DESCRIPTION
PR-C of 4 stacked PRs addressing 21 review findings on PR #260.
Stacks on top of PR-B (agent/feat/pr260-schema-tightening, PR #362).

plugins/yellow-core/commands/workflows/work.md Phase 3:

- Shell-variable isolation fix. Previous step 3a captured RUN_DIR=
  $(mktemp ...) in one Bash call and referenced $RUN_DIR in later
  Task input prompts as if the variable persisted. Bash variables do
  not survive across separate Bash tool calls. Step 3a now instructs
  the orchestrator to capture the printed path and substitute the
  literal value into Task input prompts. Flagged by adversarial (P1).

- Empty-RUN_DIR error path. If mktemp -d fails the captured path is
  empty. Step 3a now requires reporting the failure and skipping
  parallel review rather than spawning agents with empty run_dir
  (which would cause every agent to write to a non-existent path and
  silently appear failed). Flagged by correctness + silent-failure (P3).

- Cleanup step. New step after collection: rm -rf <literal path>.
  Result files may contain diff excerpts with secrets; retention in
  /tmp is data-residue risk on multi-user or long-lived machines.
  Flagged by adversarial (P2).

plugins/yellow-core/skills/create-agent-skills/SKILL.md
§Subagent Failure Convention:

- Atomic write .tmp → mv to .json. Agents now MUST write to a .tmp
  file first then mv to .json (POSIX rename atomicity per the npm
  semver/python-atomicwrites convention; researched best practices).
  The orchestrator globs only *.json, never *.tmp — partial writes
  are invisible. Lock files unnecessary because each agent owns a
  unique filename. Pattern validated against community conventions
  (barkain claude-code-workflow-orchestration plugin).

- Orchestrator example refresh. Re-frames the mktemp capture so the
  variable-substitution requirement is explicit at the canonical
  source, alongside the empty-path error advice and the data-residue
  cleanup rationale. Consolidates plan tasks 3.3 + 4.7 (originally
  duplicated across PR-C and PR-D in the plan).

No code changes — all updates are prose-instruction edits to two
authoring docs. Existing CI (validate:plugins, validate:schemas) green;
the pre-existing validate:agents failure on session-historian.md is
out of scope (it predates PR #260).

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the `RUN_DIR` / result-file convention from PR #260 across two prose-instruction files (`work.md` and `SKILL.md`). It fixes shell-variable isolation (literal path substitution instead of `$RUN_DIR`), adds empty-`RUN_DIR` error handling, introduces atomic `.tmp` → `mv` write semantics, and adds a mandatory cleanup step for data-residue risk.

- **`work.md` Phase 3** is rewritten to require literal path substitution in every Task input prompt, gate agent spawning on a non-empty `mktemp` result, and run `rm -rf` cleanup unconditionally whenever the run directory was successfully created (including on partial agent-spawn failures).
- **`SKILL.md` §Subagent Failure Convention** adds the atomic-write sequence to the agent-side example (correctly assigning the literal path at the top of the same bash fence), updates orchestrator steps 1 and 2 to use literal paths, and tightens the cleanup guidance.
- The step-3 result-reading code block in `SKILL.md` (line 354) still references bare `$RUN_DIR`; the PR partially mitigates this by adding a disclaimer labelling it \"illustrative shell logic,\" but the code itself is unchanged — this was flagged in prior review rounds.

<h3>Confidence Score: 5/5</h3>

All prose-instruction changes are correct and well-scoped; no logic regressions introduced.

Every stated goal is correctly implemented: literal path substitution replaces the phantom `$RUN_DIR` variable in all Task input prompts, the empty-mktemp guard prevents silent agent failures, the atomic `.tmp`→`mv` pattern is documented with a correct fence-local assignment, and cleanup is now unconditional whenever the run directory was created. The one pre-existing concern (step-3 result-reading block in SKILL.md still using bare `$RUN_DIR`) is unchanged but now carries an explicit disclaimer; it was flagged in prior review rounds and does not represent new risk introduced by this PR.

No files require special attention; `SKILL.md` line 354 carries a known, pre-existing issue that was flagged in earlier rounds and is partially mitigated by the new disclaimer added in this PR.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/yellow-core/commands/workflows/work.md | Step 3a, 3b, and cleanup all correctly updated: literal path substitution, empty-mktemp error path, and cleanup scoped to "only skip if mktemp itself failed" — addressing the previous P1 about agent-spawn-error residue. |
| plugins/yellow-core/skills/create-agent-skills/SKILL.md | Agent-side atomic write example and orchestrator steps 1 and 2 are correctly updated. Step-3 result-reading block still uses bare `$RUN_DIR` (line 354); the new disclaimer labels it illustrative but leaves the code unchanged — previously flagged in review. |
| .changeset/pr260-rundir-hardening.md | New changeset entry accurately describes all hardening changes; no issues. |
| plans/pr-260-followup-hardening-and-docs.md | Tracking file updated to mark PR #362 with its PR number and mark PR-C as completed; trivial bookkeeping, no issues. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant O as Orchestrator (work.md)
    participant B as Bash Tool
    participant A1 as Agent (e.g. security-sentinel)
    participant FS as /tmp filesystem

    O->>B: mktemp -d -t run-XXXXXXXX && printf path
    B-->>O: /tmp/run-abc123 (literal path captured)
    
    alt mktemp failed (empty output)
        O-->>O: Report failure, skip to step 5
    else path captured
        O->>A1: Task(run_dir: "/tmp/run-abc123")
        A1->>FS: write agent-result-X.tmp
        A1->>FS: mv agent-result-X.tmp to agent-result-X.json (atomic)
        O->>O: TaskOutput (wait for all agents)
        O->>FS: glob *.json (never *.tmp)
        FS-->>O: agent-result-X.json
        O->>O: Aggregate findings
        O->>B: rm -rf "/tmp/run-abc123"
        Note over O,B: Cleanup runs even on agent-spawn failure or TaskOutput failure
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `plugins/yellow-core/skills/create-agent-skills/SKILL.md`, line 342-358 ([link](https://github.com/kinginyellows/yellow-plugins/blob/a21f96dda8e28e1142e5f2c51b59e49f4e218960/plugins/yellow-core/skills/create-agent-skills/SKILL.md#L342-L358)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Code example in step 3 still uses `$RUN_DIR` — inconsistent with new literal-path rule**

   Steps 1 and 2 correctly explain that `$RUN_DIR` does not survive across Bash tool calls and that orchestrators must substitute the literal path. The result-reading code block in step 3 (`RESULT="$RUN_DIR/agent-result-${AGENT_NAME}.json"`) was not updated and still references `$RUN_DIR` as a shell variable. An orchestrator author who correctly substitutes the literal path when spawning agents (step 2) may then copy this code block verbatim and hit an empty variable, receiving a "result file missing" failure for every agent even when the files exist. The example should replace `$RUN_DIR` with the same `<literal mktemp path>` placeholder used in `work.md`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: plugins/yellow-core/skills/create-agent-skills/SKILL.md
   Line: 342-358

   Comment:
   **Code example in step 3 still uses `$RUN_DIR` — inconsistent with new literal-path rule**

   Steps 1 and 2 correctly explain that `$RUN_DIR` does not survive across Bash tool calls and that orchestrators must substitute the literal path. The result-reading code block in step 3 (`RESULT="$RUN_DIR/agent-result-${AGENT_NAME}.json"`) was not updated and still references `$RUN_DIR` as a shell variable. An orchestrator author who correctly substitutes the literal path when spawning agents (step 2) may then copy this code block verbatim and hit an empty variable, receiving a "result file missing" failure for every agent even when the files exist. The example should replace `$RUN_DIR` with the same `<literal mktemp path>` placeholder used in `work.md`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffix%2Fpr260-work-rundir-hardening%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffix%2Fpr260-work-rundir-hardening%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plugins%2Fyellow-core%2Fskills%2Fcreate-agent-skills%2FSKILL.md%0ALine%3A%20342-358%0A%0AComment%3A%0A**Code%20example%20in%20step%203%20still%20uses%20%60%24RUN_DIR%60%20%E2%80%94%20inconsistent%20with%20new%20literal-path%20rule**%0A%0ASteps%201%20and%202%20correctly%20explain%20that%20%60%24RUN_DIR%60%20does%20not%20survive%20across%20Bash%20tool%20calls%20and%20that%20orchestrators%20must%20substitute%20the%20literal%20path.%20The%20result-reading%20code%20block%20in%20step%203%20%28%60RESULT%3D%22%24RUN_DIR%2Fagent-result-%24%7BAGENT_NAME%7D.json%22%60%29%20was%20not%20updated%20and%20still%20references%20%60%24RUN_DIR%60%20as%20a%20shell%20variable.%20An%20orchestrator%20author%20who%20correctly%20substitutes%20the%20literal%20path%20when%20spawning%20agents%20%28step%202%29%20may%20then%20copy%20this%20code%20block%20verbatim%20and%20hit%20an%20empty%20variable%2C%20receiving%20a%20%22result%20file%20missing%22%20failure%20for%20every%20agent%20even%20when%20the%20files%20exist.%20The%20example%20should%20replace%20%60%24RUN_DIR%60%20with%20the%20same%20%60%3Cliteral%20mktemp%20path%3E%60%20placeholder%20used%20in%20%60work.md%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

2. `plugins/yellow-core/skills/create-agent-skills/SKILL.md`, line 343 ([link](https://github.com/kinginyellows/yellow-plugins/blob/3d2a550d24acdaa4a728327e17c7d9ef6550cf38/plugins/yellow-core/skills/create-agent-skills/SKILL.md#L343)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Step-3 example still uses `$RUN_DIR` shell variable**

   This PR correctly updates step 1 and step 2 to explain that `$RUN_DIR` does not survive across separate Bash tool calls, and that orchestrators must substitute the literal path. However, the result-reading code block immediately below (step 3) was not updated: `RESULT="$RUN_DIR/agent-result-${AGENT_NAME}.json"` still uses the shell variable. An orchestrator author who correctly passes the literal path when spawning agents (step 2) and then copies this block verbatim will find `$RUN_DIR` is empty in the new Bash subprocess, causing `RESULT` to resolve to a relative path — the file-existence check fails for every agent and all are reported as "result file missing" even when the files exist.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: plugins/yellow-core/skills/create-agent-skills/SKILL.md
   Line: 343

   Comment:
   **Step-3 example still uses `$RUN_DIR` shell variable**

   This PR correctly updates step 1 and step 2 to explain that `$RUN_DIR` does not survive across separate Bash tool calls, and that orchestrators must substitute the literal path. However, the result-reading code block immediately below (step 3) was not updated: `RESULT="$RUN_DIR/agent-result-${AGENT_NAME}.json"` still uses the shell variable. An orchestrator author who correctly passes the literal path when spawning agents (step 2) and then copies this block verbatim will find `$RUN_DIR` is empty in the new Bash subprocess, causing `RESULT` to resolve to a relative path — the file-existence check fails for every agent and all are reported as "result file missing" even when the files exist.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffix%2Fpr260-work-rundir-hardening%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffix%2Fpr260-work-rundir-hardening%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plugins%2Fyellow-core%2Fskills%2Fcreate-agent-skills%2FSKILL.md%0ALine%3A%20343%0A%0AComment%3A%0A**Step-3%20example%20still%20uses%20%60%24RUN_DIR%60%20shell%20variable**%0A%0AThis%20PR%20correctly%20updates%20step%201%20and%20step%202%20to%20explain%20that%20%60%24RUN_DIR%60%20does%20not%20survive%20across%20separate%20Bash%20tool%20calls%2C%20and%20that%20orchestrators%20must%20substitute%20the%20literal%20path.%20However%2C%20the%20result-reading%20code%20block%20immediately%20below%20%28step%203%29%20was%20not%20updated%3A%20%60RESULT%3D%22%24RUN_DIR%2Fagent-result-%24%7BAGENT_NAME%7D.json%22%60%20still%20uses%20the%20shell%20variable.%20An%20orchestrator%20author%20who%20correctly%20passes%20the%20literal%20path%20when%20spawning%20agents%20%28step%202%29%20and%20then%20copies%20this%20block%20verbatim%20will%20find%20%60%24RUN_DIR%60%20is%20empty%20in%20the%20new%20Bash%20subprocess%2C%20causing%20%60RESULT%60%20to%20resolve%20to%20a%20relative%20path%20%E2%80%94%20the%20file-existence%20check%20fails%20for%20every%20agent%20and%20all%20are%20reported%20as%20%22result%20file%20missing%22%20even%20when%20the%20files%20exist.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

3. `plugins/yellow-core/skills/create-agent-skills/SKILL.md`, line 345-370 ([link](https://github.com/kinginyellows/yellow-plugins/blob/e92ca3aa9caa9731d6911eba4f49f65ffdce568e/plugins/yellow-core/skills/create-agent-skills/SKILL.md#L345-L370)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Step-3 code block still uses unset `$RUN_DIR` despite new disclaimer**

   The disclaimer note added above the block (lines 345–351) correctly warns that `$RUN_DIR` from Step 1 is not in scope, and calls the block "illustrative shell logic." However, `RESULT="$RUN_DIR/agent-result-${AGENT_NAME}.json"` on line 354 still uses the bare shell variable with no in-fence assignment. An orchestrator author who copies the block verbatim — even after reading the disclaimer — gets an empty `RESULT` path; every file-existence check fails and all agents are reported as "result file missing" even when the files exist.

   The agent-side example added in this PR correctly solves this by assigning a literal path at the top of the same fence (`RUN_DIR="/tmp/yellow-work-abc123"`). The same pattern should be applied here: either assign the literal value at the top of the fence (matching the agent-side convention) or replace `$RUN_DIR` with the `<literal mktemp path>` placeholder used throughout `work.md`. The disclaimer alone does not eliminate the copy-paste hazard for the most common usage pattern.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: plugins/yellow-core/skills/create-agent-skills/SKILL.md
   Line: 345-370

   Comment:
   **Step-3 code block still uses unset `$RUN_DIR` despite new disclaimer**

   The disclaimer note added above the block (lines 345–351) correctly warns that `$RUN_DIR` from Step 1 is not in scope, and calls the block "illustrative shell logic." However, `RESULT="$RUN_DIR/agent-result-${AGENT_NAME}.json"` on line 354 still uses the bare shell variable with no in-fence assignment. An orchestrator author who copies the block verbatim — even after reading the disclaimer — gets an empty `RESULT` path; every file-existence check fails and all agents are reported as "result file missing" even when the files exist.

   The agent-side example added in this PR correctly solves this by assigning a literal path at the top of the same fence (`RUN_DIR="/tmp/yellow-work-abc123"`). The same pattern should be applied here: either assign the literal value at the top of the fence (matching the agent-side convention) or replace `$RUN_DIR` with the `<literal mktemp path>` placeholder used throughout `work.md`. The disclaimer alone does not eliminate the copy-paste hazard for the most common usage pattern.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffix%2Fpr260-work-rundir-hardening%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffix%2Fpr260-work-rundir-hardening%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plugins%2Fyellow-core%2Fskills%2Fcreate-agent-skills%2FSKILL.md%0ALine%3A%20345-370%0A%0AComment%3A%0A**Step-3%20code%20block%20still%20uses%20unset%20%60%24RUN_DIR%60%20despite%20new%20disclaimer**%0A%0AThe%20disclaimer%20note%20added%20above%20the%20block%20%28lines%20345%E2%80%93351%29%20correctly%20warns%20that%20%60%24RUN_DIR%60%20from%20Step%201%20is%20not%20in%20scope%2C%20and%20calls%20the%20block%20%22illustrative%20shell%20logic.%22%20However%2C%20%60RESULT%3D%22%24RUN_DIR%2Fagent-result-%24%7BAGENT_NAME%7D.json%22%60%20on%20line%20354%20still%20uses%20the%20bare%20shell%20variable%20with%20no%20in-fence%20assignment.%20An%20orchestrator%20author%20who%20copies%20the%20block%20verbatim%20%E2%80%94%20even%20after%20reading%20the%20disclaimer%20%E2%80%94%20gets%20an%20empty%20%60RESULT%60%20path%3B%20every%20file-existence%20check%20fails%20and%20all%20agents%20are%20reported%20as%20%22result%20file%20missing%22%20even%20when%20the%20files%20exist.%0A%0AThe%20agent-side%20example%20added%20in%20this%20PR%20correctly%20solves%20this%20by%20assigning%20a%20literal%20path%20at%20the%20top%20of%20the%20same%20fence%20%28%60RUN_DIR%3D%22%2Ftmp%2Fyellow-work-abc123%22%60%29.%20The%20same%20pattern%20should%20be%20applied%20here%3A%20either%20assign%20the%20literal%20value%20at%20the%20top%20of%20the%20fence%20%28matching%20the%20agent-side%20convention%29%20or%20replace%20%60%24RUN_DIR%60%20with%20the%20%60%3Cliteral%20mktemp%20path%3E%60%20placeholder%20used%20throughout%20%60work.md%60.%20The%20disclaimer%20alone%20does%20not%20eliminate%20the%20copy-paste%20hazard%20for%20the%20most%20common%20usage%20pattern.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (9): Last reviewed commit: ["fix: resolve PR #364 review comments (4 ..."](https://github.com/kinginyellows/yellow-plugins/commit/3a4941b25f351864d3369fbdc53c471b508794f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30898856)</sub>

<!-- /greptile_comment -->