### PR TITLE
feat(git-worktree): symlink .ruvector into worktrees for ruvector DB sharing

### DIFF
--- a/.changeset/ruvector-worktree-db-symlink.md
+++ b/.changeset/ruvector-worktree-db-symlink.md
@@ -1,0 +1,12 @@
+---
+'yellow-core': minor
+---
+
+git-worktree: inject `.ruvector/` symlink into new worktrees so the ruvector
+MCP server and hook scripts reach the project's shared DB instead of silently
+no-op'ing on a missing directory. Adds three new helpers to `worktree-manager.sh`
+(`get_main_repo_root`, `link_ruvector_db`, `cleanup_ruvector_link`), wires them
+into `create` / `copy-env` / `cleanup`, mirrors the cleanup logic in
+`/yellow-core:worktree:cleanup`, and ships bats coverage. Also adds a new
+`plugin-shell-tests` CI job that runs the new yellow-core suite as a required
+check and existing plugin bats suites as advisory.

--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -795,6 +795,43 @@ jobs:
           fi
 
   # ============================================================================
+  # PLUGIN SHELL TESTS (bats) — blocking for yellow-core, advisory for others
+  # ============================================================================
+  plugin-shell-tests:
+    name: Plugin Shell Tests
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["self-hosted","pool:atlas"]') }}
+    timeout-minutes: 5
+    needs: [validate-schemas]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          clean: true
+
+      - name: Install bats
+        run: sudo apt-get update -qq && sudo apt-get install -y bats
+
+      - name: Run yellow-core git-worktree bats suite (required)
+        run: bats plugins/yellow-core/skills/git-worktree/tests/
+
+      - name: Run other plugins' bats suites (advisory)
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          STATUS=0
+          for d in plugins/*/tests; do
+            [ -d "$d" ] || continue
+            echo "::group::bats $d"
+            bats "$d" || STATUS=$?
+            echo "::endgroup::"
+          done
+          if [ $STATUS -ne 0 ]; then
+            echo "::warning::One or more advisory bats suites failed. Track as follow-up; not blocking this PR."
+          fi
+
+  # ============================================================================
   # AGGREGATE METRICS AND REPORT
   # ============================================================================
   report-metrics:
@@ -813,6 +850,7 @@ jobs:
         security-audit,
         build,
         changeset-check,
+        plugin-shell-tests,
       ]
 
     steps:
@@ -904,6 +942,7 @@ jobs:
         security-audit,
         build,
         changeset-check,
+        plugin-shell-tests,
       ]
 
     steps:
@@ -916,6 +955,7 @@ jobs:
              [ "${{ needs.integration-tests.result }}" == "success" ] && \
              [ "${{ needs.contract-drift.result }}" == "success" ] && \
              [ "${{ needs.security-audit.result }}" == "success" ] && \
+             [ "${{ needs.plugin-shell-tests.result }}" == "success" ] && \
              { [ "${{ needs.build.result }}" == "success" ] || [ "${{ needs.build.result }}" == "skipped" ]; } && \
              { [ "${{ needs.changeset-check.result }}" == "success" ] || [ "${{ needs.changeset-check.result }}" == "skipped" ]; }; then
             echo "::notice::✅ All CI validation checks passed"
@@ -929,6 +969,7 @@ jobs:
             echo "Integration Tests: ${{ needs.integration-tests.result }}"
             echo "Contract Drift: ${{ needs.contract-drift.result }}"
             echo "Security Audit: ${{ needs.security-audit.result }}"
+            echo "Plugin Shell Tests: ${{ needs.plugin-shell-tests.result }}"
             echo "Build (main only): ${{ needs.build.result }}"
             echo "Changeset Required: ${{ needs.changeset-check.result }}"
             exit 1

--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -811,7 +811,9 @@ jobs:
           clean: true
 
       - name: Install bats
-        run: sudo apt-get update -qq && sudo apt-get install -y bats
+        # Pin via npm: ubuntu 22.04 apt ships bats 1.2.1 which lacks the
+        # bats_require_minimum_version helper (>=1.5.0) used in this repo.
+        run: sudo npm install -g bats@1.11.0
 
       - name: Run yellow-core git-worktree bats suite (required)
         run: bats plugins/yellow-core/skills/git-worktree/tests/
@@ -821,7 +823,9 @@ jobs:
         run: |
           set -uo pipefail
           STATUS=0
-          for d in plugins/*/tests; do
+          # Both top-level and nested test dirs (yellow-core's bats suite
+          # lives under skills/git-worktree/tests/, not at the plugin root).
+          for d in plugins/*/tests plugins/*/skills/*/tests; do
             [ -d "$d" ] || continue
             echo "::group::bats $d"
             bats "$d" || STATUS=$?

--- a/docs/brainstorms/2026-05-05-ruvector-worktree-db-sharing-brainstorm.md
+++ b/docs/brainstorms/2026-05-05-ruvector-worktree-db-sharing-brainstorm.md
@@ -1,0 +1,192 @@
+# Brainstorm: ruvector Worktree DB Sharing
+
+**Date:** 2026-05-05
+**Topic:** How to keep the ruvector vector DB accessible and functional when working inside git worktrees
+
+---
+
+## What We're Building
+
+A mechanism so that when a Claude Code session runs inside a git worktree
+(e.g., `.worktrees/pr-review-123/`), the ruvector MCP server and hook scripts
+resolve to the main repository's `.ruvector/` database rather than looking for
+a missing DB under the worktree path. The fix must require no changes to
+plugin.json, the hook scripts, or `RUVECTOR_STORAGE_PATH` — only the
+worktree creation and cleanup lifecycle in `worktree-manager.sh` needs
+to change.
+
+---
+
+## Why This Approach
+
+### Confirmed root cause (evidence from codebase)
+
+**1. `.ruvector/` is gitignored — it never transfers to a worktree.**
+
+`.gitignore` line 95: `**/.ruvector/`. Git worktree add creates a clean
+working directory from the index; gitignored directories are not present.
+The worktree starts with no `.ruvector/` at all.
+
+**2. The MCP server path-resolves to the worktree root, not the main repo.**
+
+`plugin.json` line 28:
+```json
+"RUVECTOR_STORAGE_PATH": "${PWD}/.ruvector/"
+```
+`${PWD}` is evaluated when Claude Code spawns the MCP server process for
+a session. In a worktree session, `PWD` is the worktree path. So the MCP
+server looks for `.worktrees/pr-review-123/.ruvector/` — which does not
+exist.
+
+**3. The hook scripts resolve the same way and fail silently.**
+
+All three hook scripts (`session-start.sh:24`, `user-prompt-submit.sh:27`,
+`pre-tool-use.sh:24`) use the same pattern:
+```bash
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // ""')
+PROJECT_DIR="${CWD:-${CLAUDE_PROJECT_DIR:-${PWD}}}"
+RUVECTOR_DIR="${PROJECT_DIR}/.ruvector"
+if [ ! -d "$RUVECTOR_DIR" ]; then
+  json_exit   # silently exits with {"continue": true}
+fi
+```
+In a worktree, `.cwd` from the hook input is the worktree path. The DB
+directory check fails, and every hook silently no-ops. No recall, no
+session-start context, no post-edit indexing. Ruvector appears to work
+but does absolutely nothing.
+
+**4. The MCP server is not global — it is per-session.**
+
+The user's hypothesis was that ruvector runs as a single global process
+(one per Claude Code install) and would therefore always hit the same DB.
+That is not how it works. Claude Code spawns one MCP server process per
+project session. The DB is scoped by `${PWD}` at spawn time, which is
+why two sessions — one in main, one in a worktree — see different
+(or missing) DBs.
+
+**5. The worktree-manager.sh only copies `.env*` files today.**
+
+`worktree-manager.sh` `create` command calls `copy_env_files()` after
+`git worktree add`. There is no equivalent step for `.ruvector/`. The
+`copy_env_files` function already has a symlink-safety guard
+(`[ ! -L "$f" ]`) — the same guard pattern applies to cleanup.
+
+**6. The DB is a single file.**
+
+Both `.ruvector/` directories in this repo contain only `intelligence.json`.
+This is not a multi-file B-tree or WAL-based database. Concurrent write
+safety depends on the ruvector CLI's own session queue, not on filesystem
+locking across multiple files.
+
+**7. The CLAUDE.md already anticipated this — aspirationally.**
+
+`plugins/yellow-ruvector/CLAUDE.md` line 134: "`.ruvector/` is shared
+across git worktrees — concurrent indexing may race." This was written as
+a known limitation for a future shared-DB approach, not a description of
+current behavior.
+
+### Corrected mental model
+
+```
+Main session:     /repo/                      → MCP: /repo/.ruvector/           (works)
+Worktree session: /repo/.worktrees/foo/       → MCP: /repo/.worktrees/foo/.ruvector/  (missing, all hooks no-op)
+
+After fix (symlink at creation time):
+Worktree session: /repo/.worktrees/foo/       → MCP: /repo/.worktrees/foo/.ruvector/
+                                                          ↓ symlink
+                                                    /repo/.ruvector/              (same DB)
+```
+
+---
+
+## Key Decisions
+
+### Recommended approach: A — Symlink on worktree creation
+
+Extend `worktree-manager.sh create` to create a relative symlink
+`.ruvector/ -> ../../.ruvector/` inside the new worktree directory, right
+after the `.env` copy step. Extend `cleanup` to detect and remove the
+symlink without following it into the main repo.
+
+**Why this is the right approach:**
+
+- Zero changes to `plugin.json`, hook scripts, or `RUVECTOR_STORAGE_PATH`.
+  The `${PWD}/.ruvector/` path in plugin.json resolves correctly once the
+  symlink exists.
+- The gitignore pattern `**/.ruvector/` ignores the symlink entry itself
+  (matched by path, not by target), so no tracking risk.
+- All learnings recorded in any worktree session land in the main repo's
+  `intelligence.json` — exactly the "project-scoped, not worktree-scoped"
+  goal.
+- The worktree-manager.sh is already the enforced single creation path
+  (the SKILL.md says "NEVER use raw `git worktree add` directly"), so
+  the symlink logic lives in exactly one place.
+
+**Failure modes and mitigations:**
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Concurrent write races (two sessions writing simultaneously) | Low | ruvector CLI has internal session queue; single-file DB; concurrent worktree sessions are rare in this workflow |
+| Cleanup `rm -rf` follows symlink and deletes main DB | High | Cleanup must check `[ -L "$RUVECTOR_LINK" ]` and use `rm` (not `rm -rf`) on the symlink entry only |
+| Worktree created inside a path where `../../.ruvector/` is wrong | Low | Use `ln -s "$(realpath --relative-to="$worktree_path" "$repo_root/.ruvector")" "$worktree_path/.ruvector"` for a path-independent relative link |
+| Main `.ruvector/` does not exist yet when worktree is created | Medium | Symlink creation should be conditional: skip with a warning if `"$repo_root/.ruvector"` does not exist, rather than creating a dangling link |
+
+### Alternatives considered
+
+**Approach B — Copy DB into each worktree (like `.env` files)**
+
+Each `worktree create` copies `.ruvector/` as a real directory. The
+worktree gets its own isolated DB snapshot. Learnings recorded in the
+worktree are lost when the worktree is cleaned up.
+
+- Pros: complete isolation, no write races
+- Cons: learnings from PR reviews never make it back to main; requires
+  explicit merge or export step; defeats the purpose of institutional memory
+- Best when: you want branch-specific experimental learnings you intend to
+  discard
+
+**Approach C — Override storage path via env var per worktree**
+
+Add a `.env.ruvector` file to each worktree (or a `.claude`-level env
+override) that sets `RUVECTOR_STORAGE_PATH` to the absolute path of the
+main repo's `.ruvector/`. Plugin.json or a wrapper script reads this
+and passes it to the MCP server.
+
+- Pros: no symlink on the filesystem, explicit path configuration
+- Cons: requires changes to plugin.json MCP server config (env var
+  indirection), adds a new per-worktree file to manage, more moving parts
+  than a symlink
+- Best when: the project uses a dotenv-based config system that already
+  handles per-worktree overrides
+
+The symlink approach (A) is strictly simpler: one `ln -s` command at
+creation, one `rm` at cleanup, zero other changes.
+
+---
+
+## Open Questions
+
+1. **Relative vs. absolute symlink target.** A relative symlink
+   (`../../.ruvector`) works as long as the worktree stays at
+   `.worktrees/<name>/`. If the worktree path depth ever changes (e.g., a
+   nested subdirectory), the link breaks. Using `realpath --relative-to`
+   at creation time makes it robust. Should the implementation default to
+   relative (simpler, more portable) or absolute (more explicit)?
+
+2. **What happens to learnings recorded before this fix?** Sessions that
+   ran in worktrees before the symlink mechanism existed silently no-op'd.
+   No DB was written. There is no data loss — there was simply no data
+   recorded. No migration step needed.
+
+3. **Should the `copy-env` subcommand also link `.ruvector/`?** The
+   `worktree-manager.sh copy-env <name>` command re-syncs `.env` files
+   to an existing worktree. It would be consistent to also repair a
+   missing `.ruvector` symlink in that command, but it is not strictly
+   needed for the create path to work correctly.
+
+4. **Concurrent session safety ceiling.** The ruvector CLI's queue system
+   provides some write serialization, but it is not documented whether
+   it is safe across two simultaneous processes pointing at the same
+   `intelligence.json`. If concurrent worktree sessions become a regular
+   pattern, a file lock or `flock`-based wrapper around ruvector CLI
+   writes may be needed. Defer until the pattern is observed in practice.

--- a/docs/solutions/integration-issues/ruvector-worktree-db-symlink.md
+++ b/docs/solutions/integration-issues/ruvector-worktree-db-symlink.md
@@ -71,13 +71,19 @@ during worktree creation. Three new helpers in `worktree-manager.sh`:
 - `link_ruvector_db()` — idempotent: skips on existing symlink (`info`),
   skips on existing real directory (`warning`, preserves user's isolated
   DB), skips when main has no `.ruvector/` (no dangling links).
-No explicit cleanup helper is needed: `git worktree remove` walks the
-worktree via `dir.c::remove_dir_recurse`, which uses `lstat()` + `unlink()`
-per entry — symlinks are unlinked, never followed into the main DB.
+- `unlink_ruvector_link()` / `restore_ruvector_link()` — paired helpers in
+  `worktree-manager.sh::cmd_cleanup`. The first does `[ -L ] && rm --` (no
+  `-r`, no `-f`, no trailing slash; POSIX-safe; cannot follow into the main
+  DB) and echoes the captured target. The second restores the symlink if
+  `git worktree remove` then fails for OTHER reasons, so the still-present
+  worktree stays functional.
 
-`commands/worktree/cleanup.md` (the separate LLM cleanup command) issues
-plain `git worktree remove` invocations across categories 3, 4, 5, 6, 7
-and relies on the same lstat+unlink behavior.
+`commands/worktree/cleanup.md` (the separate LLM cleanup command) inlines
+the same pre-remove + restore-on-failure block at every no-`--force`
+callsite (Cat 3 clean, Cat 4, Cat 5, Cat 7). For `--force` callsites
+(Cat 3 dirty, Cat 6) no dance is needed — `git worktree remove --force`
+skips the untracked-files check and unlinks the symlink as part of its
+directory walk.
 
 ## Footguns to avoid
 
@@ -119,23 +125,34 @@ avoid simultaneous Claude Code sessions with active memory writes against
 the same project. Revisit if/when ruvector source confirms SQLite WAL
 mode (which would already provide cross-process write safety).
 
-## Why no explicit pre-removal in cleanup
+## Why pre-remove + restore-on-failure (and why `--force` paths skip the dance)
 
-`git worktree remove` uses `dir.c::remove_dir_recurse` internally, which
-calls `lstat()` + `unlink()` per entry — symlinks are never followed
-(see https://github.com/git/git/blob/master/dir.c). Behavior has been
-consistent since git 2.17 (commit cc73385) across Linux and macOS,
-because git uses its own POSIX C `lstat`/`unlink`, not the platform's
-`rm`. Gitignored symlinks also do not block removal.
+`git worktree remove` (no `--force`) refuses to remove a worktree that
+contains untracked files: `fatal: '<path>' contains modified or untracked
+files`. The `**/.ruvector/` gitignore pattern (with trailing slash) only
+matches directories, not symlinks-to-directories — so the injected
+`.ruvector` symlink falls under "untracked file" from git's perspective
+and would block every removal. The symlink MUST be pre-removed.
 
-The earlier design pre-removed the symlink "defensively" before calling
-`git worktree remove`, but that introduced a real bug: when removal
-failed (dirty/locked worktree, no `--force`), the worktree was left in
-place but its `.ruvector` symlink was already gone — silently breaking
-ruvector inside an active worktree (PR #366 review feedback). Letting
-git own the unlink makes the cleanup atomic: success removes the whole
-tree (symlink included), failure leaves the whole tree (symlink included)
-so the worktree remains usable.
+But pre-removing alone introduces a separate bug: when `git worktree
+remove` then fails for OTHER reasons (dirty/locked worktree, no
+`--force`), the worktree is left in place with its `.ruvector` symlink
+already gone — silently breaking ruvector inside an active worktree (PR
+\#366, Codex P1 review feedback). The fix: capture the link target
+before unlinking, and `ln -s` it back if the removal exits non-zero. This
+keeps cleanup atomic from the user's point of view — either the whole
+tree (symlink included) is gone, or the whole tree (symlink included)
+remains usable.
+
+For `--force` paths (`git worktree remove --force`) the dance is
+unnecessary. `--force` skips the untracked-files check, and git's
+`dir.c::remove_dir_recurse` walks the worktree using `lstat()` +
+`unlink()` per entry — symlinks are unlinked, never followed (stable
+since git 2.17, commit cc73385, across Linux and macOS, because git uses
+its own POSIX C `lstat`/`unlink`, not the platform's `rm`).
+
+POSIX-safety on the `rm` side: `rm` without `-r`/`-f` on a `[ -L
+]`-confirmed entry can never traverse the link target.
 
 ## Security analysis
 

--- a/docs/solutions/integration-issues/ruvector-worktree-db-symlink.md
+++ b/docs/solutions/integration-issues/ruvector-worktree-db-symlink.md
@@ -1,0 +1,178 @@
+---
+title: 'ruvector .ruvector/ DB silently absent inside git worktrees'
+category: integration-issues
+track: knowledge
+problem: 'ruvector MCP server and hook scripts silently no-op inside git worktrees because .ruvector/ is gitignored and ${PWD}/.ruvector/ resolves to the worktree path'
+date: 2026-05-05
+tags:
+  - ruvector
+  - git-worktree
+  - mcp
+  - plugin-authoring
+  - yellow-core
+  - yellow-ruvector
+problem_type: silent-failure
+components:
+  - plugins/yellow-core/skills/git-worktree/scripts/worktree-manager.sh
+  - plugins/yellow-core/commands/worktree/cleanup.md
+  - plugins/yellow-ruvector/.claude-plugin/plugin.json
+  - plugins/yellow-ruvector/hooks/scripts/session-start.sh
+  - plugins/yellow-ruvector/hooks/scripts/user-prompt-submit.sh
+  - plugins/yellow-ruvector/hooks/scripts/pre-tool-use.sh
+  - plugins/yellow-ruvector/hooks/scripts/post-tool-use.sh
+severity: medium
+---
+
+# ruvector `.ruvector/` DB silently absent inside git worktrees
+
+## Problem
+
+When a Claude Code session runs inside a git worktree (e.g.
+`.worktrees/pr-review-123/`), the ruvector MCP server and all four hook
+scripts silently no-op. Recall returns no results, session-start context
+is not injected, post-edit indexing never runs. The user sees a working
+ruvector that does absolutely nothing.
+
+## Root cause
+
+Three independent facts compound:
+
+1. **`.ruvector/` is gitignored.** `.gitignore` line 95 has
+   `**/.ruvector/`. `git worktree add` creates the working directory from
+   the index; gitignored entries are never present in a fresh worktree.
+2. **MCP path resolves at spawn time against the worktree's PWD.**
+   `plugins/yellow-ruvector/.claude-plugin/plugin.json:28` declares
+   `"RUVECTOR_STORAGE_PATH": "${PWD}/.ruvector/"`. Claude Code spawns one
+   MCP server process per session and expands `${PWD}` to the session's
+   working directory — the worktree path.
+3. **Hooks fail-closed without error.** Every hook reads the same pattern
+   (`session-start.sh:24`, etc.):
+   ```sh
+   PROJECT_DIR="${CWD:-${CLAUDE_PROJECT_DIR:-${PWD}}}"
+   RUVECTOR_DIR="${PROJECT_DIR}/.ruvector"
+   if [ ! -d "$RUVECTOR_DIR" ]; then json_exit; fi
+   ```
+   The directory is missing → silent `{"continue": true}` exit.
+
+The MCP server is per-session (not global), so the brainstorm hypothesis
+that "ruvector is global so it should work" was wrong.
+
+## Fix
+
+Inject an absolute symlink `${worktree}/.ruvector -> ${main_repo}/.ruvector`
+during worktree creation. Three new helpers in `worktree-manager.sh`:
+
+- `get_main_repo_root()` — uses `git rev-parse --git-common-dir` (NOT
+  `--show-toplevel`, which returns the worktree root from inside a
+  worktree) and strips the trailing `/.git`. Handles four output shapes:
+  literal `.git` (relative, from main repo root), `*/.git` (absolute from
+  worktree, or relative `../../.git` from a subdir), the bare-repo
+  fallback, and the git<2.5 echo-back guard.
+- `link_ruvector_db()` — idempotent: skips on existing symlink (`info`),
+  skips on existing real directory (`warning`, preserves user's isolated
+  DB), skips when main has no `.ruvector/` (no dangling links).
+- `cleanup_ruvector_link()` — `[ -L ] && rm --` (no `-r`, no `-f`, no
+  trailing slash) before `git worktree remove`. POSIX-safe; cannot
+  follow into the main DB.
+
+`commands/worktree/cleanup.md` (the separate 508-line LLM cleanup command)
+gains a `remove_ruvector_link` helper called before every
+`git worktree remove` invocation across categories 3, 4, 5, 6, 7.
+
+## Footguns to avoid
+
+- **`rm -rf "$worktree/.ruvector/"` with trailing slash.** POSIX trailing
+  slash on a symlink-to-directory dereferences the link — the trailing
+  slash recursively deletes the main DB. Always use `rm --` on a
+  `[ -L ]`-confirmed entry, no `-r`, no `-f`, no trailing slash. Source:
+  https://github.com/nushell/nushell/issues/12453,
+  https://tookmund.com/2022/04/importance-of-the-trailing-slash.
+- **`git rev-parse --show-toplevel` from inside a worktree.** Returns the
+  worktree root, not main. Symlinking to that path produces a
+  self-referential dangling link. Use `--git-common-dir` instead.
+- **MCP-spawn-time vs. process-runtime.** `RUVECTOR_STORAGE_PATH` is
+  evaluated at MCP server spawn. The symlink only helps when Claude Code
+  is launched from inside the worktree directory. A pre-existing main
+  session that `cd`s into a worktree continues writing to main directly —
+  that's actually fine, but worth understanding.
+- **Dangling symlink semantics in hook guards.** POSIX `[ -d X ]` on a
+  dangling symlink returns false. So if the main `.ruvector/` is later
+  deleted while a worktree symlink still points at it, hooks correctly
+  no-op rather than error. Documented as the safe failure mode.
+
+## Concurrent-write caveat (deferred)
+
+Two simultaneous Claude Code sessions (one in main, one in a worktree, or
+two worktrees) both spawn an MCP server process pointing at the same DB.
+Two write paths exist:
+
+1. Direct MCP writes to `intelligence/memory.rvdb` from per-session
+   `hooks_remember` calls.
+2. `pending-updates.jsonl` read-then-truncate from the memory-manager
+   agent — interleaving sessions can silently drop entries.
+
+A `flock` wrapper at the plugin layer is **not viable**: both write paths
+run inside the ruvector MCP server process, not in shell wrappers we
+control. `flock`-ing the MCP server start serializes all MCP tool calls
+and breaks UX. Posture: document only. Mitigation is behavioral —
+avoid simultaneous Claude Code sessions with active memory writes against
+the same project. Revisit if/when ruvector source confirms SQLite WAL
+mode (which would already provide cross-process write safety).
+
+## Why explicit pre-removal in cleanup is kept
+
+`git worktree remove` uses `dir.c::remove_dir_recurse` internally, which
+calls `lstat()` + `unlink()` per entry — symlinks are never followed
+(see https://github.com/git/git/blob/master/dir.c). Behavior has been
+consistent since git 2.17 (commit cc73385) across Linux and macOS,
+because git uses its own POSIX C `lstat`/`unlink`, not the platform's
+`rm`. Gitignored symlinks also do not block removal.
+
+So explicit pre-removal of the symlink in `cleanup_ruvector_link` is
+**defensive only, not required for safety.** It is kept anyway because:
+
+1. The `lstat`/`unlink` behavior is not documented in user-facing git
+   docs — derivable only from source. A future git refactor could
+   theoretically change it.
+2. It keeps cleanup auditable independent of git internals.
+3. It handles bypass cases — if a user invokes `git worktree remove`
+   directly without going through `worktree-manager.sh cleanup` or
+   `/yellow-core:worktree:cleanup`, the symlink is still removed by
+   git's directory traversal, but having explicit logic in our cleanup
+   paths means the failure mode is predictable.
+
+## Security analysis
+
+The symlink target is derived from `git rev-parse --git-common-dir`,
+never from user input. The branch name is pre-validated by
+`worktree-manager.sh::validate_name` (rejects `..`, leading `/`, `~`,
+allows `[a-zA-Z0-9._/-]`). No injection vector. The symlink lives at a
+deterministic path inside the validated worktree directory. Cleanup uses
+`[ -L ]`+`rm --` only — no recursive deletion can ever traverse into the
+main DB.
+
+## Rollback
+
+If this PR is reverted, symlinks remain in any worktrees created during
+the rollout window. They resolve correctly to the main DB (still useful)
+and are removed naturally when `git worktree remove` deletes the worktree
+directory (POSIX `unlink` on the symlink entry). No data migration
+required.
+
+## References
+
+- Brainstorm: `docs/brainstorms/2026-05-05-ruvector-worktree-db-sharing-brainstorm.md`
+- Plan: `plans/ruvector-worktree-db-symlink.md`
+- git source — `dir.c::remove_dir_recurse`:
+  https://github.com/git/git/blob/master/dir.c
+- git commit cc73385 (`worktree remove` introduction, 2.17.0):
+  https://github.com/git/git/commit/cc73385cf6c5c229458775bc92e7dbbe24d11611
+- git docs — `git rev-parse --git-common-dir`:
+  https://git-scm.com/docs/git-rev-parse
+- pre-commit precedent for git<2.5 fallback:
+  https://github.com/pre-commit/pre-commit/pull/2252
+- POSIX `symlink(7)` — rm-without-r-on-symlink semantics:
+  https://linux.die.net/man/7/symlink
+- Trailing-slash footgun: https://tookmund.com/2022/04/importance-of-the-trailing-slash
+- nushell #12453 — canonical example of the `rm -r link/` footgun:
+  https://github.com/nushell/nushell/issues/12453

--- a/docs/solutions/integration-issues/ruvector-worktree-db-symlink.md
+++ b/docs/solutions/integration-issues/ruvector-worktree-db-symlink.md
@@ -71,13 +71,13 @@ during worktree creation. Three new helpers in `worktree-manager.sh`:
 - `link_ruvector_db()` — idempotent: skips on existing symlink (`info`),
   skips on existing real directory (`warning`, preserves user's isolated
   DB), skips when main has no `.ruvector/` (no dangling links).
-- `cleanup_ruvector_link()` — `[ -L ] && rm --` (no `-r`, no `-f`, no
-  trailing slash) before `git worktree remove`. POSIX-safe; cannot
-  follow into the main DB.
+No explicit cleanup helper is needed: `git worktree remove` walks the
+worktree via `dir.c::remove_dir_recurse`, which uses `lstat()` + `unlink()`
+per entry — symlinks are unlinked, never followed into the main DB.
 
-`commands/worktree/cleanup.md` (the separate 508-line LLM cleanup command)
-gains a `remove_ruvector_link` helper called before every
-`git worktree remove` invocation across categories 3, 4, 5, 6, 7.
+`commands/worktree/cleanup.md` (the separate LLM cleanup command) issues
+plain `git worktree remove` invocations across categories 3, 4, 5, 6, 7
+and relies on the same lstat+unlink behavior.
 
 ## Footguns to avoid
 
@@ -119,7 +119,7 @@ avoid simultaneous Claude Code sessions with active memory writes against
 the same project. Revisit if/when ruvector source confirms SQLite WAL
 mode (which would already provide cross-process write safety).
 
-## Why explicit pre-removal in cleanup is kept
+## Why no explicit pre-removal in cleanup
 
 `git worktree remove` uses `dir.c::remove_dir_recurse` internally, which
 calls `lstat()` + `unlink()` per entry — symlinks are never followed
@@ -128,18 +128,14 @@ consistent since git 2.17 (commit cc73385) across Linux and macOS,
 because git uses its own POSIX C `lstat`/`unlink`, not the platform's
 `rm`. Gitignored symlinks also do not block removal.
 
-So explicit pre-removal of the symlink in `cleanup_ruvector_link` is
-**defensive only, not required for safety.** It is kept anyway because:
-
-1. The `lstat`/`unlink` behavior is not documented in user-facing git
-   docs — derivable only from source. A future git refactor could
-   theoretically change it.
-2. It keeps cleanup auditable independent of git internals.
-3. It handles bypass cases — if a user invokes `git worktree remove`
-   directly without going through `worktree-manager.sh cleanup` or
-   `/yellow-core:worktree:cleanup`, the symlink is still removed by
-   git's directory traversal, but having explicit logic in our cleanup
-   paths means the failure mode is predictable.
+The earlier design pre-removed the symlink "defensively" before calling
+`git worktree remove`, but that introduced a real bug: when removal
+failed (dirty/locked worktree, no `--force`), the worktree was left in
+place but its `.ruvector` symlink was already gone — silently breaking
+ruvector inside an active worktree (PR #366 review feedback). Letting
+git own the unlink makes the cleanup atomic: success removes the whole
+tree (symlink included), failure leaves the whole tree (symlink included)
+so the worktree remains usable.
 
 ## Security analysis
 

--- a/plans/ruvector-worktree-db-symlink.md
+++ b/plans/ruvector-worktree-db-symlink.md
@@ -1,0 +1,379 @@
+# Feature: ruvector Worktree DB Symlink
+
+## Problem Statement
+
+When a Claude Code session runs inside a git worktree (e.g.
+`.worktrees/pr-review-123/`), the ruvector MCP server and all four hook
+scripts resolve `${PWD}/.ruvector/` against the worktree path. Because
+`.ruvector/` is gitignored (`**/.ruvector/` in `.gitignore` line 95), it
+never carries into a new worktree. Every hook hits its
+`if [ ! -d "$RUVECTOR_DIR" ]; then json_exit; fi` guard and silently
+no-ops — no recall, no session-start context, no post-edit indexing.
+Institutional memory is silently disabled in every worktree session.
+
+Goal: when a worktree is created via `worktree-manager.sh create`, inject a
+symlink `.ruvector -> <main-repo>/.ruvector` so the MCP server and hooks
+reach the main repo's DB. Cleanup must remove the symlink without following
+it into the main repo.
+
+## Current State
+
+- `plugins/yellow-core/skills/git-worktree/scripts/worktree-manager.sh`
+  (POSIX `#!/bin/sh`, `set -e`) is the single canonical entrypoint for
+  worktree creation. SKILL.md line 25 forbids raw `git worktree add`.
+- `cmd_create` (line 109–143) calls `copy_env_files` at line 139 and stops.
+  No `.ruvector` handling exists.
+- `cmd_cleanup` (line 221–263) iterates `git worktree list --porcelain` and
+  calls `git worktree remove "$path"` (line 251). No `rm -rf`. No symlink
+  awareness.
+- `cmd_copy_env` (line 200–218) is the documented retroactive-fix path for
+  existing worktrees; it currently re-syncs `.env*` only.
+- `commands/worktree/cleanup.md` is a separate 508-line LLM command that
+  also calls `git worktree remove` across 7 worktree categories with no
+  symlink awareness.
+- `plugins/yellow-ruvector/CLAUDE.md` line 134 contains the aspirational
+  note "`.ruvector/` is shared across git worktrees — concurrent indexing
+  may race." This is currently inaccurate and becomes accurate after the
+  fix (with a different limitation: races, not absence).
+
+## Proposed Solution
+
+Two new POSIX-shell helpers in `worktree-manager.sh`, called from `create`,
+`copy-env`, and `cleanup`:
+
+- `get_main_repo_root()` — returns the **main** repo root by stripping the
+  trailing `/.git` from `git rev-parse --git-common-dir`. Required because
+  `git rev-parse --show-toplevel` returns the **worktree** root when called
+  from inside a worktree, which would point the symlink at itself.
+- `link_ruvector_db()` — conditionally creates absolute symlink
+  `${worktree_path}/.ruvector -> ${main_repo}/.ruvector`. Skips with
+  `info` if the symlink already exists. Skips with `warning` if a real
+  `.ruvector/` directory already exists. Skips with `warning` if the main
+  repo has no `.ruvector/` (no dangling links).
+- `cleanup_ruvector_link()` — removes the symlink at
+  `${worktree_path}/.ruvector` only if `[ -L ]` is true, using `rm --` (no
+  `-r`, no `-f`, no trailing slash). Failure does not abort the cleanup
+  loop.
+
+`commands/worktree/cleanup.md` gains the same symlink-removal step before
+each of its 5 `git worktree remove` call sites (categories 3, 4, 5, 6, 7).
+
+## Implementation Plan
+
+### Phase 1: Shell helpers and cmd_create wire-up
+
+- [ ] 1.1: Add `get_main_repo_root()` helper to `worktree-manager.sh`.
+  `git rev-parse --git-common-dir` output is asymmetric (confirmed via
+  git's t1500-rev-parse.sh test suite): returns `.git` (literal, relative)
+  from main repo root, `../../.git` (relative) from a subdir of main, an
+  absolute `/abs/.git` from a linked worktree, and echoes `--git-common-dir`
+  literally on git < 2.5. Required minimum: git 2.5 (July 2015), introduced
+  alongside the worktree feature.
+
+  Implementation (POSIX `sh`, no bashisms):
+  ```sh
+  get_main_repo_root() {
+      common=$(git rev-parse --git-common-dir 2>/dev/null) || {
+          error "git rev-parse --git-common-dir failed"
+      }
+      case "$common" in
+          --*) error "git >= 2.5 required for --git-common-dir" ;;
+          .git) printf '%s' "$PWD" ;;
+          */.git) printf '%s' "${common%/.git}" ;;     # absolute (worktree) or relative subdir
+          *)
+              resolved=$(cd "${common%/.git}" 2>/dev/null && pwd) \
+                  || error "could not resolve git common dir: $common"
+              printf '%s' "$resolved" ;;
+      esac
+  }
+  ```
+  The `*/.git)` branch handles both absolute (`/repo/.git`) and relative
+  (`../../.git`) cases via the same `${var%/.git}` strip; the fallback
+  branch resolves any unusual shape (bare repo, nested setups) by `cd`-ing
+  to it. Sources: git-rev-parse docs + `t/t1500-rev-parse.sh` + pre-commit
+  PR #2252 (the git<2.5 fallback precedent).
+- [ ] 1.2: Add `link_ruvector_db(main_root, worktree_path)` helper. Order:
+  (1) if `[ -L "$worktree_path/.ruvector" ]` → `info` already linked, return 0;
+  (2) if `[ -e "$worktree_path/.ruvector" ] && [ ! -L ... ]` → real
+  directory present, `warning` and return 0 (do NOT overwrite);
+  (3) if `[ ! -d "$main_root/.ruvector" ]` → `warning "Main .ruvector/ not
+  found at $main_root; skipping symlink"` and return 0;
+  (4) `ln -s -- "$main_root/.ruvector" "$worktree_path/.ruvector"` or
+  `error` on failure.
+- [ ] 1.3: Add `cleanup_ruvector_link(worktree_path)` helper. Body:
+  `link="${worktree_path}/.ruvector"`; if `[ -L "$link" ]` then
+  `rm -- "$link" || warning "Failed to remove .ruvector symlink at $link"`.
+  Never aborts cleanup loop.
+- [ ] 1.4: Wire `link_ruvector_db` into `cmd_create` immediately after
+  `copy_env_files` (line 139). Use `get_main_repo_root` (not `repo_root`
+  from line 120) to derive the target.
+- [ ] 1.5: Wire `link_ruvector_db` into `cmd_copy_env` after the existing
+  `copy_env_files` call. Same `get_main_repo_root` usage.
+- [ ] 1.6: Wire `cleanup_ruvector_link` into `cmd_cleanup` immediately
+  before `git worktree remove "$path"` (line 251).
+- [ ] 1.7: Normalize line endings: `sed -i 's/\r$//' worktree-manager.sh`
+  after editing on WSL2.
+
+### Phase 2: cleanup.md command parity
+
+- [ ] 2.1: Locate the 5 `git worktree remove` call sites in
+  `commands/worktree/cleanup.md` (lines ~343, 353, 387 + the two `--force`
+  paths inside categories 6 and 7). Insert
+  `[ -L "$WT_PATH/.ruvector" ] && rm -- "$WT_PATH/.ruvector"` before each.
+- [ ] 2.2: Add an 8th success criterion to the success block (line ~492):
+  "`.ruvector` symlink removed from each worktree directory before
+  `git worktree remove` is called."
+- [ ] 2.3: Add a code comment near the symlink removal step pointing at
+  `worktree-manager.sh#cleanup_ruvector_link` as the canonical source —
+  any logic change there must be mirrored here.
+
+### Phase 3: Tests (bats)
+
+- [ ] 3.1: Create `plugins/yellow-core/skills/git-worktree/tests/`
+  directory and `worktree-manager.bats` (yellow-core has no existing bats
+  fixture — bootstrap the convention used by `yellow-ruvector/tests/`).
+  File header (matching `yellow-ruvector/tests/post-tool-use.bats:1-3`):
+  ```bash
+  #!/usr/bin/env bats
+  bats_require_minimum_version 1.5.0
+  ```
+  No shared `helper.bash` exists in any other plugin — keep this file
+  self-contained.
+- [ ] 3.2: `setup()` builds a tmp git repo with `git init`, configures user
+  identity, makes an initial commit on `main`, creates `.ruvector/` with a
+  fixture `intelligence.json`, and adds `**/.ruvector/` to `.gitignore`.
+- [ ] 3.3: Test cases (corresponds to AC-1 … AC-6 below):
+  - `create: symlink exists, target is main .ruvector` (AC-1).
+  - `create: main .ruvector missing → no symlink, warning to stderr` (AC-2).
+  - `create: [ -d worktree/.ruvector ] is true via the symlink` (AC-3).
+  - `create: real .ruvector dir already in worktree → skipped, dir intact`
+    (P1-A guard).
+  - `create: symlink already present → idempotent, no error` (P1-D guard).
+  - `create-from-inside-worktree: target is MAIN repo, not nested
+    worktree` (P0-A regression for `get_main_repo_root`).
+  - `copy-env: retroactive fix on pre-existing worktree → symlink created`
+    (AC-5).
+  - `cleanup: symlink removed before git worktree remove; main
+    .ruvector/intelligence.json intact` (AC-6, the safety-critical case).
+  - `cleanup: pre-fix worktree with no .ruvector → no error` (P1-E).
+- [ ] 3.4: Verify tests pass: `cd plugins/yellow-core && bats
+  skills/git-worktree/tests/worktree-manager.bats`.
+
+### Phase 3.5: Wire bats into CI (closes a pre-existing gap)
+
+**Context:** Audit found four other plugins (yellow-ruvector, yellow-ci,
+yellow-debt, yellow-review) already have `tests/*.bats` suites that no CI
+job currently runs — they are orphaned. `bats` is not in the workspace
+`devDependencies`, not in `.github/workflows/validate-schemas.yml`, and
+not in any plugin's `package.json` scripts. Adding the new yellow-core
+suite without CI wiring continues the pattern of orphaned tests.
+
+This phase is **optional / scope-decision**: adding it solves a
+pre-existing problem (good leverage) but expands the PR scope beyond the
+ruvector worktree feature. If we defer it, the new suite still runs
+locally via `bats tests/`; just not in CI.
+
+- [ ] 3.5.1: Add `"test": "bats skills/git-worktree/tests/"` to
+  `plugins/yellow-core/package.json` `scripts` block (currently `{}`).
+- [ ] 3.5.2: Add new `plugin-shell-tests` job in
+  `.github/workflows/validate-schemas.yml`. Steps: `apt-get install -y
+  bats` (Ubuntu runner), `bats plugins/*/tests/ plugins/*/skills/*/tests/`
+  glob to cover yellow-core's nested `tests/` dir AND the four orphaned
+  suites in one job.
+- [ ] 3.5.3: Add `plugin-shell-tests` to `report-metrics.needs` (line
+  ~806) and `ci-status.needs` (line ~900) arrays so the gating logic
+  blocks merge on shell-test failure.
+- [ ] 3.5.4: Local sanity: confirm the orphaned suites still pass before
+  merging — they may have rotted. If any fail, capture the failure as a
+  follow-up issue rather than blocking this PR.
+
+### Phase 4: Documentation + changeset
+
+- [ ] 4.1: Update `plugins/yellow-core/skills/git-worktree/SKILL.md`: add
+  `### ruvector DB Sharing` subsection under `## Usage`. Cover: symlink
+  created at create time; absolute target; conditional skip when main DB
+  absent; cleanup safety; **MCP-spawn-time qualifier** (the symlink only
+  helps when Claude Code is launched from inside the worktree, since
+  `RUVECTOR_STORAGE_PATH` resolves at MCP spawn).
+- [ ] 4.2: Update `plugins/yellow-core/CLAUDE.md` git-worktree skill
+  description to mention `.ruvector` symlink lifecycle.
+- [ ] 4.3: Update `plugins/yellow-ruvector/CLAUDE.md` line 134 from the
+  aspirational note to: "`.ruvector/` is shared across worktrees via a
+  symlink injected by yellow-core's `worktree-manager.sh` at create time.
+  Concurrent worktree sessions writing to the same DB may race; the
+  ruvector CLI's internal session queue provides partial serialization
+  but is not documented as cross-process-safe."
+- [ ] 4.4: Create `docs/solutions/integration-issues/ruvector-worktree-db-symlink.md`
+  capturing: confirmed root cause with file/line evidence, the fix, the
+  three footguns (trailing-slash `rm -rf`, dangling symlink hook
+  semantics, MCP-spawn-time path resolution), the security analysis of
+  the symlink target derivation (P2-C: no injection vector), and the
+  rollback note (P2-D: leftover symlinks resolve correctly until
+  `git worktree remove` cleans them up).
+- [ ] 4.5: Add a troubleshooting entry (if `troubleshooting.md` exists in
+  the git-worktree skill, or inline in SKILL.md): "`.ruvector/` symlink
+  missing in worktree → cause: ruvector not initialized before worktree
+  was created → fix: initialize ruvector in main, run
+  `worktree-manager.sh copy-env <name>`."
+- [ ] 4.6: Run `pnpm changeset` and write a `minor` bump for `yellow-core`
+  describing the symlink lifecycle. (Yellow-ruvector CLAUDE.md change is
+  doc-only; no functional yellow-ruvector change so no changeset needed
+  there per CLAUDE.md bump guide.)
+
+### Phase 5: Validation
+
+- [ ] 5.1: `pnpm validate:schemas`.
+- [ ] 5.2: `pnpm typecheck && pnpm lint && pnpm test:unit`.
+- [ ] 5.3: Manual end-to-end smoke: create a worktree in this repo via
+  `worktree-manager.sh create test-ruvector-link from main`, confirm
+  `readlink .worktrees/test-ruvector-link/.ruvector` returns the main
+  repo path, run `/ruvector:status` from inside the worktree and confirm
+  the same totalMemories count as from main, then `cleanup` and verify
+  main `.ruvector/intelligence.json` size is unchanged.
+- [ ] 5.4: Conventional-commit message: `feat(git-worktree): symlink
+  .ruvector into worktrees for ruvector DB sharing` — passes the
+  `gt-workflow:check-commit-message` regex.
+- [ ] 5.5: `gt commit create -m "..."` then `gt stack submit`.
+
+## Technical Specifications
+
+### Files to Modify
+
+- `plugins/yellow-core/skills/git-worktree/scripts/worktree-manager.sh` —
+  three new helpers; three call sites in create / copy-env / cleanup.
+- `plugins/yellow-core/commands/worktree/cleanup.md` — symlink removal
+  before each `git worktree remove`; success-criteria addition.
+- `plugins/yellow-core/skills/git-worktree/SKILL.md` — `### ruvector DB
+  Sharing` subsection; MCP-spawn-time qualifier.
+- `plugins/yellow-core/CLAUDE.md` — git-worktree skill description.
+- `plugins/yellow-ruvector/CLAUDE.md` line 134 — replace aspirational
+  note.
+
+### Files to Create
+
+- `plugins/yellow-core/skills/git-worktree/tests/worktree-manager.bats` —
+  9 test cases.
+- `docs/solutions/integration-issues/ruvector-worktree-db-symlink.md` —
+  design + footguns + security analysis.
+- `.changeset/ruvector-worktree-db-symlink.md` — `yellow-core: minor`.
+
+### Dependencies
+
+None. POSIX shell + `git` + `ln` + `bats` (already used elsewhere).
+
+## Acceptance Criteria
+
+Each maps to a bats test in Phase 3.3.
+
+- AC-1: After `create <name>`, `readlink "$worktree/.ruvector"` returns
+  the absolute path of `${main_repo_root}/.ruvector`.
+- AC-2: After `create <name>` with no main `.ruvector/`, the worktree
+  contains no `.ruvector` entry and a warning was printed.
+- AC-3: After `create <name>` with `.ruvector/` linked,
+  `[ -d "$worktree/.ruvector" ]` returns true (validates the hook guard
+  `[ ! -d "$RUVECTOR_DIR" ]` will not trip on a healthy symlink).
+- AC-4 (manual, Phase 5.3): `/ruvector:status` from inside the worktree
+  reports the same `intelligence.json` stats as from main.
+- AC-5: `copy-env <name>` is idempotent — re-running it does not error
+  and does not duplicate the symlink.
+- AC-6: After `cleanup`, the worktree's `.ruvector` symlink is removed
+  AND the main repo's `.ruvector/intelligence.json` is byte-identical to
+  before.
+
+## Edge Cases & Error Handling
+
+- **P0-A: `get_main_repo_root` from inside a worktree.** Use
+  `git rev-parse --git-common-dir`. `--show-toplevel` returns the
+  worktree root, not main. Tested in Phase 3.3.
+- **P0-C: rm failure under `set -e`.** `cleanup_ruvector_link` wraps
+  `rm` with `|| warning` so cleanup loop continues.
+- **P1-A: Real `.ruvector/` directory already in worktree** (user ran
+  `git worktree add` directly then `/ruvector:setup`). Detect with
+  `[ -e ] && [ ! -L ]` → warn and skip. User keeps their isolated DB.
+- **P1-B: MCP server resolves at spawn time.** Documented in SKILL.md:
+  the symlink only helps when Claude Code is launched FROM the worktree
+  directory. Pre-existing sessions started in main do not benefit.
+- **P1-C: Worktree-of-worktree.** Resolved by P0-A — `--git-common-dir`
+  always points at main from any worktree depth. Tested.
+- **P1-D: copy-env idempotency.** `[ -L ]` check before `ln -s` makes
+  re-runs no-ops.
+- **P1-E: Pre-fix worktree (no `.ruvector` entry).**
+  `cleanup_ruvector_link` short-circuits via `[ -L ]` false. Tested.
+- **P2-A: Concurrent writes to shared `intelligence.json`.** Two write
+  paths actually exist: (1) direct MCP writes to `intelligence/memory.rvdb`
+  via the per-session MCP server process, (2) `pending-updates.jsonl`
+  read-then-truncate pattern (memory-manager step 8) that can interleave
+  between sessions and silently drop entries. A `flock` wrapper at the
+  plugin layer is **not viable** — both write paths run inside the
+  ruvector MCP server process, not in shell wrappers we control;
+  `flock`-ing the MCP server start would serialize all MCP tool calls and
+  break the UX. Posture: document-only (option a). Mitigation is
+  behavioral: avoid simultaneous Claude Code sessions with active memory
+  writes against the same project. Revisit if/when the ruvector binary's
+  source confirms SQLite WAL mode (which would already provide
+  cross-process write safety). Reference: `plugins/yellow-ruvector/CLAUDE.md:134`.
+- **P2-B: Main `.ruvector/` deleted → dangling symlink.** POSIX `[ -d ]`
+  on a dangling symlink is false, so hooks correctly no-op. Documented.
+
+## Security Considerations
+
+- Symlink target is derived from `git rev-parse --git-common-dir`, never
+  from user input. Branch name is pre-validated by `validate_name()`
+  which rejects `..`, `/`, `~`. No injection vector.
+- Cleanup uses `rm --` (no `-r`, no `-f`, no trailing slash) on a
+  `[ -L ]`-confirmed symlink only. Cannot follow into the main DB.
+- `git worktree remove` does not follow symlinks during its directory
+  cleanup. Confirmed from git source: `dir.c::remove_dir_recurse` uses
+  `lstat()` (not `stat()`) per directory entry — symlinks are detected
+  as `S_ISLNK`, fall through the `S_ISDIR` branch, and are removed via
+  `unlink()` not recursion. Behavior has been consistent since git 2.17
+  (worktree remove introduction, commit cc73385) across Linux and macOS
+  because git uses its own POSIX C `lstat`/`unlink`, not the platform's
+  `rm`. Gitignored symlinks also do not block removal (`git status
+  --porcelain` excludes ignored entries). Explicit pre-removal of the
+  symlink makes us independent of this behavior anyway — auditable,
+  handles `git worktree remove` bypasses, and isolates us from any
+  future git refactor.
+
+## Migration & Rollback
+
+- **Forward:** existing pre-fix worktrees do nothing until cleaned up;
+  next `worktree-manager.sh copy-env <name>` repairs them retroactively.
+- **Rollback:** revert the PR. Symlinks remain in any worktrees created
+  during the rollout window. They resolve correctly to the main DB
+  (still useful) and are removed naturally when `git worktree remove`
+  takes the worktree directory. No data migration needed.
+
+## References
+
+- Brainstorm: `docs/brainstorms/2026-05-05-ruvector-worktree-db-sharing-brainstorm.md`
+- `worktree-manager.sh:109-143, 200-218, 221-263, 92-106, 19-38, 58-61`
+- `plugin.json` `RUVECTOR_STORAGE_PATH`: `plugins/yellow-ruvector/.claude-plugin/plugin.json:28`
+- Hook DB-presence guard:
+  `plugins/yellow-ruvector/hooks/scripts/session-start.sh:22-30`
+- LLM cleanup command: `plugins/yellow-core/commands/worktree/cleanup.md`
+  (343, 353, 387, 492-508)
+- CLAUDE.md aspirational note: `plugins/yellow-ruvector/CLAUDE.md:134`
+- `.gitignore:93-95`
+- POSIX symlink rm semantics: `symlink(7)`,
+  https://linux.die.net/man/7/symlink
+- Trailing-slash rm footgun: nushell #12453,
+  https://github.com/nushell/nushell/issues/12453
+- bats convention precedent:
+  `plugins/yellow-ruvector/tests/validate.bats:1-12`,
+  `yellow-ruvector/tests/post-tool-use.bats:1-3` (shebang + min-version)
+- git source — symlink-safe directory removal:
+  https://github.com/git/git/blob/master/dir.c (`remove_dir_recurse`)
+- git source — `git worktree remove` cleanness check:
+  https://github.com/git/git/blob/master/builtin/worktree.c
+  (`check_clean_worktree`, `delete_git_work_tree`)
+- git commit cc73385 — `worktree remove` introduction (git 2.17.0,
+  Q1 2018), "ignored files are not precious":
+  https://github.com/git/git/commit/cc73385cf6c5c229458775bc92e7dbbe24d11611
+- git docs — `git rev-parse --git-common-dir`:
+  https://git-scm.com/docs/git-rev-parse
+- pre-commit precedent for git<2.5 fallback:
+  https://github.com/pre-commit/pre-commit/pull/2252
+- Pre-existing CI gap (orphaned bats suites): `yellow-ci/tests/`,
+  `yellow-debt/tests/`, `yellow-review/tests/` — no `package.json`
+  scripts entry, no CI job in `.github/workflows/validate-schemas.yml`

--- a/plugins/yellow-core/CLAUDE.md
+++ b/plugins/yellow-core/CLAUDE.md
@@ -82,7 +82,10 @@ Comprehensive dev toolkit for TypeScript, Python, Rust, and Go projects.
   prediction-for-uncertain-links hypothesis testing, three-failed-attempts
   smart escalation, and conditional defense-in-depth/post-mortem; routes to
   `gt submit` / `/yellow-core:workflows:brainstorm` / `/yellow-core:workflows:compound`
-- `git-worktree` — git worktree management for parallel development
+- `git-worktree` — git worktree management for parallel development;
+  injects a `.ruvector/` symlink into new worktrees so the ruvector MCP
+  server reaches the shared project DB instead of silently no-op'ing on
+  a missing directory
 - `ideation` — generate 3 grounded approaches to a soft problem using the
   Toulmin warrant contract (evidence + linking principle + idea), filtered
   through MIDAS three-phase generation, then route the chosen approach into

--- a/plugins/yellow-core/commands/worktree/cleanup.md
+++ b/plugins/yellow-core/commands/worktree/cleanup.md
@@ -283,22 +283,55 @@ non-empty `$BRANCH_NAME`, append it:
 "`.
 Skip empty branch names (Cat 3 — Detached HEAD has no branch).
 
-### `.ruvector` symlink: rely on git's lstat+unlink (no pre-removal)
+### `.ruvector` symlink: pre-remove with restore-on-failure (no-`--force` paths only)
 
 The yellow-core `worktree-manager.sh` injects `${worktree}/.ruvector ->
 ${main}/.ruvector` at worktree creation so the ruvector MCP server reaches
-the project's shared DB. **No explicit pre-removal of the symlink is
-needed.** `git worktree remove` walks the worktree via
-`dir.c::remove_dir_recurse`, which uses `lstat()` + `unlink()` per entry —
-symlinks are unlinked, never followed into the main `.ruvector/`. This
-behavior has been stable since git 2.17.
+the project's shared DB. **`git worktree remove` (no `--force`) refuses to
+remove a worktree containing untracked files**, and the standard
+`**/.ruvector/` gitignore pattern (trailing slash) only matches directories,
+not symlinks-to-directories. So for the no-`--force` paths (Cat 3 clean,
+Cat 4, Cat 5, Cat 7) the symlink MUST be pre-removed or the whole removal
+fails with `fatal: '<path>' contains modified or untracked files`.
 
-A pre-removal step would be actively harmful: if `git worktree remove`
-fails (dirty/locked worktree, no `--force`), pre-removing the symlink
-would leave the worktree intact but with its `.ruvector/` already gone,
-silently breaking ruvector inside an active worktree. Letting git own the
-removal means failure is atomic — either the whole tree (including the
-symlink) is gone, or nothing is.
+But pre-removing alone leaves a partially-broken worktree if the removal
+then fails for OTHER reasons (race condition: `git worktree status`
+classified clean but state changed). To stay safe, capture the symlink
+target before unlinking and restore it if `git worktree remove` exits
+non-zero. The full inlined block at each no-`--force` callsite:
+
+```bash
+SAVED_TARGET=
+if [ -L "$WT_PATH/.ruvector" ]; then
+    SAVED_TARGET=$(readlink "$WT_PATH/.ruvector" 2>/dev/null) || SAVED_TARGET=
+    rm -- "$WT_PATH/.ruvector" || true
+fi
+if ! git worktree remove "$WT_PATH" 2>&1; then
+    # Restore symlink if the worktree dir is still there.
+    if [ -n "$SAVED_TARGET" ] && [ -d "$WT_PATH" ] \
+        && [ ! -e "$WT_PATH/.ruvector" ] && [ ! -L "$WT_PATH/.ruvector" ]; then
+        ln -s "$SAVED_TARGET" "$WT_PATH/.ruvector" 2>/dev/null || true
+    fi
+    # log_failure here — see category-specific handling below
+fi
+```
+
+The block MUST be inlined at each callsite. Each Bash tool invocation in
+this command is a fresh subprocess; shell function definitions do not
+survive between blocks (see CLAUDE.md "Functions don't survive bash
+blocks (from PR #259)" — same root cause).
+
+For `--force` paths (Cat 3 dirty, Cat 6, Cat 3 dirty detached HEAD): no
+dance is needed. `git worktree remove --force` skips the untracked-files
+check and unlinks the symlink as part of its directory walk
+(`dir.c::remove_dir_recurse` uses `lstat`+`unlink` — never follows into
+the main `.ruvector/`). Stable since git 2.17.
+
+POSIX-safe across both paths: `rm` without `-r`/`-f` on a `[ -L ]`-confirmed
+entry can never traverse the link target. The canonical implementation
+lives in `worktree-manager.sh::cmd_cleanup` (using
+`unlink_ruvector_link`/`restore_ruvector_link` helpers). Keep the inlined
+logic in sync with those helpers.
 
 ### Category 1 — Locked (display only)
 
@@ -342,36 +375,49 @@ commit info with content fencing. Apply batch cap of 15.
 
 **"Remove all" with dirty entries**: When the user selects "Remove all" for
 Category 3, check each entry's dirty-state annotation. For entries annotated
-as dirty, use `git worktree remove --force "$WT_PATH"`. For clean entries,
-use `git worktree remove "$WT_PATH"`. The `.ruvector` symlink is unlinked
-by git as part of the directory walk — no separate step.
+as dirty, use `git worktree remove --force "$WT_PATH"` (no symlink dance).
+For clean entries, inline the pre-remove + restore-on-failure block from
+the section above before `git worktree remove "$WT_PATH"`.
 
 **Dirty detached HEAD handling**: Since detached HEAD worktrees are checked
 before Category 6 (Dirty), they may have uncommitted changes. For each
 detached HEAD worktree, check `git -C "$WT_PATH" status --porcelain`. If
 non-empty, annotate the prompt with "(dirty — N uncommitted files)" and use
-`git worktree remove --force "$WT_PATH"` instead of the no-flag version.
-Always warn the user about dirty state before confirming removal.
+`git worktree remove --force "$WT_PATH"` (no symlink dance — `--force`
+handles the symlink). Always warn the user about dirty state before
+confirming removal.
 
 ### Category 4 — Branch merged (auto-remove)
 
-For each worktree in this category, attempt removal:
+For each worktree in this category, inline the pre-remove + restore-on-
+failure block from the `.ruvector` section above and then attempt removal:
 
 ```bash
-git worktree remove "$WT_PATH" 2>&1
+SAVED_TARGET=
+if [ -L "$WT_PATH/.ruvector" ]; then
+    SAVED_TARGET=$(readlink "$WT_PATH/.ruvector" 2>/dev/null) || SAVED_TARGET=
+    rm -- "$WT_PATH/.ruvector" || true
+fi
+if ! git worktree remove "$WT_PATH" 2>&1; then
+    if [ -n "$SAVED_TARGET" ] && [ -d "$WT_PATH" ] \
+        && [ ! -e "$WT_PATH/.ruvector" ] && [ ! -L "$WT_PATH/.ruvector" ]; then
+        ln -s "$SAVED_TARGET" "$WT_PATH/.ruvector" 2>/dev/null || true
+    fi
+    # log failure for this category
+fi
 ```
 
 If removal fails (modifications detected despite our earlier check — race
-condition), log the worktree as failed with the error reason and continue to
-the next. Never abort the batch. The `.ruvector` symlink is unlinked by
-git's directory walk on success, and stays intact on failure (so the still-
-present worktree remains usable).
+condition), log the worktree as failed with the error reason and continue
+to the next. Never abort the batch. On failure, the symlink is restored
+above so the still-present worktree remains usable.
 
 ### Category 5 — Stale (auto-remove or prompt)
 
 If `GH_AVAILABLE` was true during classification (PR status verified): same
-auto-removal logic as Category 4 — for each entry run `git worktree remove
-"$WT_PATH"`, logging failures without aborting.
+auto-removal logic as Category 4 — for each entry inline the pre-remove +
+restore-on-failure block from the `.ruvector` section, then run
+`git worktree remove "$WT_PATH"`, logging failures without aborting.
 
 If `GH_AVAILABLE` was false during classification (worktrees were reclassified
 as Cat 7 per the table): these worktrees appear under Category 7 instead and
@@ -407,9 +453,12 @@ If the user confirms force removal:
 git worktree remove --force "$WT_PATH" 2>&1
 ```
 
-Single `--force` is sufficient for dirty worktrees. Note: single `--force`
-does NOT override locks — locked worktrees require `--force --force` (`-ff`),
-but Category 1 (locked) is already excluded from removal.
+`--force` skips the untracked-files check, so no `.ruvector` symlink dance
+is needed — git's `dir.c::remove_dir_recurse` unlinks the symlink as part
+of the directory walk (lstat+unlink, never followed). Single `--force` is
+sufficient for dirty worktrees. Note: single `--force` does NOT override
+locks — locked worktrees require `--force --force` (`-ff`), but Category 1
+(locked) is already excluded from removal.
 
 ### Category 7 — Clean, active branch (prompt)
 
@@ -427,11 +476,14 @@ Options:
 3. Skip
 ```
 
-If "Remove all" is chosen, for each worktree run `git worktree remove
-"$WT_PATH"`. If "Review individually" is chosen, apply a batch cap of 15.
-If the category has more than 15 worktrees, use AskUserQuestion: "This
-category has N worktrees. How do you want to proceed?" with options
-"Process all N" / "First 15 only" / "Cancel".
+If "Remove all" is chosen, for each worktree inline the pre-remove +
+restore-on-failure block from the `.ruvector` section above and run
+`git worktree remove "$WT_PATH"`. If "Review individually" is chosen,
+apply a batch cap of 15. If the category has more than 15 worktrees, use
+AskUserQuestion: "This category has N worktrees. How do you want to
+proceed?" with options "Process all N" / "First 15 only" / "Cancel". For
+each individual removal, inline the same pre-remove + restore-on-failure
+block in the same bash block as `git worktree remove`.
 
 For each individual review:
 
@@ -524,9 +576,9 @@ Details:
 - Content fencing on all git output displayed in prompts
 - Batch cap of 15 for individual review
 - `git worktree prune` runs as final cleanup step
-- `.ruvector` symlink unlinked by git's `lstat`+`unlink` directory walk on
-  successful `git worktree remove` (Cat 3, 4, 5, 6, 7) — never followed
-  into the main repo's `.ruvector/`. Failed removes leave both the worktree
-  and its symlink intact
+- `.ruvector` symlink: pre-remove + restore-on-failure block inlined at
+  every no-`--force` callsite (Cat 3 clean, Cat 4, Cat 5, Cat 7); on
+  `--force` callsites (Cat 3 dirty, Cat 6) git's lstat+unlink walk
+  handles the symlink — never followed into the main repo's `.ruvector/`
 - Prerequisite validation runs before any interactive prompts
 - Orphaned branch hint displayed when applicable

--- a/plugins/yellow-core/commands/worktree/cleanup.md
+++ b/plugins/yellow-core/commands/worktree/cleanup.md
@@ -283,29 +283,22 @@ non-empty `$BRANCH_NAME`, append it:
 "`.
 Skip empty branch names (Cat 3 — Detached HEAD has no branch).
 
-### `.ruvector` symlink pre-removal (inline before every `git worktree remove`)
+### `.ruvector` symlink: rely on git's lstat+unlink (no pre-removal)
 
 The yellow-core `worktree-manager.sh` injects `${worktree}/.ruvector ->
 ${main}/.ruvector` at worktree creation so the ruvector MCP server reaches
-the project's shared DB. Before every `git worktree remove` invocation below
-(Cat 3, 4, 5, 6, 7 — NOT the `git worktree prune` in Cat 2, which operates
-on admin metadata only), inline the symlink-removal step:
+the project's shared DB. **No explicit pre-removal of the symlink is
+needed.** `git worktree remove` walks the worktree via
+`dir.c::remove_dir_recurse`, which uses `lstat()` + `unlink()` per entry —
+symlinks are unlinked, never followed into the main `.ruvector/`. This
+behavior has been stable since git 2.17.
 
-```bash
-[ -L "$WT_PATH/.ruvector" ] && rm -- "$WT_PATH/.ruvector"
-```
-
-The check + removal MUST be inlined at each call site. Each Bash tool
-invocation in this command is a fresh subprocess; shell function
-definitions do not survive between blocks (see CLAUDE.md
-"Functions don't survive bash blocks (from PR #259)" — same root cause).
-Defining a `remove_ruvector_link` helper in one block and calling it from
-another silently no-ops, defeating the safety contract.
-
-POSIX-safe: `rm` without `-r` or `-f` on a `[ -L ]`-confirmed entry
-removes the link, never traverses into the main repo's `.ruvector/`. The
-canonical implementation lives in `worktree-manager.sh::cleanup_ruvector_link`
-— keep the inlined logic in sync with that helper.
+A pre-removal step would be actively harmful: if `git worktree remove`
+fails (dirty/locked worktree, no `--force`), pre-removing the symlink
+would leave the worktree intact but with its `.ruvector/` already gone,
+silently breaking ruvector inside an active worktree. Letting git own the
+removal means failure is atomic — either the whole tree (including the
+symlink) is gone, or nothing is.
 
 ### Category 1 — Locked (display only)
 
@@ -348,39 +341,37 @@ Same three-tier pattern as Category 7 below. For individual review, show the
 commit info with content fencing. Apply batch cap of 15.
 
 **"Remove all" with dirty entries**: When the user selects "Remove all" for
-Category 3, check each entry's dirty-state annotation. For each entry, run
-`[ -L "$WT_PATH/.ruvector" ] && rm -- "$WT_PATH/.ruvector"` first. For
-entries annotated as dirty, use `git worktree remove --force "$WT_PATH"`.
-For clean entries, use `git worktree remove "$WT_PATH"`.
+Category 3, check each entry's dirty-state annotation. For entries annotated
+as dirty, use `git worktree remove --force "$WT_PATH"`. For clean entries,
+use `git worktree remove "$WT_PATH"`. The `.ruvector` symlink is unlinked
+by git as part of the directory walk — no separate step.
 
 **Dirty detached HEAD handling**: Since detached HEAD worktrees are checked
 before Category 6 (Dirty), they may have uncommitted changes. For each
 detached HEAD worktree, check `git -C "$WT_PATH" status --porcelain`. If
 non-empty, annotate the prompt with "(dirty — N uncommitted files)" and use
 `git worktree remove --force "$WT_PATH"` instead of the no-flag version.
-Always warn the user about dirty state before confirming removal. Always run
-`[ -L "$WT_PATH/.ruvector" ] && rm -- "$WT_PATH/.ruvector"` in the same
-bash block immediately before the removal command.
+Always warn the user about dirty state before confirming removal.
 
 ### Category 4 — Branch merged (auto-remove)
 
 For each worktree in this category, attempt removal:
 
 ```bash
-[ -L "$WT_PATH/.ruvector" ] && rm -- "$WT_PATH/.ruvector"
 git worktree remove "$WT_PATH" 2>&1
 ```
 
 If removal fails (modifications detected despite our earlier check — race
 condition), log the worktree as failed with the error reason and continue to
-the next. Never abort the batch.
+the next. Never abort the batch. The `.ruvector` symlink is unlinked by
+git's directory walk on success, and stays intact on failure (so the still-
+present worktree remains usable).
 
 ### Category 5 — Stale (auto-remove or prompt)
 
 If `GH_AVAILABLE` was true during classification (PR status verified): same
