### PR TITLE
fix(yellow-research): correct shell-env docs + add v2.0.0 401 diagnostic

### DIFF
--- a/.changeset/yellow-research-userconfig-docs-and-diagnostic.md
+++ b/.changeset/yellow-research-userconfig-docs-and-diagnostic.md
@@ -1,0 +1,59 @@
+---
+"yellow-research": patch
+---
+
+# Fix `/research:setup` Perplexity diagnostic + correct stale shell-env docs
+
+Two related fixes that address user confusion after the v2.0.0 migration
+to userConfig-backed credentials.
+
+## Setup-time diagnostic
+
+Append a v2.0.0 migration hint to the Perplexity / Tavily / EXA "INVALID
+(HTTP 401)" decision branch in `/research:setup` Step 3. When a user has
+a key set only in shell env (not userConfig), the curl probe runs and may
+return HTTP 401 — but that 401 is structurally ambiguous. Two distinct
+causes:
+
+- (a) The key is genuinely expired or revoked.
+- (b) The key in shell env is valid, but `plugin.json` now reads
+  `${user_config.<name>}` rather than the shell env, so the MCP never
+  sees the key and fails at startup (Perplexity) or runtime (EXA /
+  Tavily) regardless.
+
+The new message names both causes and tells the user how to act on
+each: regenerate at the provider dashboard for (a), `/plugin disable
+yellow-research && /plugin enable yellow-research` to answer the
+userConfig prompt for (b). Ceramic's branch is unaffected — it has no
+userConfig entry; its REST probe and MCP authentication are independent
+and the diagnostic is gated on `provider_has_userconfig_path=1`.
+
+Implementation detail: each of the three userConfig-capable provider
+probe blocks now sets `provider_has_userconfig_path=1`; Ceramic sets
+it to `0`. The shared decision tree's 401/403 branch reads the flag
+together with `SKIP_CURL_PROBE` to distinguish "key from shell env" from
+"key from userConfig" runs.
+
+## Doc corrections
+
+The README and `research-patterns` SKILL.md still instructed users to
+`export *_API_KEY` in `~/.zshrc` and "restart Claude Code." That guidance
+became stale on PR #259 / v2.0.0 (May 5, 2026) — `plugin.json` reads
+`${user_config.<key>}` exclusively. Following the old instructions
+silently traps every new user: shell env appears configured but the MCPs
+never see the key. The instructions are replaced with the
+`/plugin disable && /plugin enable` userConfig prompt path, with the
+shell-env-only fallback documented for power users who want a wrapper
+script.
+
+`CERAMIC_API_KEY` is still documented as a shell-env var because it
+gates the REST live-probe in `/research:setup`, not the MCP server (which
+uses OAuth) — that part is correct and unchanged.
+
+## Out of scope
+
+- Restoring shell-env-as-MCP-input. PR #259 deliberately moved auth to
+  the OS keychain as a hardening pass; that decision stands.
+- Investigating whether the user's specific Perplexity key is itself
+  expired. The diagnostic distinguishes the two failure modes so the
+  user can act on the right one.

--- a/.changeset/yellow-research-userconfig-docs-and-diagnostic.md
+++ b/.changeset/yellow-research-userconfig-docs-and-diagnostic.md
@@ -25,14 +25,20 @@ The new message names both causes and tells the user how to act on
 each: regenerate at the provider dashboard for (a), `/plugin disable
 yellow-research && /plugin enable yellow-research` to answer the
 userConfig prompt for (b). Ceramic's branch is unaffected — it has no
-userConfig entry; its REST probe and MCP authentication are independent
-and the diagnostic is gated on `provider_has_userconfig_path=1`.
+userConfig entry; its REST probe and MCP authentication are independent.
 
-Implementation detail: each of the three userConfig-capable provider
-probe blocks now sets `provider_has_userconfig_path=1`; Ceramic sets
-it to `0`. The shared decision tree's 401/403 branch reads the flag
-together with `SKIP_CURL_PROBE` to distinguish "key from shell env" from
-"key from userConfig" runs.
+Implementation detail: the 401/403 diagnostic is inlined into each of
+the three userConfig-capable provider probe blocks (EXA, Tavily,
+Perplexity), inside the curl-ran branch right after `$http_status` is
+set, so the diagnostic evaluates in the same subprocess where the probe
+ran. Ceramic's block runs its own inline decision tree without the
+v2.0.0 diagnostic. The pre-existing standalone post-probe decision-tree
+block was removed: each ```` ```bash``` ```` block in a command file is
+a fresh subprocess, so variables set in the per-provider blocks
+(`$curl_exit`, `$http_status`, `$provider_status`, `$provider_detail`,
+`$SKIP_CURL_PROBE`) were never visible to a separate decision-tree
+block. See
+`docs/solutions/code-quality/bash-block-subshell-isolation-in-command-files.md`.
 
 ## Doc corrections
 

--- a/plugins/yellow-research/README.md
+++ b/plugins/yellow-research/README.md
@@ -26,22 +26,46 @@ manually: `npm install -g @ast-grep/cli`.
 
 ## API Key Setup
 
