### PR TITLE
feat(yellow-composio): bundle the Composio MCP via plugin.json + userConfig

### DIFF
--- a/.changeset/yellow-composio-bundle-mcp.md
+++ b/.changeset/yellow-composio-bundle-mcp.md
@@ -1,0 +1,64 @@
+---
+"yellow-composio": minor
+---
+
+# Bundle the Composio MCP server in `plugin.json` with userConfig prompts
+
+Replace the documentation-passthrough `/composio:setup` story with an
+actual installer. `plugins/yellow-composio/.claude-plugin/plugin.json`
+now declares:
+
+- `userConfig.composio_mcp_url` (`type: string`, non-sensitive) — the
+  per-customer MCP URL the user generates at https://mcp.composio.dev
+  or via `npx @composio/mcp@latest setup <customer_id> <app_id>`.
+- `userConfig.composio_api_key` (`type: string`, sensitive) — Composio
+  API key, sent as `X-API-Key` header on every MCP request, stored in
+  the system keychain.
+- `mcpServers.composio-server` (`type: http`) — `url` and `headers.X-API-Key`
+  read from `${user_config.composio_mcp_url}` and
+  `${user_config.composio_api_key}` respectively.
+
+Tools appear under
+`mcp__plugin_yellow-composio_composio-server__COMPOSIO_*`.
+
+## Compatibility
+
+Existing users who configured Composio manually via
+`claude mcp add --transport http composio-server ...` keep working —
+their entry in `~/.claude.json` is independent of this plugin's bundled
+MCP and continues to expose tools under `mcp__composio-server__*`. The
+plugin's `/composio:setup` and `/composio:status` commands now look for
+all three prefixes (bundled, Claude.ai native, manual) and pick whichever
+is reachable. Users on the manual path can migrate at their own pace by
+answering the new userConfig prompts and removing the manual entry.
+
+## Open: ${user_config.*} substitution in `mcpServers.url` and `headers`
+
+This is the first plugin in the marketplace to use `${user_config.*}`
+substitution inside `mcpServers.<name>.url` and inside
+`mcpServers.<name>.headers`. Every prior plugin (yellow-research,
+yellow-morph, yellow-semgrep) only uses `${user_config.*}` inside the
+`env` block of stdio servers. The schema does not field-scope
+substitution, and the harness uses generic `${user_config.KEY}`
+substitution wherever it appears (see `monitors.command` schema
+description for the security note). Substitution should work, but the
+specific HTTP-server-url + http-server-headers paths are
+empirically untested in this repo until this PR ships.
+
+If a user enables the plugin and the bundled MCP fails to start for
+this reason, the existing manual `claude mcp add` instructions remain
+in `/composio:setup` Step 2 as a fallback — see the "Fallback (manual
+`claude mcp add`)" block. The setup command's tool-prefix detection
+already covers the manual path.
+
+## Files changed
+
+- `plugins/yellow-composio/.claude-plugin/plugin.json` — add `userConfig`
+  and `mcpServers.composio-server` blocks.
+- `plugins/yellow-composio/CLAUDE.md` — flip "does NOT bundle an MCP
+  server" to describe the bundled MCP and migration path; security
+  notes section updated to reflect keychain-stored API key.
+- `plugins/yellow-composio/commands/composio/setup.md` — Step 2
+  rewritten to detect all three tool-name prefixes and to recommend
+  `/plugin disable && /plugin enable` for first-time setup, with the
+  manual `claude mcp add` instructions retained as the fallback path.

--- a/.changeset/yellow-composio-bundle-mcp.md
+++ b/.changeset/yellow-composio-bundle-mcp.md
@@ -62,3 +62,11 @@ already covers the manual path.
   rewritten to detect all three tool-name prefixes and to recommend
   `/plugin disable && /plugin enable` for first-time setup, with the
   manual `claude mcp add` instructions retained as the fallback path.
+- `plugins/yellow-composio/README.md` — Quick Start and How It Works
+  sections updated to lead with the `userConfig`-prompt path and to
+  document the three-prefix detection plus migration guidance for the
+  manual `claude mcp add` flow.
+- `plugins/yellow-composio/skills/composio-patterns/SKILL.md` — prefix
+  list expanded from two to three (bundled first), and the security
+  note flipped from "no API keys stored" to "API key stored in system
+  keychain" to match the new bundled path.