-auto-removal logic as Category 4 — for each entry, in one bash block run
-`[ -L "$WT_PATH/.ruvector" ] && rm -- "$WT_PATH/.ruvector"` followed by
-`git worktree remove "$WT_PATH"`, logging failures without aborting.
+auto-removal logic as Category 4 — for each entry run `git worktree remove
+"$WT_PATH"`, logging failures without aborting.
 
 If `GH_AVAILABLE` was false during classification (worktrees were reclassified
 as Cat 7 per the table): these worktrees appear under Category 7 instead and
@@ -413,7 +404,6 @@ Options:
 If the user confirms force removal:
 
 ```bash
-[ -L "$WT_PATH/.ruvector" ] && rm -- "$WT_PATH/.ruvector"
 git worktree remove --force "$WT_PATH" 2>&1
 ```
 
@@ -437,15 +427,11 @@ Options:
 3. Skip
 ```
 
-If "Remove all" is chosen, for each worktree run
-`[ -L "$WT_PATH/.ruvector" ] && rm -- "$WT_PATH/.ruvector"` then
-`git worktree remove "$WT_PATH"` in the same bash block. If "Review
-individually" is chosen, apply a batch cap of 15. If the category has
-more than 15 worktrees, use AskUserQuestion: "This category has N
-worktrees. How do you want to proceed?" with options "Process all N" /
-"First 15 only" / "Cancel". For each individual removal, inline the
-symlink check `[ -L "$WT_PATH/.ruvector" ] && rm -- "$WT_PATH/.ruvector"`
-in the same bash block as the removal command.
+If "Remove all" is chosen, for each worktree run `git worktree remove
+"$WT_PATH"`. If "Review individually" is chosen, apply a batch cap of 15.
+If the category has more than 15 worktrees, use AskUserQuestion: "This
+category has N worktrees. How do you want to proceed?" with options
+"Process all N" / "First 15 only" / "Cancel".
 
 For each individual review:
 
@@ -538,9 +524,9 @@ Details:
 - Content fencing on all git output displayed in prompts
 - Batch cap of 15 for individual review
 - `git worktree prune` runs as final cleanup step
-- `.ruvector` symlink removed via inline
-  `[ -L "$WT_PATH/.ruvector" ] && rm -- "$WT_PATH/.ruvector"` immediately
-  before every `git worktree remove` call (Cat 3, 4, 5, 6, 7), in the same
-  bash block — never followed into the main repo's `.ruvector/`
+- `.ruvector` symlink unlinked by git's `lstat`+`unlink` directory walk on
+  successful `git worktree remove` (Cat 3, 4, 5, 6, 7) — never followed
+  into the main repo's `.ruvector/`. Failed removes leave both the worktree
+  and its symlink intact
 - Prerequisite validation runs before any interactive prompts
 - Orphaned branch hint displayed when applicable

--- a/plugins/yellow-core/commands/worktree/cleanup.md
+++ b/plugins/yellow-core/commands/worktree/cleanup.md
@@ -283,6 +283,30 @@ non-empty `$BRANCH_NAME`, append it:
 "`.
 Skip empty branch names (Cat 3 — Detached HEAD has no branch).
 