-Add to your shell config (`~/.zshrc` or `~/.bashrc`):
+As of v2.0.0, EXA / Tavily / Perplexity API keys are stored in `userConfig`
+(system keychain), NOT shell environment variables. The MCPs read from
+`${user_config.<key>}` — exporting `*_API_KEY` in `~/.zshrc` no longer feeds
+the MCP and the Perplexity MCP will hard-fail at startup without a valid
+userConfig value.
 
-```sh
-export EXA_API_KEY="..."          # https://exa.ai/
-export TAVILY_API_KEY="..."       # https://tavily.com/
-export PERPLEXITY_API_KEY="..."   # https://www.perplexity.ai/settings/api
-export CERAMIC_API_KEY="..."      # https://platform.ceramic.ai/keys
-                                  # (REST live-probe only; the MCP uses OAuth)
+Recommended path (one-time per workstation, no restart needed):
+
+```text
+/plugin disable yellow-research
+/plugin enable yellow-research
 ```
 
-Restart Claude Code after setting keys.
+Claude Code prompts for each key on enable. Answer the prompts for the
+sources you want; dismiss the others. Values persist in the system keychain
+(or `~/.claude/.credentials.json` at 0600 on minimal Linux).
 
-The **Parallel Task** and **Ceramic** servers use OAuth — Claude Code handles
-authentication automatically. You'll be prompted to authorize on first use
-(no API key needed). `CERAMIC_API_KEY` is optional and only powers the
-`/research:setup` REST live-probe.
+`CERAMIC_API_KEY` is the only shell-env key still in use — it powers the
+`/research:setup` REST live-probe only (the Ceramic MCP itself authenticates
+via OAuth):
+
+```sh
+export CERAMIC_API_KEY="..."   # https://platform.ceramic.ai/keys
+                               # REST probe only; MCP uses OAuth
+```
+
+Get keys at:
+
+- EXA — https://exa.ai/
+- Tavily — https://tavily.com/
+- Perplexity — https://www.perplexity.ai/settings/api
+
+The **Parallel Task** and **Ceramic** MCP servers use OAuth — Claude Code
+handles authentication automatically. You'll be prompted to authorize on
+first use (no API key needed).
+
+Power users who insist on shell-env-driven auth can bridge with a per-MCP
+wrapper script (see `plugins/yellow-morph/bin/start-morph.sh` for the
+canonical pattern). `plugin.json` no longer reads shell `*_API_KEY` vars
+directly.
 
 ## Usage
 

--- a/plugins/yellow-research/commands/research/setup.md
+++ b/plugins/yellow-research/commands/research/setup.md
@@ -276,6 +276,7 @@ has_userconfig() {
 # Note: exa MCP @ 3.1.8 starts without a key and only fails at tool invocation,
 # so MCP startup does NOT validate this credential — we only know the key is
 # stored in the keychain.
+provider_has_userconfig_path=1   # consumed by the v2.0.0 shell-env-only diagnostic below
 SKIP_CURL_PROBE=0
 [ -z "${EXA_API_KEY:-}" ] && has_userconfig yellow-research exa_api_key && SKIP_CURL_PROBE=1
 if [ $SKIP_CURL_PROBE -eq 1 ]; then
@@ -325,6 +326,7 @@ has_userconfig() {
 # Skip curl probe when key is userConfig-only — MCP reads it from userConfig.
 # Note: tavily MCP @ 0.2.17 starts without a key and only fails at tool
 # invocation, so MCP startup does NOT validate this credential.
+provider_has_userconfig_path=1   # consumed by the v2.0.0 shell-env-only diagnostic below
 SKIP_CURL_PROBE=0
 [ -z "${TAVILY_API_KEY:-}" ] && has_userconfig yellow-research tavily_api_key && SKIP_CURL_PROBE=1
 if [ $SKIP_CURL_PROBE -eq 1 ]; then
@@ -379,6 +381,7 @@ has_userconfig() {
 # Skip curl probe when key is userConfig-only — MCP reads it from userConfig.
 # Note: perplexity MCP @ 0.8.2 hard-fails at startup without a valid key
 # (tools disappear entirely), so MCP startup IS a credential signal here.
+provider_has_userconfig_path=1   # consumed by the v2.0.0 shell-env-only diagnostic below
 SKIP_CURL_PROBE=0
 [ -z "${PERPLEXITY_API_KEY:-}" ] && has_userconfig yellow-research perplexity_api_key && SKIP_CURL_PROBE=1
 if [ $SKIP_CURL_PROBE -eq 1 ]; then
@@ -412,6 +415,7 @@ mark it absent and skip; do not call `has_userconfig` (no userConfig path
 exists for this credential).
 
 ```bash
+provider_has_userconfig_path=0   # Ceramic has no userConfig entry; MCP uses OAuth.
 if [ -z "${CERAMIC_API_KEY:-}" ]; then
   provider_status="ABSENT"
   provider_detail="CERAMIC_API_KEY not in shell env (REST probe skipped). MCP OAuth path unaffected."
@@ -441,7 +445,18 @@ elif [ "$http_status" = "200" ]; then
   provider_detail="Live test passed"
 elif [ "$http_status" = "401" ] || [ "$http_status" = "403" ]; then
   provider_status="INVALID"
