### PR TITLE
feat(yellow-debt): confirm v2.0 schema emission across all 5 scanners (Wave 3 #7)

### DIFF
--- a/.changeset/yellow-debt-scanner-v2-audit.md
+++ b/.changeset/yellow-debt-scanner-v2-audit.md
@@ -3,22 +3,28 @@
 ---
 
 Audit-only confirmation that all 5 scanner agents (ai-pattern, architecture,
-complexity, duplication, security-debt) emit the v2.0 schema fields
-(`finding`, `file`, `failure_scenario`, `confidence`) per the canonical
-`debt-conventions` skill. Closes Wave 3 #7 from the EveryInc merge plan.
+complexity, duplication, security-debt) emit the canonical v2.0 schema per
+the `debt-conventions` skill. The full v2.0 finding schema includes
+`finding`, `file`, `failure_scenario`, `confidence`, `category`, `severity`,
+`effort`, and `fix` (see `plugins/yellow-debt/skills/debt-conventions/SKILL.md`
+for the authoritative field list); each scanner's "Output Requirements"
+section delegates to that skill rather than enumerating the fields inline.
+Closes Wave 3 #7 from the EveryInc merge plan.
 
-Verified by line-grep against each scanner's "Output Requirements" section:
+Verified by line-grep against each scanner's "## Output Requirements" section
+(referencing section heading rather than line number so this audit record
+does not go stale on subsequent edits):
 
-- `ai-pattern-scanner.md` line 98–99 → cites `debt-conventions` v2.0 ✓
-- `architecture-scanner.md` line 104–106 → cites v2.0 ✓
-- `complexity-scanner.md` line 123–125 → cites v2.0 ✓
-- `duplication-scanner.md` line 122–124 → cites v2.0 ✓
-- `security-debt-scanner.md` line 105–107 → cites v2.0 ✓
+- `ai-pattern-scanner.md` "## Output Requirements" → cites `debt-conventions` v2.0 ✓
+- `architecture-scanner.md` "## Output Requirements" → cites v2.0 ✓
+- `complexity-scanner.md` "## Output Requirements" → cites v2.0 ✓
+- `duplication-scanner.md` "## Output Requirements" → cites v2.0 ✓
+- `security-debt-scanner.md` "## Output Requirements" → cites v2.0 ✓
 
-The dual-read logic in `audit-synthesizer.md` (lines 34–167) handles
-v1.0 → v2.0 migration via explicit `schema_version` field check, so existing
-`.debt/scanner-output/*.json` files do not break on re-encounter. No code
-changes required in this PR.
+The dual-read logic in `audit-synthesizer.md` ("### 1. Read Scanner Outputs"
+section) handles v1.0 → v2.0 migration via explicit `schema_version` field
+check, so existing `.debt/scanner-output/*.json` files do not break on
+re-encounter. No code changes required in this PR.
 
 No body changes to scanner agents; this PR exists to record the audit
 completion in the changelog and bump the patch version so downstream

--- a/.changeset/yellow-debt-scanner-v2-audit.md
+++ b/.changeset/yellow-debt-scanner-v2-audit.md
@@ -1,0 +1,25 @@
+---
+"yellow-debt": patch
+---
+
+Audit-only confirmation that all 5 scanner agents (ai-pattern, architecture,
+complexity, duplication, security-debt) emit the v2.0 schema fields
+(`finding`, `file`, `failure_scenario`, `confidence`) per the canonical
+`debt-conventions` skill. Closes Wave 3 #7 from the EveryInc merge plan.
+
+Verified by line-grep against each scanner's "Output Requirements" section:
+
+- `ai-pattern-scanner.md` line 98–99 → cites `debt-conventions` v2.0 ✓
+- `architecture-scanner.md` line 104–106 → cites v2.0 ✓
+- `complexity-scanner.md` line 123–125 → cites v2.0 ✓
+- `duplication-scanner.md` line 122–124 → cites v2.0 ✓
+- `security-debt-scanner.md` line 105–107 → cites v2.0 ✓
+
+The dual-read logic in `audit-synthesizer.md` (lines 34–167) handles
+v1.0 → v2.0 migration via explicit `schema_version` field check, so existing
+`.debt/scanner-output/*.json` files do not break on re-encounter. No code
+changes required in this PR.
+
+No body changes to scanner agents; this PR exists to record the audit
+completion in the changelog and bump the patch version so downstream
+catalog version sync reflects the verified state.


### PR DESCRIPTION
Audit-only PR closing Wave 3 #7 from the EveryInc merge plan. All 5 scanner agents (ai-pattern, architecture, complexity, duplication, security-debt) already cite the v2.0 schema in debt-conventions and require failure_scenario per their Output Requirements sections. The dual-read logic in audit-synthesizer.md handles v1.0 -> v2.0 migration via schema_version field check; no code changes needed. Changeset is patch-only (no body changes; the audit completion is the deliverable).

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->