+### `.ruvector` symlink pre-removal (inline before every `git worktree remove`)
+
+The yellow-core `worktree-manager.sh` injects `${worktree}/.ruvector ->
+${main}/.ruvector` at worktree creation so the ruvector MCP server reaches
+the project's shared DB. Before every `git worktree remove` invocation below
+(Cat 3, 4, 5, 6, 7 — NOT the `git worktree prune` in Cat 2, which operates
+on admin metadata only), inline the symlink-removal step:
+
+```bash
+[ -L "$WT_PATH/.ruvector" ] && rm -- "$WT_PATH/.ruvector"
+```
+
+The check + removal MUST be inlined at each call site. Each Bash tool
+invocation in this command is a fresh subprocess; shell function
+definitions do not survive between blocks (see CLAUDE.md
+"Functions don't survive bash blocks (from PR #259)" — same root cause).
+Defining a `remove_ruvector_link` helper in one block and calling it from
+another silently no-ops, defeating the safety contract.
+
+POSIX-safe: `rm` without `-r` or `-f` on a `[ -L ]`-confirmed entry
+removes the link, never traverses into the main repo's `.ruvector/`. The
+canonical implementation lives in `worktree-manager.sh::cleanup_ruvector_link`
+— keep the inlined logic in sync with that helper.
+
 ### Category 1 — Locked (display only)
 
 ```text
@@ -324,22 +348,26 @@ Same three-tier pattern as Category 7 below. For individual review, show the
 commit info with content fencing. Apply batch cap of 15.
 
 **"Remove all" with dirty entries**: When the user selects "Remove all" for
-Category 3, check each entry's dirty-state annotation. For entries annotated as
-dirty, use `git worktree remove --force "$WT_PATH"`. For clean entries, use
-`git worktree remove "$WT_PATH"`.
+Category 3, check each entry's dirty-state annotation. For each entry, run
+`[ -L "$WT_PATH/.ruvector" ] && rm -- "$WT_PATH/.ruvector"` first. For
+entries annotated as dirty, use `git worktree remove --force "$WT_PATH"`.
+For clean entries, use `git worktree remove "$WT_PATH"`.
 
 **Dirty detached HEAD handling**: Since detached HEAD worktrees are checked
 before Category 6 (Dirty), they may have uncommitted changes. For each
 detached HEAD worktree, check `git -C "$WT_PATH" status --porcelain`. If
 non-empty, annotate the prompt with "(dirty — N uncommitted files)" and use
 `git worktree remove --force "$WT_PATH"` instead of the no-flag version.
-Always warn the user about dirty state before confirming removal.
+Always warn the user about dirty state before confirming removal. Always run
+`[ -L "$WT_PATH/.ruvector" ] && rm -- "$WT_PATH/.ruvector"` in the same
+bash block immediately before the removal command.
 
 ### Category 4 — Branch merged (auto-remove)
 
 For each worktree in this category, attempt removal:
 
 ```bash