-  provider_detail="Key rejected by API (HTTP $http_status)"
+  # v2.0.0 shell-env-only diagnostic: a 401 on a userConfig-capable provider
+  # (EXA / Tavily / Perplexity) when the curl probe ran (i.e., the key was
+  # in shell env, not userConfig) is structurally ambiguous — the key in
+  # shell env may genuinely be expired, OR the user may have a valid key
+  # in shell env that still fails to reach the MCP because plugin.json now
+  # injects ${user_config.<key>} into the MCP env. Distinguish so the user
+  # knows whether to regenerate or migrate.
+  if [ "${provider_has_userconfig_path:-0}" = "1" ] && [ "${SKIP_CURL_PROBE:-0}" = "0" ]; then
+    provider_detail="Key in shell env was rejected by the live API (HTTP $http_status). Two distinct causes — check both: (a) the key may be expired or revoked — regenerate at the provider dashboard. (b) as of yellow-research 2.0.0 the MCP reads the key from userConfig (system keychain), NOT shell env — even a valid shell-env key never reaches the MCP. To migrate: /plugin disable yellow-research && /plugin enable yellow-research, then answer the userConfig prompt."
+  else
+    provider_detail="Key rejected by API (HTTP $http_status)"
+  fi
 elif [ "$http_status" = "429" ]; then
   provider_status="RATE LIMITED"
   provider_detail="Key may be valid; service is busy. Try again later."

--- a/plugins/yellow-research/commands/research/setup.md
+++ b/plugins/yellow-research/commands/research/setup.md
@@ -276,7 +276,6 @@ has_userconfig() {
 # Note: exa MCP @ 3.1.8 starts without a key and only fails at tool invocation,
 # so MCP startup does NOT validate this credential — we only know the key is
 # stored in the keychain.
-provider_has_userconfig_path=1   # consumed by the v2.0.0 shell-env-only diagnostic below
 SKIP_CURL_PROBE=0
 [ -z "${EXA_API_KEY:-}" ] && has_userconfig yellow-research exa_api_key && SKIP_CURL_PROBE=1
 if [ $SKIP_CURL_PROBE -eq 1 ]; then
@@ -291,6 +290,35 @@ else
     -d '{"query":"test","numResults":1}')
   curl_exit=$?
   http_status=$(printf '%s' "$response" | tail -n1)
+
+  # Inline decision tree — must run in the same subprocess as the curl probe so
+  # $curl_exit and $http_status are still in scope (each ```bash``` block is a
+  # fresh subprocess; see comment at the top of this Step).
+  if [ "$curl_exit" -ne 0 ]; then
+    provider_status="UNREACHABLE"
+    provider_detail="API unreachable (curl exit $curl_exit — timeout or network error)"
+  elif [ "$http_status" = "200" ]; then
+    provider_status="ACTIVE"
+    provider_detail="Live test passed"
+  elif [ "$http_status" = "401" ] || [ "$http_status" = "403" ]; then
+    provider_status="INVALID"
+    # v2.0.0 shell-env-only diagnostic: a 401 here means the key was in shell
+    # env (we ran the curl probe). The shell-env path no longer reaches the
+    # MCP — plugin.json reads ${user_config.exa_api_key} — so a valid key
+    # in shell env still fails to authenticate the MCP. Distinguish "key
+    # expired" from "key never reached MCP" so the user can act on the right
+    # cause.
+    provider_detail="Key in shell env was rejected by the live API (HTTP $http_status). Two distinct causes — check both: (a) the key may be expired or revoked — regenerate at the provider dashboard. (b) as of yellow-research 2.0.0 the MCP reads the key from userConfig (system keychain), NOT shell env — even a valid shell-env key never reaches the MCP. To migrate: /plugin disable yellow-research && /plugin enable yellow-research, then answer the userConfig prompt."
+  elif [ "$http_status" = "429" ]; then
+    provider_status="RATE LIMITED"
+    provider_detail="Key may be valid; service is busy. Try again later."
+  elif printf '%s' "$http_status" | grep -qE '^5[0-9][0-9]$'; then
+    provider_status="UNREACHABLE"
+    provider_detail="API server error (HTTP $http_status)"
+  else
+    provider_status="UNREACHABLE"
+    provider_detail="Unexpected HTTP $http_status"
+  fi
 fi
 ```
 
@@ -326,7 +354,6 @@ has_userconfig() {
 # Skip curl probe when key is userConfig-only — MCP reads it from userConfig.
 # Note: tavily MCP @ 0.2.17 starts without a key and only fails at tool
 # invocation, so MCP startup does NOT validate this credential.
-provider_has_userconfig_path=1   # consumed by the v2.0.0 shell-env-only diagnostic below
 SKIP_CURL_PROBE=0
 [ -z "${TAVILY_API_KEY:-}" ] && has_userconfig yellow-research tavily_api_key && SKIP_CURL_PROBE=1
 if [ $SKIP_CURL_PROBE -eq 1 ]; then
@@ -346,6 +373,28 @@ else
     -d "$tavily_body")
   curl_exit=$?
   http_status=$(printf '%s' "$response" | tail -n1)
+
+  # Inline decision tree — must run in the same subprocess as the curl probe.
+  if [ "$curl_exit" -ne 0 ]; then
+    provider_status="UNREACHABLE"
+    provider_detail="API unreachable (curl exit $curl_exit — timeout or network error)"
+  elif [ "$http_status" = "200" ]; then
+    provider_status="ACTIVE"
+    provider_detail="Live test passed"
+  elif [ "$http_status" = "401" ] || [ "$http_status" = "403" ]; then
+    provider_status="INVALID"
+    # v2.0.0 shell-env-only diagnostic: see EXA block above for rationale.
+    provider_detail="Key in shell env was rejected by the live API (HTTP $http_status). Two distinct causes — check both: (a) the key may be expired or revoked — regenerate at the provider dashboard. (b) as of yellow-research 2.0.0 the MCP reads the key from userConfig (system keychain), NOT shell env — even a valid shell-env key never reaches the MCP. To migrate: /plugin disable yellow-research && /plugin enable yellow-research, then answer the userConfig prompt."
+  elif [ "$http_status" = "429" ]; then
+    provider_status="RATE LIMITED"
+    provider_detail="Key may be valid; service is busy. Try again later."
+  elif printf '%s' "$http_status" | grep -qE '^5[0-9][0-9]$'; then
+    provider_status="UNREACHABLE"
+    provider_detail="API server error (HTTP $http_status)"
+  else
+    provider_status="UNREACHABLE"
+    provider_detail="Unexpected HTTP $http_status"
+  fi
 fi
 ```
 
