### PR TITLE
fix(scripts): validate per-event array shape in hooks/hooks.json

### DIFF
--- a/scripts/validate-plugin.js
+++ b/scripts/validate-plugin.js
@@ -727,7 +727,23 @@ function validatePlugin(pluginDir) {
           errors,
           'hooks/hooks.json: top-level "hooks" key is required and must be a non-null object — Claude Code 2.1.131+ rejects plugins with a different shape'
         );
-      } else if (hasInlineHooks) {
+      } else {
+        // Per-event shape check: each event's value must be an array of hook
+        // entries. Claude Code's runtime expects Record<EventName, Array<...>>;
+        // a non-array value (string, object, number) passes the top-level
+        // shape check but fails at install time. Runs unconditionally — hooks-
+        // only plugins (no inline hooks in plugin.json) must also be validated.
+        for (const [event, value] of Object.entries(hooksField)) {
+          if (!Array.isArray(value)) {
+            addError(
+              errors,
+              `hooks/hooks.json: event "${event}" must be an array of hook entries — got ${value === null ? 'null' : typeof value}; Claude Code 2.1.131+ rejects non-array event values`
+            );
+          }
+        }
+      }
+
+      if (hasValidShape && hasInlineHooks) {
         // Drift check between plugin.json inline hooks and hooks.json.
         const hooksJsonHooks = hooksField;
         const manifestHooks = inlineHooks;

--- a/scripts/validate-plugin.js
+++ b/scripts/validate-plugin.js
@@ -733,7 +733,15 @@ function validatePlugin(pluginDir) {
         // a non-array value (string, object, number) passes the top-level
         // shape check but fails at install time. Runs unconditionally — hooks-
         // only plugins (no inline hooks in plugin.json) must also be validated.
+        // Event-name recognition mirrors the inline-hooks check above so typos
+        // (e.g., "SesionStart") are caught even when plugin.json has no inline
+        // hooks to trigger that branch.
         for (const [event, value] of Object.entries(hooksField)) {
+          if (!VALID_HOOK_EVENTS.has(event)) {
+            logWarning(
+              `hooks/hooks.json: unknown hook event "${event}". Known events: ${[...VALID_HOOK_EVENTS].join(', ')}`
+            );
+          }
           if (!Array.isArray(value)) {
             addError(
               errors,

--- a/tests/integration/validate-plugin.test.ts
+++ b/tests/integration/validate-plugin.test.ts
@@ -573,18 +573,30 @@ printf 'plain text\\n'
     expect(stderr).not.toMatch(/hooks\/hooks\.json/);
   });
 
-  it('errors when hooks/hooks.json has a non-array event value (RULE 7: per-event shape check)', () => {
+  it('errors when hooks/hooks.json has a non-array event value with inline hooks present (RULE 7: per-event shape check)', () => {
     // Top-level shape can be valid ({ hooks: { ... } }) but each event must be
     // an array of hook entries. Claude Code's runtime expects
     // Record<EventName, Array<HookEntry>>; a string/object/number value under
-    // an event key passes the top-level check but fails at install time.
+    // an event key passes the top-level check but fails at install time. This
+    // case exercises the hasInlineHooks=true branch — the next test exercises
+    // the hooks-only path.
     mkdirSync(join(pluginDir, 'hooks'), { recursive: true });
     writeFileSync(
       join(pluginDir, 'hooks', 'hooks.json'),
       JSON.stringify({ hooks: { SessionStart: 'not-an-array' } }, null, 2),
       'utf8'
     );
-    writePluginManifest(pluginDir, VALID_BASE_MANIFEST); // no inline hooks
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      hooks: {
+        SessionStart: [
+          {
+            matcher: '*',
+            hooks: [{ type: 'command', command: 'echo ok' }],
+          },
+        ],
+      },
+    });
     const { status, stderr } = runValidator(pluginDir);
     expect(status).toBeGreaterThan(0);
     expect(stderr).toMatch(

--- a/tests/integration/validate-plugin.test.ts
+++ b/tests/integration/validate-plugin.test.ts
@@ -572,4 +572,41 @@ printf 'plain text\\n'
     expect(status).toBe(0);
     expect(stderr).not.toMatch(/hooks\/hooks\.json/);
   });
+
+  it('errors when hooks/hooks.json has a non-array event value (RULE 7: per-event shape check)', () => {
+    // Top-level shape can be valid ({ hooks: { ... } }) but each event must be
+    // an array of hook entries. Claude Code's runtime expects
+    // Record<EventName, Array<HookEntry>>; a string/object/number value under
+    // an event key passes the top-level check but fails at install time.
+    mkdirSync(join(pluginDir, 'hooks'), { recursive: true });
+    writeFileSync(
+      join(pluginDir, 'hooks', 'hooks.json'),
+      JSON.stringify({ hooks: { SessionStart: 'not-an-array' } }, null, 2),
+      'utf8'
+    );
+    writePluginManifest(pluginDir, VALID_BASE_MANIFEST); // no inline hooks
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(
+      /hooks\/hooks\.json: event "SessionStart" must be an array of hook entries — got string/
+    );
+  });
+
+  it('runs per-event array check even when plugin.json has no inline hooks (RULE 7: hoisted out of drift branch)', () => {
+    // The per-event check must fire for hooks-only plugins (plugin.json with
+    // no inline hooks). Previously this validation lived inside the
+    // hasInlineHooks-gated drift branch and silently passed.
+    mkdirSync(join(pluginDir, 'hooks'), { recursive: true });
+    writeFileSync(
+      join(pluginDir, 'hooks', 'hooks.json'),
+      JSON.stringify({ hooks: { PostToolUse: { matcher: '*' } } }, null, 2),
+      'utf8'
+    );
+    writePluginManifest(pluginDir, VALID_BASE_MANIFEST); // no inline hooks
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(
+      /hooks\/hooks\.json: event "PostToolUse" must be an array of hook entries — got object/
+    );
+  });
 });

--- a/tests/integration/validate-plugin.test.ts
+++ b/tests/integration/validate-plugin.test.ts
@@ -609,4 +609,25 @@ printf 'plain text\\n'
       /hooks\/hooks\.json: event "PostToolUse" must be an array of hook entries — got object/
     );
   });