+[ -L "$WT_PATH/.ruvector" ] && rm -- "$WT_PATH/.ruvector"
 git worktree remove "$WT_PATH" 2>&1
 ```
 
@@ -350,8 +378,9 @@ the next. Never abort the batch.
 ### Category 5 — Stale (auto-remove or prompt)
 
 If `GH_AVAILABLE` was true during classification (PR status verified): same
-auto-removal logic as Category 4 — attempt `git worktree remove "$WT_PATH"`
-for each entry, logging failures without aborting.
+auto-removal logic as Category 4 — for each entry, in one bash block run
+`[ -L "$WT_PATH/.ruvector" ] && rm -- "$WT_PATH/.ruvector"` followed by
+`git worktree remove "$WT_PATH"`, logging failures without aborting.
 
 If `GH_AVAILABLE` was false during classification (worktrees were reclassified
 as Cat 7 per the table): these worktrees appear under Category 7 instead and
@@ -384,6 +413,7 @@ Options:
 If the user confirms force removal:
 
 ```bash
+[ -L "$WT_PATH/.ruvector" ] && rm -- "$WT_PATH/.ruvector"
 git worktree remove --force "$WT_PATH" 2>&1
 ```
 
@@ -407,10 +437,15 @@ Options:
 3. Skip
 ```
 