@@ -381,7 +430,6 @@ has_userconfig() {
 # Skip curl probe when key is userConfig-only — MCP reads it from userConfig.
 # Note: perplexity MCP @ 0.8.2 hard-fails at startup without a valid key
 # (tools disappear entirely), so MCP startup IS a credential signal here.
-provider_has_userconfig_path=1   # consumed by the v2.0.0 shell-env-only diagnostic below
 SKIP_CURL_PROBE=0
 [ -z "${PERPLEXITY_API_KEY:-}" ] && has_userconfig yellow-research perplexity_api_key && SKIP_CURL_PROBE=1
 if [ $SKIP_CURL_PROBE -eq 1 ]; then
@@ -404,6 +452,28 @@ else
     -d '{"model":"sonar","messages":[{"role":"user","content":"hi"}],"max_tokens":1}')
   curl_exit=$?
   http_status=$(printf '%s' "$response" | tail -n1)
+
+  # Inline decision tree — must run in the same subprocess as the curl probe.
+  if [ "$curl_exit" -ne 0 ]; then
+    provider_status="UNREACHABLE"
+    provider_detail="API unreachable (curl exit $curl_exit — timeout or network error)"
+  elif [ "$http_status" = "200" ]; then
+    provider_status="ACTIVE"
+    provider_detail="Live test passed"
+  elif [ "$http_status" = "401" ] || [ "$http_status" = "403" ]; then
+    provider_status="INVALID"
+    # v2.0.0 shell-env-only diagnostic: see EXA block above for rationale.
+    provider_detail="Key in shell env was rejected by the live API (HTTP $http_status). Two distinct causes — check both: (a) the key may be expired or revoked — regenerate at the provider dashboard. (b) as of yellow-research 2.0.0 the MCP reads the key from userConfig (system keychain), NOT shell env — even a valid shell-env key never reaches the MCP. To migrate: /plugin disable yellow-research && /plugin enable yellow-research, then answer the userConfig prompt."
+  elif [ "$http_status" = "429" ]; then
+    provider_status="RATE LIMITED"
+    provider_detail="Key may be valid; service is busy. Try again later."
+  elif printf '%s' "$http_status" | grep -qE '^5[0-9][0-9]$'; then
+    provider_status="UNREACHABLE"
+    provider_detail="API server error (HTTP $http_status)"
+  else
+    provider_status="UNREACHABLE"
+    provider_detail="Unexpected HTTP $http_status"
+  fi
 fi
 ```
 
@@ -415,12 +485,9 @@ mark it absent and skip; do not call `has_userconfig` (no userConfig path
 exists for this credential).
 
 ```bash
-provider_has_userconfig_path=0   # Ceramic has no userConfig entry; MCP uses OAuth.
 if [ -z "${CERAMIC_API_KEY:-}" ]; then
   provider_status="ABSENT"
   provider_detail="CERAMIC_API_KEY not in shell env (REST probe skipped). MCP OAuth path unaffected."
-  curl_exit=0
-  http_status="000"
 else
   response=$(curl -s --connect-timeout 5 --max-time 5 \
     -w "\n%{http_code}" \
@@ -430,44 +497,38 @@ else
     -d '{"query":"test"}')
   curl_exit=$?
   http_status=$(printf '%s' "$response" | tail -n1)
