### PR TITLE
fix(yellow-codex): probe codex login status instead of ~/.codex/auth.json

### DIFF
--- a/.changeset/yellow-codex-login-status-probe.md
+++ b/.changeset/yellow-codex-login-status-probe.md
@@ -1,0 +1,37 @@
+---
+"yellow-codex": patch
+---
+
+# Fix auth detection for Codex CLI v0.118+ across `/codex:setup` and `/codex:status`
+
+Replace the `~/.codex/auth.json` file-existence check in
+`/codex:setup` Step 2 and `/codex:status` Step 4 with a
+`codex login status` probe. The Rust-based CLI (v0.118+) stores
+OAuth state in the OS keyring (libsecret on Linux, Keychain on
+macOS, Credential Manager on Windows) rather than `auth.json`, so
+the old check reported "not configured" for every authenticated
+user on a current CLI.
+
+`codex login status` is the canonical, version-stable probe — it
+reads from wherever the installed CLI persists credentials and
+returns a string like `Logged in using ChatGPT` or `Not logged in`.
+The grep match is anchored to `^logged in` so the negative case
+`Not logged in` is not silently classified as authenticated. Both
+commands fall through to a "legacy auth.json found" note when the
+file still exists (for users on pre-v0.118 CLIs) and to "not
+configured" otherwise.
+
+Companion doc updates:
+
+- `plugins/yellow-codex/skills/codex-patterns/SKILL.md` —
+  Authentication Methods table updated: ChatGPT OAuth row points
+  to OS keyring with `codex login status` as the state probe;
+  legacy `auth.json` retained as a separate row for pre-v0.118.
+  Prose corrected to scope `codex login status` to OAuth/keyring
+  state; API key auth is checked via `[ -n "$OPENAI_API_KEY" ]`.
+- `plugins/yellow-codex/CLAUDE.md` — Required Environment section
+  rewritten to describe the keyring-based storage and the
+  `codex login status` probe.
+
+No agent or command behavior changes — `codex exec` invocations
+are unaffected (they read auth from wherever the CLI resolves it).

--- a/plugins/yellow-codex/CLAUDE.md
+++ b/plugins/yellow-codex/CLAUDE.md
@@ -19,7 +19,10 @@ reviews, a rescue path for stuck tasks, and an alternative research lens.
   GitHub Releases.
 - **Authentication** — One of:
   - `OPENAI_API_KEY` environment variable (`sk-` or `sk-proj-` prefix)
-  - ChatGPT OAuth via `codex login` (stored in `~/.codex/auth.json`)
+  - ChatGPT OAuth via `codex login` (v0.118+ stores state in the OS
+    keyring — libsecret on Linux, Keychain on macOS, Credential Manager
+    on Windows; older versions wrote `~/.codex/auth.json`). Probe with
+    `codex login status`.
 
 ## Conventions
 

--- a/plugins/yellow-codex/commands/codex/setup.md
+++ b/plugins/yellow-codex/commands/codex/setup.md
@@ -137,10 +137,11 @@ if command -v codex >/dev/null 2>&1; then
   if [ "$login_exit" -eq 0 ] && printf '%s' "$login_status" | grep -qi '^logged in'; then
     # Do NOT echo $login_status — codex CLI may include API key fragments (e.g. "Logged in using an API key - sk-proj-***...")
     printf '[yellow-codex] codex login: authenticated\n'
+  elif [ -f "${HOME}/.codex/auth.json" ]; then
+    # Check legacy file before reporting probe error — pre-v0.118 CLIs may lack the `login status` subcommand entirely (non-zero exit) yet still be authenticated via auth.json.
+    printf '[yellow-codex] codex login: legacy auth.json found (pre-v0.118 format)\n'
   elif [ "$login_exit" -ne 0 ]; then
     printf '[yellow-codex] codex login: probe error (codex login status exited %d; run it manually to diagnose)\n' "$login_exit" >&2
-  elif [ -f "${HOME}/.codex/auth.json" ]; then
-    printf '[yellow-codex] codex login: legacy auth.json found (pre-v0.118 format)\n'
   else
     printf '[yellow-codex] codex login: not configured (run `codex login` to authenticate via ChatGPT)\n'
   fi

