### PR TITLE
feat(schema): add `pattern` regex field to userConfigEntry + RULE 10

### DIFF
--- a/.changeset/yellow-composio-https-pattern.md
+++ b/.changeset/yellow-composio-https-pattern.md
@@ -4,7 +4,7 @@
 
 Enforce HTTPS-only on `composio_mcp_url` via `userConfig` `pattern`
 
-Adds `"pattern": "^https://[a-zA-Z0-9][a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}(?:/|$)"`
+Adds `"pattern": "^https://[a-zA-Z0-9][a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}(?:/\\S*)?$"`
 to the `composio_mcp_url` userConfig entry. Closes the security concern
 raised in PR #396 review (greptile P1 thread `PRRT_kwDOQ3SUys6AIYpq`):
 without a schema-level constraint, a user pasting `http://mcp.composio.dev/...`
@@ -16,8 +16,12 @@ blocked this fix; the sibling change in this same PR
 unblocks it.
 
 The pattern requires `https://`, an alphanumeric host start, a dot, and
-a TLD-like trailing segment, then either a `/` or end-of-string. The
-simpler `^https://` prefix-only form was rejected per security review
+a TLD-like trailing segment, optionally followed by a `/` and a
+non-whitespace path/query segment, end-anchored. Both anchors are
+required because JS `.test()` returns true on any substring match —
+without a trailing `$`, `https://mcp.composio.dev/ bad` would still
+pass (codex P2 finding on PR #409). The simpler `^https://`
+prefix-only form was rejected per security review
 (bypassable via URL confusion: `https://evil.com#@victim.com` and
 similar payloads pass `^https://` while routing the request to an
 attacker-controlled host). See

--- a/.changeset/yellow-composio-https-pattern.md
+++ b/.changeset/yellow-composio-https-pattern.md
@@ -1,0 +1,25 @@
+---
+"yellow-composio": patch
+---
+
+Enforce HTTPS-only on `composio_mcp_url` via `userConfig` `pattern`
+
+Adds `"pattern": "^https://[a-zA-Z0-9][a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}(?:/|$)"`
+to the `composio_mcp_url` userConfig entry. Closes the security concern
+raised in PR #396 review (greptile P1 thread `PRRT_kwDOQ3SUys6AIYpq`):
+without a schema-level constraint, a user pasting `http://mcp.composio.dev/...`
+would have the keychain-protected `composio_api_key` (sent as
+`X-API-Key`) transmitted in cleartext on the wire. The `additionalProperties:
+false` posture of the local `userConfigEntry` definition previously
+blocked this fix; the sibling change in this same PR
+(`feat(schema): add pattern regex field to userConfigEntry + RULE 10`)
+unblocks it.
+
+The pattern requires `https://`, an alphanumeric host start, a dot, and
+a TLD-like trailing segment, then either a `/` or end-of-string. The
+simpler `^https://` prefix-only form was rejected per security review
+(bypassable via URL confusion: `https://evil.com#@victim.com` and
+similar payloads pass `^https://` while routing the request to an
+attacker-controlled host). See
+`docs/solutions/build-errors/userconfig-pattern-field-schema-extension.md`
+for the full pattern recipes appendix.

--- a/docs/solutions/build-errors/userconfig-pattern-field-schema-extension.md
+++ b/docs/solutions/build-errors/userconfig-pattern-field-schema-extension.md
@@ -153,15 +153,24 @@ optional.
 "composio_mcp_url": {
   "type": "string",
   "title": "Composio MCP URL",
-  "pattern": "^https://[^\\s/$.?#].[^\\s]*$"
+  "pattern": "^https://[a-zA-Z0-9][a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}(?:/|$)"
 }
 ```
 
-Looser variant accepting any HTTPS URL:
+This pattern requires `https://`, an alphanumeric host start, a dot,
+and a TLD-like trailing segment, then either a `/` or end-of-string.
 
-```json
-"pattern": "^https://"
-```
+**Do NOT** use the simpler `^https://` prefix-only check for
+security-sensitive credentials. Prefix-only validation is bypassable
+via URL confusion: `https://evil.com#@victim.com`,
+`https://evil.com\@victim.com`, and similar payloads pass `^https://`
+while routing the request to an attacker-controlled host. The whole
+point of TLS enforcement is to prevent credential leakage; a bypassable
+TLS check is worse than none because it gives a false sense of safety.
+
+If full hostname enforcement is needed, use a runtime check (the schema
+`pattern` field cannot express "URL parses to allowed host") and pin
+the host explicitly: `^https://mcp\.composio\.dev/`.
 
 ### Vendor-prefixed API keys
 
@@ -171,23 +180,42 @@ Looser variant accepting any HTTPS URL:
 | Anthropic `sk-ant-...` | `^sk-ant-[A-Za-z0-9_-]{20,}$` |
 | Composio `cog_...` | `^cog_[A-Za-z0-9_-]{16,}$` |
 | GitHub PAT (classic) | `^ghp_[A-Za-z0-9]{36}$` |
-| GitHub PAT (fine-grained) | `^github_pat_[A-Za-z0-9_]{82}$` |
+| GitHub PAT (fine-grained) | `^github_pat_[A-Za-z0-9_]{40,}$` |
 | Generic alphanumeric token | `^[A-Za-z0-9_\\-]{20,}$` |
 
 ### Filesystem path inputs (anti-traversal)
+
+The naive character-class pattern `^[A-Za-z0-9_./\\-]+$` allows `..`
+(each character is individually in the set), so `../../../etc/passwd`
+matches and bypasses the intended traversal block. Use ONE of the two
+patterns below — never the naive form alone.
+
+**Option 1 — single pattern with negative lookahead** (works on AJV
+and modern JSON Schema engines that support `(?!...)`):
 
 ```json
 "workspace_dir": {
   "type": "directory",
   "title": "Workspace directory",
-  "pattern": "^[A-Za-z0-9_./\\-]+$"
+  "pattern": "^(?!.*\\.\\.)[A-Za-z0-9_./-]+$"
 }
 ```
 
-For deeper traversal protection, combine with a `not.pattern` rejection
-of `..` segments. Some JSON Schema implementations do not support
-lookaheads, so the explicit anti-pattern is more portable than negative
-lookahead inside the main pattern.
+**Option 2 — pair `pattern` with `not.pattern`** (portable to engines
+without lookahead support):
+
+```json
+"workspace_dir": {
+  "type": "directory",
+  "title": "Workspace directory",
+  "pattern": "^[A-Za-z0-9_./-]+$",
+  "not": { "pattern": "\\.\\." }
+}
+```
+
+(Note: the local schema's `userConfigEntry` does not currently allow
+`not` as a property — Option 2 requires a sibling schema extension.
+Until that ships, use Option 1.)
 
 ### File-path with extension constraint
 
@@ -274,7 +302,7 @@ jq '.userConfig // empty | to_entries[] | select(.value.pattern) | {key: .key, p
 - `docs/brainstorms/2026-05-05-plugin-manifest-userconfig-validator-drift-brainstorm.md`
   — Decision 4 implementation note documenting the script-vs-schema
   enforcement reality.
-- `scripts/validate-plugin.js:856–864` — source-of-truth comment on the
+- `scripts/validate-plugin.js:856–875` — source-of-truth comment on the
   AJV-vs-script split.
 - AJV docs: <https://ajv.js.org/json-schema.html#if-then-else>
 - AJV strict-mode `strictRequired` reference:

--- a/docs/solutions/build-errors/userconfig-pattern-field-schema-extension.md
+++ b/docs/solutions/build-errors/userconfig-pattern-field-schema-extension.md
@@ -153,12 +153,17 @@ optional.
 "composio_mcp_url": {
   "type": "string",
   "title": "Composio MCP URL",
-  "pattern": "^https://[a-zA-Z0-9][a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}(?:/|$)"
+  "pattern": "^https://[a-zA-Z0-9][a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}(?:/\\S*)?$"
 }
 ```
 
 This pattern requires `https://`, an alphanumeric host start, a dot,
-and a TLD-like trailing segment, then either a `/` or end-of-string.
+and a TLD-like trailing segment, optionally followed by a `/` and a
+non-whitespace path/query segment. Both anchors (`^` ... `$`) are
+required: JS `RegExp.test()` returns `true` on any substring match,
+so a host-only pattern without a trailing `$` accepts arbitrary
+appended garbage (e.g., `https://mcp.composio.dev/ bad` or embedded
+newlines), defeating the safety goal.
 
 **Do NOT** use the simpler `^https://` prefix-only check for
 security-sensitive credentials. Prefix-only validation is bypassable

--- a/docs/solutions/build-errors/userconfig-pattern-field-schema-extension.md
+++ b/docs/solutions/build-errors/userconfig-pattern-field-schema-extension.md
@@ -1,0 +1,282 @@
+---
+title: "Schema extension: optional `pattern` regex field on userConfigEntry"
+category: build-errors
+track: feature
+problem: "Plugin authors had no schema-level mechanism to enforce regex constraints on user-supplied userConfig values (URLs, API keys, file paths). The local schema's userConfigEntry used additionalProperties: false and did not list `pattern` as a recognized property, so any plugin that wrote `\"pattern\": \"^https://\"` into plugin.json failed `pnpm validate:plugins` with an additional-property error."
+tags:
+  - plugin-manifest
+  - userConfig
+  - schema-validation
+  - two-validator-drift
+  - input-validation
+  - regex
+severity: P2
+components:
+  - schemas/plugin.schema.json
+  - scripts/validate-plugin.js
+  - tests/integration/validate-plugin.test.ts
+  - tests/integration/example-files-schema.test.ts
+  - examples/plugin-extended.example.json
+error_pattern: 'must NOT have additional properties \(pattern\) at #/properties/userConfig/properties/<key>'
+date_resolved: 2026-05-06
+---
+
+# Schema extension: optional `pattern` regex field on `userConfigEntry`
+
+## Problem
+
+A reviewer on PR #396 (yellow-composio bundles HTTP MCP via `userConfig`)
+flagged that `composio_api_key` is `sensitive: true` (keychain-backed) but
+is sent as the `X-API-Key` header to whatever URL the user enters in
+`composio_mcp_url`. With no schema-level constraint enforcing an `https://`
+prefix, a user who pastes `http://mcp.composio.dev/...` (or any non-TLS URL)
+leaks the keychain-protected credential in cleartext on the wire.
+
+The reviewer proposed adding `"pattern": "^https://"` to the
+`composio_mcp_url` userConfig entry. But the local schema's
+`userConfigEntry` definition at `schemas/plugin.schema.json` used:
+
+```json
+"required": ["type", "title"],
+"additionalProperties": false
+```
+
+…and did not list `pattern` as a recognized property. Writing `pattern`
+into any `plugin.json` therefore failed `pnpm validate:plugins` with an
+"additional property not allowed" AJV error, blocking the security fix.
+
+The class of problem extends beyond URL TLS enforcement: any future plugin
+handling user-supplied URLs, file paths, or vendor-prefixed tokens cannot
+express input-format constraints declaratively.
+
+## Solution
+
+Add `pattern` as an optional schema-level property on `userConfigEntry`,
+gated to `string`-typed values (and `directory`/`file` path-shape values),
+with a corresponding hand-rolled RULE 10 in `scripts/validate-plugin.js`
+that enforces the same constraints from the script path that does NOT
+AJV-load the schema (the same architectural reality that motivated RULE 9
+for `type`+`title`).
+
+### Schema layer (`schemas/plugin.schema.json`)
+
+Add `pattern` to `definitions.userConfigEntry.properties`:
+
+```json
+"pattern": {
+  "type": "string",
+  "minLength": 1,
+  "description": "Regular expression (JavaScript syntax, anchored with ^ and $ recommended) the user-supplied value must match. Only valid when `type` is one of: string, directory, file (number/boolean values cannot meaningfully carry a regex constraint). Enforced locally by scripts/validate-plugin.js RULE 10; remote-validator support is empirically untested at the time of introduction."
+}
+```
+
+Add a 6th `if/then` block to the existing `allOf` array that rejects
+`pattern` on number/boolean entries:
+
+```json
+{
+  "if": {
+    "properties": { "type": { "enum": ["number", "boolean"] } },
+    "required": ["type"]
+  },
+  "then": { "properties": { "pattern": false } }
+}
+```
+
+The `properties: { pattern: false }` formulation (rather than
+`not: { required: ["pattern"] }`) is required because AJV strict-mode
+rejects the `not.required` formulation as `strictRequired` (it expects
+properties named in `required` to also be declared in the local schema's
+`properties`, even inside a `not` clause). The `false`-schema idiom is
+both stricter and AJV-strict-mode-friendly.
+
+### Script layer (`scripts/validate-plugin.js` RULE 10)
+
+`validate-plugin.js` does NOT AJV-load `schemas/plugin.schema.json`. The
+schema layer alone catches `pattern` misuse only when an example fixture
+runs through `tests/integration/example-files-schema.test.ts`. To make
+`pnpm validate:plugins` enforce the same constraints, RULE 10 was added
+inside the existing `validateUserConfigEntries` helper. The check fires
+in both invocations (top-level `userConfig` and `channels[i].userConfig`)
+and validates four invariants per entry:
+
+1. `pattern` is a non-empty string when present.
+2. `pattern` is only valid when `type` is one of `{string, directory, file}`.
+3. `pattern` compiles as a JavaScript `RegExp` (via `new RegExp` in a
+   try/catch) — invalid regex syntax is rejected with the V8 compile
+   error message verbatim.
+4. When `default` is present alongside `pattern` and is a string, the
+   default itself must match the pattern. This catches internally
+   inconsistent manifests (e.g., `pattern: "^https://"` with
+   `default: "http://example.com"`).
+
+### Test coverage
+
+- `tests/integration/validate-plugin.test.ts` — new "PR-B" describe block
+  with 10 fixture-based cases exercising every accept/reject path (string
+  + directory + file accept; non-string, empty, number, boolean, invalid
+  regex, default-mismatch reject; back-compat without `pattern`).
+- `tests/integration/example-files-schema.test.ts` — new "PR-C" describe
+  block with 8 cases that AJV-validate synthetic plugin manifests against
+  the loaded `plugin.schema.json`. Plus: `examples/plugin-extended.example.json`
+  now sets `pattern: "^https://"` on its `userConfig.api_endpoint` entry,
+  exercising the field through the existing fixture loop.
+
+## Architectural rationale: why both layers
+
+The two-validator drift discussed in
+`userconfig-type-title-remote-validator-drift.md` applies here too. The
+`pnpm validate:schemas` chain runs four Node scripts; only
+`validate-marketplace.js` AJV-loads its schema, and
+`validate-plugin.js` is a 900-line hand-rolled validator that does NOT
+load `schemas/plugin.schema.json`. Tightening the schema therefore
+catches drift only via `pnpm test:integration` (which validates example
+fixtures against the schema), not via `pnpm validate:plugins`. The
+authoritative statement of this architectural reality lives in the
+`validate-plugin.js` source comment at lines 856–864 (RULE 9 leading
+comment), which RULE 10's leading comment now extends.
+
+This is "Approach C" from the userConfig type+title brainstorm: schema
+tightening + hand-rolled script rule. Approach B (schema only) was
+rejected because `validate-plugin.js` does not AJV-load and would silently
+miss the constraint on the script path.
+
+## Common pattern recipes
+
+These regex shapes are production-grade for common userConfig input types.
+Always anchor with `^` and `$`. Adopt incrementally — `pattern` is purely
+optional.
+
+### HTTPS-only URL (the immediate motivating case)
+
+```json
+"composio_mcp_url": {
+  "type": "string",
+  "title": "Composio MCP URL",
+  "pattern": "^https://[^\\s/$.?#].[^\\s]*$"
+}
+```
+
+Looser variant accepting any HTTPS URL:
+
+```json
+"pattern": "^https://"
+```
+
+### Vendor-prefixed API keys
+
+| Vendor | Pattern |
+|---|---|
+| OpenAI `sk-...` | `^sk-[A-Za-z0-9_-]{20,}$` |
+| Anthropic `sk-ant-...` | `^sk-ant-[A-Za-z0-9_-]{20,}$` |
+| Composio `cog_...` | `^cog_[A-Za-z0-9_-]{16,}$` |
+| GitHub PAT (classic) | `^ghp_[A-Za-z0-9]{36}$` |
+| GitHub PAT (fine-grained) | `^github_pat_[A-Za-z0-9_]{82}$` |
+| Generic alphanumeric token | `^[A-Za-z0-9_\\-]{20,}$` |
+
+### Filesystem path inputs (anti-traversal)
+
+```json
+"workspace_dir": {
+  "type": "directory",
+  "title": "Workspace directory",
+  "pattern": "^[A-Za-z0-9_./\\-]+$"
+}
+```
+
+For deeper traversal protection, combine with a `not.pattern` rejection
+of `..` segments. Some JSON Schema implementations do not support
+lookaheads, so the explicit anti-pattern is more portable than negative
+lookahead inside the main pattern.
+
+### File-path with extension constraint
+
+```json
+"config_file": {
+  "type": "file",
+  "title": "Config file",
+  "pattern": "\\.json$"
+}
+```
+
+The schema's own `relativeFile` pattern at line 65 of
+`schemas/plugin.schema.json` is a reusable in-repo precedent for path
+shape constraints.
+
+## Empirical question: does the remote validator honor `pattern`?
+
+As of the time of introduction, the Anthropic Claude Code remote validator
+(`claude doctor`) has not been observed to honor or reject `pattern` on
+userConfig entries. No public plugin in the observable ecosystem has
+shipped this field. The local schema and RULE 10 enforce it deterministically
+during `pnpm validate:plugins`; the remote may silently ignore it (best
+case) or reject the entry as carrying an unknown field (worst case — same
+class of failure as the `changelog` and `repository` field drift).
+
+**Empirical-test recipe:**
+
+1. Add `"pattern": "^https://"` to one `userConfig` entry in a test
+   plugin's `plugin.json`.
+2. Run `pnpm validate:schemas` locally — must pass after this PR lands.
+3. `/plugin marketplace add <test-plugin>` in a clean Claude Code
+   environment.
+4. `claude doctor` — if it passes without a manifest validation error,
+   `pattern` is accepted by the remote validator (silently or with
+   enforcement, TBD).
+5. Set a userConfig value violating the pattern. If Claude Code surfaces
+   an error → remote enforces. If the value is silently accepted →
+   remote ignores. Either way, local enforcement catches violations
+   before publish.
+
+Update this doc with the result once empirically verified.
+
+## ReDoS risk note
+
+ReDoS (catastrophic backtracking) risk for plugin-author-supplied regex
+is **low** in this threat model. The compile path is one-shot at
+validation time, not a hot path; ReDoS requires both an adversarial regex
+AND an adversarial input length to manifest. The plugin-author trust
+boundary is the same as `npm install` — if a plugin author wrote a
+malicious regex, you have bigger problems. AJV itself does not guard
+pattern strings, nor do `semantic-release`, `lerna`, or `Renovate` in
+their config validators. If evidence of ReDoS-shaped patterns
+recurs, `safe-regex` (npm) is the standard mitigation tool to wire into
+RULE 10 as a warning (not a hard failure).
+
+## Detection
+
+To audit existing plugins for `pattern` adoption opportunities:
+
+```bash
+# Plugins with a userConfig field
+jq '.userConfig // empty | keys' plugins/*/.claude-plugin/plugin.json
+
+# Plugins that already use pattern (after this PR)
+jq '.userConfig // empty | to_entries[] | select(.value.pattern) | {key: .key, pattern: .value.pattern}' plugins/*/.claude-plugin/plugin.json
+```
+
+## Prevention
+
+- New plugin authoring docs reference this doc when discussing userConfig
+  fields.
+- `validate-plugin.js` RULE 10 enforces the four invariants on every
+  CI run.
+- The `additionalProperties: false` posture of `userConfigEntry` remains
+  the contract — any future userConfig field requires the same
+  schema + RULE pairing.
+
+## References
+
+- PR #396 review thread `PRRT_kwDOQ3SUys6AIYpq` (greptile P1 finding) —
+  the motivating cleartext-credential incident.
+- `docs/solutions/build-errors/userconfig-type-title-remote-validator-drift.md`
+  — prior art using the same schema + RULE pairing.
+- `docs/brainstorms/2026-05-05-plugin-manifest-userconfig-validator-drift-brainstorm.md`
+  — Decision 4 implementation note documenting the script-vs-schema
+  enforcement reality.
+- `scripts/validate-plugin.js:856–864` — source-of-truth comment on the
+  AJV-vs-script split.
+- AJV docs: <https://ajv.js.org/json-schema.html#if-then-else>
+- AJV strict-mode `strictRequired` reference:
+  <https://ajv.js.org/strict-mode.html#prohibit-required-keyword-in-shared-properties>
+- JSON Schema draft-07: <https://json-schema.org/draft-07/json-schema-validation.html>

--- a/examples/plugin-extended.example.json
+++ b/examples/plugin-extended.example.json
@@ -55,7 +55,8 @@
       "title": "API endpoint",
       "description": "Your team's API endpoint",
       "required": true,
-      "sensitive": false
+      "sensitive": false,
+      "pattern": "^https://"
     },
     "api_token": {
       "type": "string",

--- a/plans/userconfig-pattern-enforcement.md
+++ b/plans/userconfig-pattern-enforcement.md
@@ -1,0 +1,617 @@
+# Feature: `userConfigEntry.pattern` schema field for input regex constraints
+
+## Problem Statement
+
+PR #396 (`yellow-composio` bundles HTTP MCP via userConfig) introduced the first
+plugin in this repo to read user-supplied secrets and URLs into an HTTP MCP
+server's `url` and `X-API-Key` header. A reviewer (greptile, P1 security) flagged
+that `composio_api_key` is `sensitive: true` (keychain-backed) but is sent as the
+`X-API-Key` header to whatever URL the user enters in `composio_mcp_url`. With
+no schema-level constraint enforcing an `https://` prefix, a user who pastes
+`http://mcp.composio.dev/...` (or any non-TLS URL) leaks the keychain-protected
+credential in cleartext on the wire. The advisory text in the description
+(`"Only https://mcp.composio.dev/* URLs are expected"`) is documentation, not
+enforcement.
+
+Adding `"pattern": "^https://"` to the `composio_mcp_url` userConfig entry
+would close this gap. But the local schema's `userConfigEntry` definition uses
+`additionalProperties: false` and does not list `pattern` — so writing it
+directly into `plugin.json` fails `pnpm validate:plugins` with an
+"additional property not allowed" AJV error. This blocks the security fix on
+PR #396 and on any future plugin needing input-format enforcement (numeric
+ranges, file path constraints, vendor-specific token prefixes).
+
+The right fix is at the schema layer: add `pattern` to the `userConfigEntry`
+definition, gate it to string-typed values, and add a hand-rolled rule
+(`scripts/validate-plugin.js` RULE 10) so the constraint is also enforced when
+the schema is bypassed (validate-plugin.js does NOT AJV-load the schema — see
+the userConfig type+title drift doc).
+
+## Linear Issues
+
+(none — no Linear issue tracker integration on this work)
+
+## Current State
+
+- **Schema** (`schemas/plugin.schema.json`, `definitions.userConfigEntry`):
+  - Properties: `type`, `title`, `description`, `default`, `required`,
+    `sensitive`
+  - `required: ["type", "title"]`
+  - `additionalProperties: false`
+  - `type` enum: `string|number|boolean|directory|file`
+  - Has an `allOf` block of `if/then` constraints linking `default` shape to
+    `type` (strings keep string defaults, numbers keep numeric defaults, etc.) —
+    this is the established pattern for type-conditional schema rules.
+
+- **Validator** (`scripts/validate-plugin.js`):
+  - Hand-rolled, does NOT AJV-load `schemas/plugin.schema.json`.
+  - RULE 9 (line 856–878 region) — `validateUserConfigEntries` walks both
+    top-level `userConfig` and `channels[].userConfig`, requiring `type` and
+    `title`. Same loop is the natural place to add `pattern` validation.
+  - `USER_CONFIG_TYPES` Set at line 65–69 — module-scope, mirrors the
+    schema enum.
+
+- **Tests** (`tests/integration/validate-plugin.test.ts`):
+  - Fixture-based: each test writes a `plugin.json` to a temp dir, runs the
+    validator as a child process, asserts on exit code (0/1/2) and stderr.
+  - Existing block "PR-A" added by an earlier hardening PR — RULE 7 tests live
+    here.
+
+- **Plugin manifests** (`plugins/*/.claude-plugin/plugin.json`):
+  - 4 plugins currently have `userConfig` (yellow-devin, yellow-research,
+    yellow-morph, yellow-semgrep) — none use `pattern`.
+  - PR #396's `yellow-composio` adds 2 more keys (`composio_mcp_url`,
+    `composio_api_key`) — also no pattern (deferred pending this PR).
+
+- **Prior art**:
+  - The `userConfigEntry.title` + `type` requirement was enforced via the
+    same schema-tightening + RULE 9 hand-roll combination — see
+    `docs/solutions/build-errors/userconfig-type-title-remote-validator-drift.md`
+    and `docs/brainstorms/2026-05-05-plugin-manifest-userconfig-validator-drift-brainstorm.md`.
+  - That doc documents the empirical reality that the local schema and
+    Claude Code's remote validator can drift silently and the right
+    posture is "tighten local first, file an issue for the remote if
+    behavior diverges."
+
+## Proposed Solution
+
+Add `pattern` as an optional schema-level property on `userConfigEntry`,
+enforced for `string`-typed values (and conditionally for `directory`/`file`
+path-shape values when set), with a corresponding hand-rolled RULE 10 in
+`scripts/validate-plugin.js` so the constraint also fires from the script
+path that does not AJV-load the schema. Then apply the pattern to PR #396's
+`composio_mcp_url` (and any other already-shipped userConfig entries that
+benefit) in a follow-up commit on the same branch.
+
+### Key design decisions
+
+**D1. Enum scope of `pattern`.** Restrict pattern enforcement to
+`type ∈ {string, directory, file}`. Numbers and booleans cannot meaningfully
+carry a regex constraint at the value-shape level (numbers should use
+`minimum`/`maximum`; booleans only have two values). Directory and file are
+included because path-format constraints (e.g.,
+`^[A-Za-z0-9_-]+$` for safe slug-like paths) are a real use case.
+
+**D2. Pattern is optional, not required.** Existing 4 plugins (and PR #396's
+2 keys) ship without it. Making it optional is the only backward-compatible
+choice — and `pattern` is only correct for some keys (URL, file path),
+not all (description text, freeform IDs).
+
+**D3. Local enforcement only — no claim about remote validator behavior.**
+Per the userConfig type+title drift solutions doc, the Anthropic remote
+validator (`claude doctor`) may or may not honor `pattern`. The schema and
+RULE 10 enforce locally; if the remote silently ignores `pattern`, local CI
+is still the right backstop because every PR runs `pnpm validate:plugins`.
+Document this empirical question in the changeset.
+
+**D4. `if/then` block in `allOf` for type-gated pattern rejection.**
+Mirror the existing allOf pattern that links `default` shape to `type`. Add a
+sibling `if/then` block that says: "if `type ∈ {number, boolean}`, then the
+schema must NOT contain `pattern`." This catches `pattern` misuse on
+unsupported types via AJV alone.
+
+**D5. RULE 10 in validate-plugin.js does the same work hand-rolled.**
+Mirroring RULE 9, walk both top-level and `channels[].userConfig`, validate
+that:
+- `pattern` is a string when present
+- `pattern` compiles as a JavaScript regex (via `new RegExp(pattern)` in a
+  try/catch — same engine as runtime substitution)
+- `pattern` is only set when `type` is one of `{string, directory, file}`
+- when `default` is present alongside `pattern`, the default itself matches
+  the pattern (catches "pattern says ^https:// but default is http://...")
+
+**D6. Document the security cross-link.** The pattern field's primary motivating
+case is the `composio_mcp_url` cleartext-credential risk. The plan ships
+the schema enablement only — applying `^https://` to PR #396's plugin.json
+happens in a sibling commit on this branch (or a follow-up PR), gated by
+PR #396 merging first. Document this ordering.
+
+### Why this approach (vs alternatives)
+
+- **Approach A — manifest-only (write `pattern` into composio plugin.json,
+  add it to schema lazily):** Already tried in the PR #396 resolver pass;
+  fails CI because of `additionalProperties: false`. Not viable.
+- **Approach B — schema only (no RULE 10):** Would work for plugin manifests
+  read via AJV-loaded paths (`tests/integration/example-files-schema.test.ts`)
+  but `validate-plugin.js` does not AJV-load. The userConfig type+title
+  brainstorm doc explicitly notes this and that's why RULE 9 was added.
+  Skipping the hand-rolled rule would repeat the same gap.
+- **Approach C — schema + RULE 10 (this plan):** Matches established repo
+  doctrine. Both validation paths agree.
+
+## Implementation Plan
+
+### Phase 1: Schema change
+
+- [ ] **1.1** — In `schemas/plugin.schema.json` `definitions.userConfigEntry.properties`,
+  add a `pattern` property:
+  ```json
+  "pattern": {
+    "type": "string",
+    "minLength": 1,
+    "description": "Regular expression (JavaScript syntax) the user-supplied value must match. Enforced at install time by the Claude Code remote validator (when supported) AND locally by scripts/validate-plugin.js RULE 10. Only valid when type is one of: string, directory, file."
+  }
+  ```
+- [ ] **1.2** — Extend the `allOf` block with an `if/then` rule rejecting
+  `pattern` when `type ∈ {number, boolean}`:
+  ```json
+  {
+    "if": {
+      "properties": { "type": { "enum": ["number", "boolean"] } },
+      "required": ["type"]
+    },
+    "then": { "not": { "required": ["pattern"] } }
+  }
+  ```
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** The existing `allOf` at `schemas/plugin.schema.json` lines
+> 34–55 has 5 `if/then` blocks, all using `{ "type": { "const": "<x>" } }` +
+> a positive `then.properties.default` constraint. The proposed 6th block
+> uses `enum` (not `const`) and `then.not.required` (negative, not positive).
+> This is valid draft-07 but is structurally different from the existing 5 —
+> worth a leading-comment in the schema diff so future readers see the
+> intent. Confirmed: `additionalProperties: false` is at line 33.
+<!-- /deepen-plan -->
+
+<!-- deepen-plan: external -->
+> **Research:** AJV/JSON Schema draft-07 idiomatic guidance — the proposed
+> `if/then` shape is the canonical pattern. **Critical:** the `if` clause
+> MUST include `"required": ["type"]` as written; without it, an entry with
+> no `type` field would match the `if` (because `properties` without
+> `required` does not assert presence) and would incorrectly be forbidden
+> from having `pattern`. Plan has this correct.
+> Alternatives considered: `dependentSchemas` (wrong tool — fires on
+> property *presence*, not value), `oneOf` per-type subschemas (5× more
+> schema text; only worth it for per-type pattern format validation).
+> See: <https://ajv.js.org/json-schema.html#if-then-else>
+<!-- /deepen-plan -->
+
+- [ ] **1.3** — Run `jq empty schemas/plugin.schema.json` to confirm valid JSON
+  (no trailing-comma drift on `additionalProperties: false` block).
+- [ ] **1.4** — Run `pnpm validate:schemas` and confirm it passes (no
+  existing manifest is invalidated; pattern is purely additive).
+
+**Verification:** `pnpm test:integration -- example-files-schema` continues to
+pass against the test fixtures under `tests/integration/`. AJV reports `pattern`
+as accepted.
+
+### Phase 2: Hand-rolled RULE 10 in `validate-plugin.js`
+
+- [ ] **2.1** — Read the full RULE 9 source at
+  `scripts/validate-plugin.js:856–878` to extract the `validateUserConfigEntries`
+  helper signature and structure.
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Line numbers in this plan are off — `validateUserConfigEntries`
+> is defined at **line 866** (not 808); RULE 9 leading comment block starts
+> at **line 856** (correct); top-level call site at **line 903**;
+> `channels[i].userConfig` call site at **line 908** (NOT 844–851 as the
+> plan body says). The full RULE 9 region is **lines 856–911**. Module-scope
+> `VALID_USER_CONFIG_TYPES` Set is at **lines 71–77**. Update Phase 2.1
+> reference and Phase 2.3 line range, and the "Validator entry point" line
+> in the References section, before reading those files during work.
+<!-- /deepen-plan -->
+
+- [ ] **2.2** — Add RULE 10 inside `validateUserConfigEntries` (or as a sibling
+  helper called from the same loop). For each entry:
+  - If `pattern` is present:
+    - Reject if `typeof pattern !== 'string'` or `pattern.length === 0`.
+    - Reject if `type` is not in `{string, directory, file}` —
+      include the offending key path in the error message.
+    - Compile via `new RegExp(pattern)` inside `try/catch`; on
+      `SyntaxError`, report the regex compile error verbatim.
+    - If `default` is also present and is a string, test it against the
+      compiled regex; if it doesn't match, report:
+      `userConfig.<key>: default "<value>" does not match pattern "<regex>"`.
+
+<!-- deepen-plan: external -->
+> **Research:** AJV's default `pattern`-failure error is
+> `"must match pattern \"<regex>\""` — functional but opaque for plugin
+> authors. Two options for clearer messages:
+> 1. **`ajv-errors` package** — adds an `errorMessage` keyword
+>    (<https://github.com/ajv-validator/ajv-errors>). Requires `allErrors:
+>    true` on the AJV instance. Best when errors surface directly to end
+>    users.
+> 2. **Post-process AJV's error array** in `validate-plugin.js` — map
+>    `keyword === 'pattern'` errors to a human-readable template. No new
+>    dependency, sufficient for validator scripts where you control output.
+>
+> **Recommended for this plan:** option 2 (post-process). RULE 10 already
+> hand-rolls the validation, so the error message is fully under our
+> control without pulling in `ajv-errors`. Phase 2.2's existing
+> `userConfig.<key>: default "<value>" does not match pattern "<regex>"`
+> format is exactly the right shape.
+<!-- /deepen-plan -->
+
+- [ ] **2.3** — Wire calls in both invocations (top-level
+  `validateUserConfigEntries(manifest.userConfig, 'userConfig')` at
+  `scripts/validate-plugin.js:903` and the `channels[i].userConfig` loop
+  at `scripts/validate-plugin.js:908`, both inside the RULE 9 region
+  ending at line 911 — see codebase annotation on Phase 2.1).
+- [ ] **2.4** — Update the "RULE 9: userConfig entries must declare `type` and
+  `title`" leading comment block to also mention RULE 10's pattern semantics
+  so a future maintainer sees both rules together.
+
+**Verification:** `pnpm validate:plugins` continues to pass on all existing
+plugins (no plugin uses `pattern` yet, so no false positives). Manual test:
+write a fixture plugin with `"type": "number", "pattern": "^[0-9]+$"` —
+RULE 10 must reject it.
+
+### Phase 3: Integration tests
+
+- [ ] **3.1** — In `tests/integration/validate-plugin.test.ts`, add a
+  describe block "PR-B: userConfig pattern field (RULE 10)" with the
+  following cases (mirror the PR-A fixture-based pattern):
+  - Accept: `type: "string"` + `pattern: "^https://"` + `default: "https://example.com"` — exit 0
+  - Reject: `type: "string"` + `pattern` not a string (e.g., `pattern: 123`) — exit 1, stderr mentions "must be string"
+  - Reject: `type: "number"` + `pattern: "^[0-9]+$"` — exit 1, stderr mentions "pattern only valid for type ∈ {string, directory, file}"
+  - Reject: `type: "string"` + `pattern: "[unclosed"` (invalid regex) — exit 1, stderr mentions regex compile error
+  - Reject: `type: "string"` + `pattern: "^https://"` + `default: "http://example.com"` — exit 1, stderr mentions "default does not match pattern"
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** PR-A describe block confirmed at
+> `tests/integration/validate-plugin.test.ts:316–645`. Append the new
+> "PR-B" block directly after line 645. Use the existing scaffolding:
+> `mkdtempSync(join(tmpdir(), 'yellow-validate-plugin-new-'), ...)` in
+> `beforeEach`; plugin name MUST match the temp dir basename
+> (`test-plugin`) per RULE 2; `writePluginManifest(pluginDir, manifest)`
+> writes `.claude-plugin/plugin.json`; `runValidator(pluginDir)` returns
+> `{ status, stdout, stderr }` from `spawnSync('node', [VALIDATOR,
+> pluginDir])`. `VALID_BASE_MANIFEST` is at lines 101–107
+> (`{ name: 'test-plugin', description, author, version }`) — start each
+> case from `{ ...VALID_BASE_MANIFEST, userConfig: { ... } }`.
+<!-- /deepen-plan -->
+
+- [ ] **3.2** — In `tests/integration/example-files-schema.test.ts` (or the
+  AJV-loaded fixture path it covers), add at minimum one positive case
+  exercising the schema's accept-pattern path so we know AJV is loading
+  the new property.
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** `tests/integration/example-files-schema.test.ts` AJV-loads
+> `schemas/plugin.schema.json` via `AjvValidatorFactory.loadSchemaFromFile`
+> (lines 35, 62–66) and iterates all `examples/plugin*.json` files
+> (lines 77–94). It already has a `'semverRange custom keyword (PR-B)'`
+> describe block at line 97 — DO NOT name the new block "PR-B" here
+> (collision); call it **`'userConfigEntry.pattern field (PR-C)'`** or
+> similar. The lowest-friction positive case is to add `"pattern":
+> "^https://"` to the existing `userConfig.api_endpoint` entry in
+> `examples/plugin-extended.example.json` (line 53 of that fixture) —
+> the existing fixture loop will validate it automatically. Then add a
+> dedicated synthetic-schema describe block for the negative cases
+> (number+pattern rejected, etc.) the same way the semverRange PR-B
+> block does.
+<!-- /deepen-plan -->
+
+- [ ] **3.3** — Run `pnpm test:integration` and confirm both files pass.
+
+### Phase 4: Apply to PR #396 (sibling commit on this branch)
+
+This phase ships a commit on this branch — independent of PR #396's merge
+state — applying `pattern: "^https://"` to `composio_mcp_url`. The commit
+references PR #396 in its body but does not stack on PR #396.
+
+If PR #396 is still open when this branch is ready:
+- Add a comment on PR #396 noting that this branch enables the schema
+  field and the `^https://` enforcement can be added to `composio_mcp_url`
+  in a follow-up commit on this branch (rather than re-opening PR #396).
+
+If PR #396 has merged:
+- Apply the change directly here on this branch.
+
+- [ ] **4.1** — Decide based on PR #396 merge state at implementation time.
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** This branch (`agent/feat/userconfig-pattern-enforcement`)
+> was created off `main` BEFORE PR #396's tip commit. In the current
+> working tree, `plugins/yellow-composio/.claude-plugin/plugin.json` does
+> NOT have a `userConfig` field at all — the composio userConfig keys
+> live on the sibling branch `agent/feat/yellow-composio-bundle-mcp`
+> (PR #396, tip `eb8315a9`). Phase 4 cannot be executed in the current
+> working tree as-is. Three implementation paths:
+> 1. **Wait for PR #396 to merge to `main`**, then `gt sync` this branch
+>    so the composio userConfig appears, then apply Phase 4 here.
+> 2. **Stack this branch on top of `agent/feat/yellow-composio-bundle-mcp`**
+>    via `gt move --onto agent/feat/yellow-composio-bundle-mcp` (rebase),
+>    then apply Phase 4. Use this if PR #396 is blocked.
+> 3. **Skip Phase 4 entirely** and ship Phases 1–3 as a "schema enablement
+>    only" PR. Add the `^https://` pattern to composio in a follow-up PR
+>    once #396 has merged.
+> Phase 4.1 should be rewritten as a "decision gate" that picks one of
+> these three paths. Recommended at planning time: option 1 (wait for #396
+> to merge) — Phases 1–3 stand on their own as a schema-features patch.
+<!-- /deepen-plan -->
+
+- [ ] **4.2** — Apply the pattern to `plugins/yellow-composio/.claude-plugin/plugin.json`
+  (`composio_mcp_url.pattern = "^https://"`).
+- [ ] **4.3** — Re-run `pnpm validate:plugins` to confirm the pattern is
+  accepted now that the schema supports it.
+
+### Phase 5: Solutions doc + memory
+
+- [ ] **5.1** — Write
+  `docs/solutions/build-errors/userconfig-pattern-field-schema-extension.md`
+  documenting:
+  - The motivating cleartext-credential incident (PR #396 review).
+  - The schema-vs-validator-script split that requires both Phase 1 and
+    Phase 2 changes.
+  - The empirical question of remote validator support for `pattern`
+    (treat as locally-enforced; document if/when the remote behavior is
+    confirmed).
+  - The migration recipe for existing plugins to add `pattern` if they
+    want input enforcement.
+- [ ] **5.2** — Append a one-line entry to the
+  `Plugin Manifest Validation` section of the auto-memory `MEMORY.md`
+  index pointing to the new solutions doc.
+
+### Phase 6: Changeset, validation, commit
+
+- [ ] **6.1** — Run `pnpm validate:schemas && pnpm test:unit && pnpm lint && pnpm typecheck`
+  (the CI baseline gate).
+- [ ] **6.2** — `pnpm changeset` — bump type `patch` for any plugins whose
+  manifests change in Phase 4 (just `yellow-composio` if applied here).
+  No changeset for the schema/script change alone (those are repo-root
+  files, not versioned plugins).
+- [ ] **6.3** — Create the commit(s):
+  - One commit for Phase 1+2+3 (schema + validator + tests).
+  - One commit for Phase 4 (composio pattern application) if applied here.
+  - One commit for Phase 5 (solutions doc + memory).
+  - One commit for Phase 6.2 (changeset).
+- [ ] **6.4** — `gt submit --no-interactive`.
+
+## Technical Specifications
+
+### Files to Modify
+
+- `schemas/plugin.schema.json` — add `pattern` to `userConfigEntry.properties`,
+  add `if/then` rejecting `pattern` for number/boolean types.
+- `scripts/validate-plugin.js` — add RULE 10 inside the existing
+  `validateUserConfigEntries` helper (line ~808–850).
+- `tests/integration/validate-plugin.test.ts` — new "PR-B: userConfig
+  pattern" describe block with 5 cases.
+- `tests/integration/example-files-schema.test.ts` — at least one positive
+  fixture case for AJV-side pattern handling.
+- `plugins/yellow-composio/.claude-plugin/plugin.json` — apply
+  `pattern: "^https://"` to `composio_mcp_url` (Phase 4 — conditional).
+- `MEMORY.md` (auto-memory) — index entry pointing to the new solutions doc.
+
+### Files to Create
+
+- `docs/solutions/build-errors/userconfig-pattern-field-schema-extension.md`
+  — solutions doc documenting the schema extension and the empirical
+  question of remote validator support.
+- `.changeset/userconfig-pattern-field.md` — changeset for the
+  yellow-composio patch bump (only if Phase 4 is applied on this branch).
+
+### Dependencies
+
+None. The change uses only existing AJV (already in `package.json`) and
+JavaScript's built-in `RegExp` constructor for compile validation. No new
+package deps.
+
+## Acceptance Criteria
+
+1. **Schema accepts `pattern`** — `pnpm validate:schemas` passes after
+   Phase 1; AJV reports `pattern` as a recognized property of
+   `userConfigEntry`.
+2. **Validator script rejects misuse** — RULE 10 fires with a clear error
+   message for each of the 4 reject cases listed in 3.1 (non-string,
+   wrong type, invalid regex, default-pattern mismatch).
+3. **Existing plugins still pass** — `pnpm validate:plugins` exits 0 on
+   the current state of `plugins/*` after the schema and validator
+   changes (no plugin uses `pattern` yet, so all should remain valid).
+4. **Composio cleartext-credential risk closed (Phase 4)** — when the
+   pattern is applied, `pnpm validate:plugins` accepts the new manifest
+   AND a synthetic test of `http://` for `composio_mcp_url` is rejected
+   at install time (verified via fixture).
+5. **CI baseline gate passes** — `pnpm validate:schemas && pnpm test:unit
+   && pnpm lint && pnpm typecheck` exits 0.
+6. **Solutions doc shipped** — new doc exists at the path in 5.1, indexed
+   in `MEMORY.md`.
+
+## Edge Cases
+
+- **`pattern` is a non-RegExp string at runtime.** Some users may write an
+  ECMAScript-incompatible regex (e.g., POSIX bracket expressions). RULE 10
+  compiles via `new RegExp` so JavaScript's compile error is the source of
+  truth — no need to reinvent.
+- **`default` is undefined when `pattern` is set.** Allowed — the default-
+  vs-pattern check only fires when both fields are present.
+- **`pattern` on `directory` or `file` types.** Allowed by the schema's
+  `if/then` rule (number/boolean are excluded; string/directory/file are
+  the implicit allow-set). A plugin author setting
+  `pattern: "^[A-Za-z0-9_-]+$"` on a `directory` userConfig entry to
+  enforce safe slug names is a legitimate use.
+- **Empty pattern string.** Rejected by `minLength: 1` in the schema and
+  the `pattern.length === 0` guard in RULE 10.
+- **Remote validator silently ignores `pattern`.** Documented in the
+  solutions doc as an empirical risk. Local enforcement still helps —
+  every PR runs the script. If users hit `claude doctor` errors that
+  indicate the remote DOES enforce pattern with stricter rules, the
+  remote behavior catches what local misses; if the remote silently
+  ignores, local is still right.
+
+<!-- deepen-plan: external -->
+> **Research:** Anthropic's Claude Code remote validator behavior on
+> `pattern` is empirically unverified — no public plugin in the
+> observable ecosystem (as of 2026-05) has shipped a `pattern` userConfig
+> field. The yellow-composio PR is the first known attempt. **Empirical
+> test recipe** (run after Phase 1+2 land):
+> 1. Push the schema + RULE 10 to a test branch with a fresh plugin that
+>    sets `"pattern": "^https://"` on a userConfig key.
+> 2. `pnpm validate:schemas` locally — must pass.
+> 3. `/plugin marketplace add <test-plugin>` in a clean Claude Code
+>    environment.
+> 4. `claude doctor` — if it passes, the remote accepts `pattern` as a
+>    field (silently or with enforcement, TBD).
+> 5. Set a userConfig value violating the pattern. If Claude Code
+>    surfaces an error → remote enforces. If accepts silently → remote
+>    ignores. Either way, local enforcement catches it via RULE 10
+>    before publish.
+> Document the result in the solutions doc Phase 5.1 produces.
+<!-- /deepen-plan -->
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** `validate-plugin.js` does NOT AJV-load
+> `schemas/plugin.schema.json` (the plan asserts this — confirmed). The
+> explicit statement lives in the validate-plugin.js source comment at
+> lines 856–864 (RULE 9 leading comment), not in the
+> `userconfig-type-title-remote-validator-drift.md` solutions doc itself.
+> The doc documents the symptom (remote-vs-local drift) and the
+> resolution pattern (schema tightening + hand-rolled rule). When
+> citing the architectural rationale, reference both:
+> `scripts/validate-plugin.js:856–864` (the source-of-truth comment)
+> AND the solutions doc (the symptom-and-pattern documentation).
+<!-- /deepen-plan -->
+
+- **Channels-scoped `userConfig` (`channels[].userConfig`)** — RULE 9's
+  loop already covers this. RULE 10 must follow the exact same wiring
+  (call `validateUserConfigEntries` for every channel, with a
+  `pathPrefix` like `channels[i].userConfig` so error messages locate
+  the offending key).
+
+## Performance Considerations
+
+- RULE 10 adds at most one `new RegExp(pattern)` compile per userConfig
+  entry per plugin. Across the entire repo (currently 5 plugins with
+  userConfig × ~3 keys average) that's ~15 regex compiles per CI run —
+  negligible.
+- AJV `if/then` blocks are O(N) on the keyword count; adding one more
+  block to the existing 5 is irrelevant at the scale of plugin
+  manifests (small, hand-edited files).
+
+## Security Considerations
+
+- The whole point of `pattern` is to add a defensive constraint. The
+  immediate beneficiary is `composio_mcp_url` (PR #396 P1), but any
+  future plugin handling user-supplied URLs, file paths, or
+  vendor-prefixed tokens benefits.
+- **Do not log the actual user-supplied value when reporting a pattern
+  mismatch at install time.** RULE 10 reports the pattern and a hint
+  (e.g., "value did not match pattern"), never the value itself —
+  important when the value is `sensitive: true`. The default-vs-pattern
+  check at validate-plugin time is safe to report verbatim because the
+  default is a manifest-author-supplied test value, not user input.
+
+<!-- deepen-plan: external -->
+> **Research:** ReDoS (catastrophic backtracking) risk for plugin-author-
+> supplied regex is **low** in this threat model. The compile path is
+> one-shot at validation time, not a hot path; ReDoS requires both an
+> adversarial regex AND an adversarial input length to manifest. The
+> plugin-author trust boundary is the same as `npm install` — if a
+> plugin author wrote a malicious regex, you have bigger problems.
+> AJV itself does NOT guard pattern strings, nor do `semantic-release`,
+> `lerna`, or `Renovate` in their config validators. **Optional
+> defense-in-depth (NOT required for this PR):** wire the
+> [`safe-regex`](https://www.npmjs.com/package/safe-regex) npm package
+> into RULE 10 — emit a warning (not a hard failure) for high-star-height
+> patterns. Defer until evidence of recurring ReDoS-shaped patterns.
+> Reference: <https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS>
+<!-- /deepen-plan -->
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** No in-repo "input-validation regex catalog" exists. The
+> closest precedents:
+> - `schemas/plugin.schema.json` itself uses `pattern` on `name`
+>   (`^[a-z0-9-]+$` line 99), `version` (`^[0-9]+\.[0-9]+\.[0-9]+$`
+>   line 106), and `relativeDir`/`relativeFile` (lines 60, 65) — these
+>   are the in-repo idioms.
+> - `plugins/yellow-ci/skills/ci-conventions/references/security-patterns.md`
+>   documents shell-script *redaction* regexes for `sk-`, `ghp_`,
+>   `github_pat_`, `AKIA`, `Bearer` — different use case (output
+>   filtering vs input validation) but the token-shape examples are
+>   directly transferable. The Phase 5.1 solutions doc should reuse
+>   the schema's own patterns as the worked examples and reference
+>   security-patterns.md for token-shape inspiration.
+<!-- /deepen-plan -->
+
+### Common pattern recipes (for the Phase 5.1 solutions doc)
+
+<!-- deepen-plan: external -->
+> **Research:** Production-grade regex shapes for common userConfig
+> input types — drawn from npm `package.json` schema, GitHub Actions
+> input validation, and Renovate config. Always anchor with `^` and
+> `$`.
+>
+> **HTTPS-only URL** (the immediate composio case):
+> `^https://[^\s/$.?#].[^\s]*$`
+>
+> **Vendor-prefixed API keys:**
+> | Vendor | Pattern |
+> |---|---|
+> | OpenAI `sk-...` | `^sk-[A-Za-z0-9_-]{20,}$` |
+> | Anthropic `sk-ant-...` | `^sk-ant-[A-Za-z0-9_-]{20,}$` |
+> | Composio `cog_...` | `^cog_[A-Za-z0-9_-]{16,}$` |
+> | GitHub PAT (classic) | `^ghp_[A-Za-z0-9]{36}$` |
+> | GitHub PAT (fine-grained) | `^github_pat_[A-Za-z0-9_]{82}$` |
+> | Generic | `^[A-Za-z0-9_\-]{20,}$` |
+>
+> **Filesystem path (anti-traversal):**
+> `^[A-Za-z0-9_\-./]+$` combined with `not: { pattern: "\\.\\." }` to
+> reject `..` segments without relying on lookaheads (some JSON Schema
+> engines do not support lookaheads).
+<!-- /deepen-plan -->
+
+## Migration & Rollback
+
+- **Migration:** None required for existing plugins. `pattern` is purely
+  additive. Plugin authors can adopt it incrementally.
+- **Rollback:** If the schema change causes unexpected issues, revert the
+  Phase 1 and Phase 2 commits. `pattern` becomes unrecognized again
+  (rejected by `additionalProperties: false`) but no plugin depends on
+  it being recognized except yellow-composio (Phase 4) — which would
+  also be rolled back as part of the same revert.
+
+## References
+
+- **PR #396 review thread (motivating case):** greptile P1 finding on
+  `plugins/yellow-composio/.claude-plugin/plugin.json:20-25`. Comment ID
+  `PRRT_kwDOQ3SUys6AIYpq`. Skipped during PR #396 resolve pass with the
+  rationale "needs schema-level work."
+- **Prior art (same pattern, type+title):**
+  `docs/solutions/build-errors/userconfig-type-title-remote-validator-drift.md`
+  and
+  `docs/brainstorms/2026-05-05-plugin-manifest-userconfig-validator-drift-brainstorm.md`.
+- **Schema entry point:** `schemas/plugin.schema.json` →
+  `definitions.userConfigEntry`.
+- **Validator entry point:** `scripts/validate-plugin.js` →
+  `validateUserConfigEntries` (RULE 9 region, lines 856–911 — function
+  body at line 866; top-level call site line 903; channels call site
+  line 908). RULE 10 goes in the same helper or as a peer in the same
+  loop. **The "line ~856–878" range used elsewhere in this plan is
+  wrong — see the codebase annotation under Phase 2.1.**
+
+- **AJV / JSON Schema reference docs:**
+  - <https://ajv.js.org/json-schema.html#if-then-else>
+  - <https://json-schema.org/draft-07/json-schema-validation.html>
+  - <https://github.com/ajv-validator/ajv-errors>
+  - <https://www.npmjs.com/package/safe-regex> (optional ReDoS guard)
+  - <https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS>
+- **Test conventions:** `tests/integration/validate-plugin.test.ts`
+  (PR-A block — fixture-based) and
+  `tests/integration/example-files-schema.test.ts` (AJV-loaded fixtures).
+- **Repo doctrine on schema-vs-script split:**
+  `CLAUDE.md` (project section "High-Level Architecture" → "Schemas") and
+  the userConfig brainstorm doc Decision 4 implementation note.
+- **Auto-memory index:** `MEMORY.md` "Plugin Manifest Validation" section.

--- a/plans/userconfig-pattern-enforcement.md
+++ b/plans/userconfig-pattern-enforcement.md
@@ -160,9 +160,18 @@ PR #396 merging first. Document this ordering.
       "properties": { "type": { "enum": ["number", "boolean"] } },
       "required": ["type"]
     },
-    "then": { "not": { "required": ["pattern"] } }
+    "then": { "properties": { "pattern": false } }
   }
   ```
+
+> **Implementation deviation note (2026-05-06):** the original plan
+> body proposed `"then": { "not": { "required": ["pattern"] } }`. AJV
+> strict mode rejects that formulation as `strictRequired` (the
+> property name appearing in `required` must also be declared in the
+> local schema's `properties`, even inside a `not` clause). The
+> `properties: { pattern: false }` idiom (a `false` schema means
+> "always invalid") is both stricter AND AJV-strict-mode-friendly.
+> The shipped code uses the latter.
 
 <!-- deepen-plan: codebase -->
 > **Codebase:** The existing `allOf` at `schemas/plugin.schema.json` lines

--- a/plugins/yellow-composio/.claude-plugin/plugin.json
+++ b/plugins/yellow-composio/.claude-plugin/plugin.json
@@ -21,6 +21,7 @@
       "type": "string",
       "title": "Composio MCP URL",
       "description": "Per-customer Composio MCP endpoint. Generate via the Composio dashboard or `npx @composio/mcp@latest setup YOUR_CUSTOMER_ID YOUR_APP_ID`. Looks like https://mcp.composio.dev/<id>. Only `https://mcp.composio.dev/*` URLs are expected — Claude Code will make HTTP MCP connections to whatever you provide here, so do not paste arbitrary URLs (file://, internal hosts, metadata endpoints). If left blank, the bundled MCP server will fail to start — fall back to a manual `claude mcp add` setup (see /composio:setup).",
+      "pattern": "^https://[a-zA-Z0-9][a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}(?:/|$)",
       "sensitive": false,
       "required": false
     },

--- a/plugins/yellow-composio/.claude-plugin/plugin.json
+++ b/plugins/yellow-composio/.claude-plugin/plugin.json
@@ -21,7 +21,7 @@
       "type": "string",
       "title": "Composio MCP URL",
       "description": "Per-customer Composio MCP endpoint. Generate via the Composio dashboard or `npx @composio/mcp@latest setup YOUR_CUSTOMER_ID YOUR_APP_ID`. Looks like https://mcp.composio.dev/<id>. Only `https://mcp.composio.dev/*` URLs are expected — Claude Code will make HTTP MCP connections to whatever you provide here, so do not paste arbitrary URLs (file://, internal hosts, metadata endpoints). If left blank, the bundled MCP server will fail to start — fall back to a manual `claude mcp add` setup (see /composio:setup).",
-      "pattern": "^https://[a-zA-Z0-9][a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}(?:/|$)",
+      "pattern": "^https://[a-zA-Z0-9][a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}(?:/\\S*)?$",
       "sensitive": false,
       "required": false
     },

--- a/schemas/plugin.schema.json
+++ b/schemas/plugin.schema.json
@@ -31,7 +31,7 @@
         "pattern": {
           "type": "string",
           "minLength": 1,
-          "description": "Regular expression (JavaScript syntax, anchored with ^ and $ recommended) the user-supplied value must match. Only valid when `type` is one of: string, directory, file (number/boolean values cannot meaningfully carry a regex constraint). Enforced locally by scripts/validate-plugin.js RULE 10; remote-validator support is empirically untested at the time of introduction."
+          "description": "Regular expression (JavaScript syntax) the user-supplied value must match. MUST be anchored with `^` and `$` when used to enforce security constraints (URL scheme, token format) — an unanchored pattern matches anywhere in the string and can be bypassed (`https://` matches `http://evil/https://`). Only valid when `type` is one of: string, directory, file. Entries with absent `type` skip RULE 10 enforcement (RULE 9 reports the missing-type error independently). See docs/solutions/build-errors/userconfig-pattern-field-schema-extension.md for the empirical-test recipe; remote-validator support is empirically untested."
         }
       },
       "required": ["type", "title"],

--- a/schemas/plugin.schema.json
+++ b/schemas/plugin.schema.json
@@ -27,6 +27,11 @@
           "type": "boolean",
           "default": false,
           "description": "Store value in OS keychain when true."
+        },
+        "pattern": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Regular expression (JavaScript syntax, anchored with ^ and $ recommended) the user-supplied value must match. Only valid when `type` is one of: string, directory, file (number/boolean values cannot meaningfully carry a regex constraint). Enforced locally by scripts/validate-plugin.js RULE 10; remote-validator support is empirically untested at the time of introduction."
         }
       },
       "required": ["type", "title"],