-fi
-```
 
-After each probe, evaluate `$curl_exit` first, then `$http_status`. Apply this
-explicit decision tree for each provider:
-
-```bash
-if [ "$curl_exit" -ne 0 ]; then
-  provider_status="UNREACHABLE"
-  provider_detail="API unreachable (curl exit $curl_exit — timeout or network error)"
-elif [ "$http_status" = "200" ]; then
-  provider_status="ACTIVE"
-  provider_detail="Live test passed"
-elif [ "$http_status" = "401" ] || [ "$http_status" = "403" ]; then
-  provider_status="INVALID"
-  # v2.0.0 shell-env-only diagnostic: a 401 on a userConfig-capable provider
-  # (EXA / Tavily / Perplexity) when the curl probe ran (i.e., the key was
-  # in shell env, not userConfig) is structurally ambiguous — the key in
-  # shell env may genuinely be expired, OR the user may have a valid key
-  # in shell env that still fails to reach the MCP because plugin.json now
-  # injects ${user_config.<key>} into the MCP env. Distinguish so the user
-  # knows whether to regenerate or migrate.
-  if [ "${provider_has_userconfig_path:-0}" = "1" ] && [ "${SKIP_CURL_PROBE:-0}" = "0" ]; then
-    provider_detail="Key in shell env was rejected by the live API (HTTP $http_status). Two distinct causes — check both: (a) the key may be expired or revoked — regenerate at the provider dashboard. (b) as of yellow-research 2.0.0 the MCP reads the key from userConfig (system keychain), NOT shell env — even a valid shell-env key never reaches the MCP. To migrate: /plugin disable yellow-research && /plugin enable yellow-research, then answer the userConfig prompt."
-  else
+  # Inline decision tree — Ceramic has no userConfig path (MCP authenticates
+  # via OAuth), so the v2.0.0 shell-env-only diagnostic does not apply here:
+  # a 401 means the REST key is genuinely bad. Keep the simple message.
+  if [ "$curl_exit" -ne 0 ]; then
+    provider_status="UNREACHABLE"
+    provider_detail="API unreachable (curl exit $curl_exit — timeout or network error)"
+  elif [ "$http_status" = "200" ]; then
+    provider_status="ACTIVE"
+    provider_detail="Live test passed"
+  elif [ "$http_status" = "401" ] || [ "$http_status" = "403" ]; then
+    provider_status="INVALID"
     provider_detail="Key rejected by API (HTTP $http_status)"
+  elif [ "$http_status" = "429" ]; then
+    provider_status="RATE LIMITED"
+    provider_detail="Key may be valid; service is busy. Try again later."
+  elif printf '%s' "$http_status" | grep -qE '^5[0-9][0-9]$'; then
+    provider_status="UNREACHABLE"
+    provider_detail="API server error (HTTP $http_status)"
+  else
+    provider_status="UNREACHABLE"
+    provider_detail="Unexpected HTTP $http_status"
   fi
-elif [ "$http_status" = "429" ]; then
-  provider_status="RATE LIMITED"
-  provider_detail="Key may be valid; service is busy. Try again later."
-elif printf '%s' "$http_status" | grep -qE '^5[0-9][0-9]$'; then
-  provider_status="UNREACHABLE"
-  provider_detail="API server error (HTTP $http_status)"
-else
-  provider_status="UNREACHABLE"
-  provider_detail="Unexpected HTTP $http_status"
 fi
 ```
+
+Each provider block above runs its own inline decision tree (in the same
+subprocess as the curl probe) so `$curl_exit` and `$http_status` stay in
+scope. A standalone post-probe decision tree was tried earlier but failed —
+each ``` ```bash``` ``` block is a fresh subprocess, so variables set in one
+block are invisible to the next. See
+`docs/solutions/code-quality/bash-block-subshell-isolation-in-command-files.md`.
 
 Never display raw API response bodies for any provider — only `provider_status`
 and `provider_detail` are used in the results table. If body content must ever

--- a/plugins/yellow-research/commands/research/setup.md
+++ b/plugins/yellow-research/commands/research/setup.md
@@ -308,7 +308,7 @@ else
     # in shell env still fails to authenticate the MCP. Distinguish "key
     # expired" from "key never reached MCP" so the user can act on the right
     # cause.
-    provider_detail="Key in shell env was rejected by the live API (HTTP $http_status). Two distinct causes — check both: (a) the key may be expired or revoked — regenerate at the provider dashboard. (b) as of yellow-research 2.0.0 the MCP reads the key from userConfig (system keychain), NOT shell env — even a valid shell-env key never reaches the MCP. To migrate: /plugin disable yellow-research && /plugin enable yellow-research, then answer the userConfig prompt."
+    provider_detail="Key in shell env was rejected by the live API (HTTP $http_status). Two distinct causes — check both: (a) the key may be expired or revoked — regenerate at the provider dashboard. (b) as of yellow-research 2.0.0 the MCP reads the key from userConfig (system keychain), NOT shell env — even a valid shell-env key never reaches the MCP. To migrate: run /plugin disable yellow-research, then /plugin enable yellow-research, and answer the userConfig prompt."
   elif [ "$http_status" = "429" ]; then
     provider_status="RATE LIMITED"
     provider_detail="Key may be valid; service is busy. Try again later."
@@ -384,7 +384,7 @@ else
   elif [ "$http_status" = "401" ] || [ "$http_status" = "403" ]; then
     provider_status="INVALID"
     # v2.0.0 shell-env-only diagnostic: see EXA block above for rationale.
-    provider_detail="Key in shell env was rejected by the live API (HTTP $http_status). Two distinct causes — check both: (a) the key may be expired or revoked — regenerate at the provider dashboard. (b) as of yellow-research 2.0.0 the MCP reads the key from userConfig (system keychain), NOT shell env — even a valid shell-env key never reaches the MCP. To migrate: /plugin disable yellow-research && /plugin enable yellow-research, then answer the userConfig prompt."
+    provider_detail="Key in shell env was rejected by the live API (HTTP $http_status). Two distinct causes — check both: (a) the key may be expired or revoked — regenerate at the provider dashboard. (b) as of yellow-research 2.0.0 the MCP reads the key from userConfig (system keychain), NOT shell env — even a valid shell-env key never reaches the MCP. To migrate: run /plugin disable yellow-research, then /plugin enable yellow-research, and answer the userConfig prompt."
   elif [ "$http_status" = "429" ]; then
     provider_status="RATE LIMITED"
     provider_detail="Key may be valid; service is busy. Try again later."
@@ -463,7 +463,7 @@ else
   elif [ "$http_status" = "401" ] || [ "$http_status" = "403" ]; then
     provider_status="INVALID"
     # v2.0.0 shell-env-only diagnostic: see EXA block above for rationale.
-    provider_detail="Key in shell env was rejected by the live API (HTTP $http_status). Two distinct causes — check both: (a) the key may be expired or revoked — regenerate at the provider dashboard. (b) as of yellow-research 2.0.0 the MCP reads the key from userConfig (system keychain), NOT shell env — even a valid shell-env key never reaches the MCP. To migrate: /plugin disable yellow-research && /plugin enable yellow-research, then answer the userConfig prompt."
+    provider_detail="Key in shell env was rejected by the live API (HTTP $http_status). Two distinct causes — check both: (a) the key may be expired or revoked — regenerate at the provider dashboard. (b) as of yellow-research 2.0.0 the MCP reads the key from userConfig (system keychain), NOT shell env — even a valid shell-env key never reaches the MCP. To migrate: run /plugin disable yellow-research, then /plugin enable yellow-research, and answer the userConfig prompt."
   elif [ "$http_status" = "429" ]; then
     provider_status="RATE LIMITED"
     provider_detail="Key may be valid; service is busy. Try again later."

--- a/plugins/yellow-research/skills/research-patterns/SKILL.md
+++ b/plugins/yellow-research/skills/research-patterns/SKILL.md
@@ -100,28 +100,46 @@ If an MCP server is unavailable (key not set, connection error, rate limit):
 
 ## API Key Setup
 
-Add to `~/.zshrc` (or equivalent shell config):
+As of v2.0.0, EXA / Tavily / Perplexity API keys are stored in `userConfig`
+(system keychain). `plugin.json` reads `${user_config.<key>}`; shell env
+vars are no longer wired into the MCP processes. Perplexity hard-fails at
+startup without a valid userConfig value (tools disappear entirely); EXA
+and Tavily start but tool calls error at invocation.
 
-```sh
-export EXA_API_KEY="your-key-here"
-export TAVILY_API_KEY="your-key-here"
-export PERPLEXITY_API_KEY="your-key-here"
-export CERAMIC_API_KEY="your-key-here"   # optional — REST live-probe only;
-                                         # Ceramic MCP itself uses OAuth
+To configure (one-time, no restart needed):
+
+```text
+/plugin disable yellow-research
+/plugin enable yellow-research
 ```