--- a/plugins/yellow-composio/.claude-plugin/plugin.json
+++ b/plugins/yellow-composio/.claude-plugin/plugin.json
@@ -20,14 +20,15 @@
     "composio_mcp_url": {
       "type": "string",
       "title": "Composio MCP URL",
-      "description": "Per-customer Composio MCP endpoint. Generate via the Composio dashboard or `npx @composio/mcp@latest setup <customer_id> <app_id>`. Looks like https://mcp.composio.dev/<id>. Only `https://mcp.composio.dev/*` URLs are expected — Claude Code will make HTTP MCP connections to whatever you provide here, so do not paste arbitrary URLs (file://, internal hosts, metadata endpoints). If left blank, the bundled MCP server will fail to start — fall back to a manual `claude mcp add` setup (see /composio:setup).",
+      "description": "Per-customer Composio MCP endpoint. Generate via the Composio dashboard or `npx @composio/mcp@latest setup YOUR_CUSTOMER_ID YOUR_APP_ID`. Looks like https://mcp.composio.dev/<id>. Only `https://mcp.composio.dev/*` URLs are expected — Claude Code will make HTTP MCP connections to whatever you provide here, so do not paste arbitrary URLs (file://, internal hosts, metadata endpoints). If left blank, the bundled MCP server will fail to start — fall back to a manual `claude mcp add` setup (see /composio:setup).",
       "sensitive": false
     },
     "composio_api_key": {
       "type": "string",
       "title": "Composio API key",
       "description": "Composio API key from https://app.composio.dev/settings. Sent as the X-API-Key header on every MCP request. Stored in the system keychain.",
-      "sensitive": true
+      "sensitive": true,
+      "required": false
     }
   },
   "mcpServers": {

--- a/plugins/yellow-composio/.claude-plugin/plugin.json
+++ b/plugins/yellow-composio/.claude-plugin/plugin.json
@@ -20,7 +20,7 @@
     "composio_mcp_url": {
       "type": "string",
       "title": "Composio MCP URL",
-      "description": "Per-customer Composio MCP endpoint. Generate via the Composio dashboard or `npx @composio/mcp@latest setup <customer_id> <app_id>`. Looks like https://mcp.composio.dev/<id>. If left blank, the MCP server is skipped and you can fall back to a manual `claude mcp add` setup (see /composio:setup).",
+      "description": "Per-customer Composio MCP endpoint. Generate via the Composio dashboard or `npx @composio/mcp@latest setup <customer_id> <app_id>`. Looks like https://mcp.composio.dev/<id>. Only `https://mcp.composio.dev/*` URLs are expected — Claude Code will make HTTP MCP connections to whatever you provide here, so do not paste arbitrary URLs (file://, internal hosts, metadata endpoints). If left blank, the bundled MCP server will fail to start — fall back to a manual `claude mcp add` setup (see /composio:setup).",
       "sensitive": false
     },
     "composio_api_key": {

--- a/plugins/yellow-composio/.claude-plugin/plugin.json
+++ b/plugins/yellow-composio/.claude-plugin/plugin.json
@@ -21,7 +21,8 @@
       "type": "string",
       "title": "Composio MCP URL",
       "description": "Per-customer Composio MCP endpoint. Generate via the Composio dashboard or `npx @composio/mcp@latest setup YOUR_CUSTOMER_ID YOUR_APP_ID`. Looks like https://mcp.composio.dev/<id>. Only `https://mcp.composio.dev/*` URLs are expected — Claude Code will make HTTP MCP connections to whatever you provide here, so do not paste arbitrary URLs (file://, internal hosts, metadata endpoints). If left blank, the bundled MCP server will fail to start — fall back to a manual `claude mcp add` setup (see /composio:setup).",
-      "sensitive": false
+      "sensitive": false,
+      "required": false
     },
     "composio_api_key": {
       "type": "string",

--- a/plugins/yellow-composio/.claude-plugin/plugin.json
+++ b/plugins/yellow-composio/.claude-plugin/plugin.json
@@ -15,5 +15,28 @@
     "workbench",
     "usage-tracking",
     "mcp"
-  ]
+  ],
+  "userConfig": {
+    "composio_mcp_url": {
+      "type": "string",
+      "title": "Composio MCP URL",
+      "description": "Per-customer Composio MCP endpoint. Generate via the Composio dashboard or `npx @composio/mcp@latest setup <customer_id> <app_id>`. Looks like https://mcp.composio.dev/<id>. If left blank, the MCP server is skipped and you can fall back to a manual `claude mcp add` setup (see /composio:setup).",
+      "sensitive": false
+    },
+    "composio_api_key": {
+      "type": "string",
+      "title": "Composio API key",
+      "description": "Composio API key from https://app.composio.dev/settings. Sent as the X-API-Key header on every MCP request. Stored in the system keychain.",
+      "sensitive": true
+    }
+  },
+  "mcpServers": {
+    "composio-server": {
+      "type": "http",
+      "url": "${user_config.composio_mcp_url}",
+      "headers": {
+        "X-API-Key": "${user_config.composio_api_key}"
+      }
+    }
+  }
 }