--- a/plugins/yellow-codex/commands/codex/setup.md
+++ b/plugins/yellow-codex/commands/codex/setup.md
@@ -130,11 +130,15 @@ returns a line like `Logged in using ChatGPT` or `Not logged in`.
 
 ```bash
 if command -v codex >/dev/null 2>&1; then
-  # Note: codex CLI writes login status to stderr (eprintln!), not stdout — capture both via 2>&1
-  login_status=$(codex login status 2>&1 || true)
-  if printf '%s' "$login_status" | grep -qi '^logged in'; then
+  # Note: codex CLI writes login status to stderr (eprintln!), not stdout — capture both via 2>&1.
+  # Capture exit code separately so probe failures (keyring locked, config corruption) are
+  # distinguishable from the "Not logged in" unauthenticated case (both leave the grep unmatched).
+  if login_status=$(codex login status 2>&1); then login_exit=0; else login_exit=$?; fi
+  if [ "$login_exit" -eq 0 ] && printf '%s' "$login_status" | grep -qi '^logged in'; then
     # Do NOT echo $login_status — codex CLI may include API key fragments (e.g. "Logged in using an API key - sk-proj-***...")
     printf '[yellow-codex] codex login: authenticated\n'
+  elif [ "$login_exit" -ne 0 ]; then
+    printf '[yellow-codex] codex login: probe error (codex login status exited %d; run it manually to diagnose)\n' "$login_exit" >&2
   elif [ -f "${HOME}/.codex/auth.json" ]; then
     printf '[yellow-codex] codex login: legacy auth.json found (pre-v0.118 format)\n'
   else

--- a/plugins/yellow-codex/commands/codex/setup.md
+++ b/plugins/yellow-codex/commands/codex/setup.md
@@ -121,22 +121,27 @@ fi
 
 **Method 2: ChatGPT OAuth via `codex login`**
 
+The Rust-based Codex CLI (v0.118+) stores its authentication in the OS
+keyring (libsecret on Linux, Keychain on macOS, Credential Manager on
+Windows) — NOT in `~/.codex/auth.json` (that path was the pre-Rust storage
+format). The `codex login status` subcommand is the canonical, version-stable
+probe; it reads from wherever the current CLI persists credentials and
+returns a line like `Logged in using ChatGPT` or `Not logged in`.
+
 ```bash
-if [ -f "${HOME}/.codex/auth.json" ]; then
-  if command -v jq >/dev/null 2>&1; then
-    auth_mode=$(jq -r '.auth_mode // empty' "${HOME}/.codex/auth.json" 2>/dev/null || true)
-    if [ "$auth_mode" = "chatgpt" ]; then
-      printf '[yellow-codex] codex login: authenticated (ChatGPT OAuth)\n'
-    elif [ -n "$auth_mode" ]; then
-      printf '[yellow-codex] codex login: authenticated (%s)\n' "$auth_mode"
-    else
-      printf '[yellow-codex] codex login: auth file exists but mode unknown\n'
-    fi
+if command -v codex >/dev/null 2>&1; then
+  # Note: codex CLI writes login status to stderr (eprintln!), not stdout — capture both via 2>&1
+  login_status=$(codex login status 2>&1 || true)
+  if printf '%s' "$login_status" | grep -qi '^logged in'; then
+    # Do NOT echo $login_status — codex CLI may include API key fragments (e.g. "Logged in using an API key - sk-proj-***...")
+    printf '[yellow-codex] codex login: authenticated\n'
+  elif [ -f "${HOME}/.codex/auth.json" ]; then
+    printf '[yellow-codex] codex login: legacy auth.json found (pre-v0.118 format)\n'
   else
-    printf '[yellow-codex] codex login: auth file exists (jq not installed; mode unknown)\n'
+    printf '[yellow-codex] codex login: not configured (run `codex login` to authenticate via ChatGPT)\n'
   fi
 else
-  printf '[yellow-codex] codex login: not configured\n'
+  printf '[yellow-codex] codex login: skipped (codex CLI not installed)\n'
 fi
 ```
 
@@ -145,7 +150,7 @@ If neither method is configured:
 ```text
 [yellow-codex] Warning: No authentication configured.
   Option 1: export OPENAI_API_KEY="sk-..." in ~/.zshrc