+
+Claude Code prompts for each key. Answer the ones you want; dismiss the
+rest. Stored in OS keychain (or `~/.claude/.credentials.json` at 0600 on
+minimal Linux).
 
 Get keys from:
 
 - EXA: https://exa.ai/
 - Tavily: https://tavily.com/
 - Perplexity: https://www.perplexity.ai/settings/api
-- Ceramic (optional): https://platform.ceramic.ai/keys
 
-The **Parallel Task** and **Ceramic** servers use OAuth (no API key needed).
-Claude Code handles authentication automatically — you'll be prompted to
-authorize on first use of each.
+The **Parallel Task** and **Ceramic** servers use OAuth (no API key
+needed). Claude Code handles authentication automatically — you'll be
+prompted to authorize on first use of each.
 
-After adding keys: source `~/.zshrc` and restart Claude Code.
+`CERAMIC_API_KEY` is the one remaining shell-env var. It is optional and
+powers only the `/research:setup` REST live-probe (the Ceramic MCP uses
+OAuth). Get a REST key at https://platform.ceramic.ai/keys if you want
+that probe to run.
+
+```sh
+# Optional, REST live-probe only
+export CERAMIC_API_KEY="your-key-here"
+```
+
+Power users who want a fully shell-env-driven setup can wrap each MCP in a
+per-MCP launcher script (see `plugins/yellow-morph/bin/start-morph.sh`).
+The plugin no longer reads `*_API_KEY` from shell env directly.
 
 ## MCP Tool Name Verification
 


### PR DESCRIPTION
The README and research-patterns SKILL.md still told users to export
*_API_KEY in ~/.zshrc and restart Claude Code. That stopped being true
in PR #259 / v2.0.0 (May 5, 2026), where plugin.json switched to read
${user_config.<key>} exclusively. Following the old instructions
silently traps every new user — shell env looks configured but the
MCPs never see the key, and Perplexity hard-fails at startup. Replace
both docs with the /plugin disable + /plugin enable userConfig prompt
flow.

Also append a structural-diagnosis hint to /research:setup Step 3 when
a userConfig-capable provider returns HTTP 401 with a key in shell
env. The old message ("Key rejected by API") couldn't tell the user
whether the key was expired (regenerate) or the storage path was
wrong (migrate to userConfig). The new message names both causes and
the action for each. Gated on a per-provider flag so Ceramic's
OAuth-only branch is unaffected.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects two pieces of stale v2.0.0 documentation (README and SKILL.md still described the old `export *_API_KEY` shell-env setup path) and restructures the `/research:setup` Step 3 probe blocks to inline their decision trees — fixing a subprocess isolation bug that made the standalone post-probe block unreachable.

