### PR TITLE
fix(plugin-manifests): add type and title to userConfig entries

### DIFF
--- a/.changeset/userconfig-type-title-validator-drift.md
+++ b/.changeset/userconfig-type-title-validator-drift.md
@@ -1,0 +1,45 @@
+---
+"yellow-devin": patch
+"yellow-research": patch
+"yellow-morph": patch
+"yellow-semgrep": patch
+---
+
+# Fix `userConfig` manifest validator drift — add required `type` and `title`
+
+Add `"type": "string"` and `"title": "<sentence-case label>"` to every
+`userConfig` entry in the four plugins that declared user-supplied
+credentials. The Claude Code remote validator (surfaced via `claude doctor`)
+rejects any `userConfig` entry missing either field; local CI was passing
+because `schemas/plugin.schema.json` made `type` optional and used `label`
+instead of `title`.
+
+Affected entries (7 total):
+
+- `yellow-devin`: `devin_service_user_token`, `devin_org_id`
+- `yellow-research`: `perplexity_api_key`, `tavily_api_key`, `exa_api_key`
+- `yellow-morph`: `morph_api_key`
+- `yellow-semgrep`: `semgrep_app_token`
+
+Companion changes outside the plugins (no changeset needed — repo root):
+
+- `schemas/plugin.schema.json` — `userConfigEntry` tightened: `type` and
+  `title` now required, `type` enum extended with `directory` and `file`
+  (parity with remote validator), unused `label` property removed, dead
+  `allOf` branch (the `if not required type` fall-through) removed,
+  `directory`/`file` default-type-string constraint branches added.
+- `scripts/validate-plugin.js` — RULE 9 added: hand-rolled `userConfig`
+  enforcement (per-entry `type` enum check + `title` non-empty string
+  check). The repo's local CI does not currently AJV-load
+  `plugin.schema.json`, so script-level enforcement is what actually
+  catches this drift before `claude doctor`.
+- `docs/solutions/build-errors/userconfig-type-title-remote-validator-drift.md` —
+  new solutions doc cross-referencing the prior `changelog`/`repository`
+  drift incidents.
+
+**Behavior change for users:** `sensitive: true` (or `false` for
+`devin_org_id`) is preserved verbatim — keychain storage and credential
+masking are unchanged. The new `title` field is a UI label only; it never
+carries the credential value. Plugin install behavior is unchanged for
+existing users; the change unblocks fresh installs that hit the strict
+remote validator.

--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -609,10 +609,12 @@ jobs:
             # declarations (lines ending in `: {` are object-typed field
             # openings, not secret values); ${user_config.*} template
             # references (substituted at runtime, not literal secrets);
-            # `"description":` lines (documentation prose mentioning "token"
-            # or "API key" describing what the field is, not its value).
+            # `"description":` and `"title":` lines (documentation /
+            # UI-label metadata mentioning "token" or "API key" describing
+            # what the field is, not its value — the Claude Code remote
+            # validator requires `"title":` on every userConfig entry).
             SENSITIVE=$(grep -rE '(api[_-]?key|password|token|secret)' .claude-plugin/ plugins/ --include="*.json" \
-              | grep -vE '"permissionScopes"|:[[:space:]]*\{[[:space:]]*$|\$\{user_config\.|"description":' \
+              | grep -vE '"permissionScopes"|:[[:space:]]*\{[[:space:]]*$|\$\{user_config\.|"description":|"title":' \
               || true)
             if [ -n "$SENSITIVE" ]; then
               echo "$SENSITIVE"