-  Option 2: codex login (authenticates via ChatGPT)
+  Option 2: codex login (authenticates via ChatGPT, stored in OS keyring)
 ```
 
 Never echo the actual API key value. If detected, replace output with:

--- a/plugins/yellow-codex/commands/codex/status.md
+++ b/plugins/yellow-codex/commands/codex/status.md
@@ -84,11 +84,15 @@ fi
 if [ -n "${OPENAI_API_KEY:-}" ]; then
   printf '[yellow-codex] Auth: OPENAI_API_KEY set\n'
 elif command -v codex >/dev/null 2>&1; then
-  # Note: codex CLI writes login status to stderr (eprintln!), not stdout — capture both via 2>&1
-  login_status=$(codex login status 2>&1 || true)
-  if printf '%s' "$login_status" | grep -qi '^logged in'; then
+  # Note: codex CLI writes login status to stderr (eprintln!), not stdout — capture both via 2>&1.
+  # Capture exit code separately so probe failures (keyring locked, config corruption) are
+  # distinguishable from the "Not logged in" unauthenticated case (both leave the grep unmatched).
+  if login_status=$(codex login status 2>&1); then login_exit=0; else login_exit=$?; fi
+  if [ "$login_exit" -eq 0 ] && printf '%s' "$login_status" | grep -qi '^logged in'; then
     # Do NOT echo $login_status — codex CLI may include API key fragments (e.g. "Logged in using an API key - sk-proj-***...")
     printf '[yellow-codex] Auth: codex login\n'
+  elif [ "$login_exit" -ne 0 ]; then
+    printf '[yellow-codex] Auth: probe error (codex login status exited %d)\n' "$login_exit" >&2
   elif [ -f "${HOME}/.codex/auth.json" ]; then
     printf '[yellow-codex] Auth: legacy auth.json found (pre-v0.118 format)\n'
   else

--- a/plugins/yellow-codex/commands/codex/status.md
+++ b/plugins/yellow-codex/commands/codex/status.md
@@ -83,15 +83,19 @@ fi
 ```bash
 if [ -n "${OPENAI_API_KEY:-}" ]; then
   printf '[yellow-codex] Auth: OPENAI_API_KEY set\n'
-elif [ -f "${HOME}/.codex/auth.json" ]; then
-  if command -v jq >/dev/null 2>&1; then
-    auth_mode=$(jq -r '.auth_mode // "unknown"' "${HOME}/.codex/auth.json" 2>/dev/null || echo "unknown")
-    printf '[yellow-codex] Auth: codex login (%s)\n' "$auth_mode"
+elif command -v codex >/dev/null 2>&1; then
+  # Note: codex CLI writes login status to stderr (eprintln!), not stdout — capture both via 2>&1
+  login_status=$(codex login status 2>&1 || true)
+  if printf '%s' "$login_status" | grep -qi '^logged in'; then
+    # Do NOT echo $login_status — codex CLI may include API key fragments (e.g. "Logged in using an API key - sk-proj-***...")
+    printf '[yellow-codex] Auth: codex login\n'
+  elif [ -f "${HOME}/.codex/auth.json" ]; then
+    printf '[yellow-codex] Auth: legacy auth.json found (pre-v0.118 format)\n'
   else
-    printf '[yellow-codex] Auth: codex login (auth file exists, jq not installed)\n'
+    printf '[yellow-codex] Auth: not configured\n'
   fi
 else