- **Doc fixes**: Both `README.md` and `research-patterns/SKILL.md` replace the `~/.zshrc` key export instructions with the `/plugin disable && /plugin enable` userConfig prompt flow; `CERAMIC_API_KEY` is correctly preserved as the one remaining shell-env var.
- **Diagnostic improvement**: A two-cause 401 hint (expired key vs. key-never-reached-MCP) is inlined into each of the three userConfig-capable provider probe blocks (EXA, Tavily, Perplexity); Ceramic's block keeps the simple \"Key rejected\" message since it has no userConfig path.
- **Subprocess isolation fix**: The previously shared post-probe decision-tree block is removed and each provider block now owns its own inline tree, keeping `$curl_exit` and `$http_status` in scope.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the majority of users; one existing-user scenario produces a misleading diagnostic message.

A user who has a key in both shell env and userConfig (i.e., migrated correctly after v2.0.0) will still have the curl probe run against their stale shell-env key. If that key is expired, the new two-cause 401 diagnostic tells them to run /plugin disable && /plugin enable — but they already did that, and re-running it would overwrite the valid userConfig entry with whatever they type. The condition guarding the probe skip checks only for an empty shell-env var; it does not consult userConfig independently. All other changes — doc rewrites and the subprocess isolation fix — are correct and beneficial.