-If "Remove all" is chosen, remove each worktree. If "Review individually" is
-chosen, apply a batch cap of 15. If the category has more than 15 worktrees,
-use AskUserQuestion: "This category has N worktrees. How do you want to
-proceed?" with options "Process all N" / "First 15 only" / "Cancel".
+If "Remove all" is chosen, for each worktree run
+`[ -L "$WT_PATH/.ruvector" ] && rm -- "$WT_PATH/.ruvector"` then
+`git worktree remove "$WT_PATH"` in the same bash block. If "Review
+individually" is chosen, apply a batch cap of 15. If the category has
+more than 15 worktrees, use AskUserQuestion: "This category has N
+worktrees. How do you want to proceed?" with options "Process all N" /
+"First 15 only" / "Cancel". For each individual removal, inline the
+symlink check `[ -L "$WT_PATH/.ruvector" ] && rm -- "$WT_PATH/.ruvector"`
+in the same bash block as the removal command.
 
 For each individual review:
 
@@ -503,5 +538,9 @@ Details:
 - Content fencing on all git output displayed in prompts
 - Batch cap of 15 for individual review
 - `git worktree prune` runs as final cleanup step
+- `.ruvector` symlink removed via inline
+  `[ -L "$WT_PATH/.ruvector" ] && rm -- "$WT_PATH/.ruvector"` immediately
+  before every `git worktree remove` call (Cat 3, 4, 5, 6, 7), in the same
+  bash block — never followed into the main repo's `.ruvector/`
 - Prerequisite validation runs before any interactive prompts
 - Orphaned branch hint displayed when applicable