--- a/plugins/yellow-composio/CLAUDE.md
+++ b/plugins/yellow-composio/CLAUDE.md
@@ -5,11 +5,11 @@ Optional Composio accelerator for batch workflows with local usage tracking.
 ## How It Works
 
 This plugin bundles a `type: http` Composio MCP server, declared in
-`plugin.json` and configured via two `userConfig` prompts on first enable:
-the per-customer MCP URL and the Composio API key. Both are stored in
-the system keychain (URL non-sensitive, API key sensitive). Bundled
-tools appear under the `mcp__plugin_yellow-composio_composio-server__*`
-prefix.
+`plugin.json` and configured via two `userConfig` prompts on enable: the
+per-customer MCP URL and the Composio API key. The API key is stored in
+the system keychain (`sensitive: true`); the MCP URL is stored as plain
+(non-sensitive) `userConfig`. Bundled tools appear under the
+`mcp__plugin_yellow-composio_composio-server__*` prefix.
 
 The plugin still works with externally-configured Composio MCPs — if the
 userConfig prompts are dismissed (URL left blank), the bundled server

--- a/plugins/yellow-composio/CLAUDE.md
+++ b/plugins/yellow-composio/CLAUDE.md
@@ -4,20 +4,34 @@ Optional Composio accelerator for batch workflows with local usage tracking.
 
 ## How It Works
 
-This plugin does NOT bundle an MCP server. Composio tools are provided by
-the user's MCP connector (prefix varies by configuration -- e.g.,
-`mcp__claude_ai_composio__*` for native integrations or
-`mcp__composio-server__*` for manual `.mcp.json` setups). The plugin provides:
+This plugin bundles a `type: http` Composio MCP server, declared in
+`plugin.json` and configured via two `userConfig` prompts on first enable:
+the per-customer MCP URL and the Composio API key. Both are stored in
+the system keychain (URL non-sensitive, API key sensitive). Bundled
+tools appear under the `mcp__plugin_yellow-composio_composio-server__*`
+prefix.
 
-1. Setup validation to confirm Composio is configured and reachable
-2. Local usage tracking since Composio has no billing/usage API
-3. A patterns skill documenting Workbench, Multi-Execute, and degradation
+The plugin still works with externally-configured Composio MCPs — if the
+userConfig prompts are dismissed (URL left blank), the bundled server
+will fail to start and the plugin falls back to detecting any of the
+external Composio variants (`mcp__claude_ai_composio__*` for native
+integrations, `mcp__composio-server__*` for manual `.mcp.json` setups).
+This is the legacy migration path for users who configured the MCP
+manually before this plugin bundled it.
+
+The plugin provides:
+
+1. Bundled MCP server with `userConfig`-prompt-driven credentials
+2. Setup validation to confirm Composio is configured and reachable
+3. Local usage tracking since Composio has no billing/usage API
+4. A patterns skill documenting Workbench, Multi-Execute, and degradation
    conventions for consuming plugins
 
-## Composio MCP Tools (Not Bundled)
+## Composio MCP Tools
 
-The following tools are provided by the user's Composio MCP connector (not by
-this plugin). They are discoverable via ToolSearch:
+These tools are now bundled via this plugin (preferred) and may also be
+provided by external connectors (legacy / fallback). All variants are
+discoverable via ToolSearch:
 
 - `COMPOSIO_SEARCH_TOOLS` -- Discover tools, get schemas, check connection status
 - `COMPOSIO_GET_TOOL_SCHEMAS` -- Full parameter schemas for specific tools
@@ -64,7 +78,10 @@ Composio has no billing API. This is the only way to monitor execution budget.
 
 ## Security Notes
 
