### PR TITLE
fix(yellow-morph): wrap hooks/hooks.json under "hooks" key

### DIFF
--- a/.changeset/yellow-morph-hooks-json-schema.md
+++ b/.changeset/yellow-morph-hooks-json-schema.md
@@ -1,0 +1,7 @@
+---
+"yellow-morph": patch
+---
+
+Fix `hooks/hooks.json` shape so Claude Code 2.1.131+ can load the plugin's `SessionStart` prewarm hook.
+
+The reference file had `SessionStart` at the top level instead of nested under a `"hooks"` key. Recent Claude Code releases auto-discover and validate `hooks/hooks.json` against `{ hooks: Record<EventName, …> }`, so the plugin failed `/doctor` with `Hook load failed: expected "record", received undefined at path ["hooks"]`. The inline `hooks` block in `plugin.json` is unchanged; only the reference file was rewrapped to match the schema and the shape used by every other plugin in this repo (gt-workflow, yellow-ci, yellow-debt, yellow-ruvector).

--- a/plugins/yellow-morph/hooks/hooks.json
+++ b/plugins/yellow-morph/hooks/hooks.json
@@ -1,15 +1,17 @@
 {
   "_comment": "Reference only — Claude Code reads inline hooks from plugin.json. The authoritative SessionStart hook runs hooks/scripts/prewarm-morph.sh.",
-  "SessionStart": [
-    {
-      "matcher": "*",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prewarm-morph.sh",
-          "timeout": 30
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prewarm-morph.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Claude Code 2.1.131+ auto-discovers and validates hooks/hooks.json against
{ hooks: Record<EventName, ...> }. yellow-morph had SessionStart at the top
level instead of nested under "hooks", causing /doctor to report 'Hook
load failed: expected record, received undefined at path ["hooks"]'.

Rewrap to match the schema and the shape used by gt-workflow, yellow-ci,
yellow-debt, and yellow-ruvector. The inline hooks block in plugin.json
is unchanged. Drift check now passes (was silently treating events as
absent due to the missing wrapper).

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `plugins/yellow-morph/hooks/hooks.json` so its schema matches what Claude Code 2.1.131+ expects when auto-discovering hook files — wrapping the `SessionStart` event under a top-level `"hooks"` key rather than placing it at the root.

- **Schema fix**: `SessionStart` is now nested under `{ "hooks": { "SessionStart": […] } }`, matching the `Record<EventName, …>` shape validated at load time; the flat layout caused `/doctor` to report `Hook load failed: expected "record", received undefined at path ["hooks"]`.
- **Consistency**: The updated shape is identical to every other plugin in the repo (`gt-workflow`, `yellow-ci`, `yellow-debt`, `yellow-ruvector`), and a patch-level changeset entry documents the change.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal JSON restructuring with no logic changes, fully consistent with the established pattern across all sibling plugins.

The change rewraps a single JSON file to match the schema already used by every other plugin in the repo. No logic, no scripts, and no runtime behavior is altered — the hook command and timeout are unchanged.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/yellow-morph/hooks/hooks.json | Wraps SessionStart event under a top-level "hooks" key to match the { hooks: Record<EventName, …> } schema expected by Claude Code 2.1.131+; structure now matches all other plugin hooks.json files in the repo. |
| .changeset/yellow-morph-hooks-json-schema.md | Patch-level changeset entry accurately describing the schema fix and its motivation. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Claude Code 2.1.131+ startup] --> B{Auto-discover hooks/hooks.json}
    B --> C{Validate schema\nhooks: Record-EventName-...}
    C -- Before fix\nSessionStart at root --> D[Hook load failed\nexpected record, received undefined\nat path hooks]
    C -- After fix\nSessionStart under hooks key --> E[Schema valid\nSessionStart hook registered]
    E --> F[SessionStart fires\nprewarm-morph.sh executed]
```

<sub>Reviews (3): Last reviewed commit: ["fix(yellow-morph): wrap hooks/hooks.json..."](https://github.com/kinginyellows/yellow-plugins/commit/75b697b62096ddc26502c8b9f67d34a609a265ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31045674)</sub>

<!-- /greptile_comment -->