-  printf '[yellow-codex] Auth: not configured\n'
+  printf '[yellow-codex] Auth: not configured (codex CLI not installed)\n'
 fi
 ```
 

--- a/plugins/yellow-codex/commands/codex/status.md
+++ b/plugins/yellow-codex/commands/codex/status.md
@@ -91,10 +91,11 @@ elif command -v codex >/dev/null 2>&1; then
   if [ "$login_exit" -eq 0 ] && printf '%s' "$login_status" | grep -qi '^logged in'; then
     # Do NOT echo $login_status — codex CLI may include API key fragments (e.g. "Logged in using an API key - sk-proj-***...")
     printf '[yellow-codex] Auth: codex login\n'
+  elif [ -f "${HOME}/.codex/auth.json" ]; then
+    # Check legacy file before reporting probe error — pre-v0.118 CLIs may lack the `login status` subcommand entirely (non-zero exit) yet still be authenticated via auth.json.
+    printf '[yellow-codex] Auth: legacy auth.json found (pre-v0.118 format)\n'
   elif [ "$login_exit" -ne 0 ]; then
     printf '[yellow-codex] Auth: probe error (codex login status exited %d)\n' "$login_exit" >&2
-  elif [ -f "${HOME}/.codex/auth.json" ]; then
-    printf '[yellow-codex] Auth: legacy auth.json found (pre-v0.118 format)\n'
   else
     printf '[yellow-codex] Auth: not configured\n'
   fi

--- a/plugins/yellow-codex/skills/codex-patterns/SKILL.md
+++ b/plugins/yellow-codex/skills/codex-patterns/SKILL.md
@@ -289,14 +289,19 @@ Truncation limits:
 
 ## Authentication Methods
 
-| Method | Env Var | Config File | Priority |
-|--------|---------|-------------|----------|
-| API Key | `OPENAI_API_KEY` | — | Checked first |
-| ChatGPT OAuth | — | `~/.codex/auth.json` | Checked second |
-| Manual login | — | Run `codex login` | Interactive only |
+| Method | Env Var | Storage | State Probe |
+|--------|---------|---------|-------------|
+| API Key | `OPENAI_API_KEY` | Shell env | `[ -n "$OPENAI_API_KEY" ]` |
+| ChatGPT OAuth | — | OS keyring (libsecret/Keychain/CredMgr) | `codex login status` |
+| Legacy OAuth | — | `~/.codex/auth.json` (pre-v0.118 only) | File existence |
 
-The plugin never stores credentials. Users manage keys in their shell profile
-or via `codex login`.
+The Rust CLI (v0.118+) writes its OAuth state to the OS keyring, not to
+`~/.codex/auth.json`. Use `codex login status` to probe OAuth/keyring
+login state — it reads from wherever the installed CLI version actually
+persists credentials. For API key auth, check `[ -n "$OPENAI_API_KEY" ]`
+directly; that env var is never written to disk and `codex login status`
+does not reflect its presence. The plugin never stores credentials. Users
+manage keys in their shell profile or via `codex login`.
 
 ## Cost Estimation
 


### PR DESCRIPTION
The Rust-based Codex CLI (v0.118+) stores OAuth state in the OS keyring,
not in ~/.codex/auth.json. The previous setup.md probe checked the file
and reported "not configured" for every authenticated user on a current
CLI. Replace with `codex login status`, which reads from wherever the
installed CLI version persists credentials and works for both API key
and ChatGPT OAuth flows. Pre-v0.118 auth.json detection retained as a
fallback message.

Companion doc updates correct the SKILL.md authentication-methods table
and CLAUDE.md "Required Environment" section so they match the keyring
storage reality.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated authentication docs for Codex CLI v0.118+: OAuth state is now stored in the OS keyring (libsecret/Keychain/Credential Manager).
  * Added guidance to verify authentication using the canonical "codex login status" probe and clarified status-check messages and outcomes.
  * Noted legacy ~/.codex/auth.json may still be present for pre-v0.118 CLIs and adjusted examples and wording accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the stale `~/.codex/auth.json` file-existence check with `codex login status` across `/codex:setup` and `/codex:status`, correctly targeting the OS keyring storage introduced in Codex CLI v0.118+. Companion doc updates to `SKILL.md` and `CLAUDE.md` align the authentication-methods reference with the new storage reality.

- The grep pattern is now anchored to `^logged in` (case-insensitive), preventing the false-positive match on the unauthenticated string `Not logged in` that was flagged in the previous review thread.
- `SKILL.md` prose is corrected to scope `codex login status` to OAuth/keyring state only, with `[ -n \"$OPENAI_API_KEY\" ]` called out as the separate check for API key auth \u2014 resolving the table/prose contradiction from the prior thread.
- The legacy `auth.json` fallback branch fires for any case where the keyring probe doesn\u2019t confirm authentication (including a v0.118+ user who is simply not logged in but has a leftover file); the message could note that `codex login` is needed to avoid ambiguity.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the core auth probe logic is correct and the grep anchor fix is verified; the one observation is a message-wording ambiguity, not a functional defect.

All changed code is in markdown prompt/doc files. The grep anchor (`^logged in`) correctly prevents the false-positive on "Not logged in". Exit-code capture and elif ordering are logically sound. The only open question is whether the "legacy auth.json found" message is clear enough when a fully-current user is simply not logged in — a UX wording concern, not a correctness bug.

setup.md and status.md — the legacy-fallback branch wording when a v0.118+ user has a leftover auth.json but is not keyring-authenticated.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .changeset/yellow-codex-login-status-probe.md | New changeset file documenting the auth detection fix for Codex CLI v0.118+; accurately describes the `^logged in` anchor, fallback logic, and companion doc scope. |
| plugins/yellow-codex/CLAUDE.md | Required Environment section updated to describe OS keyring storage and the `codex login status` probe; accurate and concise. |
| plugins/yellow-codex/commands/codex/setup.md | Replaces `auth.json` existence check with `codex login status`; grep anchored to `^logged in` preventing false-positive on "Not logged in"; the "legacy auth.json found" message when a v0.118+ user is not logged in but has a leftover file could be more actionable. |
| plugins/yellow-codex/commands/codex/status.md | Same probe logic as setup.md; probe-error branch correctly routes to stderr; same legacy-file-found ambiguity applies when v0.118+ user is not keyring-authenticated but has a leftover auth.json. |
| plugins/yellow-codex/skills/codex-patterns/SKILL.md | Authentication Methods table rewritten with Storage and State Probe columns; prose correctly scopes `codex login status` to OAuth/keyring and `[ -n "$OPENAI_API_KEY" ]` to API key — resolves the prior thread’s table/prose contradiction. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Start auth probe]) --> B{codex CLI installed?}
    B -- No --> Z1[skipped: codex CLI not installed]
    B -- Yes --> C["run: codex login status 2>&1\ncapture output + exit code"]
    C --> D{"login_exit == 0 AND\noutput matches '^logged in'?"}
    D -- Yes --> Z2[authenticated]
    D -- No --> E{~/.codex/auth.json exists?}
    E -- Yes --> Z3["legacy auth.json found\n(pre-v0.118 format)"]
    E -- No --> F{login_exit != 0?}
    F -- Yes --> Z4[probe error to stderr]
    F -- No --> Z5[not configured]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffix%2Fyellow-codex-login-status-probe%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffix%2Fyellow-codex-login-status-probe%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aplugins%2Fyellow-codex%2Fcommands%2Fcodex%2Fsetup.md%3A140-142%0A**%22Legacy%20auth.json%20found%22%20when%20v0.118%2B%20user%20is%20simply%20not%20logged%20in**%0A%0AThe%20%60elif%20%5B%20-f%20%22%24%7BHOME%7D%2F.codex%2Fauth.json%22%20%5D%60%20branch%20fires%20whenever%20the%20first%20condition%20%28keyring%20authenticated%29%20is%20false%20%E2%80%94%20including%20when%20%60login_exit%3D0%60%20and%20%60codex%20login%20status%60%20returns%20%60Not%20logged%20in%60%2C%20i.e.%20a%20v0.118%2B%20user%20who%20has%20an%20old%20leftover%20%60auth.json%60%20but%20is%20definitively%20not%20authenticated.%20In%20that%20case%20the%20script%20prints%20%60legacy%20auth.json%20found%20%28pre-v0.118%20format%29%60%20with%20no%20hint%20that%20the%20user%20needs%20to%20run%20%60codex%20login%60.%20Adding%20a%20brief%20note%20like%20%60%28run%20'codex%20login'%20to%20re-authenticate%29%60%20would%20prevent%20the%20status%20from%20being%20silently%20misread%20as%20%22some%20auth%20exists.%22%0A%0AThe%20same%20pattern%20applies%20in%20%60status.md%60%20lines%2094-96.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
plugins/yellow-codex/commands/codex/setup.md:140-142
**"Legacy auth.json found" when v0.118+ user is simply not logged in**

The `elif [ -f "${HOME}/.codex/auth.json" ]` branch fires whenever the first condition (keyring authenticated) is false — including when `login_exit=0` and `codex login status` returns `Not logged in`, i.e. a v0.118+ user who has an old leftover `auth.json` but is definitively not authenticated. In that case the script prints `legacy auth.json found (pre-v0.118 format)` with no hint that the user needs to run `codex login`. Adding a brief note like `(run 'codex login' to re-authenticate)` would prevent the status from being silently misread as "some auth exists."

The same pattern applies in `status.md` lines 94-96.

`````

</details>

<sub>Reviews (6): Last reviewed commit: ["fix(yellow-codex): check legacy auth.jso..."](https://github.com/kinginyellows/yellow-plugins/commit/d49b13dc272b3578b02cf155b1e0ac9266e55fd1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31062571)</sub>

<!-- /greptile_comment -->