-- **No API keys stored** -- Native MCP connector handles credentials
+- **API key stored in system keychain** -- Composio API key is sensitive
+  `userConfig` (`composio_api_key`) and held in the OS keychain. The MCP
+  URL is non-sensitive and held in plain `userConfig` storage. Never
+  echo either value in command output or commits.
 - **Remote execution** -- Workbench runs on Composio's cloud. Do not send
   secrets, private keys, or proprietary algorithms
 - **Content fencing** -- Wrap all Composio responses in `--- begin/end ---`

--- a/plugins/yellow-composio/README.md
+++ b/plugins/yellow-composio/README.md
@@ -16,12 +16,18 @@ Then install the plugin:
 
 ## Quick Start
 
-1. **Configure Composio MCP server** (if not already done):
+1. **Enable the plugin and answer the `userConfig` prompts**:
 
-   ```bash
-   claude mcp add --transport http composio-server "YOUR_MCP_URL" \
-     --headers "X-API-Key:YOUR_COMPOSIO_API_KEY"
+   ```text
+   /plugin enable yellow-composio
    ```
+
+   Two prompts appear on enable:
+   - **Composio MCP URL** -- per-customer endpoint, looks like
+     `https://mcp.composio.dev/<id>`. Generate via the Composio
+     dashboard or `npx @composio/mcp@latest setup <customer_id> <app_id>`.
+   - **Composio API key** -- from <https://app.composio.dev/settings>
+     (stored in the OS keychain).
 
 2. **Run setup**:
 
@@ -35,6 +41,11 @@ Then install the plugin:
    /composio:status
    ```
 
+If you previously ran `claude mcp add --transport http composio-server ...`
+manually, that registration keeps working as a fallback. The bundled path is
+preferred because the API key is keychain-stored. See `/composio:setup` for
+the full migration walk-through.
+
 ## Commands
 
 | Command | Description |
@@ -44,13 +55,17 @@ Then install the plugin:
 
 ## How It Works
 
-This plugin does **not** bundle an MCP server. Composio tools are provided by
-Claude's native MCP connector. The plugin provides:
+This plugin bundles a `type: http` Composio MCP server via `plugin.json`.
+Tools appear under `mcp__plugin_yellow-composio_composio-server__*` after
+the `userConfig` prompts are answered. The plugin also provides:
 
 - **Setup validation** -- Confirms Composio is configured and reachable
 - **Usage tracking** -- Local counter since Composio has no billing API
 - **Integration patterns** -- Documents Workbench, Multi-Execute, and
   degradation patterns for consuming plugins
+- **Three-prefix detection** -- `/composio:setup` recognizes the bundled
+  prefix as well as the legacy `mcp__claude_ai_composio__*` (Claude.ai
+  native) and `mcp__composio-server__*` (manual `claude mcp add`) prefixes
 
 ### Optional Accelerator Model
 
@@ -62,7 +77,8 @@ they fall back to existing local approaches with zero user-visible difference.
 ## Prerequisites
 
 - Composio account ([composio.dev](https://composio.dev))
-- Composio MCP server configured in Claude Code
+- A Composio MCP URL and API key (entered via `userConfig` on plugin enable,
+  or via a manual `claude mcp add` fallback)
 - `jq` (recommended for usage tracking)
 
 ## License

--- a/plugins/yellow-composio/README.md
+++ b/plugins/yellow-composio/README.md
@@ -25,7 +25,7 @@ Then install the plugin:
    Two prompts appear on enable:
    - **Composio MCP URL** -- per-customer endpoint, looks like
      `https://mcp.composio.dev/<id>`. Generate via the Composio
-     dashboard or `npx @composio/mcp@latest setup <customer_id> <app_id>`.
+     dashboard or `npx @composio/mcp@latest setup YOUR_CUSTOMER_ID YOUR_APP_ID`.
    - **Composio API key** -- from <https://app.composio.dev/settings>
      (stored in the OS keychain).
 

--- a/plugins/yellow-composio/commands/composio/setup.md
+++ b/plugins/yellow-composio/commands/composio/setup.md
@@ -52,8 +52,15 @@ Three possible prefixes exist; in priority order:
 If ToolSearch returns at least one Composio tool, record which prefix is
 active and proceed to Step 3.
 