plugins/yellow-research/commands/research/setup.md — the SKIP_CURL_PROBE guard in the EXA, Tavily, and Perplexity blocks.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .changeset/yellow-research-userconfig-docs-and-diagnostic.md | Patch changeset describing the userConfig doc corrections and the inlined 401 diagnostic; accurate and complete. |
| plugins/yellow-research/README.md | Replaces stale shell-env key setup instructions with the /plugin disable + /plugin enable userConfig flow; CERAMIC_API_KEY correctly left as the one remaining shell-env var. |
| plugins/yellow-research/skills/research-patterns/SKILL.md | Mirrors the README update — removes the shell-env export block and replaces it with the userConfig prompt path; Ceramic/OAuth section preserved correctly. |
| plugins/yellow-research/commands/research/setup.md | Removes the standalone post-probe decision tree (which was unreachable due to subprocess isolation) and inlines it into each provider block. One subtle edge case: a user who has a key in BOTH shell env and userConfig will have the curl probe run with the (possibly stale) shell-env key and receive the migration diagnostic even though they've already migrated. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Provider probe block\nEXA / Tavily / Perplexity] --> B{Key in shell env?}
    B -- "empty" --> C{Key in userConfig?}
    C -- "yes" --> D[SKIP_CURL_PROBE=1\nstatus: PRESENT keychain]
    C -- "no" --> E[status: ABSENT / NOT SET]
    B -- "non-empty" --> F[SKIP_CURL_PROBE=0\nRun curl probe]
    F --> G{curl_exit != 0?}
    G -- "yes" --> H[UNREACHABLE\ntimeout/network]
    G -- "no" --> I{HTTP status}
    I -- "200" --> J[ACTIVE\nLive test passed]
    I -- "401/403" --> K[INVALID\nTwo-cause diagnostic:\na key expired\nb not in userConfig]
    I -- "429" --> L[RATE LIMITED]
    I -- "5xx" --> M[UNREACHABLE\nserver error]
    I -- "other" --> N[UNREACHABLE\nunexpected status]

    subgraph Ceramic [Ceramic — no userConfig path]
        CA{CERAMIC_API_KEY set?} -- "no" --> CB[ABSENT\nprobe skipped]
        CA -- "yes" --> CC[Run curl probe]
        CC --> CD{HTTP status}
        CD -- "401/403" --> CE[INVALID\nKey rejected simple msg]
        CD -- "200" --> CF[ACTIVE]
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `plugins/yellow-research/commands/research/setup.md`, line 280 ([link](https://github.com/kinginyellows/yellow-plugins/blob/4fa67639c9cefe059fee7af42e9f3ae5e4753f68/plugins/yellow-research/commands/research/setup.md#L280)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`SKIP_CURL_PROBE` guard misses the "both shell env and userConfig" user**

   The probe-skip condition is `EXA_API_KEY empty AND userConfig present`. If a user set their key in shell env before v2.0.0 and then correctly migrated via `/plugin enable` (so it's now in userConfig too), `EXA_API_KEY` is still non-empty, so `SKIP_CURL_PROBE` stays 0, the curl runs with the stale shell-env key, and a 401 fires the "migrate to userConfig" diagnostic — even though they already migrated. The same logic applies to the Tavily and Perplexity blocks. The safest fix would be to skip the probe when userConfig is populated regardless of whether the shell-env var is also set (i.e., drop the `[ -z "${EXA_API_KEY:-}" ] &&` guard), or at minimum acknowledge in the diagnostic that userConfig might already be populated.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: plugins/yellow-research/commands/research/setup.md
   Line: 280

   Comment:
   **`SKIP_CURL_PROBE` guard misses the "both shell env and userConfig" user**

   The probe-skip condition is `EXA_API_KEY empty AND userConfig present`. If a user set their key in shell env before v2.0.0 and then correctly migrated via `/plugin enable` (so it's now in userConfig too), `EXA_API_KEY` is still non-empty, so `SKIP_CURL_PROBE` stays 0, the curl runs with the stale shell-env key, and a 401 fires the "migrate to userConfig" diagnostic — even though they already migrated. The same logic applies to the Tavily and Perplexity blocks. The safest fix would be to skip the probe when userConfig is populated regardless of whether the shell-env var is also set (i.e., drop the `[ -z "${EXA_API_KEY:-}" ] &&` guard), or at minimum acknowledge in the diagnostic that userConfig might already be populated.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffix%2Fyellow-research-userconfig-docs-and-diagnostic%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffix%2Fyellow-research-userconfig-docs-and-diagnostic%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plugins%2Fyellow-research%2Fcommands%2Fresearch%2Fsetup.md%0ALine%3A%20280%0A%0AComment%3A%0A**%60SKIP_CURL_PROBE%60%20guard%20misses%20the%20%22both%20shell%20env%20and%20userConfig%22%20user**%0A%0AThe%20probe-skip%20condition%20is%20%60EXA_API_KEY%20empty%20AND%20userConfig%20present%60.%20If%20a%20user%20set%20their%20key%20in%20shell%20env%20before%20v2.0.0%20and%20then%20correctly%20migrated%20via%20%60%2Fplugin%20enable%60%20%28so%20it's%20now%20in%20userConfig%20too%29%2C%20%60EXA_API_KEY%60%20is%20still%20non-empty%2C%20so%20%60SKIP_CURL_PROBE%60%20stays%200%2C%20the%20curl%20runs%20with%20the%20stale%20shell-env%20key%2C%20and%20a%20401%20fires%20the%20%22migrate%20to%20userConfig%22%20diagnostic%20%E2%80%94%20even%20though%20they%20already%20migrated.%20The%20same%20logic%20applies%20to%20the%20Tavily%20and%20Perplexity%20blocks.%20The%20safest%20fix%20would%20be%20to%20skip%20the%20probe%20when%20userConfig%20is%20populated%20regardless%20of%20whether%20the%20shell-env%20var%20is%20also%20set%20%28i.e.%2C%20drop%20the%20%60%5B%20-z%20%22%24%7BEXA_API_KEY%3A-%7D%22%20%5D%20%26%26%60%20guard%29%2C%20or%20at%20minimum%20acknowledge%20in%20the%20diagnostic%20that%20userConfig%20might%20already%20be%20populated.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffix%2Fyellow-research-userconfig-docs-and-diagnostic%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffix%2Fyellow-research-userconfig-docs-and-diagnostic%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aplugins%2Fyellow-research%2Fcommands%2Fresearch%2Fsetup.md%3A280%0A**%60SKIP_CURL_PROBE%60%20guard%20misses%20the%20%22both%20shell%20env%20and%20userConfig%22%20user**%0A%0AThe%20probe-skip%20condition%20is%20%60EXA_API_KEY%20empty%20AND%20userConfig%20present%60.%20If%20a%20user%20set%20their%20key%20in%20shell%20env%20before%20v2.0.0%20and%20then%20correctly%20migrated%20via%20%60%2Fplugin%20enable%60%20%28so%20it's%20now%20in%20userConfig%20too%29%2C%20%60EXA_API_KEY%60%20is%20still%20non-empty%2C%20so%20%60SKIP_CURL_PROBE%60%20stays%200%2C%20the%20curl%20runs%20with%20the%20stale%20shell-env%20key%2C%20and%20a%20401%20fires%20the%20%22migrate%20to%20userConfig%22%20diagnostic%20%E2%80%94%20even%20though%20they%20already%20migrated.%20The%20same%20logic%20applies%20to%20the%20Tavily%20and%20Perplexity%20blocks.%20The%20safest%20fix%20would%20be%20to%20skip%20the%20probe%20when%20userConfig%20is%20populated%20regardless%20of%20whether%20the%20shell-env%20var%20is%20also%20set%20%28i.e.%2C%20drop%20the%20%60%5B%20-z%20%22%24%7BEXA_API_KEY%3A-%7D%22%20%5D%20%26%26%60%20guard%29%2C%20or%20at%20minimum%20acknowledge%20in%20the%20diagnostic%20that%20userConfig%20might%20already%20be%20populated.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
plugins/yellow-research/commands/research/setup.md:280
**`SKIP_CURL_PROBE` guard misses the "both shell env and userConfig" user**

The probe-skip condition is `EXA_API_KEY empty AND userConfig present`. If a user set their key in shell env before v2.0.0 and then correctly migrated via `/plugin enable` (so it's now in userConfig too), `EXA_API_KEY` is still non-empty, so `SKIP_CURL_PROBE` stays 0, the curl runs with the stale shell-env key, and a 401 fires the "migrate to userConfig" diagnostic — even though they already migrated. The same logic applies to the Tavily and Perplexity blocks. The safest fix would be to skip the probe when userConfig is populated regardless of whether the shell-env var is also set (i.e., drop the `[ -z "${EXA_API_KEY:-}" ] &&` guard), or at minimum acknowledge in the diagnostic that userConfig might already be populated.


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["docs(yellow-research): clarify slash-com..."](https://github.com/kinginyellows/yellow-plugins/commit/4fa67639c9cefe059fee7af42e9f3ae5e4753f68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31063668)</sub>

<!-- /greptile_comment -->