@@ -51,6 +56,10 @@
         {
           "if": { "properties": { "type": { "const": "file" } }, "required": ["type"] },
           "then": { "properties": { "default": { "type": "string" } } }
+        },
+        {
+          "if": { "properties": { "type": { "enum": ["number", "boolean"] } }, "required": ["type"] },
+          "then": { "properties": { "pattern": false } }
         }
       ]
     },

--- a/scripts/validate-plugin.js
+++ b/scripts/validate-plugin.js
@@ -76,6 +76,13 @@ const VALID_USER_CONFIG_TYPES = new Set([
   'file',
 ]);
 
+// Subset of VALID_USER_CONFIG_TYPES for which `pattern` (RULE 10) is
+// meaningful. Number/boolean values cannot carry a regex constraint.
+// Module-scope to match the VALID_HOOK_EVENTS / VALID_USER_CONFIG_TYPES
+// pattern — reused across the top-level userConfig walk and the
+// per-channel walk without reallocating the Set per validatePlugin call.
+const PATTERN_VALID_TYPES = new Set(['string', 'directory', 'file']);
+
 /**
  * Resolve a hook command to a script path within the plugin directory.
  * Returns the resolved path, or null if the command is not a "bash <path>"
@@ -873,7 +880,6 @@ function validatePlugin(pluginDir) {
   //   set as a string, the default itself must match the pattern — otherwise
   //   the manifest ships an internally inconsistent constraint. See
   //   docs/solutions/build-errors/userconfig-pattern-field-schema-extension.md
-  const PATTERN_VALID_TYPES = new Set(['string', 'directory', 'file']);
   function validateUserConfigEntries(userConfig, pathPrefix) {
     if (
       typeof userConfig !== 'object' ||
@@ -914,11 +920,13 @@ function validatePlugin(pluginDir) {
             errors,
             `${pathPrefix}.${key}.pattern must be a non-empty string`
           );
-        } else if (
-          entry.type != null &&
-          VALID_USER_CONFIG_TYPES.has(entry.type) &&
-          !PATTERN_VALID_TYPES.has(entry.type)
-        ) {
+        } else if (entry.type == null || !VALID_USER_CONFIG_TYPES.has(entry.type)) {
+          // Type missing or unknown — RULE 9 already reported the underlying
+          // problem. Skip pattern enforcement entirely rather than fall
+          // through to the regex-compile path, which would produce a
+          // confusing duplicate error and silently bypass the type-allowlist
+          // gate when type is absent.
+        } else if (!PATTERN_VALID_TYPES.has(entry.type)) {
           addError(
             errors,
             `${pathPrefix}.${key}.pattern is only valid when type is one of: string, directory, file (got "${entry.type}")`
@@ -938,9 +946,15 @@ function validatePlugin(pluginDir) {
             typeof entry.default === 'string' &&
             !compiled.test(entry.default)
           ) {
+            // Redact default in error output when the field is sensitive,
+            // so a partially-correct credential never lands in CI logs.
+            const defaultDisplay =
+              entry.sensitive === true
+                ? '<redacted — sensitive field>'
+                : `"${entry.default}"`;
             addError(
               errors,
-              `${pathPrefix}.${key}.default "${entry.default}" does not match pattern "${entry.pattern}"`
+              `${pathPrefix}.${key}.default ${defaultDisplay} does not match pattern "${entry.pattern}"`
             );
           }
         }

--- a/scripts/validate-plugin.js
+++ b/scripts/validate-plugin.js
@@ -853,16 +853,27 @@ function validatePlugin(pluginDir) {
   // (RULE 8 — shebang / decision-output / set -e content checks — folded
   // into RULES 6+8 single-pass loop above via validateHookScriptPath.)
 
-  // RULE 9: userConfig entries must declare `type` and `title`. The Claude
-  // Code remote validator (claude doctor) rejects any entry missing either,
-  // and only accepts type ∈ {string, number, boolean, directory, file}. Local
-  // CI mirrors that here because the JSON Schema in schemas/plugin.schema.json
-  // is not currently AJV-loaded by validate-plugin.js — without this check
-  // the drift only surfaces at install time. The check covers both the
-  // top-level `userConfig` object AND each `channels[].userConfig` object,
-  // because `channels[*].userConfig` reuses the same `userConfigEntry`
-  // schema definition and carries the same remote-validator constraints.
-  // See docs/solutions/build-errors/userconfig-type-title-remote-validator-drift.md
+  // RULE 9 + RULE 10: userConfig entry constraints. Local CI mirrors the
+  // Claude Code remote validator here because schemas/plugin.schema.json is
+  // not currently AJV-loaded by validate-plugin.js — without these checks
+  // the drift only surfaces at install time. Both rules cover the top-level
+  // `userConfig` object AND each `channels[].userConfig` object, because
+  // `channels[*].userConfig` reuses the same `userConfigEntry` schema
+  // definition and carries the same constraints.
+  //
+  // RULE 9: every entry must declare `type` (one of string|number|boolean|
+  //   directory|file) and a non-empty `title` string. The remote validator
+  //   rejects entries missing either field. See
+  //   docs/solutions/build-errors/userconfig-type-title-remote-validator-drift.md
+  //
+  // RULE 10: optional `pattern` regex constraint. When present, `pattern`
+  //   must be a non-empty string that compiles as a JavaScript RegExp, and
+  //   `type` must be one of {string, directory, file} (number/boolean values
+  //   cannot meaningfully carry a regex constraint). When `default` is also
+  //   set as a string, the default itself must match the pattern — otherwise
+  //   the manifest ships an internally inconsistent constraint. See
+  //   docs/solutions/build-errors/userconfig-pattern-field-schema-extension.md
+  const PATTERN_VALID_TYPES = new Set(['string', 'directory', 'file']);
   function validateUserConfigEntries(userConfig, pathPrefix) {
     if (
       typeof userConfig !== 'object' ||
@@ -895,6 +906,44 @@ function validatePlugin(pluginDir) {
         );
       } else if (typeof entry.title !== 'string' || entry.title.length === 0) {
         addError(errors, `${pathPrefix}.${key}.title must be a non-empty string`);
+      }
+      // RULE 10: pattern field validation
+      if (entry.pattern !== undefined) {
+        if (typeof entry.pattern !== 'string' || entry.pattern.length === 0) {
+          addError(
+            errors,
+            `${pathPrefix}.${key}.pattern must be a non-empty string`
+          );
+        } else if (
+          entry.type != null &&
+          VALID_USER_CONFIG_TYPES.has(entry.type) &&
+          !PATTERN_VALID_TYPES.has(entry.type)
+        ) {
+          addError(
+            errors,
+            `${pathPrefix}.${key}.pattern is only valid when type is one of: string, directory, file (got "${entry.type}")`
+          );
+        } else {
+          let compiled = null;
+          try {
+            compiled = new RegExp(entry.pattern);
+          } catch (e) {
+            addError(
+              errors,
+              `${pathPrefix}.${key}.pattern is not a valid regular expression: ${e.message}`
+            );
+          }
+          if (
+            compiled !== null &&
+            typeof entry.default === 'string' &&
+            !compiled.test(entry.default)
+          ) {
+            addError(
+              errors,
+              `${pathPrefix}.${key}.default "${entry.default}" does not match pattern "${entry.pattern}"`
+            );
+          }
+        }
       }
     }
   }

--- a/tests/integration/example-files-schema.test.ts
+++ b/tests/integration/example-files-schema.test.ts
@@ -172,3 +172,95 @@ describe('semverRange custom keyword (PR-B)', () => {
     expect(factory.validate('semver-test', { version: '' }).valid).toBe(false);
   });
 });
+
+describe('userConfigEntry.pattern field (PR-C)', () => {
+  let factory: AjvValidatorFactory;
+
+  beforeAll(async () => {
+    factory = new AjvValidatorFactory();
+    await factory.loadSchemaFromFile(
+      'plugin',
+      join(SCHEMAS_DIR, 'plugin.schema.json')
+    );
+  });
+
+  function pluginWithUserConfig(
+    userConfig: Record<string, unknown>
+  ): Record<string, unknown> {
+    return {
+      name: 'test-plugin',
+      version: '1.0.0',
+      description: 'Test plugin for userConfig pattern AJV-side validation.',
+      author: 'KingInYellows',
+      userConfig,
+    };
+  }
+
+  it('accepts a string-typed entry with a valid pattern', () => {
+    const data = pluginWithUserConfig({
+      api_url: { type: 'string', title: 'API URL', pattern: '^https://' },
+    });
+    expect(factory.validate('plugin', data).valid).toBe(true);
+  });
+
+  it('accepts a directory-typed entry with a pattern', () => {
+    const data = pluginWithUserConfig({
+      workspace: {
+        type: 'directory',
+        title: 'Workspace',
+        pattern: '^[A-Za-z0-9_./-]+$',
+      },
+    });
+    expect(factory.validate('plugin', data).valid).toBe(true);
+  });
+
+  it('accepts a file-typed entry with a pattern', () => {
+    const data = pluginWithUserConfig({
+      config_file: {
+        type: 'file',
+        title: 'Config file',
+        pattern: '\\.json$',
+      },
+    });
+    expect(factory.validate('plugin', data).valid).toBe(true);
+  });
+
+  it('rejects a number-typed entry that also declares a pattern', () => {
+    const data = pluginWithUserConfig({
+      port: { type: 'number', title: 'Port', pattern: '^[0-9]+$' },
+    });
+    expect(factory.validate('plugin', data).valid).toBe(false);
+  });
+
+  it('rejects a boolean-typed entry that also declares a pattern', () => {
+    const data = pluginWithUserConfig({
+      flag: {
+        type: 'boolean',
+        title: 'Flag',
+        pattern: '^(true|false)$',
+      },
+    });
+    expect(factory.validate('plugin', data).valid).toBe(false);
+  });
+
+  it('rejects a non-string pattern value', () => {
+    const data = pluginWithUserConfig({
+      api_url: { type: 'string', title: 'API URL', pattern: 123 },
+    });
+    expect(factory.validate('plugin', data).valid).toBe(false);
+  });
+
+  it('rejects an empty string pattern', () => {
+    const data = pluginWithUserConfig({
+      api_url: { type: 'string', title: 'API URL', pattern: '' },
+    });
+    expect(factory.validate('plugin', data).valid).toBe(false);
+  });
+
+  it('accepts an entry without a pattern (back-compat)', () => {
+    const data = pluginWithUserConfig({
+      api_url: { type: 'string', title: 'API URL' },
+    });
+    expect(factory.validate('plugin', data).valid).toBe(true);
+  });
+});

--- a/tests/integration/example-files-schema.test.ts
+++ b/tests/integration/example-files-schema.test.ts
@@ -263,4 +263,50 @@ describe('userConfigEntry.pattern field (PR-C)', () => {
     });
     expect(factory.validate('plugin', data).valid).toBe(true);
   });
+
+  it('rejects pattern on a channels[].userConfig entry with type number (allOf propagates through $ref)', () => {
+    const data = {
+      name: 'test-plugin',
+      version: '1.0.0',
+      description:
+        'Test plugin to confirm userConfigEntry.allOf rules propagate through channels[].userConfig $ref.',
+      author: 'KingInYellows',
+      channels: [
+        {
+          server: 'test-channel',
+          userConfig: {
+            port: { type: 'number', title: 'Port', pattern: '^[0-9]+$' },
+          },
+        },
+      ],
+    };
+    expect(factory.validate('plugin', data).valid).toBe(false);
+  });
+
+  it('AJV does NOT enforce regex compilability — that is RULE 10 in validate-plugin.js', () => {
+    // Documents the intentional two-layer split: AJV checks
+    // type+minLength only; the script-level RULE 10 compiles the regex
+    // and surfaces SyntaxError. A future schema change that adds a
+    // regex-format keyword would silently change this surface; this
+    // test pins the boundary.
+    const data = pluginWithUserConfig({
+      api_url: { type: 'string', title: 'API URL', pattern: '[unclosed' },
+    });
+    expect(factory.validate('plugin', data).valid).toBe(true);
+  });
+
+  it('AJV does NOT enforce default-vs-pattern matching — that is RULE 10 in validate-plugin.js', () => {
+    // Same boundary: AJV's allOf only constrains the default's *type*
+    // by the userConfig type, not whether the default matches the
+    // declared pattern. Script-level RULE 10 owns that check.
+    const data = pluginWithUserConfig({
+      api_url: {
+        type: 'string',
+        title: 'API URL',
+        pattern: '^https://',
+        default: 'http://does-not-match.example',
+      },
+    });
+    expect(factory.validate('plugin', data).valid).toBe(true);
+  });
 });

--- a/tests/integration/validate-plugin.test.ts
+++ b/tests/integration/validate-plugin.test.ts
@@ -643,3 +643,172 @@ printf 'plain text\\n'
     );
   });
 });
+
+describe('validate-plugin PR-B userConfig pattern field (RULE 10)', () => {
+  let tmpRoot: string;
+  let pluginDir: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'yellow-validate-plugin-pattern-'));
+    pluginDir = join(tmpRoot, 'test-plugin');
+    mkdirSync(pluginDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('accepts a string-typed userConfig with a valid pattern and matching default', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      userConfig: {
+        api_url: {
+          type: 'string',
+          title: 'API URL',
+          pattern: '^https://',
+          default: 'https://example.com',
+        },
+      },
+    });
+    const { status } = runValidator(pluginDir);
+    expect(status).toBe(0);
+  });
+
+  it('rejects a non-string pattern value', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      userConfig: {
+        api_url: {
+          type: 'string',
+          title: 'API URL',
+          pattern: 123 as unknown as string,
+        },
+      },
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/pattern must be a non-empty string/);
+  });
+
+  it('rejects an empty string pattern', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      userConfig: {
+        api_url: { type: 'string', title: 'API URL', pattern: '' },
+      },
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/pattern must be a non-empty string/);
+  });
+
+  it('rejects a pattern when type is number', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      userConfig: {
+        port: {
+          type: 'number',
+          title: 'Port',
+          pattern: '^[0-9]+$',
+        },
+      },
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(
+      /pattern is only valid when type is one of: string, directory, file/
+    );
+  });
+
+  it('rejects a pattern when type is boolean', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      userConfig: {
+        flag: {
+          type: 'boolean',
+          title: 'Flag',
+          pattern: '^(true|false)$',
+        },
+      },
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(
+      /pattern is only valid when type is one of: string, directory, file/
+    );
+  });
+
+  it('rejects an invalid regex pattern', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      userConfig: {
+        api_url: {
+          type: 'string',
+          title: 'API URL',
+          pattern: '[unclosed',
+        },
+      },
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/pattern is not a valid regular expression/);
+  });
+
+  it('rejects a default that does not match its pattern', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      userConfig: {
+        api_url: {
+          type: 'string',
+          title: 'API URL',
+          pattern: '^https://',
+          default: 'http://example.com',
+        },
+      },
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/default ".*" does not match pattern "/);
+  });
+
+  it('accepts pattern on a directory-typed entry', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      userConfig: {
+        workspace: {
+          type: 'directory',
+          title: 'Workspace path',
+          pattern: '^[A-Za-z0-9_./-]+$',
+        },
+      },
+    });
+    const { status } = runValidator(pluginDir);
+    expect(status).toBe(0);
+  });
+
+  it('accepts pattern on a file-typed entry', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      userConfig: {
+        config_file: {
+          type: 'file',
+          title: 'Config file path',
+          pattern: '\\.json$',
+        },
+      },
+    });
+    const { status } = runValidator(pluginDir);
+    expect(status).toBe(0);
+  });
+
+  it('accepts a userConfig entry without a pattern (back-compat)', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      userConfig: {
+        api_url: { type: 'string', title: 'API URL' },
+      },
+    });
+    const { status } = runValidator(pluginDir);
+    expect(status).toBe(0);
+  });
+});

--- a/tests/integration/validate-plugin.test.ts
+++ b/tests/integration/validate-plugin.test.ts
@@ -738,7 +738,7 @@ describe('validate-plugin PR-B userConfig pattern field (RULE 10)', () => {
     );
   });
 
-  it('rejects an invalid regex pattern', () => {
+  it('rejects an invalid regex pattern with the failing key path in stderr', () => {
     writePluginManifest(pluginDir, {
       ...VALID_BASE_MANIFEST,
       userConfig: {
@@ -751,10 +751,12 @@ describe('validate-plugin PR-B userConfig pattern field (RULE 10)', () => {
     });
     const { status, stderr } = runValidator(pluginDir);
     expect(status).toBeGreaterThan(0);
-    expect(stderr).toMatch(/pattern is not a valid regular expression/);
+    expect(stderr).toMatch(
+      /userConfig\.api_url\.pattern is not a valid regular expression/
+    );
   });
 
-  it('rejects a default that does not match its pattern', () => {
+  it('rejects a default that does not match its pattern with the key path in stderr', () => {
     writePluginManifest(pluginDir, {
       ...VALID_BASE_MANIFEST,
       userConfig: {
@@ -768,7 +770,114 @@ describe('validate-plugin PR-B userConfig pattern field (RULE 10)', () => {
     });
     const { status, stderr } = runValidator(pluginDir);
     expect(status).toBeGreaterThan(0);
-    expect(stderr).toMatch(/default ".*" does not match pattern "/);
+    expect(stderr).toMatch(
+      /userConfig\.api_url\.default "http:\/\/example\.com" does not match pattern "\^https:\/\/"/
+    );
+  });
+
+  it('redacts a sensitive field default value in pattern-mismatch error', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      userConfig: {
+        secret_key: {
+          type: 'string',
+          title: 'Secret key',
+          sensitive: true,
+          pattern: '^sk-',
+          default: 'pk-leaked-value',
+        },
+      },
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(
+      /userConfig\.secret_key\.default <redacted — sensitive field> does not match pattern "\^sk-"/
+    );
+    // The actual value must not appear in stderr
+    expect(stderr).not.toMatch(/pk-leaked-value/);
+  });
+
+  it('does NOT report a RULE 10 pattern-allowlist error when type is absent (RULE 9 already errored)', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      userConfig: {
+        // intentionally missing `type`
+        api_url: { title: 'API URL', pattern: '^abc' } as unknown as Record<
+          string,
+          unknown
+        >,
+      },
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    // RULE 9 missing-type error must fire
+    expect(stderr).toMatch(/userConfig\.api_url is missing required field "type"/);
+    // RULE 10 must NOT also report a pattern-allowlist or compile error
+    expect(stderr).not.toMatch(/pattern is only valid when type is one of/);
+    expect(stderr).not.toMatch(/pattern is not a valid regular expression/);
+  });
+
+  it('does NOT report a RULE 10 pattern-allowlist error when type is an unknown string (RULE 9 already errored)', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      userConfig: {
+        api_url: {
+          type: 'secret' as unknown as string,
+          title: 'API URL',
+          pattern: '^abc',
+        },
+      },
+    });
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    // RULE 9 invalid-type error must fire
+    expect(stderr).toMatch(/type "secret" is invalid/);
+    // RULE 10 should not report a duplicate or compile error for an
+    // already-rejected type
+    expect(stderr).not.toMatch(/pattern is only valid when type is one of/);
+  });
+
+  it('does not crash when default is non-string and a pattern is set', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      userConfig: {
+        api_url: {
+          type: 'string',
+          title: 'API URL',
+          pattern: '^https://',
+          default: 42 as unknown as string,
+        },
+      },
+    });
+    // Validator should run to completion without throwing; whether the
+    // status is 0 or non-zero depends on other rules — the contract
+    // here is "no crash, no spurious pattern error".
+    const { stderr } = runValidator(pluginDir);
+    expect(stderr).not.toMatch(/does not match pattern/);
+  });
+
+  it('validates pattern field on a channels[].userConfig entry', () => {
+    writePluginManifest(pluginDir, {
+      ...VALID_BASE_MANIFEST,
+      channels: [
+        {
+          server: 'test-channel',
+          userConfig: {
+            channel_url: {
+              type: 'string',
+              title: 'Channel URL',
+              pattern: '^https://',
+              default: 'http://bad.example.com',
+            },
+          },
+        },
+      ],
+    } as unknown as Record<string, unknown>);
+    const { status, stderr } = runValidator(pluginDir);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(
+      /channels\[0\]\.userConfig\.channel_url\.default "http:\/\/bad\.example\.com" does not match pattern/
+    );
   });
 
   it('accepts pattern on a directory-typed entry', () => {


### PR DESCRIPTION
feat(schema): add `pattern` regex field to userConfigEntry + RULE 10

Adds an optional `pattern` field to `definitions.userConfigEntry` in
`schemas/plugin.schema.json` so plugin authors can declare regex
constraints on user-supplied userConfig values (URLs, API keys, file
paths). Gated to `type ∈ {string, directory, file}` via a new `if/then`
allOf block using the `properties: { pattern: false }` idiom (the
`not.required` formulation trips AJV strict-mode `strictRequired`).

Adds RULE 10 to `scripts/validate-plugin.js` inside the existing
`validateUserConfigEntries` helper. Mirrors RULE 9's coverage of both
top-level `userConfig` and `channels[i].userConfig`. Validates four
invariants: (a) pattern is a non-empty string when present, (b) type
is in the allowed set, (c) regex compiles via new RegExp, (d) when
default is also a string, it matches the pattern.

Why both layers: validate-plugin.js does NOT AJV-load the schema (see
RULE 9 leading comment, lines 856–864). The schema alone catches misuse
only via fixture-based AJV tests; the script-level RULE 10 makes
`pnpm validate:plugins` enforce the same constraints. Same architectural
posture as the userConfig type+title fix
(docs/solutions/build-errors/userconfig-type-title-remote-validator-drift.md).

Tests: 10 new PR-B fixture-based cases in tests/integration/validate-
plugin.test.ts + 8 new PR-C AJV-side cases in tests/integration/
example-files-schema.test.ts. Plus: examples/plugin-extended.example.json
now sets pattern: "^https://" on userConfig.api_endpoint, exercising
the field through the existing fixture loop. All 39 + 22 = 61 tests
in those two files pass.

CI baseline (validate:schemas + test:unit + test:integration + lint +
typecheck) passes.

Motivated by PR #396 review (greptile P1 finding on
plugins/yellow-composio/.claude-plugin/plugin.json:20-25): the schema's
additionalProperties: false blocked enforcing ^https:// on
composio_mcp_url, leaving keychain-protected composio_api_key
exposed to cleartext over http://. This PR enables that fix; applying
the pattern to composio_mcp_url is a follow-up gated on PR #396 merge.

docs(solutions): document userConfig.pattern schema extension

Adds docs/solutions/build-errors/userconfig-pattern-field-schema-extension.md
covering the schema layer + RULE 10 design, the schema-vs-validator-script
split, common pattern recipes (HTTPS URLs, vendor-prefixed API keys, file
and directory paths), the empirical-test recipe for the Anthropic remote
validator's treatment of `pattern`, and a ReDoS risk note (low risk in the
plugin-author trust model; safe-regex is the standard mitigation tool if
needed later).

Also commits the implementation plan at plans/userconfig-pattern-enforcement.md
(generated via /workflows:plan, enriched via /workflows:deepen-plan with
codebase + external research annotations).

The MEMORY.md auto-memory index entry for this work was added in the same
session (separate file outside the repo).

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an optional `pattern` regex field to `definitions.userConfigEntry` in `schemas/plugin.schema.json`, enforces it via a new RULE 10 in `scripts/validate-plugin.js`, and immediately applies a well-formed HTTPS-enforcement pattern to `composio_mcp_url` in the yellow-composio plugin — closing the cleartext-credential risk from PR #396.

- Schema change is additive and backward-compatible; the `if/then` block correctly uses the `properties: { pattern: false }` idiom to reject `pattern` on `number`/`boolean` types, and `PATTERN_VALID_TYPES` is correctly placed at module scope.
- RULE 10 covers all four invariants (non-empty string, allowed type set, regex compilability, default-vs-pattern match) with proper sensitive-default redaction and full channels-path coverage, backed by 13 new integration tests across both test files.
- The composio `composio_mcp_url` pattern is dual-anchored and includes hostname structure validation, making it significantly more robust than a prefix-only check.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive, RULE 10 logic and test coverage are thorough, and the composio security fix is correctly anchored.

The schema extension is purely additive, RULE 10 handles all four invariants correctly including edge cases for missing/unknown type, sensitive-default redaction, and channels-path coverage, and the composio pattern uses a dual-anchored hostname-validating regex.

examples/plugin-extended.example.json — the prefix-only pattern in the example contradicts the documented anchoring guidance.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| schemas/plugin.schema.json | Adds `pattern` property to `userConfigEntry` definition and an `if/then` block rejecting `pattern` on number/boolean types; schema change is additive and backward-compatible. |
| scripts/validate-plugin.js | Adds module-scope `PATTERN_VALID_TYPES` and RULE 10 inside `validateUserConfigEntries`; logic, branching, and sensitive-default redaction all look correct. |
| plugins/yellow-composio/.claude-plugin/plugin.json | Applies the composio HTTPS-enforcement pattern to `composio_mcp_url`; properly dual-anchored and more restrictive than the prefix-only form. |
| examples/plugin-extended.example.json | Adds `"pattern": "^https://"` to demonstrate the new field, but this prefix-only pattern contradicts the PR's own documented security guidance recommending dual anchors. |
| tests/integration/validate-plugin.test.ts | PR-B block covers all four RULE 10 invariants plus channels path, sensitive-default redaction, and back-compat; good coverage breadth. |
| tests/integration/example-files-schema.test.ts | PR-C block correctly pins AJV-vs-RULE10 boundary and tests schema-level accept/reject paths including channel propagation. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/integration/validate-plugin.test.ts`, line 1149 ([link](https://github.com/kinginyellows/yellow-plugins/blob/e675d91fd8d0ac581874d97a348fb07e5d44aa5d/tests/integration/validate-plugin.test.ts#L1149)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Missing channels path test for RULE 10**

   The PR-B describe block covers all four invariants for top-level `userConfig` but has no case for `channels[i].userConfig`. RULE 9's equivalent coverage in the existing PR-A block includes a channel-scoped fixture, and the RULE 10 wiring at `validate-plugin.js:955–959` delegates to the same helper — but that delegation is currently unexercised by any new test. A regression here (e.g., a future refactor that wires RULE 10 only for top-level) would go undetected.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: tests/integration/validate-plugin.test.ts
   Line: 1149

   Comment:
   **Missing channels path test for RULE 10**

   The PR-B describe block covers all four invariants for top-level `userConfig` but has no case for `channels[i].userConfig`. RULE 9's equivalent coverage in the existing PR-A block includes a channel-scoped fixture, and the RULE 10 wiring at `validate-plugin.js:955–959` delegates to the same helper — but that delegation is currently unexercised by any new test. A regression here (e.g., a future refactor that wires RULE 10 only for top-level) would go undetected.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Fuserconfig-pattern-enforcement%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Fuserconfig-pattern-enforcement%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Fintegration%2Fvalidate-plugin.test.ts%0ALine%3A%201149%0A%0AComment%3A%0A**Missing%20channels%20path%20test%20for%20RULE%2010**%0A%0AThe%20PR-B%20describe%20block%20covers%20all%20four%20invariants%20for%20top-level%20%60userConfig%60%20but%20has%20no%20case%20for%20%60channels%5Bi%5D.userConfig%60.%20RULE%209's%20equivalent%20coverage%20in%20the%20existing%20PR-A%20block%20includes%20a%20channel-scoped%20fixture%2C%20and%20the%20RULE%2010%20wiring%20at%20%60validate-plugin.js%3A955%E2%80%93959%60%20delegates%20to%20the%20same%20helper%20%E2%80%94%20but%20that%20delegation%20is%20currently%20unexercised%20by%20any%20new%20test.%20A%20regression%20here%20%28e.g.%2C%20a%20future%20refactor%20that%20wires%20RULE%2010%20only%20for%20top-level%29%20would%20go%20undetected.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Fuserconfig-pattern-enforcement%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Fuserconfig-pattern-enforcement%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aexamples%2Fplugin-extended.example.json%3A59%0AThe%20example%20uses%20%60%22%5Ehttps%3A%2F%2F%22%60%20%E2%80%94%20the%20exact%20prefix-only%20form%20the%20PR's%20changeset%2C%20solutions%20doc%2C%20and%20schema%20description%20all%20explicitly%20call%20out%20as%20bypassable%20via%20URL-confusion%20payloads.%20Plugin%20authors%20often%20model%20their%20configurations%20against%20example%20files%2C%20so%20shipping%20this%20pattern%20here%20sends%20contradictory%20guidance.%20A%20properly%20anchored%20variant%20%28matching%20what%20the%20solutions%20doc%20recommends%20for%20URL%20enforcement%29%20keeps%20the%20example%20and%20the%20documentation%20consistent.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%22pattern%22%3A%20%22%5Ehttps%3A%2F%2F%5Ba-zA-Z0-9%5D%5Ba-zA-Z0-9.-%5D%2B%5C%5C.%5Ba-zA-Z%5D%7B2%2C%7D%28%3F%3A%2F%5C%5CS*%29%3F%24%22%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
examples/plugin-extended.example.json:59
The example uses `"^https://"` — the exact prefix-only form the PR's changeset, solutions doc, and schema description all explicitly call out as bypassable via URL-confusion payloads. Plugin authors often model their configurations against example files, so shipping this pattern here sends contradictory guidance. A properly anchored variant (matching what the solutions doc recommends for URL enforcement) keeps the example and the documentation consistent.

```suggestion
      "pattern": "^https://[a-zA-Z0-9][a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}(?:/\\S*)?$"
```


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(yellow-composio): end-anchor composi..."](https://github.com/kinginyellows/yellow-plugins/commit/1c847c363715b0776fd6d2907e6fa70897a88239) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31086076)</sub>

<!-- /greptile_comment -->