-If ToolSearch returns no Composio tools, the bundled MCP did not start
-(most commonly because the `userConfig` prompt was dismissed). Report:
+If ToolSearch returns no Composio tools, the bundled MCP did not start.
+The two most common causes are:
+
+- The `userConfig` prompt was dismissed (URL or API key blank).
+- `${user_config.*}` substitution in `mcpServers.url`/`headers` is not
+  supported by your Claude Code version (this is the first plugin in the
+  marketplace to use that pattern; see the Fallback below).
+
+Report:
 
 ```text
 [yellow-composio] No Composio MCP tools found in this session.
@@ -80,6 +87,11 @@ in `mcpServers.<name>.url` is not resolved by your harness version):
 
   Then restart Claude Code and re-run /composio:setup. Tools appear
   under mcp__composio-server__* in this configuration.
+
+  Note: this manual path stores YOUR_COMPOSIO_API_KEY as plaintext in
+  ~/.claude.json (not the OS keychain). If the bundled path later starts
+  working on your version, run `claude mcp remove composio-server` to
+  drop the plaintext entry and re-rely on the keychain-backed bundle.
 ```
 
 Stop here if no tools found.
@@ -165,7 +177,7 @@ If the file does not exist, create it:
 mkdir -p .claude
 MONTH=$(date -u +%Y-%m)
 TODAY=$(date -u +%Y-%m-%d)
-cat > ".claude/composio-usage.json" << JSONEOF
+cat > ".claude/composio-usage.json" << __EOF_COMPOSIO_USAGE__
 {
   "version": 1,
   "created": "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)",
@@ -184,7 +196,7 @@ cat > ".claude/composio-usage.json" << JSONEOF
     }
   }
 }
-JSONEOF
+__EOF_COMPOSIO_USAGE__
 printf '[yellow-composio] Usage counter initialized at .claude/composio-usage.json\n'
 ```
 

--- a/plugins/yellow-composio/commands/composio/setup.md
+++ b/plugins/yellow-composio/commands/composio/setup.md
@@ -37,7 +37,7 @@ This is a soft prerequisite -- setup continues without jq.
 Use ToolSearch to discover Composio tools across all known prefixes:
 
 ```text
-ToolSearch("COMPOSIO_REMOTE_WORKBENCH")
+ToolSearch("COMPOSIO_SEARCH_TOOLS")
 ```
 
 Three possible prefixes exist; in priority order:
@@ -70,7 +70,7 @@ Recommended (bundled MCP server):
   1. Sign up at https://composio.dev and copy your API key from
      https://app.composio.dev/settings.
   2. Generate a per-customer MCP URL via the Composio dashboard or:
-       npx @composio/mcp@latest setup <customer_id> <app_id> --client claude
+       npx @composio/mcp@latest setup YOUR_CUSTOMER_ID YOUR_APP_ID --client claude
   3. Re-prompt the plugin's userConfig:
        /plugin disable yellow-composio
        /plugin enable yellow-composio

--- a/plugins/yellow-composio/commands/composio/setup.md
+++ b/plugins/yellow-composio/commands/composio/setup.md
@@ -34,30 +34,52 @@ This is a soft prerequisite -- setup continues without jq.
 
 ### Step 2: Check Composio MCP tools
 
-Use ToolSearch to discover Composio tools:
+Use ToolSearch to discover Composio tools across all known prefixes:
 
 ```text
 ToolSearch("COMPOSIO_REMOTE_WORKBENCH")
 ```
 
-If ToolSearch returns no Composio tools, report:
+Three possible prefixes exist; in priority order:
+
+1. `mcp__plugin_yellow-composio_composio-server__*` — bundled by this
+   plugin (preferred, requires both `userConfig` values to be set).
+2. `mcp__claude_ai_composio__*` — Claude.ai native Composio integration
+   (legacy, still supported).
+3. `mcp__composio-server__*` — manual `claude mcp add` setup
+   (legacy / migration path).
+
+If ToolSearch returns at least one Composio tool, record which prefix is
+active and proceed to Step 3.
+
+If ToolSearch returns no Composio tools, the bundled MCP did not start
+(most commonly because the `userConfig` prompt was dismissed). Report:
 
 ```text
-[yellow-composio] Composio MCP server not found.
+[yellow-composio] No Composio MCP tools found in this session.
 
-To configure Composio for Claude Code:
+Recommended (bundled MCP server):
 