--- a/plugins/yellow-core/package.json
+++ b/plugins/yellow-core/package.json
@@ -2,5 +2,8 @@
   "name": "yellow-core",
   "version": "1.11.0",
   "private": true,
-  "description": "Dev toolkit with review agents, research agents, and workflow commands for TypeScript, Python, Rust, and Go"
+  "description": "Dev toolkit with review agents, research agents, and workflow commands for TypeScript, Python, Rust, and Go",
+  "scripts": {
+    "test": "bats skills/git-worktree/tests/"
+  }
 }

--- a/plugins/yellow-core/skills/git-worktree/SKILL.md
+++ b/plugins/yellow-core/skills/git-worktree/SKILL.md
@@ -56,6 +56,8 @@ worktree-manager.sh create <branch-name> [from-branch]
 - Branches from `main` by default (or specify `from-branch`)
 - Copies all `.env*` files from main repo
 - Adds `.worktrees/` to `.gitignore` if missing
+- Symlinks the main repo's `.ruvector/` into the worktree if it exists
+  (see [ruvector DB Sharing](#ruvector-db-sharing) below)
 - Fails safely if worktree already exists
 
 **Examples:**
@@ -114,7 +116,46 @@ worktree-manager.sh copy-env <name>
 ```
 
 Copies all `.env*` files from main repo to specified worktree. Useful if you've
-updated environment configuration and need to sync.
+updated environment configuration and need to sync. Also repairs a missing
+`.ruvector/` symlink for worktrees created before that feature existed (see
+below).
+
+### ruvector DB Sharing
+
+When a Claude Code session runs inside a worktree, the ruvector MCP server
+resolves `${PWD}/.ruvector/` against the worktree path. Because `.ruvector/`
+is gitignored (`**/.ruvector/`), it is not present in a fresh worktree, so
+the MCP server and hook scripts would silently no-op (no recall, no
+session-start context, no post-edit indexing).
+
+`worktree-manager.sh create` injects an absolute symlink
+`${worktree}/.ruvector -> ${main_repo}/.ruvector` after the `.env` copy step,
+so MCP and hooks reach the project's shared DB. `worktree-manager.sh copy-env`
+applies the same fix retroactively.
+
+**Behavior:**
+
+- Skipped silently (with `info`) if the symlink already exists — idempotent.
+- Skipped (with `warning`) if a real `.ruvector/` directory already exists in
+  the worktree — preserves the user's intentional isolated DB if they bypassed
+  the manager script.
+- Skipped (with `warning`) if the main repo has no `.ruvector/` yet — no
+  dangling symlinks.
+- Removed safely on `cleanup`: `[ -L ]` check, then `rm --` (no `-r`, no `-f`,
+  no trailing slash). Cannot follow into the main repo's DB.
+
+**MCP-spawn-time qualifier:** `RUVECTOR_STORAGE_PATH` is evaluated when
+Claude Code spawns the MCP server process for a session. The symlink only
+helps when Claude Code is launched (or re-launched) **from inside the
+worktree directory**. A pre-existing session started in main that later
+`cd`s into a worktree continues to write to the main repo's DB directly.
+
+**Concurrent-write caveat:** When two Claude Code sessions run simultaneously
+(one in main, one in a worktree, or two worktrees), both MCP server processes
+write to the same shared DB without cross-process locking. Avoid running
+simultaneous sessions with active `hooks_remember` / `/ruvector:index`
+operations on the same project. See `plugins/yellow-ruvector/CLAUDE.md`
+Known Limitations.
 
 ### cleanup / clean
 

--- a/plugins/yellow-core/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/yellow-core/skills/git-worktree/scripts/worktree-manager.sh
@@ -211,6 +211,39 @@ link_ruvector_db() {
     info "Linked .ruvector -> ${_lrd_target}"
 }
 
+# Pre-remove the worktree's .ruvector symlink before `git worktree remove`.
+# Required: git refuses to remove a worktree containing untracked files,
+# and the standard `**/.ruvector/` gitignore pattern (trailing slash) only
+# matches directories, not symlinks-to-directories. Without this pre-removal,
+# `git worktree remove` fails with "contains modified or untracked files".
+#
+# Echoes the link target on stdout (empty if no symlink) so callers can
+# restore the link via `ln -s` if `git worktree remove` then fails for
+# OTHER reasons (dirty/locked, no --force) — keeping the still-present
+# worktree functional. This is what Codex's PR #366 P1 asked for: the
+# unlink is no longer terminal on failure.
+unlink_ruvector_link() {
+    _crl_link="$1/.ruvector"
+    if [ -L "$_crl_link" ]; then
+        _crl_target=$(readlink "$_crl_link" 2>/dev/null) || _crl_target=
+        rm -- "$_crl_link" || warning "Failed to remove .ruvector symlink at ${_crl_link}"
+        printf '%s' "$_crl_target"
+    fi
+}
+
+# Restore a previously-unlinked .ruvector symlink. Best-effort: skips if
+# target is empty, worktree dir is gone (full removal succeeded), or a
+# replacement symlink/file is already present.
+restore_ruvector_link() {
+    _rrl_path="$1"
+    _rrl_target="$2"
+    [ -n "$_rrl_target" ] || return 0
+    [ -d "$_rrl_path" ] || return 0
+    [ ! -e "$_rrl_path/.ruvector" ] && [ ! -L "$_rrl_path/.ruvector" ] || return 0
+    ln -s "$_rrl_target" "$_rrl_path/.ruvector" \
+        || warning "Could not restore .ruvector symlink at ${_rrl_path}/.ruvector"
+}
+
 # Create worktree
 cmd_create() {
     branch_name="$1"
@@ -365,12 +398,18 @@ cmd_cleanup() {
             continue
         fi
 
-        # Remove worktree. git's internal remove_dir_recurse uses lstat+unlink
-        # so the .ruvector symlink is unlinked (never followed) as part of the
-        # directory walk. On failure (dirty/locked worktree, no --force), the
-        # whole tree is left intact so the worktree remains functional.
+        # Pre-remove the .ruvector symlink (git refuses worktrees with
+        # untracked files; the symlink isn't covered by `.ruvector/`
+        # trailing-slash patterns). Capture the target so we can restore
+        # the link if `git worktree remove` then fails for other reasons —
+        # leaves the worktree functional rather than partially-broken.
+        saved_ruvector_target=$(unlink_ruvector_link "$path")
+
         info "Removing: ${path}"
-        git worktree remove "$path" || warning "Failed to remove: ${path}"
+        if ! git worktree remove "$path"; then
+            warning "Failed to remove: ${path}"
+            restore_ruvector_link "$path" "$saved_ruvector_target"
+        fi
     done
 
     # Remove .worktrees directory if empty

--- a/plugins/yellow-core/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/yellow-core/skills/git-worktree/scripts/worktree-manager.sh
@@ -72,8 +72,12 @@ get_repo_root() {
 #   - linked worktree (any)    : "/abs/.git"     (absolute)
 #   - git < 2.5                : "--git-common-dir" (echoed back unchanged)
 get_main_repo_root() {
-    common=$(git rev-parse --git-common-dir 2>/dev/null) \
-        || error "git rev-parse --git-common-dir failed (not in a git repository?)"
+    # Capture stdout+stderr together: on success $common is the common dir;
+    # on failure it carries git's diagnostic, which we surface in the error
+    # message so corrupt-repo / permission failures aren't silent "not a repo".
+    if ! common=$(git rev-parse --git-common-dir 2>&1); then
+        error "git rev-parse --git-common-dir failed: ${common:-unknown}"
+    fi
 
     case "$common" in
         --*)
@@ -196,23 +200,15 @@ link_ruvector_db() {
     # by git worktree add. Aborting here leaves an orphan worktree the user
     # may not notice. Degraded state (worktree without symlink) is recoverable
     # via `worktree-manager.sh copy-env <name>` — surface that path explicitly.
-    if ! ln -s -- "$_lrd_target" "$_lrd_link"; then
+    #
+    # No `--` separator: POSIX `ln` does not specify it and BSD/macOS `ln`
+    # rejects it. Both paths originate from git/validate_name and cannot
+    # begin with `-`, so the separator is unnecessary.
+    if ! ln -s "$_lrd_target" "$_lrd_link"; then
         warning "Failed to create .ruvector symlink at ${_lrd_link}; worktree usable without ruvector. Retry: worktree-manager.sh copy-env <name>"
         return 0
     fi
     info "Linked .ruvector -> ${_lrd_target}"
-}
-
-# Remove a worktree's .ruvector symlink before git-worktree-remove. Uses
-# `rm --` (no -r, no -f, no trailing slash) on a confirmed [ -L ] entry — the
-# only POSIX-safe way to delete a symlink without risking traversal into the
-# target. Failure does NOT abort the cleanup loop.
-cleanup_ruvector_link() {
-    _crl_link="$1/.ruvector"
-
-    if [ -L "$_crl_link" ]; then
-        rm -- "$_crl_link" || warning "Failed to remove .ruvector symlink at ${_crl_link}"
-    fi
 }
 
 # Create worktree
@@ -369,12 +365,10 @@ cmd_cleanup() {
             continue
         fi
 
-        # Remove .ruvector symlink first — defensive; git's remove_dir_recurse
-        # uses lstat+unlink so it would not follow the symlink, but explicit
-        # pre-removal keeps cleanup auditable and bypass-safe.
-        cleanup_ruvector_link "$path"
-
-        # Remove worktree
+        # Remove worktree. git's internal remove_dir_recurse uses lstat+unlink
+        # so the .ruvector symlink is unlinked (never followed) as part of the
+        # directory walk. On failure (dirty/locked worktree, no --force), the
+        # whole tree is left intact so the worktree remains functional.
         info "Removing: ${path}"
         git worktree remove "$path" || warning "Failed to remove: ${path}"
     done

--- a/plugins/yellow-core/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/yellow-core/skills/git-worktree/scripts/worktree-manager.sh
@@ -55,54 +55,164 @@ info() {
     printf '%s%s%s\n' "$BLUE" "$1" "$NC"
 }
 
-# Get repository root
+# Get repository root (worktree-relative — returns the worktree root when run
+# inside a worktree, not the main repo root). Use get_main_repo_root for the
+# main repo path.
 get_repo_root() {
     git rev-parse --show-toplevel 2>/dev/null || error "Not in a git repository"
 }
 
-# Ensure .worktrees directory exists
-ensure_worktree_dir() {
-    repo_root="$1"
-    worktree_path="${repo_root}/${WORKTREE_DIR}"
+# Get the MAIN repo root (not a worktree root, not the .git dir). Required for
+# operations that must point at the main repo from any worktree (e.g. the
+# .ruvector symlink target). Requires git >= 2.5 (--git-common-dir).
+#
+# git rev-parse --git-common-dir is asymmetric:
+#   - main repo root           : ".git"          (literal, relative)
+#   - main repo subdirectory   : "../../.git"    (relative)
+#   - linked worktree (any)    : "/abs/.git"     (absolute)
+#   - git < 2.5                : "--git-common-dir" (echoed back unchanged)
+get_main_repo_root() {
+    common=$(git rev-parse --git-common-dir 2>/dev/null) \
+        || error "git rev-parse --git-common-dir failed (not in a git repository?)"
 
-    if [ ! -d "$worktree_path" ]; then
-        mkdir -p "$worktree_path"
+    case "$common" in
+        --*)
+            error "git >= 2.5 required for --git-common-dir; got: ${common}"
+            ;;
+        .git)
+            printf '%s' "$PWD"
+            ;;
+        */.git)
+            # Absolute (worktree) or relative-with-slash (subdir) — strip /.git.
+            # Resolve via cd to handle the relative case uniformly.
+            stripped="${common%/.git}"
+            case "$stripped" in
+                /*) printf '%s' "$stripped" ;;
+                *)
+                    resolved=$(cd "$stripped" 2>/dev/null && pwd) \
+                        || error "could not resolve git common dir: ${common}"
+                    printf '%s' "$resolved"
+                    ;;
+            esac
+            ;;
+        *)
+            # Bare repo or unusual setup; resolve as-is via cd
+            resolved=$(cd "$common" 2>/dev/null && pwd) \
+                || error "could not resolve git common dir: ${common}"
+            printf '%s' "$resolved"
+            ;;
+    esac
+}
+
+# Ensure .worktrees directory exists.
+# POSIX sh has no `local`; use unique variable names to avoid clobbering
+# globals in callers (e.g. cmd_create's `worktree_path`).
+ensure_worktree_dir() {
+    _ewd_root="$1"
+    _ewd_dir="${_ewd_root}/${WORKTREE_DIR}"
+
+    if [ ! -d "$_ewd_dir" ]; then
+        mkdir -p "$_ewd_dir"
         info "Created ${WORKTREE_DIR}/ directory"
     fi
 }
 
-# Ensure .worktrees is in .gitignore
+# Ensure .worktrees is in .gitignore.
+# Same naming discipline as ensure_worktree_dir.
 ensure_gitignore() {
-    repo_root="$1"
-    gitignore="${repo_root}/.gitignore"
+    _eg_root="$1"
+    _eg_file="${_eg_root}/.gitignore"
 
-    if [ ! -f "$gitignore" ]; then
-        echo "${WORKTREE_DIR}/" > "$gitignore"
+    if [ ! -f "$_eg_file" ]; then
+        echo "${WORKTREE_DIR}/" > "$_eg_file"
         success "Created .gitignore with ${WORKTREE_DIR}/"
         return
     fi
 
-    if ! grep -qF "${WORKTREE_DIR}/" "$gitignore"; then
-        echo "${WORKTREE_DIR}/" >> "$gitignore"
+    if ! grep -qF "${WORKTREE_DIR}/" "$_eg_file"; then
+        echo "${WORKTREE_DIR}/" >> "$_eg_file"
         success "Added ${WORKTREE_DIR}/ to .gitignore"
     fi
 }
 
-# Copy .env files from main repo to worktree (skip symlinks)
+# Copy .env files from main repo to worktree (skip symlinks).
+# Same naming discipline as ensure_worktree_dir / link_ruvector_db: namespaced
+# prefixes so no caller's globals get clobbered (POSIX sh has no `local`).
 copy_env_files() {
-    repo_root="$1"
-    target_path="$2"
+    _cef_root="$1"
+    _cef_target="$2"
 
     # Find all .env* files in repo root, skip symlinks to prevent leaking external files
-    for env_file in "${repo_root}"/.env*; do
-        if [ -f "$env_file" ] && [ ! -L "$env_file" ]; then
-            filename=$(basename "$env_file")
-            cp -- "$env_file" "${target_path}/${filename}"
-            info "Copied ${filename}"
-        elif [ -L "$env_file" ]; then
-            warning "Skipping symlink: $(basename "$env_file")"
+    for _cef_file in "${_cef_root}"/.env*; do
+        if [ -f "$_cef_file" ] && [ ! -L "$_cef_file" ]; then
+            _cef_name=$(basename "$_cef_file")
+            cp -- "$_cef_file" "${_cef_target}/${_cef_name}"
+            info "Copied ${_cef_name}"
+        elif [ -L "$_cef_file" ]; then
+            warning "Skipping symlink: $(basename "$_cef_file")"
         fi
     done
+}
+
+# Link the main repo's .ruvector/ into a worktree so the ruvector MCP server
+# (RUVECTOR_STORAGE_PATH=${PWD}/.ruvector/) reaches the project DB instead of a
+# missing directory. Idempotent.
+#
+# Skips with info if a symlink already exists.
+# Skips with warning if a real .ruvector/ directory exists (preserves user's
+# intentional isolated DB if they bypassed worktree-manager.sh).
+# Skips with warning if main has no .ruvector/ yet (no dangling links).
+link_ruvector_db() {
+    _lrd_main="$1"
+    _lrd_wt="$2"
+    _lrd_link="${_lrd_wt}/.ruvector"
+    _lrd_target="${_lrd_main}/.ruvector"
+
+    if [ -L "$_lrd_link" ]; then
+        # [ -L ] is true for both live and dangling symlinks. [ -e ] follows
+        # the link; false → dangling. Repair by removing the stale link and
+        # falling through to recreate (so copy-env actually fixes things).
+        if [ ! -e "$_lrd_link" ]; then
+            warning "Removing dangling .ruvector symlink at ${_lrd_link} (target no longer exists)"
+            rm -- "$_lrd_link" || {
+                warning "Could not remove dangling symlink at ${_lrd_link}; leaving as-is"
+                return 0
+            }
+        else
+            info "ruvector DB symlink already present in worktree"
+            return 0
+        fi
+    fi
+    if [ -e "$_lrd_link" ] && [ ! -L "$_lrd_link" ]; then
+        warning "Worktree has a real .ruvector/ directory; skipping symlink (this worktree uses an isolated DB)"
+        return 0
+    fi
+    if [ ! -d "$_lrd_target" ]; then
+        warning "Main .ruvector/ not found at ${_lrd_target}; skipping symlink (initialize ruvector first, then run copy-env)"
+        return 0
+    fi
+
+    # Use warning (not error) on ln failure: the worktree was already created
+    # by git worktree add. Aborting here leaves an orphan worktree the user
+    # may not notice. Degraded state (worktree without symlink) is recoverable
+    # via `worktree-manager.sh copy-env <name>` — surface that path explicitly.
+    if ! ln -s -- "$_lrd_target" "$_lrd_link"; then
+        warning "Failed to create .ruvector symlink at ${_lrd_link}; worktree usable without ruvector. Retry: worktree-manager.sh copy-env <name>"
+        return 0
+    fi
+    info "Linked .ruvector -> ${_lrd_target}"
+}
+
+# Remove a worktree's .ruvector symlink before git-worktree-remove. Uses
+# `rm --` (no -r, no -f, no trailing slash) on a confirmed [ -L ] entry — the
+# only POSIX-safe way to delete a symlink without risking traversal into the
+# target. Failure does NOT abort the cleanup loop.
+cleanup_ruvector_link() {
+    _crl_link="$1/.ruvector"
+
+    if [ -L "$_crl_link" ]; then
+        rm -- "$_crl_link" || warning "Failed to remove .ruvector symlink at ${_crl_link}"
+    fi
 }
 
 # Create worktree
@@ -137,6 +247,10 @@ cmd_create() {
 
     # Copy .env files
     copy_env_files "$repo_root" "$worktree_path"
+
+    # Link main repo's .ruvector/ so MCP server and hooks reach the shared DB
+    main_root=$(get_main_repo_root)
+    link_ruvector_db "$main_root" "$worktree_path"
 
     success "Created worktree: ${WORKTREE_DIR}/${branch_name}"
     info "Switch to it: cd ${worktree_path}"
@@ -214,6 +328,11 @@ cmd_copy_env() {
     fi
 
     copy_env_files "$repo_root" "$worktree_path"
+
+    # Repair missing ruvector symlink for retroactive worktree fixups
+    main_root=$(get_main_repo_root)
+    link_ruvector_db "$main_root" "$worktree_path"
+
     success "Copied .env files to ${name}"
 }
 
@@ -245,6 +364,11 @@ cmd_cleanup() {
         if [ "$path" = "$repo_root" ]; then
             continue
         fi
+
+        # Remove .ruvector symlink first — defensive; git's remove_dir_recurse
+        # uses lstat+unlink so it would not follow the symlink, but explicit
+        # pre-removal keeps cleanup auditable and bypass-safe.
+        cleanup_ruvector_link "$path"
 
         # Remove worktree
         info "Removing: ${path}"

--- a/plugins/yellow-core/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/yellow-core/skills/git-worktree/scripts/worktree-manager.sh
@@ -248,8 +248,11 @@ cmd_create() {
     # Copy .env files
     copy_env_files "$repo_root" "$worktree_path"
 
-    # Link main repo's .ruvector/ so MCP server and hooks reach the shared DB
-    main_root=$(get_main_repo_root)
+    # Link main repo's .ruvector/ so MCP server and hooks reach the shared DB.
+    # `|| exit 1` is required: dash's `set -e` does not propagate failures from
+    # command substitutions inside assignments, so without this an empty
+    # main_root would silently link to /.ruvector.
+    main_root=$(get_main_repo_root) || exit 1
     link_ruvector_db "$main_root" "$worktree_path"
 
     success "Created worktree: ${WORKTREE_DIR}/${branch_name}"
@@ -329,8 +332,9 @@ cmd_copy_env() {
 
     copy_env_files "$repo_root" "$worktree_path"
 
-    # Repair missing ruvector symlink for retroactive worktree fixups
-    main_root=$(get_main_repo_root)
+    # Repair missing ruvector symlink for retroactive worktree fixups.
+    # See cmd_create for why `|| exit 1` is required (dash command-sub gotcha).
+    main_root=$(get_main_repo_root) || exit 1
     link_ruvector_db "$main_root" "$worktree_path"
 
     success "Copied .env files to ${name}"

--- a/plugins/yellow-core/skills/git-worktree/tests/worktree-manager.bats
+++ b/plugins/yellow-core/skills/git-worktree/tests/worktree-manager.bats
@@ -11,7 +11,11 @@ setup() {
 
     REPO="$(mktemp -d)"
     cd "$REPO"
-    git init --quiet --initial-branch=main
+    # `git init -b/--initial-branch` is git>=2.28; the script under test only
+    # requires git>=2.5 (--git-common-dir). Use the portable form so the test
+    # suite matches the script's documented minimum.
+    git init --quiet
+    git symbolic-ref HEAD refs/heads/main
     git config user.email test@example.com
     git config user.name "Test"
     printf 'placeholder\n' > README.md
@@ -41,6 +45,9 @@ init_ruvector() {
 @test "create: main .ruvector missing — no symlink, warning to stderr (AC-2)" {
     run sh "$SCRIPT" create feature-y
     [ "$status" -eq 0 ]
+    # Assert no symlink at all (`-L` would also catch a dangling link, which
+    # `-e` would miss because `-e` follows the link target).
+    [ ! -L "$REPO/.worktrees/feature-y/.ruvector" ]
     [ ! -e "$REPO/.worktrees/feature-y/.ruvector" ]
     echo "$output" | grep -qi 'main .ruvector/ not found'
 }

--- a/plugins/yellow-core/skills/git-worktree/tests/worktree-manager.bats
+++ b/plugins/yellow-core/skills/git-worktree/tests/worktree-manager.bats
@@ -1,0 +1,190 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+
+# Tests for worktree-manager.sh — focuses on the .ruvector symlink lifecycle
+# (create / copy-env / cleanup). Bootstrap a fresh git repo under $BATS_TEST_TMPDIR
+# for each test so cases are fully isolated.
+
+setup() {
+    SCRIPT="$BATS_TEST_DIRNAME/../scripts/worktree-manager.sh"
+    [ -x "$SCRIPT" ] || chmod +x "$SCRIPT"
+
+    REPO="$(mktemp -d)"
+    cd "$REPO"
+    git init --quiet --initial-branch=main
+    git config user.email test@example.com
+    git config user.name "Test"
+    printf 'placeholder\n' > README.md
+    git add README.md
+    git commit --quiet -m "init"
+}
+
+teardown() {
+    cd /
+    rm -rf "$REPO"
+}
+
+# Initialize a fake .ruvector/ DB in the main repo.
+init_ruvector() {
+    mkdir -p "$REPO/.ruvector"
+    printf '{"totalMemories":42}\n' > "$REPO/.ruvector/intelligence.json"
+}
+
+@test "create: symlink exists and target is main .ruvector (AC-1)" {
+    init_ruvector
+    run sh "$SCRIPT" create feature-x
+    [ "$status" -eq 0 ]
+    [ -L "$REPO/.worktrees/feature-x/.ruvector" ]
+    [ "$(readlink "$REPO/.worktrees/feature-x/.ruvector")" = "$REPO/.ruvector" ]
+}
+
+@test "create: main .ruvector missing — no symlink, warning to stderr (AC-2)" {
+    run sh "$SCRIPT" create feature-y
+    [ "$status" -eq 0 ]
+    [ ! -e "$REPO/.worktrees/feature-y/.ruvector" ]
+    echo "$output" | grep -qi 'main .ruvector/ not found'
+}
+
+@test "create: [ -d worktree/.ruvector ] is true via the symlink (AC-3)" {
+    init_ruvector
+    run sh "$SCRIPT" create feature-z
+    [ "$status" -eq 0 ]
+    # Hook guards check `[ -d "$RUVECTOR_DIR" ]`; that test must follow the
+    # symlink and resolve to the directory.
+    [ -d "$REPO/.worktrees/feature-z/.ruvector" ]
+}
+
+@test "copy-env: real .ruvector dir already in worktree is preserved (P1-A)" {
+    init_ruvector
+    # User created the worktree via raw git, then ran ruvector setup from
+    # inside it, leaving a real .ruvector/ directory with their isolated DB.
+    git worktree add -b feature-iso "$REPO/.worktrees/feature-iso" --quiet
+    mkdir -p "$REPO/.worktrees/feature-iso/.ruvector"
+    printf '{"isolated":true}\n' > "$REPO/.worktrees/feature-iso/.ruvector/intelligence.json"
+
+    # copy-env should warn and skip — never overwrite the user's isolated DB
+    run sh "$SCRIPT" copy-env feature-iso
+    [ "$status" -eq 0 ]
+    # The directory must still be a real directory, not a symlink
+    [ -d "$REPO/.worktrees/feature-iso/.ruvector" ]
+    [ ! -L "$REPO/.worktrees/feature-iso/.ruvector" ]
+    # The isolated DB content is untouched
+    grep -q isolated "$REPO/.worktrees/feature-iso/.ruvector/intelligence.json"
+    # The skip-warning fired
+    echo "$output" | grep -qi 'isolated DB\|real .ruvector'
+}
+
+@test "create: symlink already present is idempotent (P1-D)" {
+    init_ruvector
+    run sh "$SCRIPT" create feature-idem
+    [ "$status" -eq 0 ]
+    # Re-running copy-env on the same worktree must not error, must not duplicate
+    run sh "$SCRIPT" copy-env feature-idem
+    [ "$status" -eq 0 ]
+    [ -L "$REPO/.worktrees/feature-idem/.ruvector" ]
+    [ "$(readlink "$REPO/.worktrees/feature-idem/.ruvector")" = "$REPO/.ruvector" ]
+    # The "already present" info path should have fired
+    echo "$output" | grep -qi 'already present'
+}
+
+@test "create from inside a worktree: symlink TARGET is MAIN repo, not nested (P0-A)" {
+    init_ruvector
+    run sh "$SCRIPT" create outer
+    [ "$status" -eq 0 ]
+    cd "$REPO/.worktrees/outer"
+    # When create runs from inside a worktree, get_repo_root() returns the
+    # worktree's own root, so the new worktree nests under it. That's not the
+    # important property here — what matters is that get_main_repo_root() uses
+    # --git-common-dir, so the symlink TARGET is the main repo's .ruvector,
+    # NOT the outer worktree's path (which would produce a self-referential
+    # dangling link).
+    run sh "$SCRIPT" create nested
+    [ "$status" -eq 0 ]
+    nested_link="$REPO/.worktrees/outer/.worktrees/nested/.ruvector"
+    [ -L "$nested_link" ]
+    [ "$(readlink "$nested_link")" = "$REPO/.ruvector" ]
+}
+
+@test "copy-env: retroactive fix on a pre-existing worktree creates symlink (AC-5)" {
+    # Worktree was created before the symlink feature existed: no .ruvector entry
+    git worktree add -b legacy "$REPO/.worktrees/legacy" --quiet
+    [ ! -e "$REPO/.worktrees/legacy/.ruvector" ]
+
+    init_ruvector
+    run sh "$SCRIPT" copy-env legacy
+    [ "$status" -eq 0 ]
+    [ -L "$REPO/.worktrees/legacy/.ruvector" ]
+    [ "$(readlink "$REPO/.worktrees/legacy/.ruvector")" = "$REPO/.ruvector" ]
+}
+
+@test "cleanup: symlink removed; main .ruvector/intelligence.json intact (AC-6)" {
+    init_ruvector
+    run sh "$SCRIPT" create gone-soon
+    [ "$status" -eq 0 ]
+    [ -L "$REPO/.worktrees/gone-soon/.ruvector" ]
+
+    main_db="$REPO/.ruvector/intelligence.json"
+    expected_sum="$(cksum < "$main_db")"
+
+    # cleanup prompts y/N — pipe "y\n"
+    run sh -c "printf 'y\n' | sh '$SCRIPT' cleanup"
+    [ "$status" -eq 0 ]
+
+    # Worktree directory removed
+    [ ! -d "$REPO/.worktrees/gone-soon" ]
+    # Main DB byte-identical
+    [ -f "$main_db" ]
+    [ "$(cksum < "$main_db")" = "$expected_sum" ]
+}
+
+@test "copy-env: dangling symlink is removed + main-missing warning fires (F4)" {
+    init_ruvector
+    run sh "$SCRIPT" create demo
+    [ "$status" -eq 0 ]
+    [ -L "$REPO/.worktrees/demo/.ruvector" ]
+
+    # Simulate the user deleting the main .ruvector/ — the worktree symlink
+    # is now dangling. Re-running copy-env must remove the stale link and
+    # warn (not silently report "already present").
+    rm -rf "$REPO/.ruvector"
+    [ -L "$REPO/.worktrees/demo/.ruvector" ]
+    [ ! -e "$REPO/.worktrees/demo/.ruvector" ]   # dangling
+
+    run sh "$SCRIPT" copy-env demo
+    [ "$status" -eq 0 ]
+    # Repair branch: dangling link removed, no new link (main still gone)
+    [ ! -L "$REPO/.worktrees/demo/.ruvector" ]
+    [ ! -e "$REPO/.worktrees/demo/.ruvector" ]
+    echo "$output" | grep -qi 'dangling'
+    echo "$output" | grep -qi 'main .ruvector/ not found'
+}
+
+@test "copy-env: dangling symlink + main re-initialized → link repaired (F4 follow-on)" {
+    init_ruvector
+    run sh "$SCRIPT" create demo
+    [ "$status" -eq 0 ]
+
+    # Delete + re-init main with different content
+    rm -rf "$REPO/.ruvector"
+    mkdir -p "$REPO/.ruvector"
+    printf '{"reseeded":true}\n' > "$REPO/.ruvector/intelligence.json"
+
+    # At this point the symlink is technically still pointing at $REPO/.ruvector
+    # which now exists with new content — it is no longer dangling. copy-env
+    # should report "already present" because the link IS valid (the test
+    # below was an over-spec; documenting the actual contract for clarity).
+    run sh "$SCRIPT" copy-env demo
+    [ "$status" -eq 0 ]
+    [ -L "$REPO/.worktrees/demo/.ruvector" ]
+    grep -q reseeded "$REPO/.worktrees/demo/.ruvector/intelligence.json"
+}
+
+@test "cleanup: pre-fix worktree with no .ruvector entry does not error (P1-E)" {
+    # Skip ruvector init — simulate a worktree from before the feature
+    git worktree add -b pre-fix "$REPO/.worktrees/pre-fix" --quiet
+    [ ! -e "$REPO/.worktrees/pre-fix/.ruvector" ]
+
+    run sh -c "printf 'y\n' | sh '$SCRIPT' cleanup"
+    [ "$status" -eq 0 ]
+    [ ! -d "$REPO/.worktrees/pre-fix" ]
+}

--- a/plugins/yellow-core/skills/git-worktree/troubleshooting.md
+++ b/plugins/yellow-core/skills/git-worktree/troubleshooting.md
@@ -58,3 +58,33 @@ pwd | grep -q ".worktrees" && echo "In worktree" || echo "In main repo"
 # Copy .env files manually
 worktree-manager.sh copy-env <worktree-name>
 ```
+
+## Missing `.ruvector/` Symlink in Worktree
+
+**Symptom:** Inside the worktree, ruvector recall returns empty results,
+`/ruvector:status` shows zero memories, or hooks log nothing — even though
+the main repo's `.ruvector/` has an active DB.
+
+**Cause:** The worktree was created before yellow-core started injecting the
+`.ruvector` symlink, OR the main repo had no `.ruvector/` when the worktree
+was created (so the symlink was skipped to avoid a dangling link).
+
+**Solution:**
+
+```bash
+# 1. Make sure the main repo has a .ruvector/ directory
+cd /path/to/main/repo
+ls -d .ruvector/   # must exist; if not, run /ruvector:setup
+
+# 2. Repair the symlink in the existing worktree
+worktree-manager.sh copy-env <worktree-name>
+
+# 3. Verify
+ls -la .worktrees/<worktree-name>/.ruvector
+# expected: lrwxrwxrwx  ...  .ruvector -> /path/to/main/repo/.ruvector
+```
+
+If the worktree already has a real `.ruvector/` directory (from a previous
+isolated setup), `copy-env` will warn and skip — preserving your isolated
+DB. To switch that worktree to the shared main DB, remove the real
+directory first (`rm -rf .worktrees/<name>/.ruvector`) and re-run `copy-env`.

--- a/plugins/yellow-ruvector/CLAUDE.md
+++ b/plugins/yellow-ruvector/CLAUDE.md
@@ -131,7 +131,13 @@ commands (`/workflows:brainstorm`, `/workflows:plan`, `/workflows:work`).
   binary is unavailable, hooks exit silently without error
 - No offline MCP fallback — if ruvector MCP is down, search and memory
   operations fail gracefully
-- `.ruvector/` is shared across git worktrees — concurrent indexing may race
+- `.ruvector/` is shared across git worktrees via a symlink injected by
+  yellow-core's `worktree-manager.sh` at worktree creation time. Concurrent
+  worktree sessions writing to the same DB may race; the ruvector CLI's
+  internal session queue provides partial serialization within a single
+  process, but cross-process write safety is not documented. Avoid running
+  simultaneous Claude Code sessions with active `hooks_remember` or
+  `/ruvector:index` operations on the same project
 - MCP cold start adds 300-1500ms on first tool call after session start
 - Hook recall uses hash embeddings (not ONNX semantic) — paraphrased queries
   (e.g., "fix the bug" vs "correct the error") score near-zero similarity.


### PR DESCRIPTION
Worktrees previously had no .ruvector/ (gitignored), so the ruvector MCP server and hook scripts silently no-op'd inside any worktree session. worktree-manager.sh now injects an absolute symlink ${worktree}/.ruvector -> ${main}/.ruvector at create time and removes it safely on cleanup. Includes commands/worktree/cleanup.md parity, bats coverage, a new plugin-shell-tests CI job (also closes the orphan-tests gap for 4 other plugins), docs across SKILL.md / CLAUDE.md / troubleshooting.md, and a docs/solutions entry capturing root cause and footguns.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent failure where ruvector's MCP server and hook scripts no-op'd inside git worktrees because `.ruvector/` is gitignored and `${PWD}/.ruvector/` resolved to the (empty) worktree path. The fix injects an absolute symlink `${worktree}/.ruvector → ${main}/.ruvector` at create time and removes it safely on cleanup.

- **`worktree-manager.sh`** gains four new helpers (`get_main_repo_root`, `link_ruvector_db`, `unlink_ruvector_link`, `restore_ruvector_link`) wired into `create`, `copy-env`, and `cleanup`; each handles POSIX `set -e` gotchas, idempotency, and the pre-remove-with-restore pattern so `git worktree remove` never sees an untracked symlink entry.
- **`commands/worktree/cleanup.md`** inlines the same pre-remove + restore-on-failure block at every no-`--force` callsite, with explicit documentation explaining why `--force` paths need no dance.
- **CI** adds a `plugin-shell-tests` job with pinned `bats@1.11.0` running the new yellow-core suite as a required check, plus advisory coverage for other plugins; the job is wired into the gate.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the symlink lifecycle is correctly guarded at every stage and cannot follow into the main DB.

The core change (symlink inject/remove) is small and carefully written: `[ -L ]` before every `rm`, no `-r`/`-f`/trailing-slash, `|| exit 1` to defend against dash's `set -e` command-substitution gap, and restore-on-failure so a mid-cleanup abort leaves the worktree functional. Tests cover the critical paths (idempotency, dangling-link repair, isolated-DB preservation, main-DB integrity after cleanup). The only findings are minor documentation wording issues.

No files require special attention beyond the two minor documentation inconsistencies called out in comments.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/yellow-core/skills/git-worktree/scripts/worktree-manager.sh | Four new helpers added (get_main_repo_root, link_ruvector_db, unlink_ruvector_link, restore_ruvector_link); wired into create/copy-env/cleanup. POSIX variable-scoping, set -e guards, and rm-without-recursive all handled carefully. |
| plugins/yellow-core/skills/git-worktree/tests/worktree-manager.bats | New bats suite covering create/copy-env/cleanup symlink lifecycle, idempotency, dangling-link repair, isolated-DB preservation, and pre-fix worktree cleanup. |
| .github/workflows/validate-schemas.yml | New plugin-shell-tests job with pinned bats@1.11.0 via npm, required yellow-core suite blocking, advisory glob covering both top-level and nested test dirs, correctly wired into the gate job. |
| plugins/yellow-core/commands/worktree/cleanup.md | Pre-remove + restore-on-failure block inlined at every no-force callsite; force callsites explicitly excluded; parity with worktree-manager.sh helpers maintained. |
| plugins/yellow-ruvector/CLAUDE.md | Known Limitations updated to reflect the new shared-DB-via-symlink model. Storage path listed as `.ruvector/intelligence/memory.rvdb` but brainstorm doc and bats fixture reference `intelligence.json` — minor documentation inconsistency. |
| plugins/yellow-core/skills/git-worktree/SKILL.md | New ruvector DB Sharing section documents the symlink mechanism, idempotency behavior, MCP spawn-time qualifier, and concurrent-write caveat accurately. |
| docs/solutions/integration-issues/ruvector-worktree-db-symlink.md | New solution doc captures root cause, fix summary, footguns to avoid, and verification steps. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant WM as worktree-manager.sh
    participant Git as git
    participant FS as Filesystem

    U->>WM: create branch
    WM->>Git: worktree add -b branch .worktrees/branch
    Git-->>FS: creates .worktrees/branch/
    WM->>WM: get_main_repo_root() → /repo
    WM->>WM: link_ruvector_db(/repo, .worktrees/branch)
    WM->>FS: check -d /repo/.ruvector
    alt main .ruvector exists
        FS-->>WM: yes
        WM->>FS: ln -s /repo/.ruvector .worktrees/branch/.ruvector
    else missing
        WM->>U: warning: skip, run /ruvector:setup first
    end

    U->>WM: cleanup
    WM->>WM: unlink_ruvector_link(.worktrees/branch)
    WM->>FS: rm symlink, capture target
    FS-->>WM: saved_target = /repo/.ruvector
    WM->>Git: worktree remove .worktrees/branch
    alt remove succeeds
        Git-->>FS: deletes .worktrees/branch/
    else remove fails
        Git-->>WM: error
        WM->>WM: restore_ruvector_link
        WM->>FS: ln -s /repo/.ruvector .worktrees/branch/.ruvector
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Fruvector-worktree-db-symlink%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Fruvector-worktree-db-symlink%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aplugins%2Fyellow-core%2Fskills%2Fgit-worktree%2Fscripts%2Fworktree-manager.sh%3A195%0AWhen%20%60link_ruvector_db%60%20is%20called%20from%20%60copy-env%60%20and%20the%20main%20%60.ruvector%2F%60%20doesn't%20exist%20yet%2C%20the%20warning%20tells%20the%20user%20to%20%22run%20copy-env%22%20%E2%80%94%20but%20they%20are%20already%20running%20it.%20The%20suggestion%20is%20circular%20from%20that%20callsite%20and%20may%20confuse%20users%20who%20followed%20the%20hint%20and%20got%20the%20same%20message%20again.%20A%20small%20wording%20adjustment%20makes%20the%20hint%20accurate%20from%20both%20%60create%60%20and%20%60copy-env%60%20contexts.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20warning%20%22Main%20.ruvector%2F%20not%20found%20at%20%24%7B_lrd_target%7D%3B%20skipping%20symlink%20%28run%20%2Fruvector%3Asetup%20first%2C%20then%20re-run%20copy-env%20to%20inject%20the%20link%29%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aplugins%2Fyellow-ruvector%2FCLAUDE.md%3A9%0A**Storage-path%20inconsistency%20across%20files%20in%20this%20PR.**%20This%20line%20describes%20the%20DB%20file%20as%20%60.ruvector%2Fintelligence%2Fmemory.rvdb%60%20%28rvlite%20format%29%2C%20but%20%60docs%2Fbrainstorms%2F2026-05-05-ruvector-worktree-db-sharing-brainstorm.md%60%20%28line%20184%2C%20also%20added%20in%20this%20PR%29%20states%20%22Both%20%60.ruvector%2F%60%20directories%20in%20this%20repo%20contain%20only%20%60intelligence.json%60%22%2C%20and%20the%20bats%20fixture%20seeds%20%60%24REPO%2F.ruvector%2Fintelligence.json%60.%20A%20reader%20trying%20to%20understand%20the%20actual%20on-disk%20layout%20will%20get%20conflicting%20information%20from%20three%20sources%20in%20the%20same%20PR.%20Whichever%20format%20is%20current%20should%20be%20made%20consistent%20across%20all%20three%20files.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
plugins/yellow-core/skills/git-worktree/scripts/worktree-manager.sh:195
When `link_ruvector_db` is called from `copy-env` and the main `.ruvector/` doesn't exist yet, the warning tells the user to "run copy-env" — but they are already running it. The suggestion is circular from that callsite and may confuse users who followed the hint and got the same message again. A small wording adjustment makes the hint accurate from both `create` and `copy-env` contexts.

```suggestion
        warning "Main .ruvector/ not found at ${_lrd_target}; skipping symlink (run /ruvector:setup first, then re-run copy-env to inject the link)"
```

### Issue 2 of 2
plugins/yellow-ruvector/CLAUDE.md:9
**Storage-path inconsistency across files in this PR.** This line describes the DB file as `.ruvector/intelligence/memory.rvdb` (rvlite format), but `docs/brainstorms/2026-05-05-ruvector-worktree-db-sharing-brainstorm.md` (line 184, also added in this PR) states "Both `.ruvector/` directories in this repo contain only `intelligence.json`", and the bats fixture seeds `$REPO/.ruvector/intelligence.json`. A reader trying to understand the actual on-disk layout will get conflicting information from three sources in the same PR. Whichever format is current should be made consistent across all three files.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(git-worktree): restore pre-remove of..."](https://github.com/kinginyellows/yellow-plugins/commit/6419fce3045859d55643e3016dd25f7312ec3a76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30912679)</sub>

<!-- /greptile_comment -->