--- a/docs/brainstorms/2026-05-05-plugin-manifest-userconfig-validator-drift-brainstorm.md
+++ b/docs/brainstorms/2026-05-05-plugin-manifest-userconfig-validator-drift-brainstorm.md
@@ -1,0 +1,317 @@
+---
+title: "Plugin manifest userConfig validator drift — type + title required by remote, absent locally"
+category: build-errors
+track: bug
+date: 2026-05-05
+tags:
+  - plugin-manifest
+  - userConfig
+  - schema-validation
+  - two-validator-drift
+  - sensitive-credentials
+  - release-coordination
+affected_plugins:
+  - yellow-devin@2.3.0
+  - yellow-research@3.0.1
+  - yellow-morph@1.2.0
+  - yellow-semgrep@4.0.2
+---
+
+# Plugin manifest userConfig validator drift — type + title required by remote
+
+## What We're Building
+
+A fix for 4 plugins whose `userConfig` entries are rejected by Claude Code's
+remote validator when reported via `claude doctor`. All 4 plugins declare API
+tokens/secrets using a `sensitive: true` flag and a `description` string but
+omit `type` and `title` — fields the remote validator requires. Local CI
+(`pnpm validate:schemas`) passes because the local schema allows `sensitive`
+and does not mandate `type` or `title`. We need to add the missing fields,
+tighten the local schema to prevent this class of drift from recurring, and
+ship through the standard Changesets release flow.
+
+## Root Cause Confirmation (from reading actual files)
+
+All 4 affected `plugin.json` files share the same structure for their
+`userConfig` entries — neither `type` nor `title` is present, only
+`description` and `sensitive`:
+
+```json
+"userConfig": {
+  "devin_service_user_token": {
+    "description": "...",
+    "sensitive": true
+  }
+}
+```
+
+The remote validator reports two errors per key:
+- `type: Invalid option: expected one of "string"|"number"|"boolean"|"directory"|"file"`
+  — because `type` is absent (the remote validator apparently does not accept
+  absence as defaulting to `"string"` the way the local schema does)
+- `title: Invalid input: expected string, received undefined` — `title` field
+  is not in the local schema at all (`label` is present locally, `title` is not)
+
+**Local schema state** (`schemas/plugin.schema.json` `userConfigEntry`):
+- Allows: `type` (enum: `string|number|boolean`, default `"string"`), `label`,
+  `description`, `default`, `required`, `sensitive`
+- Does NOT require `type` or `title`
+- Does NOT include `"directory"` or `"file"` in the enum (remote adds these two)
+- Uses `label` where remote uses `title` (field name mismatch)
+
+**Affected plugins and keys:**
+| Plugin | Keys |
+|---|---|
+| yellow-devin@2.3.0 | `devin_service_user_token`, `devin_org_id` |
+| yellow-research@3.0.1 | `perplexity_api_key`, `tavily_api_key`, `exa_api_key` |
+| yellow-morph@1.2.0 | `morph_api_key` |
+| yellow-semgrep@4.0.2 | `semgrep_app_token` |
+
+**Other plugins at risk:** `rg -l '"userConfig"' plugins/*/plugin.json` returns
+only these 4 files. No other plugins are affected.
+
+## Key Decisions
+
+### Decision 1: Which `type` value to use for API tokens/secrets?
+
+The remote validator accepts `"string"|"number"|"boolean"|"directory"|"file"`.
+All affected keys are API tokens — alphanumeric strings with vendor-specific
+prefixes (`cog_`, `sgp_`, etc.). The correct type is `"string"`.
+
+`"directory"` and `"file"` are for filesystem path inputs and would
+semantically misrepresent the values. `"number"` and `"boolean"` are obviously
+wrong.
+
+**Decision: use `"type": "string"` for all 7 keys across all 4 plugins.**
+
+The `"sensitive": true` field handles keychain storage — `type` is purely for
+the validator's input form rendering. Critically: the `sensitive` flag is what
+prevents the value from being echoed back, and it is preserved. Nothing in this
+fix changes the security posture.
+
+### Decision 2: What value to use for `title`?
+
+`title` is a required string the remote validator uses as a human-readable
+label in the Claude Code setup UI. The local schema called this `label` — same
+semantic, different field name. The fix is to add a `title` field alongside
+(or instead of) `label`.
+
+Since the local schema has `additionalProperties: false` on `userConfigEntry`,
+we cannot simply add `title` without updating the schema. Options:
+- Rename `label` → `title` in both the schema and plugin.json files (none of
+  the 4 affected files currently use `label` at all — so there is nothing to
+  rename in the manifests, only the schema definition to update)
+- Keep `label` in the schema, add `title` as a new optional field
+
+Given that no plugin.json currently uses `label` and the remote validator
+requires `title` (not `label`), the correct move is to add `title` to the
+`userConfigEntry` definition in the local schema and add it to every affected
+key in the 4 plugin.json files.
+
+**Decision: add `"title"` to `userConfigEntry` in the schema; add a `title`
+value to each of the 7 keys in the 4 plugin.json files. Keep `label` for
+backward compatibility but mark it as the legacy alternative.**
+
+### Decision 3: Should the local schema be tightened to match the remote?
+
+Three divergences to address:
+
+| Gap | Local schema | Remote validator | Fix |
+|---|---|---|---|
+| `type` required | Optional (defaults to `"string"`) | Effectively required (absence causes error) | Make `type` required in `userConfigEntry` |
+| `title` field | Not present (uses `label`) | Required string | Add `title` as required to `userConfigEntry` |
+| `type` enum | `string|number|boolean` | `string|number|boolean|directory|file` | Extend enum to add `directory` and `file` |
+
+Making `type` required in the local schema would fail all 4 files immediately
+during local validate:schemas — which is exactly the desired behavior. The cost
+is that future plugin authors must always specify `type` explicitly. Given that
+the default is always `"string"` for tokens, this is a low burden with a high
+safety return.
+
+**Decision: tighten the local schema on all three gaps.** This converts a
+runtime `claude doctor` failure into a local CI failure — the correct direction.
+
+### Decision 4: Should `validate-plugin.js` grow a hard-coded check?
+
+`validate-plugin.js` runs the JSON Schema validator. If the schema is tightened
+(Decision 3), AJV catches missing `type` and `title` automatically — no
+hard-coded check needed. A hard-coded check would be redundant.
+
+However, `validate-plugin.js` could add an explicit check that bans `sensitive`
+without `title` as a belt-and-suspenders guard, in case a future schema update
+accidentally loosens the constraint again. Given the history of two-validator
+drift in this repo, this extra guard has value.
+
+**Decision: defer the hard-coded check to a follow-up — the schema tightening
+is sufficient for now (YAGNI). Document the gap in the solutions doc.**
+
+### Decision 5: Single changeset or one per plugin?
+
+All 4 fixes are patch bumps (bug fix to a non-user-facing manifest field).
+They are independent (no cross-plugin changes required). Recent practice
+(`608ba247 chore: version packages`) shows the version bot batches multiple
+plugins into one PR, so a single changeset file listing all 4 plugins at
+`patch` bump type is appropriate and matches the existing release flow.
+
+The schema change (`schemas/plugin.schema.json`) is not versioned separately —
+it lives in the repo root and is not a plugin. No changeset needed for it.
+
+**Decision: one changeset spanning all 4 plugins at `patch` level.**
+
+### Decision 6: Schema change backward compatibility
+
+Adding `title` as required and adding `directory|file` to the enum is backward
+compatible for all existing plugins that currently pass validation (they have no
+userConfig at all, or will have it added in this fix). The only risk is if a
+plugin.json already uses `label` expecting it to behave as `title` — confirmed
+above: no plugin.json currently uses `label`, so no backward compatibility issue.
+
+Removing the default `"string"` from `type` (by making it required) will not
+break anything already in the repo because all 4 affected files are being fixed
+in this same change.
+
+## Why This Approach
+
+The fix is surgical: add 2 fields per userConfig key (`type: "string"` and a
+`title` string), update the local schema to enforce both, ship as a single
+patch changeset. This is the minimum change that eliminates the `claude doctor`
+errors, hardens local CI to catch this class of drift going forward, and
+follows the established two-validator doctrine from prior solutions docs.
+
+The alternative of leaving the local schema permissive and only fixing the
+manifests would repeat the same gap that caused the `changelog` and `repository`
+incidents. Schema tightening is the established pattern in this repo.
+
+## Approach Options
+
+### Approach A: Manifest-only patch (minimal scope)
+
+Add `type: "string"` and `title: "..."` to each of the 7 userConfig keys
+across the 4 plugin.json files. Leave the local schema unchanged.
+
+**Pros:** Smallest possible diff; no risk of breaking `pnpm validate:schemas`
+for other plugins; fastest to ship.
+
+**Cons:** Does not prevent recurrence — the next person adding a userConfig
+entry will hit the same `claude doctor` failure because local CI still won't
+catch missing `type` or `title`. Perpetuates two-validator drift.
+
+**Best when:** You want the narrowest possible change and are willing to rely on
+manual discipline rather than tooling.
+
+### Approach B: Manifest patch + schema tightening (recommended)
+
+Add `type: "string"` and `title: "..."` to the 7 keys, AND update
+`schemas/plugin.schema.json` to: (1) make `type` required, (2) add `title`
+as required, (3) extend the `type` enum with `"directory"` and `"file"`.
+Also add a `docs/solutions/build-errors/` entry documenting the userConfig
+drift pattern.
+
+**Pros:** Local CI (`pnpm validate:schemas`) now catches any future userConfig
+entry missing `type` or `title` before it reaches `claude doctor`. Closes the
+two-validator gap. Matches established repo doctrine (see `changelog` and
+`repository` fixes). Self-documenting via the new solutions doc.
+
+**Cons:** Schema change is slightly more surface area; future authors must
+always specify `type` explicitly even when it's obviously `"string"`. One-time
+cost of writing the solutions doc.
+
+**Best when:** You want tooling to enforce correctness, not just fix the
+immediate symptoms. This is the appropriate choice given the recurring
+two-validator drift history in this repo.
+
+### Approach C: Manifest patch + schema tightening + validate-plugin.js guard
+
+Everything in Approach B, plus add a hard-coded check in `validate-plugin.js`
+that explicitly fails if any userConfig entry has `sensitive: true` but no
+`title`, as a belt-and-suspenders guard against future schema loosening.
+
+**Pros:** Maximum defense-in-depth; explicit error message can reference the
+exact `claude doctor` failure mode.
+
+**Cons:** Redundant with the schema (AJV already enforces required fields once
+the schema is tightened); adds maintenance surface in the validator script;
+violates YAGNI — the schema fix alone is sufficient until there is evidence of
+schema drift recurring.
+
+**Best when:** After a third or fourth instance of two-validator drift where
+schema tightening has demonstrably not been enough.
+
+## Recommended Approach
+
+**Approach B.** The manifest patch is required; the schema tightening is the
+right call given this repo's track record of two-validator drift producing P0
+install blockers. The `changelog` fix (PR #66) and the `repository`/`hooks` fix
+(PR #66 family) both followed this pattern — fix the manifests AND tighten the
+schema. Repeating only the manifest fix without the schema is explicitly
+identified as insufficient in the prevention checklist in
+`docs/solutions/build-errors/plugin-json-changelog-key-schema-drift-remote-validator.md`.
+
+## Implementation Checklist (for /workflows:plan)
+
+1. **Confirm remote validator's exact `title` field name** — the problem
+   statement says `title`, local schema uses `label`. This brainstorm assumes
+   `title` is correct. Verify against a real `claude doctor` error message or
+   Anthropic plugin schema docs before writing code.
+
+2. **Update 4 plugin.json files** — add `"type": "string"` and `"title": "..."`
+   to each key. Title values should be concise, human-readable UI labels:
+   - `devin_service_user_token` → `"Devin service user token"`
+   - `devin_org_id` → `"Devin organization ID"`
+   - `perplexity_api_key` → `"Perplexity API key"`
+   - `tavily_api_key` → `"Tavily API key"`
+   - `exa_api_key` → `"Exa API key"`
+   - `morph_api_key` → `"Morph API key"`
+   - `semgrep_app_token` → `"Semgrep app token"`
+
+3. **Update `schemas/plugin.schema.json`** — in `userConfigEntry`:
+   - Make `type` required (add to `"required": ["type"]`)
+   - Add `"title": { "type": "string" }` to properties
+   - Add `"title"` to the required array
+   - Extend `type` enum: `["string", "number", "boolean", "directory", "file"]`
+   - Run `jq empty schemas/plugin.schema.json` to verify no trailing commas
+
+4. **Run validation** — `pnpm validate:schemas && pnpm validate:versions` must
+   pass cleanly.
+
+5. **Create changeset** — `pnpm changeset`, select patch for:
+   `yellow-devin`, `yellow-research`, `yellow-morph`, `yellow-semgrep`.
+
+6. **Write solutions doc** — `docs/solutions/build-errors/userconfig-type-title-remote-validator-drift.md`
+   documenting this specific instance with the `sensitive`/`title`/`type` drift
+   pattern, the two solutions steps, and the prevention checklist update.
+
+7. **Verify CLAUDE.md memory entry is up to date** — the "Plugin Manifest
+   Validation" section in `MEMORY.md` should be updated to include the
+   `userConfig.type` + `title` required fields as a known remote-only constraint.
+
+## Open Questions for /workflows:plan
+
+1. **Exact field name: `title` vs `label`** — the remote validator error says
+   `title: Invalid input: expected string, received undefined`. But is `title`
+   the correct field name to add, or is there a separate `label` → `title`
+   rename that Claude Code is expecting? Recommend reading a confirmed-working
+   plugin that uses userConfig (from a different marketplace) to verify before
+   writing the fix.
+
+2. **Does `sensitive` survive the schema tightening?** — The local schema has
+   `additionalProperties: false` on `userConfigEntry`. If `title` is added to
+   `properties` but `sensitive` is removed from the schema for any reason, all 4
+   plugins would fail. Confirm `sensitive` remains in the `userConfigEntry`
+   definition after the schema edit.
+
+3. **Is `"directory"` or `"file"` type needed by any existing or planned
+   plugin?** — Adding them to the enum is safe (purely additive), but confirm
+   whether any planned plugin will use them before treating their absence as the
+   cause of any future error.
+
+4. **Title string style guide** — should titles be title case ("Devin Service
+   User Token") or sentence case ("Devin service user token") or match the
+   description's opening phrase? No style is enforced by the validator but
+   consistency matters for the UI. Pick one and document it.
+
+5. **`devin_org_id` has `sensitive: false`** — this key is not a secret. The
+   fix still adds `type: "string"` and `title`, but confirm whether
+   `sensitive: false` is still needed (it is the explicit default — it could be
+   removed to reduce noise, or kept for clarity). This is a style decision, not
+   a correctness one.

--- a/docs/brainstorms/2026-05-05-plugin-manifest-userconfig-validator-drift-brainstorm.md
+++ b/docs/brainstorms/2026-05-05-plugin-manifest-userconfig-validator-drift-brainstorm.md
@@ -142,8 +142,22 @@ without `title` as a belt-and-suspenders guard, in case a future schema update
 accidentally loosens the constraint again. Given the history of two-validator
 drift in this repo, this extra guard has value.
 
-**Decision: defer the hard-coded check to a follow-up — the schema tightening
-is sufficient for now (YAGNI). Document the gap in the solutions doc.**
+**Original decision: defer the hard-coded check to a follow-up — the schema
+tightening is sufficient for now (YAGNI). Document the gap in the solutions
+doc.**
+
+**Implementation note (added during /workflows:work):** The decision was
+reversed during implementation. The `pnpm validate:schemas` chain runs four
+Node scripts and only `validate-marketplace.js` AJV-loads its schema —
+`validate-plugin.js` is a 900-line hand-rolled validator that does not
+load `schemas/plugin.schema.json` at all. Tightening the schema therefore
+catches drift only via `pnpm test:integration` (which validates example
+fixtures against the schema), not via `pnpm validate:plugins`. To make the
+script-level enforcement actually fail when a manifest violates the
+constraints, RULE 9 was added to `scripts/validate-plugin.js` covering both
+top-level `userConfig` and `channels[].userConfig`. The "AJV catches it"
+premise of the original decision was incorrect for this script. This is
+Approach C for the validator script, not Approach B.
 
 ### Decision 5: Single changeset or one per plugin?
 

--- a/docs/solutions/build-errors/userconfig-type-title-remote-validator-drift.md
+++ b/docs/solutions/build-errors/userconfig-type-title-remote-validator-drift.md
@@ -1,0 +1,161 @@
+---
+title: "Claude Code Validator Rejects userConfig Entries Missing type or title"
+category: build-errors
+track: bug
+problem: "Claude Code remote validator rejects userConfig entries that omit type or title — local CI passes but claude doctor reports 4 plugins as invalid"
+tags:
+  - plugin-manifest
+  - userConfig
+  - schema-validation
+  - two-validator-drift
+  - sensitive-credentials
+severity: P1
+components:
+  - plugins/yellow-devin/.claude-plugin/plugin.json
+  - plugins/yellow-research/.claude-plugin/plugin.json
+  - plugins/yellow-morph/.claude-plugin/plugin.json
+  - plugins/yellow-semgrep/.claude-plugin/plugin.json
+  - schemas/plugin.schema.json
+error_pattern: 'userConfig.<key>.type: Invalid option: expected one of "string"|"number"|"boolean"|"directory"|"file"'
+date_resolved: 2026-05-05
+---
+
+# Claude Code Validator Rejects userConfig Entries Missing `type` or `title`
+
+## Problem
+
+`claude doctor` reports 4 plugins with invalid manifests:
+
+```text
+✘ Plugin errors
+└ 4 plugin error(s) detected:
+  ├ yellow-devin@yellow-plugins ... Validation errors:
+    userConfig.devin_service_user_token.type: Invalid option: expected one of
+    "string"|"number"|"boolean"|"directory"|"file",
+    userConfig.devin_service_user_token.title: Invalid input: expected string,
+    received undefined, ...
+  ├ yellow-research@yellow-plugins ... (same shape × 3 keys)
+  ├ yellow-morph@yellow-plugins ... (same shape × 1 key)
+  └ yellow-semgrep@yellow-plugins ... (same shape × 1 key)
+```
+
+Per `userConfig` entry, two errors:
+
+- `type: Invalid option: expected one of "string"|"number"|"boolean"|"directory"|"file"` — `type` is absent
+- `title: Invalid input: expected string, received undefined` — `title` is absent
+
+`pnpm validate:schemas` passed locally throughout. The 4 plugins installed
+successfully on prior Claude Code versions; the remote validator now enforces
+`type` and `title` on every `userConfig` entry.
+
+## Root Cause
+
+Two-validator drift between the local CI schema and the Claude Code remote
+validator (the same class as the [`changelog` key drift](plugin-json-changelog-key-schema-drift-remote-validator.md)
+and the [`repository` / `hooks` shape drift](claude-code-plugin-manifest-validation-errors.md)):
+
+| Aspect | Local schema | Remote validator |
+|---|---|---|
+| `type` field | Optional (defaults to `"string"`) | Required; absence triggers enum-mismatch error |
+| `type` enum | `string`, `number`, `boolean` | `string`, `number`, `boolean`, `directory`, `file` |
+| Human-readable label field | `label` (optional) | `title` (required) |
+
+All 4 affected `plugin.json` files used the most permissive shape — only
+`description` and `sensitive`, no `type`, no `label`, no `title`. Local CI
+accepted them; Claude Code rejected them.
+
+## Solution
+
+Two coordinated changes:
+
+### Phase 1 — Add `type` and `title` to all 7 userConfig keys
+
+For each entry across the 4 manifests, add `"type": "string"` and
+`"title": "<sentence-case label>"` immediately above the existing `description`.
+
+| Plugin | Key | Title |
+|---|---|---|
+| yellow-devin | `devin_service_user_token` | Devin service user token |
+| yellow-devin | `devin_org_id` | Devin organization ID |
+| yellow-research | `perplexity_api_key` | Perplexity API key |
+| yellow-research | `tavily_api_key` | Tavily API key |
+| yellow-research | `exa_api_key` | Exa API key |
+| yellow-morph | `morph_api_key` | Morph API key |
+| yellow-semgrep | `semgrep_app_token` | Semgrep app token |
+
+`sensitive: true` (or `sensitive: false` for `devin_org_id`) is preserved
+verbatim — keychain storage behavior is unchanged. `title` is a UI label
+only; it never carries the credential value.
+
+### Phase 2 — Tighten `schemas/plugin.schema.json` `userConfigEntry`
+
+Convert the runtime `claude doctor` failure into a local CI failure:
+
+1. Make `type` required: add `"required": ["type", "title"]` to `userConfigEntry`
+2. Add `title` property: `"title": { "type": "string", "minLength": 1 }`
+3. Extend `type` enum: `["string", "number", "boolean", "directory", "file"]`
+4. Remove the unused `label` property
+5. Remove the dead 4th `allOf` branch (`if not required type` — unreachable now that type is required)
+6. Add `directory`/`file` constraint branches to `allOf` so their defaults must be strings (paths)
+
+After this change, `pnpm validate:schemas` blocks any future `userConfig` entry
+that omits `type` or `title`.
+
+## Why Both Changes
+
+Approach B from the brainstorm. The manifest fix alone (Approach A) restores
+install success but leaves the local schema permissive — the next person
+adding a `userConfig` entry will hit the same `claude doctor` failure. Schema
+tightening (Approach B) closes the two-validator gap, matching the established
+doctrine from PR #66 (`changelog` and `repository`/`hooks` drift fixes).
+
+## Prevention Checklist
+
+When changing any plugin manifest field or `userConfig` entry:
+
+- [ ] Confirm the local schema (`schemas/plugin.schema.json`) actually constrains
+      every field the remote validator constrains. If you see `type` defaulting
+      to a value, ask whether the remote treats absence as an error.
+- [ ] If a field has different names between local and remote schemas
+      (`label` vs `title`, `changelog` vs nothing), prefer the remote name and
+      drop the local one.
+- [ ] Run `pnpm validate:schemas` AND test a fresh `/plugin install` against a
+      clean Claude Code instance before tagging a release. Local CI alone is
+      not sufficient.
+- [ ] When tightening the schema, verify by deliberately reverting one entry
+      to the broken shape — `pnpm validate:schemas` must fail. If it passes,
+      the tightening did not actually constrain anything.
+
+## Detection
+
+Pre-flight script (run before `pnpm release:check`):
+
+```bash
+# Find any userConfigEntry that lacks "type" or "title"
+for f in plugins/*/.claude-plugin/plugin.json; do
+  if jq -e '
+    .userConfig // empty
+    | to_entries[]
+    | .value
+    | (.type == null or .title == null)
+  ' "$f" > /dev/null 2>&1; then
+    printf 'MISSING type or title: %s\n' "$f"
+  fi
+done
+```
+
+After this fix, the same check is enforced by the JSON Schema itself.
+
+## Related
+
+- [`plugin-json-changelog-key-schema-drift-remote-validator.md`](plugin-json-changelog-key-schema-drift-remote-validator.md) — earlier instance of two-validator drift (P0)
+- [`claude-code-plugin-manifest-validation-errors.md`](claude-code-plugin-manifest-validation-errors.md) — `repository` and `hooks` shape divergence
+- [`ci-schema-drift-hooks-inline-vs-string.md`](ci-schema-drift-hooks-inline-vs-string.md) — pattern reference
+
+## Files Changed
+
+- `plugins/yellow-devin/.claude-plugin/plugin.json` — 2 keys × 2 fields
+- `plugins/yellow-research/.claude-plugin/plugin.json` — 3 keys × 2 fields
+- `plugins/yellow-morph/.claude-plugin/plugin.json` — 1 key × 2 fields
+- `plugins/yellow-semgrep/.claude-plugin/plugin.json` — 1 key × 2 fields
+- `schemas/plugin.schema.json` — `userConfigEntry` definition (title + required + enum extension + dead-branch cleanup)

--- a/examples/plugin-extended.example.json
+++ b/examples/plugin-extended.example.json
@@ -52,21 +52,21 @@
   "userConfig": {
     "api_endpoint": {
       "type": "string",
-      "label": "API endpoint",
+      "title": "API endpoint",
       "description": "Your team's API endpoint",
       "required": true,
       "sensitive": false
     },
     "api_token": {
       "type": "string",
-      "label": "API token",
+      "title": "API token",
       "description": "API authentication token",
       "required": true,
       "sensitive": true
     },
     "timeout_ms": {
       "type": "number",
-      "label": "Request timeout",
+      "title": "Request timeout",
       "default": 5000,
       "sensitive": false
     }
@@ -77,11 +77,13 @@
       "userConfig": {
         "bot_token": {
           "type": "string",
+          "title": "Telegram bot token",
           "description": "Telegram bot token",
           "sensitive": true
         },
         "owner_id": {
           "type": "string",
+          "title": "Telegram owner ID",
           "description": "Your Telegram user ID",
           "sensitive": false
         }

--- a/plans/plugin-manifest-userconfig-validator-drift.md
+++ b/plans/plugin-manifest-userconfig-validator-drift.md
@@ -44,7 +44,7 @@ Reviewed files:
 3. **`devin_org_id` `sensitive: false`** — keep explicit. Defaults can change; explicit-is-better matches the existing style elsewhere in the file.
 4. **`directory`/`file` enum entries** — add for parity with remote validator, even though no current plugin uses them. Purely additive, zero risk.
 5. **`sensitive` field survival** — explicitly preserved in the new schema. Verified in step 3.2 below.
-6. **`validate-plugin.js` hard-coded check (Approach C)** — defer per YAGNI. Schema enforcement via AJV is sufficient until a third drift incident.
+6. **`validate-plugin.js` hard-coded check (Approach C)** — implemented during /workflows:work, reversing the original "defer per YAGNI" plan. Reason: `validate-plugin.js` is a hand-rolled 900-line validator that does NOT AJV-load `schemas/plugin.schema.json`. Without a script-level rule, `pnpm validate:plugins` would still pass on a manifest missing `type` or `title`. The schema tightening catches the drift via `pnpm test:integration` only, not via the plugin validator. RULE 9 was added covering both top-level `userConfig` and `channels[].userConfig`.
 
 ## Implementation Plan
 

--- a/plans/plugin-manifest-userconfig-validator-drift.md
+++ b/plans/plugin-manifest-userconfig-validator-drift.md
@@ -1,0 +1,253 @@
+# Feature: Plugin manifest userConfig validator drift fix
+
+## Problem Statement
+
+`claude doctor` reports 4 plugins with invalid `userConfig` blocks:
+
+- `yellow-devin@2.3.0` — `devin_service_user_token`, `devin_org_id`
+- `yellow-research@3.0.1` — `perplexity_api_key`, `tavily_api_key`, `exa_api_key`
+- `yellow-morph@1.2.0` — `morph_api_key`
+- `yellow-semgrep@4.0.2` — `semgrep_app_token`
+
+Per-key the remote validator emits two errors:
+
+- `userConfig.<key>.type: Invalid option: expected one of "string"|"number"|"boolean"|"directory"|"file"` — `type` is absent in all 7 entries
+- `userConfig.<key>.title: Invalid input: expected string, received undefined` — `title` is absent (the local schema uses `label`, which the remote does not recognize)
+
+Local CI (`pnpm validate:schemas`) passes today: the local `userConfigEntry` schema makes `type` optional (defaulting to `"string"`), uses `label` instead of `title`, and does not include `"directory"`/`"file"` in the type enum. This is the same two-validator drift class that produced the `changelog` and `repository` install-blocker incidents (PR #66 family).
+
+## Current State
+
+Reviewed files:
+
+- `plugins/yellow-devin/.claude-plugin/plugin.json:19-28` — 2 keys, `description` + `sensitive` only
+- `plugins/yellow-research/.claude-plugin/plugin.json:23-36` — 3 keys, same shape
+- `plugins/yellow-morph/.claude-plugin/plugin.json:19-23` — 1 key, same shape
+- `plugins/yellow-semgrep/.claude-plugin/plugin.json:19-23` — 1 key, same shape
+- `schemas/plugin.schema.json:9-48` — `userConfigEntry` with `type` enum `[string, number, boolean]`, optional `type`, `label` (not `title`)
+
+`rg -l '"userConfig"' plugins/*/.claude-plugin/plugin.json` confirms only these 4 files declare `userConfig`. No other plugins are at risk.
+
+## Proposed Solution
+
+**Approach B from the brainstorm: manifest patch + schema tightening + solutions doc.**
+
+1. Add `"type": "string"` and `"title": "<label>"` to each of the 7 `userConfig` entries.
+2. Tighten `schemas/plugin.schema.json` `userConfigEntry`: make `type` and `title` required, extend the `type` enum to include `"directory"` and `"file"` (parity with remote validator).
+3. Document the failure mode under `docs/solutions/build-errors/`.
+4. Single Changesets entry at `patch` level spanning all 4 plugins.
+
+## Resolved decisions (from brainstorm open questions)
+
+1. **Field name `title` vs `label`** — use `title`. The `claude doctor` output literally says `userConfig.X.title: Invalid input: expected string`. Confirmed unambiguous. The local schema's `label` field is removed (unused — no plugin.json currently uses it).
+2. **Title style** — sentence case, matching the existing `description` style ("Devin service user token", not "Devin Service User Token").
+3. **`devin_org_id` `sensitive: false`** — keep explicit. Defaults can change; explicit-is-better matches the existing style elsewhere in the file.
+4. **`directory`/`file` enum entries** — add for parity with remote validator, even though no current plugin uses them. Purely additive, zero risk.
+5. **`sensitive` field survival** — explicitly preserved in the new schema. Verified in step 3.2 below.
+6. **`validate-plugin.js` hard-coded check (Approach C)** — defer per YAGNI. Schema enforcement via AJV is sufficient until a third drift incident.
+
+## Implementation Plan
+
+### Phase 1: Branch setup
+
+- [ ] 1.1: `gt repo sync` — sync trunk
+- [ ] 1.2: `gt branch create fix/plugin-manifest-userconfig-validator-drift`
+
+### Phase 2: Manifest patches (4 files)
+
+For each entry, add `"type": "string"` and `"title": "<label>"` immediately above the existing `description`.
+
+- [ ] 2.1: `plugins/yellow-devin/.claude-plugin/plugin.json`
+  - `devin_service_user_token` → title `"Devin service user token"`
+  - `devin_org_id` → title `"Devin organization ID"` (keep `sensitive: false`)
+- [ ] 2.2: `plugins/yellow-research/.claude-plugin/plugin.json`
+  - `perplexity_api_key` → title `"Perplexity API key"`
+  - `tavily_api_key` → title `"Tavily API key"`
+  - `exa_api_key` → title `"Exa API key"`
+- [ ] 2.3: `plugins/yellow-morph/.claude-plugin/plugin.json`
+  - `morph_api_key` → title `"Morph API key"`
+- [ ] 2.4: `plugins/yellow-semgrep/.claude-plugin/plugin.json`
+  - `semgrep_app_token` → title `"Semgrep app token"`
+- [ ] 2.5: Verify each file with `jq empty plugins/<name>/.claude-plugin/plugin.json` — catches any trailing-comma error post-edit
+- [ ] 2.6: WSL2 line-ending check — `file plugins/*/.claude-plugin/plugin.json | grep -v 'JSON text data' || true`. If any show CRLF, run `sed -i 's/\r$//'` on them.
+
+### Phase 3: Schema tightening (`schemas/plugin.schema.json`)
+
+- [ ] 3.1: In `definitions.userConfigEntry.properties.type`, extend the enum: `["string", "number", "boolean", "directory", "file"]`. Remove the `default: "string"` field — defaults are now meaningless because `type` is required.
+- [ ] 3.2: In `definitions.userConfigEntry.properties`, add `"title": { "type": "string", "minLength": 1 }`. Verify `sensitive`, `description`, `default`, `required` properties remain unchanged.
+- [ ] 3.3: Remove the `label` property entirely (unused, replaced by `title`). Confirmed via `rg '"label"' plugins/` returns no hits inside any `userConfigEntry` block.
+- [ ] 3.4: Add `"required": ["type", "title"]` to `userConfigEntry`. Place after `properties` and before `additionalProperties`.
+- [ ] 3.5: Update the `allOf` block: the fourth branch (`if not required type`) becomes dead code — remove it. Keep the three type-specific default-constraint branches.
+- [ ] 3.6: Update the `userConfig` top-level description (currently mentions `label` at line 249) — change `"declare type, label, description, default, required, sensitive"` to `"declare type, title, description, default, required, sensitive"`.
+- [ ] 3.7: `jq empty schemas/plugin.schema.json` — verify no trailing comma after property removal.
+
+### Phase 4: Solutions doc
+
+- [ ] 4.1: Create `docs/solutions/build-errors/userconfig-type-title-remote-validator-drift.md` documenting:
+  - Symptom: `claude doctor` errors with `type: Invalid option` and `title: Invalid input: expected string, received undefined`
+  - Root cause: local schema permitted absent `type` and used `label` instead of `title`
+  - Fix: 2 fields added per entry + schema tightening
+  - Prevention: schema is now strict — `pnpm validate:schemas` blocks future occurrences
+  - Cross-reference: `claude-code-plugin-manifest-validation-errors.md` and `plugin-json-changelog-key-schema-drift-remote-validator.md`
+
+### Phase 5: Memory + CLAUDE.md updates
+
+- [ ] 5.1: Update auto-memory file `.claude/projects/-home-kinginyellow-projects-yellow-plugins/memory/MEMORY.md` "Plugin Manifest Validation" section with one-line entry pointing to the new solutions doc
+- [ ] 5.2: No `plugins/<name>/CLAUDE.md` updates needed — the plugin docs reference `userConfig` in narrative form, not field-by-field, so no stale references to fix.
+
+### Phase 6: Validation, changeset, submit
+
+- [ ] 6.1: `pnpm validate:schemas` — must pass
+- [ ] 6.2: `pnpm validate:versions` — must pass (no version changes yet, but confirms baseline)
+- [ ] 6.3: `pnpm test:unit` — must pass (validates schema-test fixtures still align)
+- [ ] 6.4: `pnpm changeset` — select `patch` for: `yellow-devin`, `yellow-research`, `yellow-morph`, `yellow-semgrep`. Summary: `fix(plugin-manifests): add type and title to userConfig entries — fixes claude doctor remote-validator rejection`
+- [ ] 6.5: `gt commit create -m "fix(plugin-manifests): add type and title to userConfig entries"`
+- [ ] 6.6: `gt stack submit`
+
+## Technical Specifications
+
+### Files to modify (6)
+
+| File | Change |
+|---|---|
+| `plugins/yellow-devin/.claude-plugin/plugin.json` | +2 fields × 2 keys = 4 lines |
+| `plugins/yellow-research/.claude-plugin/plugin.json` | +2 fields × 3 keys = 6 lines |
+| `plugins/yellow-morph/.claude-plugin/plugin.json` | +2 fields × 1 key = 2 lines |
+| `plugins/yellow-semgrep/.claude-plugin/plugin.json` | +2 fields × 1 key = 2 lines |
+| `schemas/plugin.schema.json` | enum extension + `title` property + required array + remove dead `label` and dead `allOf` branch |
+| `docs/solutions/build-errors/userconfig-type-title-remote-validator-drift.md` | new file |
+
+### Files to create (2)
+
+| File | Purpose |
+|---|---|
+| `.changeset/<random-name>.md` | Patch bumps for all 4 plugins |
+| `docs/solutions/build-errors/userconfig-type-title-remote-validator-drift.md` | Solutions documentation |
+
+### Example diff (yellow-morph entry)
+
+Before:
+```json
+"morph_api_key": {
+  "description": "Morph API key (...). Stored in system keychain or ~/.claude/.credentials.json.",
+  "sensitive": true
+}
+```
+
+After:
+```json
+"morph_api_key": {
+  "type": "string",
+  "title": "Morph API key",
+  "description": "Morph API key (...). Stored in system keychain or ~/.claude/.credentials.json.",
+  "sensitive": true
+}
+```
+
+### Schema diff (excerpt)
+
+Before:
+```json
+"userConfigEntry": {
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["string", "number", "boolean"],
+      "default": "string"
+    },
+    "label": { "type": "string" },
+    "description": { "type": "string" },
+    ...
+  },
+  "additionalProperties": false,
+  "allOf": [
+    { "if": { "properties": { "type": { "const": "string" } }, "required": ["type"] },
+      "then": { "properties": { "default": { "type": "string" } } } },
+    { "if": { "properties": { "type": { "const": "number" } }, "required": ["type"] },
+      "then": { "properties": { "default": { "type": "number" } } } },
+    { "if": { "properties": { "type": { "const": "boolean" } }, "required": ["type"] },
+      "then": { "properties": { "default": { "type": "boolean" } } } },
+    { "if": { "not": { "required": ["type"] } },
+      "then": { "properties": { "default": { "type": "string" } } } }
+  ]
+}
+```
+
+After:
+```json
+"userConfigEntry": {
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["string", "number", "boolean", "directory", "file"]
+    },
+    "title": { "type": "string", "minLength": 1 },
+    "description": { "type": "string" },
+    ...
+  },
+  "required": ["type", "title"],
+  "additionalProperties": false,
+  "allOf": [
+    { "if": { "properties": { "type": { "const": "string" } }, "required": ["type"] },
+      "then": { "properties": { "default": { "type": "string" } } } },
+    { "if": { "properties": { "type": { "const": "number" } }, "required": ["type"] },
+      "then": { "properties": { "default": { "type": "number" } } } },
+    { "if": { "properties": { "type": { "const": "boolean" } }, "required": ["type"] },
+      "then": { "properties": { "default": { "type": "boolean" } } } }
+  ]
+}
+```
+
+(Note: `properties` truncated for clarity. `default`, `required`, `sensitive` are preserved verbatim.)
+
+### Dependencies
+
+None added. AJV already validates JSON Schema in `packages/infrastructure`.
+
+## Acceptance Criteria
+
+1. `pnpm validate:schemas` passes after the manifest changes (proves the new schema accepts the patched files).
+2. `pnpm validate:schemas` fails if any `userConfigEntry` is intentionally reverted to omit `type` or `title` (proves the schema actually enforces). Manual sanity check: temporarily delete `"type": "string"` from one entry, run validate, confirm failure, restore.
+3. After `pnpm changeset version` simulation (or after the auto-version bot runs in CI), all 4 plugins show patch bumps and the three-way version sync (`package.json` → `plugin.json` → `marketplace.json`) holds.
+4. Local install of the marketplace HEAD on a fresh Claude Code instance: `claude doctor` returns 0 plugin errors. (Cannot verify in-repo — verify post-merge as part of the release smoke test.)
+5. `pnpm validate:versions` passes.
+6. `pnpm test:unit` passes (no test fixtures regress).
+7. `git diff --stat` shows ≤ 7 files changed (4 manifests + 1 schema + 1 solutions doc + 1 changeset).
+
+## Edge Cases
+
+1. **`devin_org_id` is not sensitive** — fix still applies (`type: "string"`, `title: "Devin organization ID"`). `sensitive: false` stays.
+2. **Schema reads `label` somewhere we missed** — guarded by `rg '"label"' plugins/ schemas/ scripts/ packages/` returning no hits inside any `userConfigEntry` context. If any production code reads `label`, switch the migration to add `title` while keeping `label` deprecated, instead of removing it.
+3. **A plugin grows a `default` value for a userConfig field later** — the `allOf` constraint chain still enforces type-matched defaults. The 4th `if/then` branch was only reachable when `type` was absent; with `type` now required, that branch is unreachable and is correctly removed.
+4. **A future plugin adds `userConfig` after this lands** — author will get a local schema error if `type` or `title` is missing. This is the desired behavior (catch at PR time, not at `claude doctor` time on a user's machine).
+5. **CRLF on WSL2** — every JSON write goes through Edit (not Write), so existing LF endings are preserved. Validation step 2.6 catches accidental CRLF.
+
+## Performance / Security Considerations
+
+- **Performance:** None. Adding two scalar fields per entry. No runtime cost.
+- **Security:** `sensitive: true` is preserved on every credential field — keychain storage behavior unchanged. `title` is a UI label only; it never carries the credential value. No echo-back risk.
+- **Backward compatibility:** Schema additions are stricter, not looser. Any plugin currently passing validation continues to pass after the manifest fix is applied. No external consumer of the schema has been identified that would break.
+
+## Migration & Rollback
+
+- **Deployment:** Standard Changesets flow. Patch bumps for 4 plugins. Single PR. Single auto-version PR after merge.
+- **Rollback:** Revert the PR. The 4 plugins regress to the pre-fix state (still passing local CI, still failing `claude doctor`). No data migration. No cache invalidation needed beyond Claude Code's normal plugin cache refresh.
+
+## References
+
+### Internal
+
+- `docs/brainstorms/2026-05-05-plugin-manifest-userconfig-validator-drift-brainstorm.md` — full design rationale and approach options
+- `docs/solutions/build-errors/claude-code-plugin-manifest-validation-errors.md` — prior `repository`/`hooks` drift incident
+- `docs/solutions/build-errors/plugin-json-changelog-key-schema-drift-remote-validator.md` — prior `changelog` drift incident; prevention checklist
+- `schemas/plugin.schema.json:9-48` — `userConfigEntry` definition
+- `CLAUDE.md` "Plugin Manifest Validation" memory section
+- `CONTRIBUTING.md` — Changesets flow
+
+### Recent commits showing analogous patterns
+
+- PR #66 — repository/hooks schema drift fix (manifest + schema in same change)
+- `e0405546 docs(yellow-core, yellow-review)` — recent doc-only fix style
+- `608ba247 chore: version packages` — Changesets version PR shape

--- a/plugins/yellow-devin/.claude-plugin/plugin.json
+++ b/plugins/yellow-devin/.claude-plugin/plugin.json
@@ -18,10 +18,14 @@
   ],
   "userConfig": {
     "devin_service_user_token": {
+      "type": "string",
+      "title": "Devin service user token",
       "description": "Devin V3 service user token (cog_ prefix). Create at Devin Enterprise Settings > Service Users. Stored in system keychain.",
       "sensitive": true
     },
     "devin_org_id": {
+      "type": "string",
+      "title": "Devin organization ID",
       "description": "Devin organization ID. Find at Devin Enterprise Settings > Organizations.",
       "sensitive": false
     }

--- a/plugins/yellow-morph/.claude-plugin/plugin.json
+++ b/plugins/yellow-morph/.claude-plugin/plugin.json
@@ -18,6 +18,8 @@
   ],
   "userConfig": {
     "morph_api_key": {
+      "type": "string",
+      "title": "Morph API key",
       "description": "Morph API key (get one at https://morphllm.com — free tier 250K credits/month). Stored in system keychain or ~/.claude/.credentials.json.",
       "sensitive": true
     }

--- a/plugins/yellow-research/.claude-plugin/plugin.json
+++ b/plugins/yellow-research/.claude-plugin/plugin.json
@@ -22,14 +22,20 @@
   "outputStyles": "./output-styles",
   "userConfig": {
     "perplexity_api_key": {
+      "type": "string",
+      "title": "Perplexity API key",
       "description": "Optional Perplexity API key. Get one at https://www.perplexity.ai/settings/api. Without a key, perplexity MCP will fail at startup and those tools are skipped — other sources (tavily, exa, parallel, ast-grep) continue to work. Stored in system keychain.",
       "sensitive": true
     },
     "tavily_api_key": {
+      "type": "string",
+      "title": "Tavily API key",
       "description": "Optional Tavily API key. Get one at https://app.tavily.com. Tavily MCP starts without a key but tool calls return runtime errors — key required for actual searches. Stored in system keychain.",
       "sensitive": true
     },
     "exa_api_key": {
+      "type": "string",
+      "title": "Exa API key",
       "description": "Optional Exa API key. Get one at https://dashboard.exa.ai. Exa MCP starts without a key but tool calls return runtime errors — key required for actual searches. Stored in system keychain.",
       "sensitive": true
     }

--- a/plugins/yellow-semgrep/.claude-plugin/plugin.json
+++ b/plugins/yellow-semgrep/.claude-plugin/plugin.json
@@ -18,6 +18,8 @@
   ],
   "userConfig": {
     "semgrep_app_token": {
+      "type": "string",
+      "title": "Semgrep app token",
       "description": "Semgrep API token (sgp_ prefix). Must have Web API scope. Create at Semgrep Organization Settings > API Tokens. Stored in system keychain.",
       "sensitive": true
     }

--- a/schemas/plugin.schema.json
+++ b/schemas/plugin.schema.json
@@ -11,13 +11,16 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["string", "number", "boolean"],
-          "default": "string"
+          "enum": ["string", "number", "boolean", "directory", "file"]
         },
-        "label": { "type": "string" },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable label shown in the Claude Code setup UI when prompting for this value. Required by the Claude Code remote validator (claude doctor); absence causes a manifest-rejection at install time."
+        },
         "description": { "type": "string" },
         "default": {
-          "description": "Default value. Must match the declared `type` (string|number|boolean). Constrained via allOf below to prevent a string default containing shell metacharacters from being interpolated unsafely into monitor.command via ${user_config.KEY}."
+          "description": "Default value. Must match the declared `type` (string|number|boolean for value types; string for directory/file path types). Constrained via allOf below to prevent a string default containing shell metacharacters from being interpolated unsafely into monitor.command via ${user_config.KEY}."
         },
         "required": { "type": "boolean" },
         "sensitive": {
@@ -26,6 +29,7 @@
           "description": "Store value in OS keychain when true."
         }
       },
+      "required": ["type", "title"],
       "additionalProperties": false,
       "allOf": [
         {
@@ -41,7 +45,11 @@
           "then": { "properties": { "default": { "type": "boolean" } } }
         },
         {
-          "if": { "not": { "required": ["type"] } },
+          "if": { "properties": { "type": { "const": "directory" } }, "required": ["type"] },
+          "then": { "properties": { "default": { "type": "string" } } }
+        },
+        {
+          "if": { "properties": { "type": { "const": "file" } }, "required": ["type"] },
           "then": { "properties": { "default": { "type": "string" } } }
         }
       ]
@@ -246,7 +254,7 @@
     },
     "userConfig": {
       "type": "object",
-      "description": "Config keys prompted at install time. Values substituted as ${user_config.KEY} and exported as CLAUDE_PLUGIN_OPTION_<KEY> env vars. Each entry may declare type, label, description, default, required, sensitive.",
+      "description": "Config keys prompted at install time. Values substituted as ${user_config.KEY} and exported as CLAUDE_PLUGIN_OPTION_<KEY> env vars. Each entry must declare type and title (required by the Claude Code remote validator), and may declare description, default, required, sensitive.",
       "propertyNames": {
         "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
       },

--- a/scripts/validate-plugin.js
+++ b/scripts/validate-plugin.js
@@ -780,6 +780,63 @@ function validatePlugin(pluginDir) {
   // (RULE 8 — shebang / decision-output / set -e content checks — folded
   // into RULES 6+8 single-pass loop above via validateHookScriptPath.)
 
+  // RULE 9: userConfig entries must declare `type` and `title`. The Claude
+  // Code remote validator (claude doctor) rejects any entry missing either,
+  // and only accepts type ∈ {string, number, boolean, directory, file}. Local
+  // CI mirrors that here because the JSON Schema in schemas/plugin.schema.json
+  // is not currently AJV-loaded by validate-plugin.js — without this check
+  // the drift only surfaces at install time. See
+  // docs/solutions/build-errors/userconfig-type-title-remote-validator-drift.md
+  if (manifest.userConfig !== undefined) {
+    if (
+      typeof manifest.userConfig !== 'object' ||
+      manifest.userConfig === null ||
+      Array.isArray(manifest.userConfig)
+    ) {
+      addError(errors, 'userConfig must be an object keyed by config name');
+    } else {
+      const VALID_USER_CONFIG_TYPES = new Set([
+        'string',
+        'number',
+        'boolean',
+        'directory',
+        'file',
+      ]);
+      for (const [key, entry] of Object.entries(manifest.userConfig)) {
+        if (
+          typeof entry !== 'object' ||
+          entry === null ||
+          Array.isArray(entry)
+        ) {
+          addError(errors, `userConfig.${key} must be an object`);
+          continue;
+        }
+        if (entry.type === undefined) {
+          addError(
+            errors,
+            `userConfig.${key} is missing required field "type" (one of: string, number, boolean, directory, file)`
+          );
+        } else if (!VALID_USER_CONFIG_TYPES.has(entry.type)) {
+          addError(
+            errors,
+            `userConfig.${key}.type "${entry.type}" is invalid — must be one of: string, number, boolean, directory, file`
+          );
+        }
+        if (entry.title === undefined) {
+          addError(
+            errors,
+            `userConfig.${key} is missing required field "title" (human-readable UI label)`
+          );
+        } else if (typeof entry.title !== 'string' || entry.title.length === 0) {
+          addError(
+            errors,
+            `userConfig.${key}.title must be a non-empty string`
+          );
+        }
+      }
+    }
+  }
+
   // Summary
   if (errors.length === 0) {
     logSuccess(`Plugin "${manifest.name}" is valid`);

--- a/scripts/validate-plugin.js
+++ b/scripts/validate-plugin.js
@@ -19,10 +19,11 @@
 // NOTE: JSON Schema validation (AJV) runs separately via validate-schemas.js /
 // `pnpm validate:schemas`. This script enforces additional rules not expressible
 // in JSON Schema: path existence, directory structure, .md file presence, hook
-// script sanity, and hooks.json drift. Always run both together via
+// script sanity, hooks.json drift, and (since the userConfig type/title fix
+// per docs/solutions/build-errors/userconfig-type-title-remote-validator-drift.md)
+// the userConfig shape constraints. Always run both together via
 // `pnpm validate:schemas` — running this script alone does not catch schema
-// shape violations in fields like monitors, channels, userConfig, and
-// dependencies.
+// shape violations in fields like monitors and dependencies.
 
 const fs = require('fs');
 const path = require('path');
@@ -59,6 +60,20 @@ const DECISION_PROTOCOL_EVENTS = new Set([
   'PostToolUse',
   'Stop',
   'SessionStart',
+]);
+
+// Valid `type` values for a userConfig entry, mirroring the Claude Code
+// remote validator's enum. Module-scope so RULE 9 can reuse the Set across
+// both the top-level userConfig walk and the per-channel walk without
+// reallocating it per validatePlugin call (matches the VALID_HOOK_EVENTS
+// pattern above). Keep in sync with `definitions.userConfigEntry.properties.type.enum`
+// in schemas/plugin.schema.json.
+const VALID_USER_CONFIG_TYPES = new Set([
+  'string',
+  'number',
+  'boolean',
+  'directory',
+  'file',
 ]);
 
 /**
@@ -785,56 +800,56 @@ function validatePlugin(pluginDir) {
   // and only accepts type ∈ {string, number, boolean, directory, file}. Local
   // CI mirrors that here because the JSON Schema in schemas/plugin.schema.json
   // is not currently AJV-loaded by validate-plugin.js — without this check
-  // the drift only surfaces at install time. See
-  // docs/solutions/build-errors/userconfig-type-title-remote-validator-drift.md
-  if (manifest.userConfig !== undefined) {
+  // the drift only surfaces at install time. The check covers both the
+  // top-level `userConfig` object AND each `channels[].userConfig` object,
+  // because `channels[*].userConfig` reuses the same `userConfigEntry`
+  // schema definition and carries the same remote-validator constraints.
+  // See docs/solutions/build-errors/userconfig-type-title-remote-validator-drift.md
+  function validateUserConfigEntries(userConfig, pathPrefix) {
     if (
-      typeof manifest.userConfig !== 'object' ||
-      manifest.userConfig === null ||
-      Array.isArray(manifest.userConfig)
+      typeof userConfig !== 'object' ||
+      userConfig === null ||
+      Array.isArray(userConfig)
     ) {
-      addError(errors, 'userConfig must be an object keyed by config name');
-    } else {
-      const VALID_USER_CONFIG_TYPES = new Set([
-        'string',
-        'number',
-        'boolean',
-        'directory',
-        'file',
-      ]);
-      for (const [key, entry] of Object.entries(manifest.userConfig)) {
-        if (
-          typeof entry !== 'object' ||
-          entry === null ||
-          Array.isArray(entry)
-        ) {
-          addError(errors, `userConfig.${key} must be an object`);
-          continue;
-        }
-        if (entry.type === undefined) {
-          addError(
-            errors,
-            `userConfig.${key} is missing required field "type" (one of: string, number, boolean, directory, file)`
-          );
-        } else if (!VALID_USER_CONFIG_TYPES.has(entry.type)) {
-          addError(
-            errors,
-            `userConfig.${key}.type "${entry.type}" is invalid — must be one of: string, number, boolean, directory, file`
-          );
-        }
-        if (entry.title === undefined) {
-          addError(
-            errors,
-            `userConfig.${key} is missing required field "title" (human-readable UI label)`
-          );
-        } else if (typeof entry.title !== 'string' || entry.title.length === 0) {
-          addError(
-            errors,
-            `userConfig.${key}.title must be a non-empty string`
-          );
-        }
+      addError(errors, `${pathPrefix} must be an object keyed by config name`);
+      return;
+    }
+    for (const [key, entry] of Object.entries(userConfig)) {
+      if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+        addError(errors, `${pathPrefix}.${key} must be an object`);
+        continue;
+      }
+      if (entry.type == null) {
+        addError(
+          errors,
+          `${pathPrefix}.${key} is missing required field "type" (one of: string, number, boolean, directory, file)`
+        );
+      } else if (!VALID_USER_CONFIG_TYPES.has(entry.type)) {
+        addError(
+          errors,
+          `${pathPrefix}.${key}.type "${entry.type}" is invalid — must be one of: string, number, boolean, directory, file`
+        );
+      }
+      if (entry.title == null) {
+        addError(
+          errors,
+          `${pathPrefix}.${key} is missing required field "title" (human-readable UI label)`
+        );
+      } else if (typeof entry.title !== 'string' || entry.title.length === 0) {
+        addError(errors, `${pathPrefix}.${key}.title must be a non-empty string`);
       }
     }
+  }
+
+  if (manifest.userConfig !== undefined) {
+    validateUserConfigEntries(manifest.userConfig, 'userConfig');
+  }
+  if (Array.isArray(manifest.channels)) {
+    manifest.channels.forEach((ch, i) => {
+      if (ch && typeof ch === 'object' && ch.userConfig !== undefined) {
+        validateUserConfigEntries(ch.userConfig, `channels[${i}].userConfig`);
+      }
+    });
   }
 
   // Summary


### PR DESCRIPTION
Resolves 4 plugin errors reported by claude doctor: yellow-devin, yellow-research, yellow-morph, yellow-semgrep. Each affected userConfig entry now declares 'type': 'string' and a sentence-case 'title'. Sensitive flag preserved verbatim — keychain storage behavior unchanged.

Companion changes outside the plugins:
- schemas/plugin.schema.json: userConfigEntry tightened (type+title required, type enum extended with directory/file, unused label removed, dead allOf branch removed).
- scripts/validate-plugin.js: RULE 9 added (hand-rolled enforcement, since the JSON schema is not AJV-loaded by validate:schemas — script-level check is what actually catches this drift before claude doctor).

Solutions doc: docs/solutions/build-errors/userconfig-type-title-remote-validator-drift.md cross-references prior changelog/repository drift incidents.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "directory" and "file" configuration field types in plugins.

* **Chores**
  * Enhanced plugin manifest validation to require configuration field metadata.
  * Improved configuration field labels for better UI clarity across plugins.
  * Updated schema definitions for stricter manifest validation.
  * Added documentation on plugin configuration validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes four plugins (`yellow-devin`, `yellow-research`, `yellow-morph`, `yellow-semgrep`) whose `userConfig` entries were rejected by the Claude Code remote validator because they omitted the required `type` and `title` fields — local CI passed because the local schema made both optional and used `label` instead of `title`.

- **Manifest patches**: Adds `\"type\": \"string\"` and a sentence-case `\"title\"` to all 7 affected `userConfig` keys across the four plugins; `sensitive` flags are preserved verbatim.
- **Schema tightening** (`schemas/plugin.schema.json`): Makes `type` and `title` required, extends the `type` enum to include `directory`/`file`, removes the unused `label` property and a now-unreachable `allOf` fallback branch.
- **Script-level guard** (`scripts/validate-plugin.js`): Adds RULE 9, a hand-rolled `validateUserConfigEntries` helper covering both top-level and per-channel `userConfig`, because the script does not AJV-load the JSON Schema and would otherwise still pass on non-conforming manifests.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the manifest fixes are surgical and correct, the schema tightening is additive, and all four plugins are updated in the same change so no existing plugin is left stranded.

The core manifest changes and schema tightening are straightforward and well-scoped. The two minor gaps — minLength: 1 in the schema and length === 0 in the validator script both accepting whitespace-only titles — are cosmetic: no current title value is at risk and the remote validator would likely reject a blank label at runtime anyway.

schemas/plugin.schema.json and scripts/validate-plugin.js carry the small whitespace-title gap noted in the inline suggestions; the four plugin.json files and the workflow change are clean.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/yellow-devin/.claude-plugin/plugin.json | Adds type and sentence-case title to devin_service_user_token and devin_org_id; sensitive flags preserved verbatim. |
| plugins/yellow-morph/.claude-plugin/plugin.json | Adds type and title to the single morph_api_key entry; no other changes. |
| plugins/yellow-research/.claude-plugin/plugin.json | Adds type and title to all three API key entries (Perplexity, Tavily, Exa); all marked sensitive: true and unchanged. |
| plugins/yellow-semgrep/.claude-plugin/plugin.json | Adds type and title to semgrep_app_token; sensitive: true preserved. |
| schemas/plugin.schema.json | Tightens userConfigEntry: makes type and title required, extends type enum with directory/file, removes unused label property, replaces dead fallback allOf branch. Minor gap: minLength: 1 permits whitespace-only titles. |
| scripts/validate-plugin.js | Adds RULE 9 as a hand-rolled validateUserConfigEntries helper covering both top-level and per-channel userConfig. Minor: whitespace-only titles pass the length === 0 guard. |
| .github/workflows/validate-schemas.yml | Adds title: to the sensitive-scan grep exclusion list so UI-label lines naming token/API key don't false-positive; comment updated. |
| examples/plugin-extended.example.json | Renames label to title in top-level entries and adds missing title to channel userConfig entries to match the tightened schema. |
| .changeset/userconfig-type-title-validator-drift.md | Registers patch bumps for all four affected plugins with a clear summary of the validator-drift fix. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[plugin.json userConfig entry] --> B{has type?}
    B -- No --> C[❌ RULE 9: missing required field type]
    B -- Yes --> D{type ∈ enum?}
    D -- No --> E[❌ RULE 9: invalid type value]
    D -- Yes --> F{has title?}
    F -- No --> G[❌ RULE 9: missing required field title]
    F -- Yes --> H{title non-empty?}
    H -- No --> I[❌ RULE 9: title must be non-empty string]
    H -- Yes --> J[✅ Passes local CI]
    J --> K[✅ Passes remote claude doctor]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffix%2Fplugin-manifest-userconfig-validator-drift%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffix%2Fplugin-manifest-userconfig-validator-drift%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aschemas%2Fplugin.schema.json%3A16-20%0AThe%20%60minLength%3A%201%60%20constraint%20on%20%60title%60%20permits%20a%20value%20of%20%60%22%20%22%60%20%28one%20or%20more%20spaces%29%2C%20which%20would%20render%20as%20a%20blank%20label%20in%20the%20Claude%20Code%20setup%20UI%20and%20still%20pass%20both%20schema%20validation%20and%20the%20RULE%209%20script%20check%20%28%60entry.title.length%20%3D%3D%3D%200%60%29.%20Adding%20a%20%60pattern%60%20that%20requires%20at%20least%20one%20non-whitespace%20character%20closes%20this%20gap%20without%20changing%20the%20valid%20title%20space%20for%20any%20real%20usage.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%22title%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%22type%22%3A%20%22string%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22minLength%22%3A%201%2C%0A%20%20%20%20%20%20%20%20%20%20%22pattern%22%3A%20%22%5C%5CS%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22description%22%3A%20%22Human-readable%20label%20shown%20in%20the%20Claude%20Code%20setup%20UI%20when%20prompting%20for%20this%20value.%20Required%20by%20the%20Claude%20Code%20remote%20validator%20%28claude%20doctor%29%3B%20absence%20causes%20a%20manifest-rejection%20at%20install%20time.%22%0A%20%20%20%20%20%20%20%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fvalidate-plugin.js%3A838-839%0AThe%20title%20validation%20mirrors%20the%20schema's%20%60minLength%3A%201%60%20but%20not%20its%20intent%3A%20%60%22%20%22%60%20%28all-whitespace%29%20passes%20the%20%60length%20%3D%3D%3D%200%60%20check.%20Trimming%20before%20the%20length%20check%20keeps%20the%20script%20consistent%20with%20the%20spirit%20of%20a%20%22non-empty%22%20label%20without%20needing%20a%20separate%20regex.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%7D%20else%20if%20%28typeof%20entry.title%20!%3D%3D%20'string'%20%7C%7C%20entry.title.trim%28%29.length%20%3D%3D%3D%200%29%20%7B%0A%20%20%20%20%20%20%20%20addError%28errors%2C%20%60%24%7BpathPrefix%7D.%24%7Bkey%7D.title%20must%20be%20a%20non-empty%2C%20non-whitespace%20string%60%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
schemas/plugin.schema.json:16-20
The `minLength: 1` constraint on `title` permits a value of `" "` (one or more spaces), which would render as a blank label in the Claude Code setup UI and still pass both schema validation and the RULE 9 script check (`entry.title.length === 0`). Adding a `pattern` that requires at least one non-whitespace character closes this gap without changing the valid title space for any real usage.

```suggestion
        "title": {
          "type": "string",
          "minLength": 1,
          "pattern": "\\S",
          "description": "Human-readable label shown in the Claude Code setup UI when prompting for this value. Required by the Claude Code remote validator (claude doctor); absence causes a manifest-rejection at install time."
        },
```

### Issue 2 of 2
scripts/validate-plugin.js:838-839
The title validation mirrors the schema's `minLength: 1` but not its intent: `" "` (all-whitespace) passes the `length === 0` check. Trimming before the length check keeps the script consistent with the spirit of a "non-empty" label without needing a separate regex.

```suggestion
      } else if (typeof entry.title !== 'string' || entry.title.trim().length === 0) {
        addError(errors, `${pathPrefix}.${key}.title must be a non-empty, non-whitespace string`);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: exclude userConfig title fields from..."](https://github.com/kinginyellows/yellow-plugins/commit/04baae980c129a2843df242ac1b32a02cbe0cd79) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30955160)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->