+
+  it('warns on unknown hook event name in hooks/hooks.json even when plugin.json has no inline hooks (RULE 7: event-name recognition)', () => {
+    // Mirrors the inline-hooks unknown-event warning so typos in hooks-only
+    // plugins (e.g., "SesionStart") are caught — the inline branch is gated
+    // on hasInlineHooks and would otherwise skip them.
+    mkdirSync(join(pluginDir, 'hooks'), { recursive: true });
+    writeFileSync(
+      join(pluginDir, 'hooks', 'hooks.json'),
+      JSON.stringify(
+        { hooks: { SesionStart: [{ hooks: [{ type: 'command', command: 'echo ok' }] }] } },
+        null,
+        2
+      ),
+      'utf8'
+    );
+    writePluginManifest(pluginDir, VALID_BASE_MANIFEST); // no inline hooks
+    const { stderr } = runValidator(pluginDir);
+    expect(stderr).toMatch(
+      /hooks\/hooks\.json: unknown hook event "SesionStart"/
+    );
+  });
 });


### PR DESCRIPTION
PR #391 hardened the top-level hooks/hooks.json shape check ({ hooks: ... }
must be a non-null object). The shape gate stopped there: a file with
hooks: { SessionStart: 'string' } passed validation but Claude Code's
runtime expects Record<EventName, Array<HookEntry>> and rejects non-array
event values at install time.

Two related gaps in scripts/validate-plugin.js Rule 7, identified in the
review of #391:

- Per-event values were never validated. Add an unconditional loop after
  hasValidShape passes that calls addError for any event whose value is
  not an Array.
- The drift block (gated on hasInlineHooks) was the only place that
  touched per-event values, so hooks-only plugins (no inline hooks in
  plugin.json) had no per-event coverage at all. Splitting the per-event
  check out of the else-if and into its own else block ensures it runs
  regardless of hasInlineHooks.

Two integration tests added covering: non-array event value with inline
hooks (positive: error fires), non-array event value WITHOUT inline hooks
(positive: error still fires — the hoist out of the drift branch).

No changeset required — change scope is scripts/ + tests/ (per
CONTRIBUTING.md changeset policy).

Stacked on top of PR #391.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a per-event shape validation gap in `scripts/validate-plugin.js` Rule 7: `hooks/hooks.json` event values must be arrays, but that check was previously buried inside the `hasInlineHooks`-gated drift block and was silently skipped for hooks-only plugins. The fix restructures the block so the per-event array check runs unconditionally whenever the top-level shape is valid, and the drift logic is lifted into its own `if (hasValidShape && hasInlineHooks)` guard.

- **Per-event loop hoisted**: `else if (hasInlineHooks)` → `else` (unconditional when `hasValidShape`) ensures non-array event values are caught regardless of whether `plugin.json` carries inline hooks.
- **Drift check preserved**: Moved to a separate `if (hasValidShape && hasInlineHooks)` block; internal `!Array.isArray(jEntries)` guard already skips non-array entries without producing duplicate errors.
- **Three new integration tests**: cover the inline-hooks path, the hooks-only path (the previously silent gap), and unknown event name recognition for hooks-only plugins — though the PR description says only two tests were added.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the restructuring is minimal and well-scoped, the drift check's internal array guard prevents any double-error regression, and three integration tests confirm the previously silent path now fires correctly.

The per-event loop was moved out of a conditional branch into the unconditional else block, and the drift check was promoted to a standalone if with the same guard condition it had before. No existing behavior is altered for plugins that already had inline hooks; only the previously unchecked hooks-only path gains coverage. The logic is sound and the new tests exercise both paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/validate-plugin.js | Restructures the hooks.json validation block: moves per-event array check into the unconditional `else` (hasValidShape=true) branch and promotes the drift check to a separate `if (hasValidShape && hasInlineHooks)` guard — correctly closing the gap for hooks-only plugins. |
| tests/integration/validate-plugin.test.ts | Adds three integration tests: non-array event with inline hooks, non-array event without inline hooks (the hoisted path), and unknown event name for a hooks-only plugin. PR description says "two tests" but three are present — coverage is broader, not narrower. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(scripts): exercise hasInlineHooks=t..."](https://github.com/kinginyellows/yellow-plugins/commit/91245736cc1d6cd9a9a4097cc618dc3b12b73d62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31053019)</sub>

<!-- /greptile_comment -->