-  1. Sign up at https://composio.dev and get your API key
-  2. Generate an MCP URL via the Composio dashboard or SDK
-  3. Add to Claude Code:
+  1. Sign up at https://composio.dev and copy your API key from
+     https://app.composio.dev/settings.
+  2. Generate a per-customer MCP URL via the Composio dashboard or:
+       npx @composio/mcp@latest setup <customer_id> <app_id> --client claude
+  3. Re-prompt the plugin's userConfig:
+       /plugin disable yellow-composio
+       /plugin enable yellow-composio
+     Answer "Composio MCP URL" and "Composio API key" when prompted.
+     Tools appear under mcp__plugin_yellow-composio_composio-server__*.
+  4. Re-run /composio:setup to verify.
 
-     claude mcp add --transport http composio-server "YOUR_MCP_URL" \
-       --headers "X-API-Key:YOUR_COMPOSIO_API_KEY"
+Fallback (manual claude mcp add — for older Claude Code versions or if
+the bundled MCP fails to start, e.g., because user_config substitution
+in `mcpServers.<name>.url` is not resolved by your harness version):
 
-  4. Restart Claude Code and re-run /composio:setup
+  claude mcp add --transport http composio-server "YOUR_MCP_URL" \
+    --headers "X-API-Key:YOUR_COMPOSIO_API_KEY"
 
-Alternative (npx):
-  npx @composio/mcp@latest setup "<customer_id>" "<app_id>" --client claude
+  Then restart Claude Code and re-run /composio:setup. Tools appear
+  under mcp__composio-server__* in this configuration.
 ```
 
 Stop here if no tools found.
@@ -68,10 +90,19 @@ Step 2 confirmed Composio tools are discoverable via ToolSearch. Now call
 `COMPOSIO_SEARCH_TOOLS` directly to validate authentication and network
 connectivity.
 
-**Note**: The fully-qualified MCP tool name varies by configuration
-(e.g., `mcp__claude_ai_composio__COMPOSIO_SEARCH_TOOLS` for native
-integrations, `mcp__composio-server__COMPOSIO_SEARCH_TOOLS` for manual
-`.mcp.json` setups). Use the exact tool name returned by ToolSearch in Step 2.
+**Note**: The fully-qualified MCP tool name varies by configuration:
+
+- `mcp__plugin_yellow-composio_composio-server__COMPOSIO_SEARCH_TOOLS` —
+  bundled MCP from this plugin (preferred).
+- `mcp__claude_ai_composio__COMPOSIO_SEARCH_TOOLS` — Claude.ai native
+  Composio integration.
+- `mcp__composio-server__COMPOSIO_SEARCH_TOOLS` — manual `claude mcp add`
+  setup.
+
+Use the exact tool name returned by ToolSearch in Step 2. Step 3 should
+exercise the active prefix and proceed even if multiple prefixes are
+visible (it is normal for users mid-migration to have both the bundled
+and the legacy MCP registered until they remove the manual entry).
 
 ```text
 COMPOSIO_SEARCH_TOOLS({

--- a/plugins/yellow-composio/skills/composio-patterns/SKILL.md
+++ b/plugins/yellow-composio/skills/composio-patterns/SKILL.md
@@ -14,9 +14,15 @@ processing, usage tracking, graceful degradation, and security rules.
 Composio is a managed tool integration platform providing 1,000+ toolkits and
 11,000+ actions via a single MCP server. In yellow-plugins, Composio is an
 **optional accelerator** -- all workflows must function without it. Tools are
-provided by the user's MCP connector (prefix varies by configuration, e.g.,
-`mcp__claude_ai_composio__*` or `mcp__composio-server__*`), not bundled by
-this plugin.
+discovered via ToolSearch and may appear under one of three prefixes,
+checked in priority order:
+
+1. `mcp__plugin_yellow-composio_composio-server__*` -- bundled by this
+   plugin (preferred, requires both `userConfig` values to be set).
+2. `mcp__claude_ai_composio__*` -- Claude.ai native Composio integration
+   (legacy, still supported).
+3. `mcp__composio-server__*` -- manual `claude mcp add` setup
+   (legacy / migration path).
 
 ## Tool Reference
 
@@ -265,8 +271,12 @@ Pattern:
   infrastructure. Do not send sensitive file contents, credentials, private
   keys, or proprietary algorithms. Use Workbench for data processing and API
   orchestration, not as a trusted execution environment.
-- **No API keys stored**: This plugin does not store or manage Composio API
-  keys. The native MCP connector handles credential management.
+- **API key stored in system keychain**: When the bundled MCP path is used,
+  the `composio_api_key` `userConfig` value is stored in the OS keychain
+  (`sensitive: true`) and sent as the `X-API-Key` header on every request.
+  Never echo, log, or transmit the value. Legacy `mcp__claude_ai_composio__*`
+  and `mcp__composio-server__*` paths use Claude Code's native or manual
+  credential management instead.
 - **Content fencing**: Wrap all Composio responses in `--- begin/end ---`
   delimiters per repository convention.
 - **Data transmission**: Tool call parameters and Workbench code are sent to


### PR DESCRIPTION
Replaces /composio:setup's documentation-passthrough story with an
actual installer. plugin.json now declares two userConfig keys
(composio_mcp_url, composio_api_key) and an mcpServers.composio-server
entry of type http that reads ${user_config.composio_mcp_url} into url
and ${user_config.composio_api_key} into the X-API-Key header. Tools
will appear under mcp__plugin_yellow-composio_composio-server__* once
the user answers the prompts on plugin enable.

CLAUDE.md flips from "does NOT bundle an MCP server" to a description
of the bundled server and migration path. Security notes are updated
to reflect keychain-stored credentials. Setup command's Step 2 detects
all three known prefixes (bundled, claude.ai native, manual) and
recommends /plugin disable && /plugin enable for first-time setup,
keeping the manual claude mcp add instructions as a fallback.

This is the first plugin to use ${user_config.*} substitution in
mcpServers.url and mcpServers.headers. The schema does not field-scope
substitution (every prior plugin uses it only in env blocks of stdio
servers), so this PR is also the empirical test that the harness
resolves it in url + headers. If the harness does not, the manual
claude mcp add path remains documented in setup.md.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR converts yellow-composio from a documentation-passthrough plugin into a self-contained one by bundling a `type: http` MCP server in `plugin.json`, driven by two new `userConfig` prompts (`composio_mcp_url` and `composio_api_key`). All documentation — `CLAUDE.md`, `README.md`, `setup.md`, and `SKILL.md` — is updated to reflect the three-prefix detection order (bundled → native → manual) and to document the migration path for users who previously ran `claude mcp add` manually.

- **`plugin.json`** declares `mcpServers.composio-server` with `${user_config.*}` substitution in both `url` and `headers`; the changeset explicitly flags this as the first use of that pattern in HTTP server fields and retains the manual `claude mcp add` path as a documented fallback if substitution is not resolved by the harness.
- **`setup.md`** Step 2 now searches for `COMPOSIO_SEARCH_TOOLS` (replacing `COMPOSIO_REMOTE_WORKBENCH`), enumerates all three prefixes, and adds a named heredoc delimiter (`__EOF_COMPOSIO_USAGE__`) to avoid potential shell collision with the old `JSONEOF` sentinel.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is entirely configuration and documentation with a well-documented manual fallback if the harness does not resolve the new substitution pattern.

All changed files are plugin configuration and Markdown documentation. The only runtime risk — whether the harness resolves ${user_config.*} inside an HTTP server's url and headers fields — is fully acknowledged in the changeset and covered by a manual fallback path documented in setup.md. No existing user data is affected; users on the prior manual path keep working unchanged.

plugin.json is the only file where a harness behavior assumption (user_config substitution in HTTP url/headers) could silently break for users on older Claude Code versions — the fallback path in setup.md mitigates this but the assumption itself is worth verifying before broad rollout.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/yellow-composio/.claude-plugin/plugin.json | Adds userConfig (composio_mcp_url + composio_api_key) and mcpServers.composio-server (type: http); substitution in url/headers fields is empirically untested per the changeset; no schema-level HTTPS enforcement on the URL field (both flagged in prior threads). |
| plugins/yellow-composio/commands/composio/setup.md | Step 2 rewritten to detect all three tool prefixes and provide a well-documented fallback path; ToolSearch query updated to COMPOSIO_SEARCH_TOOLS; heredoc delimiter safely renamed from JSONEOF to __EOF_COMPOSIO_USAGE__. |
| plugins/yellow-composio/CLAUDE.md | Flipped 'does NOT bundle an MCP server' to describe the bundled HTTP server; security notes updated to reflect keychain storage; consistent with plugin.json and README. |
| plugins/yellow-composio/README.md | Quick Start updated to lead with userConfig prompts; three-prefix detection and manual claude mcp add migration guidance added clearly. |
| plugins/yellow-composio/skills/composio-patterns/SKILL.md | Overview expanded to list bundled prefix first; security note updated from 'no API keys stored' to keychain-backed storage; consumer detection pattern unchanged (still uses COMPOSIO_REMOTE_WORKBENCH as intended). |
| .changeset/yellow-composio-bundle-mcp.md | Comprehensive minor-version changeset documenting the substitution uncertainty, compatibility story, and all affected files. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[plugin enable yellow-composio] --> B{userConfig prompts answered?}
    B -->|URL + key provided| C[composio-server starts via plugin.json]
    B -->|URL blank| D[Bundled MCP fails to start]
    B -->|URL set, key blank| E[MCP starts — tools visible but calls return 401]
    C --> F[Tools under mcp__plugin_yellow-composio_composio-server__STAR]
    D --> G{Legacy MCP present?}
    E --> H[setup Step 3 detects 401]
    G -->|mcp__claude_ai_composio__STAR| I[Native integration path]
    G -->|mcp__composio-server__STAR| J[Manual mcp add path]
    G -->|none| K[Show fallback instructions]
    F --> L[composio:setup verifies connectivity]
    I --> L
    J --> L
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Fyellow-composio-bundle-mcp%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Fyellow-composio-bundle-mcp%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aplugins%2Fyellow-composio%2F.claude-plugin%2Fplugin.json%3A30%0AThe%20%60composio_api_key%60%20description%20is%20silent%20on%20blank%2Fdismiss%20behavior%2C%20unlike%20%60composio_mcp_url%60%20which%20explicitly%20documents%20the%20%22fail%20to%20start%22%20path.%20If%20a%20user%20supplies%20a%20valid%20MCP%20URL%20but%20dismisses%20the%20API%20key%20prompt%2C%20the%20MCP%20server%20will%20start%20successfully%20%28non-empty%20URL%29%2C%20tools%20will%20appear%20in%20ToolSearch%2C%20but%20every%20authenticated%20tool%20call%20will%20fail%20with%20401.%20A%20user%20in%20this%20state%20will%20reach%20Step%203%20of%20%60%2Fcomposio%3Asetup%60%20before%20hitting%20the%20error%2C%20which%20may%20be%20confusing.%20Adding%20a%20one-line%20note%20to%20the%20description%20%E2%80%94%20matching%20the%20pattern%20on%20the%20URL%20field%20%E2%80%94%20surfaces%20the%20failure%20mode%20at%20configuration%20time.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%22description%22%3A%20%22Composio%20API%20key%20from%20https%3A%2F%2Fapp.composio.dev%2Fsettings.%20Sent%20as%20the%20X-API-Key%20header%20on%20every%20MCP%20request.%20Stored%20in%20the%20system%20keychain.%20If%20left%20blank%20while%20the%20MCP%20URL%20is%20set%2C%20the%20bundled%20server%20will%20start%20but%20all%20tool%20calls%20will%20fail%20with%20401%20%E2%80%94%20fall%20back%20to%20a%20manual%20%60claude%20mcp%20add%60%20setup%20%28see%20%2Fcomposio%3Asetup%29.%22%2C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
plugins/yellow-composio/.claude-plugin/plugin.json:30
The `composio_api_key` description is silent on blank/dismiss behavior, unlike `composio_mcp_url` which explicitly documents the "fail to start" path. If a user supplies a valid MCP URL but dismisses the API key prompt, the MCP server will start successfully (non-empty URL), tools will appear in ToolSearch, but every authenticated tool call will fail with 401. A user in this state will reach Step 3 of `/composio:setup` before hitting the error, which may be confusing. Adding a one-line note to the description — matching the pattern on the URL field — surfaces the failure mode at configuration time.

```suggestion
      "description": "Composio API key from https://app.composio.dev/settings. Sent as the X-API-Key header on every MCP request. Stored in the system keychain. If left blank while the MCP URL is set, the bundled server will start but all tool calls will fail with 401 — fall back to a manual `claude mcp add` setup (see /composio:setup).",
```

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(yellow-composio): add required:false..."](https://github.com/kinginyellows/yellow-plugins/commit/bffb9de34dafedb66b06fbbf3a114963d038e1d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31064575)</sub>

<!-- /greptile_comment -->