### PR TITLE
fix(scripts): skip CHANGELOG.md in subagent_type validator (X-02)

### DIFF
--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -18,7 +18,7 @@
 
 ## 1. Repository map
 
-```
+```text
 yellow-plugins/                          # pnpm monorepo (no published runtime)
 ├── .claude-plugin/marketplace.json      # 18-plugin catalog, schema-validated
 ├── plugins/                             # 18 plugins (auto-discovery)

--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -1,0 +1,203 @@
+# yellow-plugins Audit Report
+
+**Generated:** 2026-05-07
+**Scope:** read-only audit of the marketplace + 18 plugins under `plugins/`
+**Toolchain run:** `pnpm validate:schemas` (full pipeline: marketplace → plugin → setup-all → agent-authoring), plus targeted `find`/`grep`/`jq`/`awk` introspection of every `.claude-plugin/plugin.json`, every `commands/*.md`, every `agents/**/*.md`, every `skills/<name>/SKILL.md`, every hook script, and every `.mcp.json`-equivalent `mcpServers` block.
+
+---
+
+## Executive summary (5 bullets)
+
+- **The marketplace is structurally healthy.** All 18 plugin manifests pass `validate-marketplace.js`, `validate-plugin.js`, and `validate-setup-all.js`. The single ERROR raised by `validate-agent-authoring.js` is a **false positive** in the validator itself, not a runtime defect (`yellow-review/CHANGELOG.md` documents a deprecated agent stub, and the validator greps prose without distinguishing it from declarations).
+- **`yellow-core` is the agent backbone.** Its review and research personas (knowledge-compounder, learnings-researcher, brainstorm-orchestrator, repo-research-analyst, etc.) are dispatched from at least four other plugins. A single 3-segment subagent_type rename in `yellow-core` would ripple through the marketplace — and three callers in `yellow-core/commands/workflows/plan.md` are still on the **legacy 2-segment form**, surfaced as INFO warnings.
+- **Hook surface is small but session-start is dominated by yellow-morph.** Only 5 plugins ship hooks; 4 of them fire on SessionStart in parallel. yellow-morph's prewarm hook has a **30-second timeout** on the hot path, which sets the floor for cold-session latency for any user who installs morph. This is the single largest user-visible perf cost in the marketplace.
+- **Cross-plugin "silent" dependencies exist but degrade gracefully.** yellow-debt's `/debt:sync`, yellow-ci's `/ci:report-linear`, and yellow-chatprd's `/chatprd:link-linear` all silently require yellow-linear's MCP. yellow-linear's `/linear:delegate` requires yellow-devin's userConfig env. These are documented in some cases (per-skill, per-CLAUDE.md) but no single index lists them — making install-time failures opaque.
+- **Highest-impact, lowest-effort cleanup.** Three INFO warnings + one ERROR + one WARNING are already surfaced by the validators and trivially fixable. The largest *correctness* find is the 30s morph prewarm; the largest *architecture* find is that the validator itself trips on its own CHANGELOG (a tooling improvement, not a content fix).
+
+---
+
+## 1. Repository map
+
+```
+yellow-plugins/                          # pnpm monorepo (no published runtime)
+├── .claude-plugin/marketplace.json      # 18-plugin catalog, schema-validated
+├── plugins/                             # 18 plugins (auto-discovery)
+│   ├── gt-workflow/                     # 7 cmds, 0 agents, 0 skills, 2 hooks, 1 MCP
+│   ├── yellow-core/                     # 8 cmds, 18 agents, 17 skills (backbone)
+│   ├── yellow-linear/                   # 9 cmds, 3 agents, 1 skill, 1 MCP
+│   ├── yellow-devin/                    # 10 cmds, 1 agent, 1 skill, 2 MCPs
+│   ├── yellow-chatprd/                  # 6 cmds, 4 agents, 1 skill, 1 MCP
+│   ├── yellow-review/                   # 5 cmds, 16 agents, 1 skill
+│   ├── yellow-ruvector/                 # 6 cmds, 2 agents, 3 skills, 5 hooks, 1 MCP
+│   ├── yellow-browser-test/             # 4 cmds, 3 agents, 2 skills
+│   ├── yellow-debt/                     # 6 cmds, 7 agents, 1 skill, 1 hook
+│   ├── yellow-ci/                       # 9 cmds, 4 agents, 2 skills, 1 hook
+│   ├── yellow-composio/                 # 2 cmds, 0 agents, 1 skill, 1 MCP, 2 userConfig
+│   ├── yellow-research/                 # 4 cmds, 2 agents, 1 skill, 6 MCPs
+│   ├── yellow-morph/                    # 2 cmds, 0 agents, 0 skills, 1 hook, 1 MCP
+│   ├── yellow-semgrep/                  # 5 cmds, 2 agents, 1 skill, 1 MCP
+│   ├── yellow-docs/                     # 6 cmds, 10 agents, 1 skill
+│   ├── yellow-codex/                    # 4 cmds, 3 agents, 1 skill
+│   ├── yellow-council/                  # 2 cmds, 2 agents, 1 skill
+│   └── yellow-mempalace/                # 6 cmds, 2 agents, 2 skills, 1 MCP
+├── packages/{domain,infrastructure,cli} # Layered TS validators (never published)
+├── schemas/                             # Local JSON schemas (drift from remote possible)
+└── scripts/                             # validate-{marketplace,plugin,setup-all,agent-authoring,versions}.js
+```
+
+**Aggregate:** 18 plugins · 105 commands · 79 agents · 38 skills · 9 inline-hook entries (across 5 plugins) · 16 MCP servers (across 11 plugins) · 9 userConfig entries (across 6 plugins).
+
+---
+
+## 2. Workflow analysis (top 7)
+
+| ID | Workflow | Entry point | Agents/commands chained | Output |
+|---|---|---|---|---|
+| W1 | Brainstorm → Plan → Work → Review → Compound | `/workflows:brainstorm` | brainstorm-orchestrator → /workflows:plan (repo-research-analyst, best-practices-researcher, spec-flow-analyzer, optionally research-conductor + devin-orchestrator) → /workflows:work → /review:pr → /review:resolve → /workflows:compound (knowledge-compounder) | docs/{brainstorms,plans,solutions}/<slug>.md, MEMORY.md |
+| W2 | CI failure → Linear bug | `/ci:status` | failure-analyst → optional runner-diagnostics → /ci:report-linear (yellow-linear MCP create_issue) | Linear issue, diagnosis report |
+| W3 | Tech-debt audit cycle | `/debt:audit` (preceded by SessionStart hook seeding `.debt/`) | 5 parallel scanners (ai-pattern, architecture, complexity, duplication, security-debt) → audit-synthesizer (opus) → /debt:triage → /debt:fix → /debt:sync | `.debt/` artefacts, optional Linear issues |
+| W4 | Document/PRD lifecycle | `/chatprd:create` | /docs:review (6 always-on personas + adversarial conditional) → /chatprd:link-linear → /linear:work → optional /linear:delegate | ChatPRD doc, Linear issues, possible Devin session |
+| W5 | Research-first dev | `/research:code` (inline) or `/research:deep` | research-conductor (opus) → /workflows:deepen-plan annotates an existing plan | docs/research/<slug>.md, annotated plan |
+| W6 | Multi-lineage review | `/review:pr` | In-house adaptive personas → /codex:review → /council (Codex+Gemini+OpenCode in parallel) | Tiered P0/P1/P2/P3 findings |
+| W7 | Agent-memory cycle (passive) | SessionStart | yellow-ruvector hooks_recall + yellow-morph prewarm → UserPromptSubmit context inject → Pre/PostToolUse record → Stop flush | `ruvector.db`, recalled context, learning logs |
+
+### Cross-plugin collaboration matrix (caller → callee)
+
+Edge weight = static `subagent_type` references (excluding self-loops).
+
+| Caller \ Callee | core | review | research | docs | devin |
+|---|---|---|---|---|---|
+| yellow-core | self | — | 1 | — | 1 |
+| yellow-review | 3 | self | — | — | — |
+| yellow-docs | 1 | — | — | self | — |
+| yellow-research | 1 | — | self | — | — |
+| yellow-devin | — | 1¹ | — | — | self |
+
+¹ = the deprecated `yellow-review:review:code-reviewer` stub referenced from the CHANGELOG; not a live edge.
+
+### MCP cross-consumption (plugins consuming each other's MCP tools)
+
+| MCP | Consumed by |
+|---|---|
+| yellow-linear | yellow-debt (`/debt:sync`), yellow-ci (`/ci:report-linear`), yellow-chatprd (`/chatprd:link-linear`) |
+| yellow-devin | yellow-linear (`/linear:delegate`) |
+| yellow-ruvector | All plugins via `mcp-integration-patterns` skill (recall/remember pattern) |
+| yellow-morph | All plugins via `morph-discovery-pattern` skill (deferred-tool discovery) |
+
+### Silent dependencies (caller → undeclared dep)
+
+| Consumer | Implicit dep | Symptom if missing |
+|---|---|---|
+| `/debt:sync` | yellow-linear MCP | `mcp__plugin_yellow-linear_linear__create_issue` not registered → silent failure |
+| `/ci:report-linear` | yellow-linear MCP | same |
+| `/chatprd:link-linear` | yellow-linear MCP | same |
+| `/linear:delegate` | yellow-devin userConfig (`DEVIN_SERVICE_USER_TOKEN`) | 401 from Devin API |
+| `/council` Codex leg | yellow-codex installed + Codex CLI | Council reports "Codex unavailable" — graceful but not first-class |
+
+---
+
+## 3. Findings
+
+Severity legend: **S1** = breaks functionality · **S2** = breaks workflow but plugin still loads · **S3** = friction or maintenance debt · **S4** = polish.
+
+### Manifest & structure
+
+| ID | Sev | Evidence | Description | Fix | Effort |
+|---|---|---|---|---|---|
+| M-01 | S3 | `CLAUDE.md:8` | Repo CLAUDE.md says *"marketplace (14 plugins under `plugins/`)"*; actual count is 18 (4-plugin drift since the doc was written). | Update to "(18 plugins …)". Optional: derive count via a doc-build hook that reads `.claude-plugin/marketplace.json`. | S |
+| M-02 | S4 | `plugins/yellow-morph/hooks/scripts/prewarm-morph.sh` is `rw-r--r--` | Hook is invoked via `bash …prewarm-morph.sh` so the missing exec-bit doesn't break it, but `validate-plugin.js` flags it and it's the only hook script in the repo without `+x`. | `chmod +x plugins/yellow-morph/hooks/scripts/prewarm-morph.sh`. | S |
+| M-03 | S4 | `plugins/yellow-devin/commands/devin/README.md` | A `README.md` lives inside `plugins/yellow-devin/commands/devin/` — it is auto-discovered as a "command" by `find …/commands -name '*.md'`. It has no frontmatter so Claude Code won't list it, but inflates the command count and is a portable trip hazard. | Move to `plugins/yellow-devin/docs/README.md` or `plugins/yellow-devin/CLAUDE.md`. | S |
+
+### Skills (38 total)
+
+| ID | Sev | Evidence | Description | Fix | Effort |
+|---|---|---|---|---|---|
+| S-01 | S3 | `plugins/yellow-core/skills/create-agent-skills/SKILL.md` (513 lines) | Crosses the 500-line guideline (Anthropic soft outer bound). The repo's own CLAUDE.md says "line counts are guidelines, not hard caps", so this is a *review-trigger*, not a defect. Worth audit for redundancy. | Diff against `optimize/SKILL.md` (461) and `git-worktree/SKILL.md` (440) — these three together exceed 1400 lines of authoring guidance. Consider extracting shared frontmatter rules into a sub-reference. | M |
+| S-02 | S4 | `gt-workflow/commands/gt-amend.md:3-5`; `yellow-ruvector/commands/ruvector/setup.md:3-5` | Both files use the YAML "value-on-next-line + leading-whitespace continuation" form (`description:\n  '…'`). MEMORY.md notes that *multi-line single-quoted descriptions are silently truncated by Claude Code's frontmatter parser*. The available-skills list at session-start renders both correctly in this Claude Code version, so **the risk is forward-compat, not present**. | Convert both to single-line `description: '…'`. | S |
+| S-03 | S3 | All 18 plugins | Of 38 skills, only 9 are `user-invokable: true`. The other 29 are pure-reference convention skills shared between agents. Skills without `user-invokable` only auto-trigger via description-match — meaning a typo or weak description hides them from agents. **No bad descriptions found**, but maintenance load is real: every reference skill needs its description re-read whenever the rules change. | Add an automated "skill description lint" — e.g., a `scripts/validate-skill-descriptions.js` that requires every skill description to contain a "Use when…" clause and a topic anchor (`yellow-core/CLAUDE.md` already requires this for agents). | M |
+
+### Commands (105 total)
+
+No findings of redundant skill-vs-command pairs (`grep` confirmed: zero name overlaps).
+
+| ID | Sev | Evidence | Description | Fix | Effort |
+|---|---|---|---|---|---|
+| C-01 | S4 | `plugins/gt-workflow/commands/{gt-amend,gt-sync,gt-nav,gt-stack-plan,gt-cleanup,gt-setup,smart-submit}.md` | Seven commands in gt-workflow are un-namespaced (no `gt-workflow:` prefix). Pre-namespacing convention — *intentional*, but means any future plugin adding a generic `smart-submit` would collide silently. | Decide either: (a) leave as-is and document the namespace exception in `gt-workflow/CLAUDE.md`, or (b) deprecate to `gt-workflow:amend`, `gt-workflow:sync`, etc., with backward-compat aliases for one minor cycle. | M |
+| C-02 | S2 | `plugins/yellow-core/commands/workflows/plan.md:90,98,132` | Three legacy 2-segment `subagent_type:` values: `yellow-core:repo-research-analyst`, `yellow-core:best-practices-researcher`, `yellow-core:spec-flow-analyzer`. `validate-agent-authoring.js` raises INFO; the runtime expects 3-segment form (`yellow-core:research:repo-research-analyst`, etc.). The plan command is one of the most-used in the repo. | Edit those three values to the 3-segment form. The agent files already exist at the expected paths. | S |
+
+### Agents (79 total)
+
+| ID | Sev | Evidence | Description | Fix | Effort |
+|---|---|---|---|---|---|
+| A-01 | S3 | `plugins/yellow-core/agents/review/{architecture-strategist,security-sentinel,security-reviewer,performance-oracle,performance-reviewer,polyglot-reviewer,test-coverage-analyst}.md` and 67 others | 74 of 79 agents have `model: inherit` (or no model field). Only 5 pin a model: `architecture-strategist`/`audit-synthesizer`/`research-conductor` → opus, `coherence-reviewer` → haiku, `design-lens`/`scope-guardian`/`security-lens-reviewer` → sonnet. **This means review quality varies by whatever model the user is currently on.** For agents whose value depends on depth (security-sentinel, performance-oracle, adversarial-reviewer), inheritance is risky. | Pin opus for the 4–6 deep-analysis personas (security-sentinel, performance-oracle, adversarial-reviewer, audit-synthesizer is already opus). Pin sonnet for the rest of the always-on review personas. Pin haiku for shallow string-pattern personas (comment-analyzer, project-standards-reviewer). | M |
+| A-02 | S3 | All 79 agents | None of the 79 agents declare a `tools:` restriction in frontmatter (`(none)` printed for every row in Phase 1). Plugin agents inherit the parent's tool set, which is permissive by default. **No actual exfil hazard found**, but a research-only agent like `learnings-researcher` should not need `Edit` or `Write`. | For research/review agents that should not modify the workspace, add `tools: [Read, Grep, Glob]`. For workflow agents that need to write reports, list tools explicitly. Start with the 4 yellow-core/research agents and the 16 yellow-review personas. | L |
+
+### Hooks (9 inline entries across 5 plugins)
+
+| ID | Sev | Evidence | Description | Fix | Effort |
+|---|---|---|---|---|---|
+| H-01 | S2 | `plugins/yellow-morph/.claude-plugin/plugin.json` SessionStart `timeout: 30` | The morph prewarm hook is the dominant SessionStart latency for any user who has yellow-morph installed. Three other plugins also fire SessionStart (yellow-ci 3s, yellow-debt 3s, yellow-ruvector 3s) — they all run in parallel, so wall-clock = max ≈ 30s every cold session. | Make prewarm async or move it out of SessionStart. Options: (a) lazy-warm on first morph tool call, (b) drop the prewarm and rely on first-call cold start, (c) keep SessionStart but cap to 5s with a "best-effort" semantics. | M |
+| H-02 | S3 | `plugins/yellow-ruvector/.claude-plugin/plugin.json` PreToolUse / PostToolUse `timeout: 1` | A 1-second timeout fires on **every** Bash/Edit/Write/MultiEdit. The handler at `hooks/scripts/pre-tool-use.sh` does `cat` stdin → `jq` parse → directory check → optional `hooks_recall` MCP call. If `.ruvector/` exists and the recall path is ever taken in <1s, fine; if not, the hook silently times out and the user's edit/bash proceeds without recall. | Either (a) raise to 3s and add explicit fast-path guard so the hook returns `{"continue": true}` within 200ms when no recall is warranted, or (b) keep 1s but add telemetry to count timeouts per session. | M |
+| H-03 | S3 | gt-workflow PreToolUse Bash matcher + yellow-ruvector PreToolUse Bash matcher | Both fire on every Bash. They are correctly independent (each outputs its own `{"continue": true}`), but a user editing many files sees 2× hook latency on every tool call. | Document in CLAUDE.md as a known interaction; no code fix needed unless H-02 is addressed first. | S |
+| H-04 | S4 | `plugins/yellow-ci/hooks/hooks.json`, `plugins/yellow-debt/hooks/hooks.json`, `plugins/yellow-ruvector/hooks/hooks.json`, `plugins/yellow-morph/hooks/hooks.json`, `plugins/gt-workflow/hooks/hooks.json` | All five plugins ship a `hooks/hooks.json` reference file alongside the inline `plugin.json.hooks` block. MEMORY.md notes the file is reference-only since 2026; only some carry the `_comment` annotation. | Spot-check each `hooks/hooks.json` for the `"_comment"` key and timeout-drift against `plugin.json`. (yellow-morph's `hooks/hooks.json` was previously confirmed non-authoritative.) | S |
+
+### Cross-plugin
+
+| ID | Sev | Evidence | Description | Fix | Effort |
+|---|---|---|---|---|---|
+| X-01 | S2 | `plugins/yellow-debt/commands/debt/sync.md`, `plugins/yellow-ci/commands/ci/report-linear.md`, `plugins/yellow-chatprd/commands/chatprd/link-linear.md` | Three commands silently depend on yellow-linear MCP without declaring it in `plugin.json.dependencies` (which is `{}` for all 18 plugins). Install-time failure mode is opaque: command runs, MCP tool is missing, error trickles up as "tool not found". | Either (a) document the dependency in each command's prose + `setup.md` (already partially done), or (b) extend `plugin.json.dependencies` schema to express soft cross-plugin deps and have `validate-plugin.js` warn at validation time. | M |
+| X-02 | S3 | `plugins/yellow-review/CHANGELOG.md:52,55,60,89,96` | The CHANGELOG documents the deprecation of `yellow-review:review:code-reviewer` in correct prose form, but `validate-agent-authoring.js` greps every `.md` for `subagent_type: "<plugin>:<dir>:<name>"` strings without distinguishing prose from declarations. **This is a tooling defect, not a content defect** — the validator currently produces a hard ERROR for a *correct* CHANGELOG entry. | Improve `validate-agent-authoring.js` to skip `CHANGELOG.md` files OR to require the `subagent_type:` value to be in YAML frontmatter context (i.e., between `---` blocks), not in fenced code or prose. | M |
+| X-03 | S3 | `yellow-core/agents/review/code-simplicity-reviewer.md`, `yellow-review/agents/review/code-simplifier.md`, `yellow-core/agents/review/security-lens.md`, `yellow-docs/agents/review/security-lens-reviewer.md` | Near-duplicate agent short names across plugins. FQDNs disambiguate at the runtime level, but a contributor reading two files named `security-lens*.md` cannot tell which one a plan dispatches without expanding the 3-segment form. | Add a one-line "namespace" header inside each agent body (e.g., `**FQDN:** yellow-core:review:security-lens`) so a reader sees the disambiguator without grepping plugin.json. | S |
+
+### Code quality (handler scripts, hook commands)
+
+| ID | Sev | Evidence | Description | Fix | Effort |
+|---|---|---|---|---|---|
+| Q-01 | none | All hook scripts | **No `set -e` violations** found across the 10 hook scripts. All use `set -uo pipefail` per MEMORY.md guidance and centralize exit via `json_exit`. Exemplar: `plugins/yellow-ruvector/hooks/scripts/pre-tool-use.sh:5-12`. | None — keep this as the in-repo canon. | — |
+| Q-02 | none | All hook scripts | All handler paths use `${CLAUDE_PLUGIN_ROOT}` (verified by `jq -r '.hooks[][].hooks[][].command'` across all five plugin manifests). No `BASH_SOURCE` usage. | None. | — |
+| Q-03 | S4 | `plugins/yellow-morph/hooks/scripts/prewarm-morph.sh` (and all WSL2-authored scripts) | Repo's `.gitattributes` enforces LF, but MEMORY.md notes the WSL2 `Write` tool produces CRLF; scripts created during a WSL2 session need `sed -i 's/\r$//'`. No CRLF found in current HEAD, but it's a recurring incident. | Add a pre-commit hook (or a check inside `validate-plugin.js`) that fails on any tracked `.sh` containing CR. | S |
+
+### Findings I checked for and did NOT find (avoid padding)
+
+- No skill SKILL.md exceeds 600 lines (max: 513).
+- No agent has a `permissionMode:` field (correctly dropped per MEMORY.md "subagent frontmatter field catalog").
+- No multi-line single-quoted descriptions (the truncation pattern from MEMORY.md). Two folded-block descriptions found, both currently render — flagged S4 only.
+- No hook with `matcher: "*"` doing slow work (the 4 SessionStart `*` matchers are correct — that event is global by definition).
+- No PostToolUse used for blocking, no Stop hook with infinite-loop risk.
+- No hardcoded absolute paths or credentials in handler scripts.
+- No namespace collisions between live commands.
+
+---
+
+## 4. Prioritized improvement plan
+
+Ranked by **(severity × payoff) ÷ effort**. Each item names the files it changes.
+
+| Rank | Item | Severity | Effort | Files | Expected impact |
+|---|---|---|---|---|---|
+| 1 | **C-02** Update legacy 2-segment subagent_types in `plan.md` | S2 | S | `plugins/yellow-core/commands/workflows/plan.md:90,98,132` | Removes 3 INFO warnings; future-proofs against the gate becoming hard-fail. plan.md is the entry point of W1. |
+| 2 | **X-02** Fix `validate-agent-authoring.js` so CHANGELOGs don't trip it | S3 | M | `scripts/validate-agent-authoring.js` | Removes a hard ERROR that currently blocks `pnpm release:check`. Eliminates the single biggest contributor frustration when CHANGELOGs document deletions. |
+| 3 | **H-01** Make morph prewarm async or lazy | S2 | M | `plugins/yellow-morph/.claude-plugin/plugin.json`, `plugins/yellow-morph/hooks/scripts/prewarm-morph.sh` | Up to **30s shaved off cold-session latency** for every yellow-morph user. Single biggest perf win in the marketplace. |
+| 4 | **X-01** Declare cross-plugin MCP dependencies | S2 | M | `schemas/plugin.schema.json`, `scripts/validate-plugin.js`, 3 plugin manifests | Install-time clarity for `/debt:sync`, `/ci:report-linear`, `/chatprd:link-linear`. Prevents silent failure mode when yellow-linear isn't installed. |
+| 5 | **A-01** Pin models on the deep-analysis review personas | S3 | M | `plugins/yellow-core/agents/review/{security-sentinel,performance-oracle}.md` (+ 2-3 yellow-review personas) | Stabilizes review quality across users on different default models. Already partially done (5 pinned today); extending to ~10 covers all the high-stakes personas. |
+| 6 | **M-01** Update plugin count in CLAUDE.md | S3 | S | `CLAUDE.md:8` | Cheap — gets `14 → 18` right. Onboarding fix. |
+| 7 | **C-01** Decide gt-workflow namespacing policy | S4 | M | `plugins/gt-workflow/commands/*.md`, `plugins/gt-workflow/CLAUDE.md` | Prevents future `smart-submit` collision. Aliases give one minor cycle of overlap. |
+| 8 | **A-02** Restrict tools on research/review agents | S3 | L | 20+ agent files in yellow-core, yellow-review, yellow-research | Tightens blast radius (e.g., `learnings-researcher` cannot Write). Mostly hygiene — no current incident. |
+| 9 | **S-01** Audit `create-agent-skills` (513 lines) for redundancy | S3 | M | `plugins/yellow-core/skills/create-agent-skills/SKILL.md` | Cuts skill load time slightly; reduces duplication with `optimize/SKILL.md` and `git-worktree/SKILL.md`. |
+| 10 | **M-02** `chmod +x` morph prewarm hook | S4 | S | `plugins/yellow-morph/hooks/scripts/prewarm-morph.sh` | Removes the lone WARNING from `pnpm validate:schemas`. |
+
+---
+
+## 5. Risks & open questions
+
+1. **CHANGELOG-grep false positives may re-occur.** Until X-02 lands, any future deprecation note that mentions a removed agent's FQDN will block `pnpm release:check`. Maintainers must keep mentioning removed agents using a non-`subagent_type:` formulation (e.g., back-quoted `\`yellow-review:review:code-reviewer\``) until the validator is fixed.
+2. **Local schema vs remote validator drift.** `pnpm validate:schemas` passing does not guarantee Claude Code's remote validator accepts an install. The plugin.json `changelog`/`pattern`/`userConfig.type+title` history suggests this drift is expected. Any audit fix that touches schemas must be tested on a fresh `claude plugin install` before tagging.
+3. **A-02 (tool restrictions) requires a per-agent decision.** Some review agents legitimately need `Edit`/`Write` (autonomous P1 fixers). Don't blanket-deny — audit each agent for the workflow step it serves.
+4. **The 30s morph prewarm may be load-bearing.** Making it async (H-01) means the *first* `morph` tool call after session-start may be slow instead of session-start itself. Verify with the yellow-morph maintainer that lazy warm is acceptable before changing.
+5. **Doc count drift (M-01) is symptomatic.** It suggests no automation derives the count from `marketplace.json`. The same drift may exist in `README.md` "consumer count" and other narrative docs. A doc-build hook that renders these from JSON would prevent recurrence.
+6. **No PR/changeset enforcement was checked.** This audit was scoped to plugin/manifest/skill/agent/hook content; the changeset gate and version-sync rules were assumed working because `validate-versions.js` is part of the validation chain.
+7. **Hook latency analysis is theoretical.** Real wall-clock measurements (especially for H-01 and H-02) require running Claude Code with hooks-debug enabled and timing SessionStart cold-starts on a representative machine. The 30s figure is the declared timeout, not the observed latency.
+
+---
+
+*End of audit. No source files were modified; the only file written is this `AUDIT_REPORT.md`.*

--- a/docs/brainstorms/2026-05-07-audit-followups-brainstorm.md
+++ b/docs/brainstorms/2026-05-07-audit-followups-brainstorm.md
@@ -60,13 +60,23 @@ resolves that for future contributors without incurring rename churn.
 
 #### X-02 — Fix validator CHANGELOG false positive
 - **File:** `scripts/validate-agent-authoring.js`
-- **Approach:** frontmatter-only matching — only flag `subagent_type:` values found inside
-  YAML frontmatter blocks (between `---` delimiters), not in prose, code fences, or CHANGELOG entries
-- **Rationale for approach:** skip-CHANGELOG-entirely would also miss a future README or
-  solution doc that documents a deleted agent; frontmatter-only matches the validator's
-  actual intent ("catch broken declarations")
+- **Approach (revised at implementation time):** skip `CHANGELOG.md` files entirely from
+  the `markdownFiles` walk predicate. Frontmatter-only matching was rejected on closer
+  inspection — `subagent_type:` references rarely appear in frontmatter; they appear in
+  command-file bodies (Task tool invocation pseudo-code in fenced code blocks) and inline
+  as `Task(subagent_type="...")` in prose. Restricting to frontmatter would have silently
+  dropped ~11 legitimate inline usages and effectively turned the validator into a no-op
+  for the surface it actually protects.
+- **Rationale for skip-CHANGELOG:** semantically correct — CHANGELOGs document the past,
+  not the current dispatch graph; their references are intentionally not current. The
+  filter is strictly more targeted than frontmatter-only and preserves all existing
+  validation surfaces. See
+  `docs/solutions/build-errors/validate-agent-authoring-changelog-skip.md` for the full
+  decision record.
 - **Verify:** `pnpm release:check` passes cleanly; `yellow-review/CHANGELOG.md` no longer
-  triggers the hard ERROR
+  triggers the hard ERROR. Three regression tests at
+  `tests/integration/validate-agent-authoring-changelog-skip.test.ts` cover the
+  CHANGELOG-silent / non-CHANGELOG-flagged / both-present cases.
 - **Changeset:** not required (scripts/ change, no plugin content change)
 
 #### H-01 — Morph prewarm async background

--- a/docs/brainstorms/2026-05-07-audit-followups-brainstorm.md
+++ b/docs/brainstorms/2026-05-07-audit-followups-brainstorm.md
@@ -1,0 +1,242 @@
+# Audit Followups — 2026-05-07
+
+## What We're Building
+
+This document records the decisions made after the 2026-05-07 read-only audit of the
+yellow-plugins marketplace (see `AUDIT_REPORT.md` in the repo root). The audit produced
+10 prioritized improvement items and 7 open risks; this brainstorm dialogue worked through
+all of them and assigned each a disposition: apply, defer, or split.
+
+---
+
+## Decisions Table
+
+| Item | Disposition | One-line rationale |
+|---|---|---|
+| C-02 | Apply | Mechanical 3-line fix removes 3 INFO warnings; plan.md is the most-used entry point |
+| X-02 | Apply | Active release blocker — hard ERROR on a correct CHANGELOG entry |
+| H-01 | Apply | Biggest user-visible perf win; async pattern removes the blocking 30s cold-session cost |
+| X-01 | Apply | Declares silent cross-plugin deps that currently fail opaquely at runtime |
+| A-01 | Apply | Completes an existing pattern; 5 deep-analysis personas need opus for quality guarantees |
+| M-01 | Apply (extended) | Fix 14→18 + add lint to prevent recurrence; no automation currently catches the drift |
+| M-02 | Apply | Clears the lone WARNING from `pnpm validate:schemas`; one command |
+| C-01 | Defer + document | No concrete collision trigger; rename costs exceed theoretical risk; note the exception |
+| A-02 | Split | Phase 1 (read-only agents) applies now; Phase 2 (write-capable agents) needs per-agent judgment |
+| S-01 | Defer | 13 lines over a soft cap on a working skill; no proven duplication found |
+| Risk 1 | Resolved | Obsoleted by X-02 apply — validator workaround no longer needed |
+| Risk 2 | Inherited | X-01 acceptance criteria include a fresh-install smoke test gate |
+| Risk 5 | Apply | Add `validate-doc-counts.js` lint wired into `release:check` |
+| Risk 6 | Out of scope | Changeset enforcement gap is a separate audit topic |
+| Risk 7 | Deferred | Empirical latency timing is a separate project from the H-01 async fix |
+
+---
+
+## Why This Approach
+
+The dialogue surfaced a consistent preference: fix things that are broken or actively
+blocking, document things that are theoretical, and defer anything that requires a
+judgment call across 20+ files. The split on A-02 reflects this — the obvious read-only
+restrictions are unambiguous, while write-capable agent restrictions need per-agent
+analysis that belongs in its own pass.
+
+C-01 was the only item where the answer was "you don't need to do anything" — the audit
+trigger was anxiety about future collisions, not an actual problem. The CLAUDE.md note
+resolves that for future contributors without incurring rename churn.
+
+---
+
+## Key Decisions
+
+### Apply items with acceptance criteria
+
+#### C-02 — Fix legacy 2-segment subagent_types in `plan.md`
+- **File:** `plugins/yellow-core/commands/workflows/plan.md` lines 90, 98, 132
+- **Changes:**
+  - `yellow-core:repo-research-analyst` → `yellow-core:research:repo-research-analyst`
+  - `yellow-core:best-practices-researcher` → `yellow-core:research:best-practices-researcher`
+  - `yellow-core:spec-flow-analyzer` → `yellow-core:workflow:spec-flow-analyzer`
+- **Verify:** `pnpm validate:agents` shows no INFO warnings on these three values
+- **Changeset:** patch bump on yellow-core
+
+#### X-02 — Fix validator CHANGELOG false positive
+- **File:** `scripts/validate-agent-authoring.js`
+- **Approach:** frontmatter-only matching — only flag `subagent_type:` values found inside
+  YAML frontmatter blocks (between `---` delimiters), not in prose, code fences, or CHANGELOG entries
+- **Rationale for approach:** skip-CHANGELOG-entirely would also miss a future README or
+  solution doc that documents a deleted agent; frontmatter-only matches the validator's
+  actual intent ("catch broken declarations")
+- **Verify:** `pnpm release:check` passes cleanly; `yellow-review/CHANGELOG.md` no longer
+  triggers the hard ERROR
+- **Changeset:** not required (scripts/ change, no plugin content change)
+
+#### H-01 — Morph prewarm async background
+- **Files:**
+  - `plugins/yellow-morph/hooks/scripts/prewarm-morph.sh`
+  - `plugins/yellow-morph/.claude-plugin/plugin.json`
+- **Changes:**
+  - `prewarm-morph.sh`: parent process emits `{"continue": true}` immediately; actual
+    prewarm work runs in a detached background subshell (`( prewarm_work ) & disown`)
+    before the JSON output line
+  - `plugin.json`: lower SessionStart `timeout: 30` → `timeout: 5` (parent exits in <1s;
+    the 5s is a defensive ceiling in case the parent itself stalls)
+- **Edge case to document in prewarm-morph.sh:** if the user invokes a morph tool within
+  ~30s of session start on a slow connection, they may still hit a cold cache. This is the
+  accepted trade-off.
+- **Verify:** session start no longer blocks; background process does not leave zombie
+  children (standard `& disown` handles this); `pnpm validate:schemas` passes
+- **Changeset:** patch bump on yellow-morph
+
+#### X-01 — Declare cross-plugin MCP dependencies
+- **Files:**
+  - `schemas/plugin.schema.json` — add optional `dependencies` array field
+  - `scripts/validate-plugin.js` — warn (not error) when a declared dep isn't in the
+    marketplace catalog
+  - `plugins/yellow-debt/.claude-plugin/plugin.json` — add `dependencies: [{plugin: "yellow-linear", reason: "debt:sync uses mcp__plugin_yellow-linear_linear__create_issue"}]`
+  - `plugins/yellow-ci/.claude-plugin/plugin.json` — same pattern for yellow-linear
+  - `plugins/yellow-chatprd/.claude-plugin/plugin.json` — same pattern for yellow-linear
+- **Field shape (recommendation, final shape is implementation's call):**
+  ```json
+  "dependencies": [
+    { "plugin": "yellow-linear", "reason": "string" }
+  ]
+  ```
+- **Verify:** `pnpm validate:schemas` passes; validator warns (not errors) on a manifest
+  that declares a dep not in marketplace.json
+- **Required gate:** fresh `claude plugin install` smoke test on a clean machine before
+  tagging any release that ships this schema change (Risk 2 — local CI passing does not
+  guarantee remote validator acceptance)
+- **Changeset:** patch bumps on yellow-debt, yellow-ci, yellow-chatprd; scripts/ change
+  does not require a changeset
+
+#### A-01 — Pin models on deep-analysis review personas
+- **Files (5 agent `.md` files):**
+  - `plugins/yellow-core/agents/review/security-sentinel.md` → `model: claude-opus-4-5` (or current opus)
+  - `plugins/yellow-core/agents/review/performance-oracle.md` → opus
+  - `plugins/yellow-core/agents/review/adversarial-reviewer.md` → opus
+  - `plugins/yellow-review/agents/review/agent-cli-readiness-reviewer.md` → opus
+  - `plugins/yellow-review/agents/review/agent-native-reviewer.md` → opus
+- **Existing pinned agents (do not change):** `architecture-strategist`, `audit-synthesizer`,
+  `research-conductor` → opus; `coherence-reviewer` → haiku; `design-lens`,
+  `scope-guardian`, `security-lens-reviewer` → sonnet
+- **Verify:** `pnpm validate:agents` clean; each file's frontmatter has a single-line
+  `model:` field
+- **Changeset:** patch bumps on yellow-core and yellow-review
+
+#### M-01 — Fix plugin count + add lint
+- **Reactive fix:** `CLAUDE.md` line 8 — update `"14 plugins"` → `"18 plugins"`
+- **Preventive fix — new file:** `scripts/validate-doc-counts.js` (~50 lines)
+  - Reads `.claude-plugin/marketplace.json` to derive the canonical plugin count
+  - Greps `CLAUDE.md`, `README.md`, and any other root-level narrative docs for patterns
+    matching `\d+ plugins`, `\d+ consumers`, `\d+ marketplace plugins`
+  - Fails with non-zero exit code if any claim mismatches the canonical count
+  - Prints a clear message naming the file, line, found count, and expected count
+- **Wire into release pipeline:** add `node scripts/validate-doc-counts.js` to `pnpm release:check`
+  (or as a standalone `pnpm validate:doc-counts` that release:check calls)
+- **Verify:** `pnpm release:check` passes after M-01 reactive fix; adding a fake
+  "17 plugins" string to CLAUDE.md triggers the lint failure
+- **Changeset:** not required (CLAUDE.md edit is repo-level, not a plugin change; scripts/ change has no changeset requirement)
+
+#### M-02 — `chmod +x` morph prewarm hook
+- **File:** `plugins/yellow-morph/hooks/scripts/prewarm-morph.sh`
+- **Change:** `chmod +x` — hook already works (invoked via `bash script.sh`) but this
+  clears the lone WARNING from `pnpm validate:schemas`
+- **Verify:** `pnpm validate:schemas` produces no WARNING on this file
+- **Changeset:** patch bump on yellow-morph (can bundle with H-01)
+
+#### A-02 Phase 1 — Tool restrictions on read-only research agents
+- **Approach:** add `tools: [Read, Grep, Glob]` to agents that have no legitimate need
+  for workspace modification
+- **Files (confirmed read-only research agents):**
+  - `plugins/yellow-core/agents/research/learnings-researcher.md`
+  - `plugins/yellow-core/agents/research/repo-research-analyst.md`
+  - `plugins/yellow-core/agents/research/best-practices-researcher.md`
+  - `plugins/yellow-core/agents/research/git-history-analyzer.md` — may need `Bash` for
+    git commands; verify before restricting to Read/Grep/Glob only
+  - `plugins/yellow-core/agents/workflow/spec-flow-analyzer.md`
+  - `plugins/yellow-research/agents/research/code-researcher.md` (verify agent path)
+  - `plugins/yellow-codex/agents/research/codex-analyst.md` (verify agent path)
+  - `plugins/yellow-linear/agents/research/linear-explorer.md` (verify agent path)
+- **Note:** verify each file's actual path before editing — agent paths above are inferred
+  from the audit's 3-segment FQDNs; use `find plugins -name '<agent>.md'` to confirm
+- **Verify:** `pnpm validate:agents` clean; each file's `tools:` field is populated
+- **Changeset:** patch bumps on affected plugins
+
+---
+
+### C-01 — gt-workflow namespace exception (defer + document)
+
+No command rename. Add a "Namespace exception" section to
+`plugins/gt-workflow/CLAUDE.md` with the following content (exact wording is implementation's
+call, but these three points must be covered):
+
+1. The 7 commands (`gt-amend`, `gt-sync`, `gt-nav`, `gt-stack-plan`, `gt-cleanup`,
+   `gt-setup`, `smart-submit`) ship un-namespaced intentionally — they predate the
+   `plugin-name:command` namespacing convention.
+2. Collision risk is low: six of the seven are `gt-`-prefixed and no other plugin would
+   plausibly register them. `smart-submit` is the only generic name; no competing plugin
+   has been observed shipping it.
+3. Future contributors and auditors should not re-flag this without a concrete trigger
+   (an actual collision or an incoming plugin that would clash).
+
+Changeset: patch bump on gt-workflow for the CLAUDE.md edit, OR skip if the team treats
+CLAUDE.md-only changes as no-bump. Recommendation: skip — this is documentation of an
+existing convention, not a behavior change.
+
+---
+
+## Open Questions
+
+1. **X-01 field shape** — the brainstorm recommends `{plugin, reason}` for each dep entry,
+   but the exact field names and whether to support version constraints is left to the
+   implementation pass.
+2. **git-history-analyzer tools** — needs `Bash` for git commands. Verify whether
+   `[Read, Grep, Glob, Bash]` is the right restriction or whether it should be unrestricted.
+3. **A-02 agent paths** — the 8 agents listed for Phase 1 are inferred from 3-segment FQDNs;
+   confirm each file's actual path before editing.
+4. **yellow-research and yellow-codex agents** — `code-researcher` and `codex-analyst` need
+   path verification; the audit's Phase 1 list is best-effort on those two.
+
+---
+
+## Suggested PR Slicing
+
+Group the 11 apply items into 6 stacked PRs. Stack them so reviewers see the release
+blocker first and the schema change (which needs an install smoke test) isolated.
+
+| PR | Items | Why grouped |
+|---|---|---|
+| PR 1 | X-02 | Release blocker — merge this first to unblock `pnpm release:check` |
+| PR 2 | C-02, M-01 (reactive), M-02, C-01 doc note | All mechanical / single-file; one small commit each; one changeset covers yellow-core + gt-workflow + yellow-morph |
+| PR 3 | H-01 | Perf change isolated; easier to revert if async pattern behaves unexpectedly |
+| PR 4 | X-01 | Schema + manifest change; **must not tag a release until fresh-install smoke test passes** |
+| PR 5 | A-01, A-02 phase 1 | Agent frontmatter; same reviewer can check both; validate:agents covers both |
+| PR 6 | M-01 (lint), validate-doc-counts.js | Preventive infrastructure; low risk, no plugin touches |
+
+PRs 2 and 6 can land in any order relative to each other. PR 4 is the only one with an
+explicit external gate before release.
+
+---
+
+## Items NOT Addressed in This Cycle
+
+**A-02 Phase 2 — write-capable agent tool restrictions**
+Deferred because write-capable agents (`correctness-reviewer`, `silent-failure-hunter`,
+`code-simplifier`, persona reviewers with autofix paths) require per-agent judgment on
+whether `Edit`/`Write` are legitimate. This belongs in a separate `/workflows:brainstorm`
+pass tagged "A-02 phase 2."
+
+**S-01 — `create-agent-skills` SKILL.md redundancy audit**
+Deferred because 513 lines is 13 over a soft cap on a working skill, and the audit did not
+prove actual duplication. If the skill grows further or a content audit surfaces verbatim
+overlaps with `optimize/SKILL.md` or `git-worktree/SKILL.md`, address it then.
+
+**Risk 6 — changeset enforcement gap**
+Out of scope for this audit. The changeset gate and version-sync rules were assumed working
+because `validate-versions.js` is part of the validation chain. A dedicated audit of the
+CI enforcement layer is a separate project.
+
+**Risk 7 — empirical hook latency measurement**
+The H-01 async fix is correct on principle (session-start blocking 30s is objectively bad).
+A real cold-start timing harness (hooks-debug enabled, representative machine) would
+validate the fix and establish a baseline for H-02 (ruvector 1s timeout). Deferred as a
+separate project.

--- a/docs/solutions/build-errors/validate-agent-authoring-changelog-skip.md
+++ b/docs/solutions/build-errors/validate-agent-authoring-changelog-skip.md
@@ -1,0 +1,104 @@
+---
+problem: validate-agent-authoring.js hard-errors on CHANGELOG.md prose mentioning deleted agents
+category: build-errors
+date: 2026-05-07
+related-files:
+  - scripts/validate-agent-authoring.js
+  - tests/integration/validate-agent-authoring-changelog-skip.test.ts
+related-prs:
+  - audit/x-02-validator-frontmatter-only
+---
+
+# `validate-agent-authoring.js` CHANGELOG.md skip
+
+## Problem
+
+`pnpm release:check` fails with a hard ERROR like:
+
+```
+✗ ERROR: plugins/yellow-review/CHANGELOG.md: subagent_type "yellow-review:review:code-reviewer" does not match any declared plugin agent
+```
+
+The CHANGELOG entry that triggers it documents a deprecated agent that
+was deleted. The reference is correct *as a historical fact* but the
+validator's `pluginSubagentPattern` regex matched the inline-code prose
+mention and looked up the value in the current agent registry, which
+no longer contains the deleted agent.
+
+This is a release blocker: it produces a false positive on every CI
+run that touches `release:check`.
+
+## Root cause
+
+`scripts/validate-agent-authoring.js` defined `markdownFiles` as every
+`.md` file under `plugins/`:
+
+```js
+const markdownFiles = walk(PLUGINS_DIR, (filePath) => filePath.endsWith('.md'));
+```
+
+The downstream loop scanned each markdown file's full body — including
+prose paragraphs, inline code, and CHANGELOG entries — looking for
+`subagent_type:` references. Any reference that didn't match a current
+agent was flagged. CHANGELOGs are history; their references are
+intentionally not current, so the check produced false positives.
+
+## Approaches considered
+
+1. **Frontmatter-only matching** (initial brainstorm decision): only
+   match `subagent_type:` inside YAML frontmatter blocks. **Rejected**
+   on closer inspection — `subagent_type:` references rarely appear in
+   frontmatter; they appear in command file bodies (Task tool
+   invocation pseudo-code in fenced code blocks) and inline as
+   `Task(subagent_type="...")` in prose. Restricting to frontmatter
+   would have effectively turned the validator into a no-op for the
+   surface it actually protects.
+
+2. **Line-start anchored regex** (`^\s*subagent_type` in multiline
+   mode): catches code-block dispatches but loses inline
+   `Task(subagent_type=...)` references in command file prose. Found
+   ~11 such legitimate usages in the codebase.
+
+3. **Skip CHANGELOG.md files entirely** (chosen): preserves all
+   existing validation surfaces; only sacrifices CHANGELOG history
+   scanning. Semantically correct: CHANGELOGs document the past, not
+   the current dispatch graph.
+
+## Solution
+
+Single-line filter on the walk predicate:
+
+```js
+const markdownFiles = walk(
+  PLUGINS_DIR,
+  (filePath) =>
+    filePath.endsWith('.md') && path.basename(filePath) !== 'CHANGELOG.md'
+);
+```
+
+Trade-off: if a CHANGELOG entry references an agent that DOES still
+exist, the validator no longer cross-checks it. Acceptable because:
+- The entry was correct at write time (validated then).
+- Future CHANGELOG drift on agent renames produces stale-but-harmless
+  history entries; the runtime catches actual broken dispatches at
+  execution time.
+- Solving CHANGELOG drift would require a separate "history-aware"
+  validator that knows about deleted agents — out of scope for this
+  fix.
+
+## Verification
+
+`pnpm release:check` exits 0 cleanly. Three regression tests at
+`tests/integration/validate-agent-authoring-changelog-skip.test.ts`:
+
+1. Deleted-agent reference inside `CHANGELOG.md` → NOT flagged
+2. Same reference inside a non-CHANGELOG file → STILL flagged
+3. Both files present → only the non-CHANGELOG flagged; CHANGELOG silent
+
+## Future considerations
+
+If READMEs or solution docs start producing similar false positives
+(documenting deleted agents in prose), extend the filter to a path-based
+allowlist or move to a more discriminating regex (e.g., requiring the
+match to be inside a fenced code block AND tagged as a dispatch). Not
+needed now — the only observed false-positive surface is CHANGELOGs.

--- a/docs/solutions/build-errors/validate-agent-authoring-changelog-skip.md
+++ b/docs/solutions/build-errors/validate-agent-authoring-changelog-skip.md
@@ -1,8 +1,17 @@
 ---
-problem: validate-agent-authoring.js hard-errors on CHANGELOG.md prose mentioning deleted agents
+title: 'validate-agent-authoring.js hard-errors on CHANGELOG.md prose mentioning deleted agents'
 category: build-errors
+track: bug
+problem: 'validate-agent-authoring.js hard-errors on CHANGELOG.md prose mentioning deleted agents'
 date: 2026-05-07
-related-files:
+tags:
+  - validate-agent-authoring
+  - subagent_type
+  - changelog
+  - false-positive
+  - release-check
+severity: P2
+components:
   - scripts/validate-agent-authoring.js
   - tests/integration/validate-agent-authoring-changelog-skip.test.ts
 related-prs:
@@ -15,7 +24,7 @@ related-prs:
 
 `pnpm release:check` fails with a hard ERROR like:
 
-```
+```text
 ✗ ERROR: plugins/yellow-review/CHANGELOG.md: subagent_type "yellow-review:review:code-reviewer" does not match any declared plugin agent
 ```
 
@@ -72,9 +81,15 @@ Single-line filter on the walk predicate:
 const markdownFiles = walk(
   PLUGINS_DIR,
   (filePath) =>
-    filePath.endsWith('.md') && path.basename(filePath) !== 'CHANGELOG.md'
+    filePath.endsWith('.md') &&
+    path.basename(filePath).toUpperCase() !== 'CHANGELOG.MD'
 );
 ```
+
+The case-insensitive `toUpperCase()` is intentional defense — every existing
+CHANGELOG in the repo uses canonical `CHANGELOG.md` casing, but a stray
+`Changelog.md` from a different tool's convention should not silently re-open
+the false-positive surface.
 
 Trade-off: if a CHANGELOG entry references an agent that DOES still
 exist, the validator no longer cross-checks it. Acceptable because:

--- a/plans/audit-followups-2026-05-07.md
+++ b/plans/audit-followups-2026-05-07.md
@@ -1,0 +1,1056 @@
+# Feature: Audit Followups — 2026-05-07
+
+## Overview
+
+Implement the 11 "apply" decisions from the 2026-05-07 audit followups
+brainstorm: clean three INFO warnings, remove the lone validator ERROR,
+declare cross-plugin MCP dependencies, kill the 30s session-start block,
+pin opus on five deep-analysis review personas, restrict tools on eight
+read-only research agents, and add a `validate-doc-counts.js` lint to
+prevent narrative-doc drift.
+
+Source brainstorm: `docs/brainstorms/2026-05-07-audit-followups-brainstorm.md`
+Source audit: `AUDIT_REPORT.md`
+
+## Problem Statement
+
+### Current Pain Points
+
+- **Active release blocker (X-02):** `validate-agent-authoring.js` hard-errors
+  on a correct CHANGELOG entry in `yellow-review/CHANGELOG.md` because it
+  greps prose without distinguishing it from declarations. Blocks
+  `pnpm release:check`.
+- **30s cold-session penalty (H-01):** `yellow-morph`'s SessionStart hook
+  runs synchronously with a 30s timeout, blocking every cold session for
+  any user with morph installed. Single largest user-visible perf cost.
+- **Silent cross-plugin deps (X-01):** `/debt:sync`, `/ci:report-linear`,
+  and `/chatprd:link-linear` require `yellow-linear` MCP but declare no
+  dependency; failures appear at runtime as opaque "tool not found".
+- **Three legacy 2-segment subagent_types (C-02):** `yellow-core/commands/workflows/plan.md`
+  lines 90/98/132 emit INFO warnings on every validator run.
+- **Inconsistent model pinning (A-01):** five deep-analysis reviewers
+  (security-sentinel, performance-oracle, adversarial-reviewer,
+  agent-cli-readiness-reviewer, agent-native-reviewer) inherit by default
+  while peer personas pin opus or sonnet — quality is non-deterministic.
+- **Read-only agents have full tool surface (A-02 Phase 1):** eight research
+  agents inherit `Edit`/`Write` they never legitimately use; least-privilege
+  hardening is missing.
+- **Plugin count drift (M-01):** `CLAUDE.md` says "14 plugins", `README.md`
+  says "17 plugins", actual count is 18 (`jq '.plugins | length'`). No
+  lint catches the drift.
+- **One WARNING (M-02):** `prewarm-morph.sh` is non-executable; works only
+  because `bash script.sh` is the invocation form.
+- **One INFO (X-02 fallout):** validator finding a deprecated agent
+  reference inside CHANGELOG prose triggers a false ERROR.
+
+### User Impact
+
+- Marketplace consumers who install `yellow-morph` wait ~30s on every cold
+  session.
+- Marketplace consumers who install `yellow-debt`, `yellow-ci`, or
+  `yellow-chatprd` without `yellow-linear` see opaque silent failures.
+- Plugin authors running `pnpm release:check` are blocked by the validator
+  false positive.
+- Reviewers running personas like `security-sentinel` get inconsistent
+  output quality depending on whether they happened to invoke from a
+  context where the parent's model is opus or sonnet.
+
+### Business Value
+
+- Unblocks the release pipeline (X-02).
+- Removes the largest user-visible perf cost in the marketplace (H-01).
+- Surfaces install-time dependency violations as warnings instead of
+  runtime "tool not found" errors (X-01).
+- Establishes least-privilege precedent for the agent surface (A-02 P1).
+- Self-protects narrative documentation against count drift (M-01 lint).
+
+## Proposed Solution
+
+### High-Level Architecture
+
+Six stacked PRs, ordered so the release blocker lands first and the
+schema-changing PR is isolated for an external smoke-test gate:
+
+```
+main
+ │
+ ├─ PR 1: X-02 (validator fix) — release blocker, no plugin touches
+ │
+ ├─ PR 2: C-02 + M-01 reactive + M-02 + C-01 doc note
+ │       (mechanical single-file edits across yellow-core, yellow-morph, gt-workflow)
+ │
+ ├─ PR 3: H-01 async morph prewarm (perf change isolated)
+ │
+ ├─ PR 4: X-01 cross-plugin dependency schema  ← external gate
+ │       (must pass fresh `claude plugin install` smoke test before tag)
+ │
+ ├─ PR 5: A-01 model pins + A-02 Phase 1 tool restrictions
+ │       (yellow-core, yellow-review, yellow-research, yellow-codex, yellow-linear)
+ │
+ └─ PR 6: M-01 preventive (validate-doc-counts.js + release:check wiring)
+```
+
+PRs 2 and 6 can land in any order relative to each other. PR 4 is the
+only one with an explicit external gate.
+
+### Key Design Decisions
+
+1. **X-02 — frontmatter-only matching, not skip-CHANGELOG:** The validator's
+   intent is "catch broken `subagent_type:` declarations in agent/command
+   files," not "lint prose." Restricting matches to YAML frontmatter blocks
+   (between the leading `---` delimiters) preserves intent while stopping
+   prose false positives. Skip-CHANGELOG would also miss a future README
+   or solution doc that documents a deleted agent.
+
+2. **H-01 — fork-and-disown, not nohup:** Parent process emits
+   `{"continue": true}` immediately, then the actual prewarm work runs in a
+   detached background subshell `( prewarm_work ) & disown` BEFORE the JSON
+   line is printed. Standard POSIX pattern; no zombie children. Trade-off:
+   if the user invokes a morph tool within ~30s of session start on a slow
+   connection, they may still hit a cold cache. Accepted and documented.
+
+3. **X-01 — warn-not-error:** Validator warns when a declared dep is missing
+   from `marketplace.json`. Hard error would block users who install a
+   subset of the marketplace. The warning is enough to surface the
+   coupling at install time.
+
+4. **X-01 — `{plugin, reason}` shape:** Optional array of objects with
+   `plugin` (required, string) and `reason` (required, string). No version
+   constraints in v1 — simpler to ship, easier to extend later. Implementation
+   pass may refine the shape; this is the recommended starting point.
+
+5. **A-01 — opus on the five deepest analysis personas:** The pattern is
+   already established (`audit-synthesizer`, `architecture-strategist`,
+   `research-conductor` are pinned to opus). Adding `security-sentinel`,
+   `performance-oracle`, `adversarial-reviewer`,
+   `agent-cli-readiness-reviewer`, and `agent-native-reviewer` completes
+   the convention.
+
+6. **A-02 Phase 1 — read-only research agents only:** Phase 1 restricts
+   to `[Read, Grep, Glob]` (and `Bash` for git-history-analyzer) the eight
+   agents that have no plausible reason to mutate the workspace. Phase 2
+   (write-capable agents) is deferred — those need per-agent judgment
+   that belongs in its own brainstorm pass.
+
+7. **M-01 — composite lint (`validate-doc-counts.js`):** Reads marketplace
+   as canonical source, greps narrative docs for any `\d+ plugins`-style
+   claim, fails on mismatch. Extensible to "consumers", "marketplace
+   plugins", or any other count-bearing phrase.
+
+### Trade-offs Considered
+
+- **C-01 (gt-workflow namespace):** Considered renaming the seven
+  un-namespaced commands to `gt:amend`, `gt:sync`, etc. Rejected:
+  collision risk is theoretical (six are `gt-`-prefixed; only `smart-submit`
+  is generic and no observed conflict). Documenting the exception is
+  cheaper than rename churn across user habits and docs.
+- **A-02 Phase 2 (write-capable agents):** Considered including
+  `correctness-reviewer`, `silent-failure-hunter`, `code-simplifier` etc.
+  in this pass. Rejected: each needs case-by-case judgment on whether
+  `Edit`/`Write` are legitimate (some have autofix paths, some don't).
+  Belongs in a separate brainstorm.
+- **S-01 (create-agent-skills line count):** Considered splitting the 513-line
+  SKILL.md against the 500-line soft cap. Rejected: 13 lines is well within
+  the soft-cap tolerance, and the audit found no proven duplication. Per
+  the project memory rule, line counts are guidelines, not split-triggers.
+- **Risk 7 (empirical hook timing):** Considered including a cold-start
+  timing harness in this cycle. Rejected: H-01's async-fork fix is
+  correct on principle (blocking 30s on session start is objectively bad).
+  An empirical baseline is a separate validation project.
+
+## Implementation Plan
+
+### Phase 1 — PR 1: X-02 validator frontmatter-only matching
+
+**Branch:** `audit/x-02-validator-frontmatter-only`
+**Stacks on:** `main`
+**Plugins touched:** none (scripts/ only)
+**Changeset required:** no
+
+- [ ] 1.1: Read `scripts/validate-agent-authoring.js` end-to-end; locate
+  the `subagent_type:` matching logic and the function that scans CHANGELOG
+  paths. Identify the `extractFrontmatter` helper at line 67 — confirm
+  whether the current matcher uses it or scans the full file body.
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** `scripts/validate-agent-authoring.js` line 273 applies the
+> `pluginSubagentPattern` regex to *every* `.md` file under `plugins/` via
+> `walk(PLUGINS_DIR, …)` at line 144 — including CHANGELOG.md. The
+> `extractFrontmatter` helper (line 62) is currently used only in the
+> `agentFiles` loop at line 164, NOT in the `markdownFiles` loop (lines
+> 271-298). The fix is ~3 lines: in the markdownFiles loop, call
+> `extractFrontmatter` per file, skip files where it returns null, and
+> restrict the pattern match to the frontmatter string only.
+>
+> **Test path correction:** the regression fixture in step 1.4 must go at
+> `tests/integration/validate-agent-authoring/changelog-prose.fixture.md`
+> (vitest watches `tests/integration` per package.json line 19), NOT at the
+> path written in step 1.4. The existing related test is
+> `tests/integration/validate-agent-authoring-review-rule.test.ts`.
+<!-- /deepen-plan -->
+- [x] 1.2: ⚠️ **REVISED at implementation time:** the brainstorm's
+  "frontmatter-only" approach would have lost validation of legitimate
+  body-code-block dispatches (the C-02 INFO matches in plan.md) AND inline
+  `Task(subagent_type=...)` references in command/CLAUDE files (~11 such
+  usages found via grep). Switched to **skip CHANGELOG.md only** at the
+  walk predicate. Rationale: CHANGELOGs document history including
+  deletions; their `subagent_type:` references are not live dispatches
+  and must not be validated against the current agent registry. Single-
+  line filter at `markdownFiles` walk:
+  ```js
+  const markdownFiles = walk(
+    PLUGINS_DIR,
+    (filePath) =>
+      filePath.endsWith('.md') && path.basename(filePath) !== 'CHANGELOG.md'
+  );
+  ```
+  Body-code-block validation, inline `Task(subagent_type=...)`
+  validation, and frontmatter validation all preserved. See
+  `docs/solutions/build-errors/validate-agent-authoring-changelog-skip.md`.
+- [ ] 1.3: Run `pnpm release:check` — verify the false-positive ERROR on
+  `plugins/yellow-review/CHANGELOG.md` no longer fires.
+- [ ] 1.4: Add a regression test:
+  - `tests/validate-agent-authoring/changelog-prose.fixture.md` containing
+    a `yellow-review:review:code-reviewer` reference inside a Markdown bullet
+  - Test asserts the validator does NOT flag this fixture
+  - Pair fixture: a real `agent.md` with a broken `subagent_type:` in
+    frontmatter → must still be flagged
+- [ ] 1.5: Run `pnpm test:unit && pnpm validate:schemas`.
+- [ ] 1.6: Commit with `fix(scripts): restrict subagent_type validator to frontmatter`.
+- [ ] 1.7: `gt submit` → PR 1.
+
+**Acceptance criteria:**
+- `pnpm release:check` exits 0 with no ERROR or unrelated WARNING from
+  this rule.
+- New fixture test passes; broken-frontmatter case still fails as expected.
+- No changes to `plugins/`.
+
+---
+
+### Phase 2 — PR 2: Mechanical single-file edits
+
+**Branch:** `audit/c-02-m-01-m-02-mechanical`
+**Stacks on:** `main` (independent of PR 1; can land in parallel)
+**Plugins touched:** yellow-core, yellow-morph, gt-workflow
+**Changeset required:** yes (one changeset covering all three)
+
+#### 2.1 — C-02: legacy subagent_types in plan.md
+
+- [ ] 2.1.1: Edit `plugins/yellow-core/commands/workflows/plan.md`:
+  - Line 90: `yellow-core:repo-research-analyst` → `yellow-core:research:repo-research-analyst`
+  - Line 98: `yellow-core:best-practices-researcher` → `yellow-core:research:best-practices-researcher`
+  - Line 132: `yellow-core:spec-flow-analyzer` → `yellow-core:workflow:spec-flow-analyzer`
+- [ ] 2.1.2: Run `pnpm validate:agents` — confirm the three INFO warnings
+  on these lines are gone.
+
+#### 2.2 — M-01 reactive: plugin count drift
+
+- [ ] 2.2.1: Edit `CLAUDE.md` line 8 — `"14 plugins"` → `"18 plugins"`.
+- [ ] 2.2.2: Edit `README.md` line 3 — `"17 plugins"` → `"18 plugins"`.
+  *(Bonus finding: README.md was not in the brainstorm but has the same
+  drift; the lint in PR 6 will require both to be correct anyway.)*
+
+#### 2.3 — M-02: chmod +x prewarm hook
+
+- [ ] 2.3.1: `chmod +x plugins/yellow-morph/hooks/scripts/prewarm-morph.sh`
+- [ ] 2.3.2: Run `pnpm validate:schemas` — confirm the WARNING is gone.
+
+#### 2.4 — C-01: gt-workflow namespace exception (doc note)
+
+- [ ] 2.4.1: Open `plugins/gt-workflow/CLAUDE.md`. Add a `## Namespace
+  exception` section after any existing top-level intro section (preserve
+  existing structure). Section content must cover the three points from
+  the brainstorm:
+  1. The seven commands ship un-namespaced intentionally — they predate
+     the namespacing convention.
+  2. Collision risk is low: six are `gt-`-prefixed; only `smart-submit`
+     is generic and no observed conflict.
+  3. Future contributors and auditors should not re-flag without a
+     concrete trigger (real collision or incoming clashing plugin).
+- [ ] 2.4.2: Skip the changeset bump on `gt-workflow` per the brainstorm
+  recommendation — CLAUDE.md is documentation of an existing convention,
+  not a behavior change. (If the CI changeset gate complains, add a patch
+  bump retroactively.)
+
+#### 2.5 — Validation, changeset, commit, submit
+
+- [ ] 2.5.1: Run `pnpm validate:schemas && pnpm validate:agents`.
+- [ ] 2.5.2: `pnpm changeset` — patch bump on `yellow-core` and `yellow-morph`
+  (gt-workflow only if the gate insists; otherwise skip per 2.4.2).
+- [ ] 2.5.3: Normalize line endings on any new/edited files: `sed -i 's/\r$//' <files>`
+  (WSL2 hygiene per project memory).
+- [ ] 2.5.4: Commit with `chore(audit): apply mechanical followups (C-02, M-01 reactive, M-02, C-01 doc)`.
+- [ ] 2.5.5: `gt submit` → PR 2.
+
+**Acceptance criteria:**
+- `pnpm validate:agents` shows zero INFO warnings on `plan.md` lines 90/98/132.
+- `pnpm validate:schemas` shows zero WARNING on `prewarm-morph.sh`.
+- `CLAUDE.md` and `README.md` both say "18 plugins".
+- `gt-workflow/CLAUDE.md` documents the namespace exception in three points.
+- Changeset present; PR CI baseline gate green.
+
+---
+
+### Phase 3 — PR 3: H-01 async morph prewarm
+
+**Branch:** `audit/h-01-morph-async-prewarm`
+**Stacks on:** `main` (independent; can land after PR 1/2)
+**Plugins touched:** yellow-morph
+**Changeset required:** yes (patch bump)
+
+- [ ] 3.1: Read `plugins/yellow-morph/hooks/scripts/prewarm-morph.sh`
+  in full. Identify:
+  - The `json_exit` helper at top
+  - Where the prewarm work begins (likely after sourcing `lib/`)
+  - All exit paths that currently print `{"continue": true}`
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** No precedent exists in any plugin for `& disown`, `nohup`,
+> or `setsid` — grep across `plugins/` returned zero hits. Closest comparable
+> hook is `plugins/yellow-ruvector/hooks/scripts/session-start.sh` but it
+> runs synchronously ("Must complete within 3 seconds"). `prewarm-morph.sh`
+> already has the `json_exit` helper (lines 13-18) correctly in place; the
+> script body ends at line 56. The refactor wraps lines 39-56 in
+> `( ... ) & disown` and moves `json_exit` (no-arg, success) to immediately
+> follow the disown line.
+<!-- /deepen-plan -->
+- [ ] 3.2: Refactor to fork-and-disown:
+  - Wrap the actual prewarm work in `( prewarm_work ) & disown`
+  - Print `{"continue": true}` and exit on the parent immediately after
+    spawning the background subshell — within hundreds of milliseconds, not
+    seconds
+  - The 5s parent timeout (set in plugin.json below) is a defensive ceiling
+    in case the parent itself stalls (e.g., environment lookups)
+  - Keep the existing `json_exit` helper for parent error paths
+  - Background subshell errors must NOT print to stdout (would corrupt the
+    parent's JSON output) — log to stderr only
+
+<!-- deepen-plan: external -->
+> **Research:** The brainstorm's proposed redirect `( prewarm_work >&2 2>&1 ) & disown`
+> contains a logical no-op: `>&2 2>&1` redirects stdout to stderr, then redirects
+> stderr to stderr (the second redirect is a no-op against the redirected
+> stdout). Use `>/dev/null 2>&1` instead — the canonical POSIX form, silences
+> both child streams. If child stderr should still appear in Claude Code's
+> logs, use `>/dev/null` (suppress stdout only, leave stderr through).
+>
+> `disown` alone is sufficient on bash 3.2+ (Linux and macOS — Claude Code's
+> hook runner is not a terminal session leader). `setsid` is Linux-only via
+> util-linux (not in macOS base install) and overkill here. `nohup` is for
+> terminal-hangup paths that don't apply to subprocess hooks. Zombie reaping
+> is automatic via PID 1 reparenting after the parent exits — no `wait` call
+> needed.
+>
+> Recommended final form for step 3.2:
+> ```bash
+> ( prewarm_work >/dev/null 2>&1 ) & disown
+> printf '{"continue": true}\n'
+> ```
+> Sources: bash(1) man page (`disown`, job control, SIGHUP behavior); POSIX
+> signal semantics (zombie reaping via init reparenting).
+<!-- /deepen-plan -->
+- [ ] 3.3: Add a comment block in the script documenting the trade-off:
+  "If the user invokes a morph tool within ~30s of session start on a slow
+  connection, they may still hit a cold cache. This is the accepted
+  trade-off — the alternative blocks every cold session by 30s."
+- [ ] 3.4: Edit `plugins/yellow-morph/.claude-plugin/plugin.json`:
+  - Lower `hooks.SessionStart[0].hooks[0].timeout` from `30` to `5`.
+- [ ] 3.5: Manual smoke test:
+  - Run the script directly: `bash plugins/yellow-morph/hooks/scripts/prewarm-morph.sh`
+  - Confirm parent returns in <1s
+  - Confirm the background prewarm completes (check installed package)
+  - Confirm no zombie children: `ps -ef | grep prewarm` after parent exits
+- [ ] 3.6: Run `pnpm validate:schemas`.
+- [ ] 3.7: `pnpm changeset` — patch bump on `yellow-morph`.
+- [ ] 3.8: Normalize line endings: `sed -i 's/\r$//' plugins/yellow-morph/hooks/scripts/prewarm-morph.sh`.
+- [ ] 3.9: Commit with `perf(yellow-morph): run prewarm in detached background to unblock session start`.
+- [ ] 3.10: `gt submit` → PR 3.
+
+**Acceptance criteria:**
+- Manual run shows parent process exits in <1s.
+- Background subshell completes successfully without zombies.
+- `pnpm validate:schemas` passes.
+- `plugin.json` SessionStart timeout is 5.
+
+---
+
+### Phase 4 — PR 4: X-01 cross-plugin dependency schema  ⚠️ external gate
+
+**Branch:** `audit/x-01-cross-plugin-dependencies`
+**Stacks on:** `main` (independent; do NOT tag a release until smoke test passes)
+**Plugins touched:** yellow-debt, yellow-ci, yellow-chatprd
+**Changeset required:** yes (patch bumps on all three plugins)
+
+<!-- deepen-plan: codebase -->
+> **Codebase BLOCKER:** `schemas/plugin.schema.json` lines 296-327 already
+> define a `dependencies` array with `{name: string, version: semver-range}`
+> items. The brainstorm's proposed `{plugin, reason}` shape **directly
+> conflicts** with the existing definition. `validate-plugin.js` line 26
+> explicitly notes that schema-shape validation for `dependencies` is
+> AJV-delegated to the schema. The schema is locked by `additionalProperties: false`
+> at line 329.
+>
+> **Rule numbering confirmed:** highest existing rule in `validate-plugin.js`
+> is RULE 10 (line 876). The new cross-marketplace check should be RULE 11.
+> `monitors` (schema lines 228-263) is the closest array-of-objects precedent.
+>
+> **Required reconciliation BEFORE coding** — pick one:
+> 1. **(Recommended)** Extend the existing `{name, version}` shape with
+>    optional `optional: boolean` and `reason: string` fields (see external
+>    annotation below for prior art).
+> 2. Introduce a separate `softDependencies` array — increases maintenance
+>    surface, splits intent across two fields.
+> 3. Replace the existing definition — breaks any existing manifests that
+>    use the current `{name, version}` shape (audit needed first).
+<!-- /deepen-plan -->
+
+<!-- deepen-plan: external -->
+> **Research — prior art for inter-plugin deps:**
+>
+> | Ecosystem | Field | Shape | Optional support | Reason text |
+> |---|---|---|---|---|
+> | VS Code | `extensionDependencies` | `string[]` (publisher.id) | No | No |
+> | npm 7+ | `peerDependencies` + `peerDependenciesMeta` | `{name: range}` + `{name: {optional: true}}` | **Yes (companion object)** | No |
+> | JetBrains | `<depends optional="true" config-file="...">` | string ID + attrs | **Yes (inline attr)** | No |
+> | Chrome MV3 | — | (no field) | — | — |
+> | Atom / Obsidian | — | (no field; runtime only) | — | — |
+>
+> **Dominant pattern:** hard deps in one array, optionality as a companion
+> annotation, no reason text in any schema. npm 7's `peerDependenciesMeta`
+> is the canonical "annotate without splitting" approach. JetBrains is the
+> closest precedent for optional-with-structured-consequence.
+>
+> **Recommendation: Option (a) — extend existing shape:**
+> ```json
+> "dependencies": [
+>   {
+>     "name": "yellow-linear",
+>     "version": "*",
+>     "optional": true,
+>     "reason": "debt:sync uses mcp__plugin_yellow-linear_linear__create_issue"
+>   }
+> ]
+> ```
+>
+> Schema changes (apply to existing definition, lines 296-327):
+> - Add optional `optional: boolean` (default `false`) to each dep object
+> - Add optional `reason: string` (informational, no validation enforcement)
+> - Keep `name` + `version` required; preserve existing semver-range validator
+>
+> Validator behavior (RULE 11 in `validate-plugin.js`):
+> - For each `dependencies` entry where `optional !== true`, cross-check
+>   `name` against the marketplace catalog → WARNING if missing.
+> - Optional deps stay silent when missing (matches npm `peerDependenciesMeta`
+>   semantics: declared, not enforced).
+>
+> Mark `reason` as informational in the schema description so future readers
+> understand it is non-normative. No ecosystem ships reason-text in schema,
+> but none prohibits it — net adds an audit trail at zero cost. (Sources:
+> npm `peerDependenciesMeta` docs; VS Code Extension Manifest reference;
+> JetBrains plugin.xml `<depends>` element.)
+<!-- /deepen-plan -->
+
+#### 4.1 — Schema extension
+
+- [ ] 4.1.1: ⚠️ **REVISED per codebase finding:** the `dependencies` field
+  already exists in `schemas/plugin.schema.json` (lines 296-327) with shape
+  `{name: string, version: semver-range}`. **Extend** the existing definition
+  rather than creating a new field:
+  ```json
+  // Existing item shape (lines 296-327) — keep name + version required
+  {
+    "type": "object",
+    "properties": {
+      "name": { "type": "string" },
+      "version": { "type": "string", "format": "semverRange" },
+      "optional": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, validator does not warn if dep is missing from marketplace catalog"
+      },
+      "reason": {
+        "type": "string",
+        "description": "Informational — explains why this plugin is required. Not validated."
+      }
+    },
+    "required": ["name", "version"],
+    "additionalProperties": false
+  }
+  ```
+- [ ] 4.1.2: Confirm `additionalProperties: false` at the manifest top level
+  is unchanged (the field already exists there); only the per-item object
+  schema needs the additions.
+
+#### 4.2 — Validator soft-warn
+
+- [ ] 4.2.1: Edit `scripts/validate-plugin.js`. Add RULE 11 (verified — current
+  highest is RULE 10 at line 876):
+  - For each plugin manifest, if `dependencies` is present, iterate each
+    entry's `name` field (NOT `plugin` — the existing schema field is `name`)
+  - Skip entries where `optional === true` (matches npm `peerDependenciesMeta`
+    semantics: declared but not enforced)
+  - Cross-check against the marketplace catalog (`.claude-plugin/marketplace.json`)
+  - If declared (non-optional) dep not present in catalog: WARNING (not ERROR)
+    with message naming the consuming plugin, the missing dep `name`, the
+    declared `version`, and the `reason` field for context if present
+- [ ] 4.2.2: Add a unit test fixture: a manifest declaring `dependencies:
+  [{plugin: "non-existent-plugin", reason: "..."}]` — expect WARNING.
+- [ ] 4.2.3: Add a positive test: declaring `yellow-linear` as a dep
+  → no warning.
+
+#### 4.3 — Manifest declarations
+
+- [ ] 4.3.1: Edit `plugins/yellow-debt/.claude-plugin/plugin.json`:
+  ```json
+  "dependencies": [
+    {
+      "name": "yellow-linear",
+      "version": "*",
+      "optional": true,
+      "reason": "debt:sync uses mcp__plugin_yellow-linear_linear__create_issue"
+    }
+  ]
+  ```
+- [ ] 4.3.2: Edit `plugins/yellow-ci/.claude-plugin/plugin.json`:
+  ```json
+  "dependencies": [
+    {
+      "name": "yellow-linear",
+      "version": "*",
+      "optional": true,
+      "reason": "ci:report-linear uses mcp__plugin_yellow-linear_linear__create_issue"
+    }
+  ]
+  ```
+- [ ] 4.3.3: Edit `plugins/yellow-chatprd/.claude-plugin/plugin.json`:
+  ```json
+  "dependencies": [
+    {
+      "name": "yellow-linear",
+      "version": "*",
+      "optional": true,
+      "reason": "chatprd:link-linear uses mcp__plugin_yellow-linear_linear__create_issue"
+    }
+  ]
+  ```
+
+  **Why `optional: true`:** the consumer plugins degrade gracefully when
+  yellow-linear is missing (Linear-specific commands surface "MCP not found"
+  rather than crashing the install). Marking the deps optional prevents the
+  validator from warning on installations that legitimately omit yellow-linear.
+  Hard-required deps (`optional: false` or omitted) would warn at validate
+  time but still install — the warning serves as the audit signal.
+
+#### 4.4 — Validation, changeset, smoke gate, submit
+
+- [ ] 4.4.1: Run `pnpm validate:schemas` and `pnpm test:unit`.
+- [ ] 4.4.2: `pnpm changeset` — patch bumps on `yellow-debt`, `yellow-ci`,
+  `yellow-chatprd`. The schemas/scripts changes do not require a changeset.
+- [ ] 4.4.3: ⚠️ **External gate — do NOT tag a release until this passes:**
+  Fresh `claude plugin install` on a clean machine for at least one of the
+  three modified plugins. Confirm Claude Code's remote validator accepts
+  the new `dependencies` field. Local CI passing does NOT guarantee
+  acceptance (per project memory: "Local CI ≠ remote validation").
+  - If remote rejects: rework the field shape, do NOT silently strip the
+    field; document the rejection mode in `docs/solutions/build-errors/`.
+- [ ] 4.4.4: Normalize line endings: `sed -i 's/\r$//' <touched JSON files>`.
+- [ ] 4.4.5: Commit with `feat(plugins): declare cross-plugin MCP dependencies (X-01)`.
+- [ ] 4.4.6: `gt submit` → PR 4.
+
+**Acceptance criteria:**
+- `pnpm validate:schemas` passes; new dep field validates against schema.
+- `pnpm validate:plugins` warns (not errors) on a manifest declaring a
+  fictional dep; passes silently when deps are valid.
+- All three modified manifests declare `yellow-linear` as a dep with
+  human-readable reason text.
+- Fresh-install smoke test passes before any release tag.
+
+---
+
+### Phase 5 — PR 5: A-01 model pins + A-02 Phase 1 tool restrictions
+
+**Branch:** `audit/a-01-model-pins-a-02-tool-restrictions`
+**Stacks on:** `main` (independent; can land after PR 1)
+**Plugins touched:** yellow-core, yellow-review, yellow-research, yellow-codex, yellow-linear
+**Changeset required:** yes (patch bumps on all five)
+
+#### 5.1 — A-01: pin opus on five deep-analysis review personas
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Existing pinned agent
+> `plugins/yellow-core/agents/review/architecture-strategist.md` line 4
+> uses `model: opus` (bare string), NOT `claude-opus-4-5` or any qualified
+> identifier. The plan's hedging on the opus identifier is **resolved: use
+> `model: opus`** for all 5 A-01 targets to match precedent.
+>
+> Note: the plan References section lists `audit-synthesizer.md` under
+> `agents/synthesis/` — this directory does **not exist** in the current
+> codebase. Update that reference; only `architecture-strategist.md` is
+> a confirmed precedent.
+<!-- /deepen-plan -->
+
+For each file below, change `model: inherit` (currently line 4 in all
+five) to `model: opus` (bare string, matching `architecture-strategist.md`
+precedent):
+
+- [ ] 5.1.1: `plugins/yellow-core/agents/review/security-sentinel.md` → `model: opus`
+- [ ] 5.1.2: `plugins/yellow-core/agents/review/performance-oracle.md` → `model: opus`
+- [ ] 5.1.3: `plugins/yellow-review/agents/review/adversarial-reviewer.md` → `model: opus`
+- [ ] 5.1.4: `plugins/yellow-review/agents/review/agent-cli-readiness-reviewer.md` → `model: opus`
+- [ ] 5.1.5: `plugins/yellow-review/agents/review/agent-native-reviewer.md` → `model: opus`
+- [ ] 5.1.6: Run `pnpm validate:agents` — clean; each frontmatter has a
+  single-line `model:` field.
+
+#### 5.2 — A-02 Phase 1: tool restrictions on read-only research agents
+
+<!-- deepen-plan: codebase -->
+> **Codebase — verified current `tools:` per-agent (read agent body BEFORE editing):**
+>
+> | Agent | Current `tools:` | Plan target | Final action |
+> |---|---|---|---|
+> | `learnings-researcher` | `Read, Grep, Glob` | `[Read, Grep, Glob]` | **No-op — already at target, skip** |
+> | `repo-research-analyst` | `Read, Grep, Glob, Bash` | `[Read, Grep, Glob]` | **Keep Bash** (used in body) → `[Read, Grep, Glob, Bash]` |
+> | `best-practices-researcher` | `WebSearch, WebFetch, Read, Glob, Grep` | `[Read, Grep, Glob]` | **Keep WebSearch + WebFetch** → `[Read, Grep, Glob, WebSearch, WebFetch]` |
+> | `git-history-analyzer` | `Bash, Read, Grep, Glob` | `[Read, Grep, Glob, Bash]` | Plan correct |
+> | `spec-flow-analyzer` | `Read, Grep, Glob, Bash` | `[Read, Grep, Glob]` | **Keep Bash** → `[Read, Grep, Glob, Bash]` |
+> | `code-researcher` | `Read, Grep, Glob, Bash, ToolSearch, 4× MCP` | `[Read, Grep, Glob]` | **Far too narrow — keep ToolSearch + MCP tools**; A-02 is a no-op for this agent |
+> | `codex-analyst` | `Bash, Read, Grep, Glob` | `[Read, Grep, Glob, Bash]` | Plan correct |
+> | `linear-explorer` | `Bash, ToolSearch, 5× MCP` (no Read/Grep/Glob) | `[Read, Grep, Glob, ToolSearch, mcp__*]` | **Verify Read/Grep/Glob are used in body before adding** — if not used, leave unchanged |
+>
+> **Net effect:** A-02 P1 is mostly a confirmation/audit pass, not a
+> restriction pass. Only `git-history-analyzer` and `codex-analyst` exactly
+> match the brainstorm's restriction list. `learnings-researcher` is already
+> minimal. The other five require per-body verification and produce
+> narrower changes than the brainstorm anticipated. The hardening value is
+> still present — it codifies "no Edit/Write" on agents that don't have it
+> — but the diff per agent is small or empty.
+<!-- /deepen-plan -->
+
+For each agent below, update the frontmatter `tools:` field. The
+brainstorm specifies `[Read, Grep, Glob]` for pure read-only agents; for
+`git-history-analyzer` add `Bash` (verified open question — git commands
+are required). Before editing each file, read the existing `tools:` value
+to confirm the change is a strict narrowing (no functional regression):
+
+**Per-agent actions (revised per codebase findings above):**
+
+- [ ] 5.2.1: `plugins/yellow-core/agents/research/learnings-researcher.md`
+  → **No-op** (already `[Read, Grep, Glob]`); document in commit message
+  that this agent was audited and confirmed minimal.
+- [ ] 5.2.2: `plugins/yellow-core/agents/research/repo-research-analyst.md`
+  → keep current `[Read, Grep, Glob, Bash]`; **no-op** unless body shows
+  Bash is unused. Audit only.
+- [ ] 5.2.3: `plugins/yellow-core/agents/research/best-practices-researcher.md`
+  → keep `[WebSearch, WebFetch, Read, Glob, Grep]`; **no-op** unless body
+  shows WebSearch/WebFetch unused. Audit only.
+- [ ] 5.2.4: `plugins/yellow-core/agents/research/git-history-analyzer.md`
+  → confirm `[Bash, Read, Grep, Glob]` is current; **no-op** (resolves
+  brainstorm Open Question 2 — Bash is required and present).
+- [ ] 5.2.5: `plugins/yellow-core/agents/workflow/spec-flow-analyzer.md`
+  → keep current `[Read, Grep, Glob, Bash]`; **no-op** unless body shows
+  Bash is unused. Audit only.
+- [ ] 5.2.6: `plugins/yellow-research/agents/research/code-researcher.md`
+  → keep current full set (`Read, Grep, Glob, Bash, ToolSearch, 4× MCP`);
+  **no-op** — restricting to `[Read, Grep, Glob]` would break the agent.
+  Audit only.
+- [ ] 5.2.7: `plugins/yellow-codex/agents/research/codex-analyst.md`
+  → confirm `[Bash, Read, Grep, Glob]` is current; **no-op** (Bash needed
+  for Codex CLI invocation).
+- [ ] 5.2.8: `plugins/yellow-linear/agents/research/linear-explorer.md`
+  → read body to verify whether Read/Grep/Glob are actually used. If yes,
+  add them to the existing `[Bash, ToolSearch, mcp__*]` set. If no, leave
+  unchanged. **Decision deferred to body inspection at edit time.**
+
+**A-02 P1 is largely an audit/confirmation pass.** The brainstorm
+overestimated the restriction surface — most agents already have the
+narrowed scope or legitimately need additional tools. Document the audit
+outcome in the PR description so future contributors see "these 8 agents
+were checked for least-privilege; current tools are correct."
+
+**On-touch rule reminder:** every edited `.md` must have:
+- Single-line `description:` (NOT folded scalar `>` and NOT multi-line
+  single-quoted) — grep `'^description: [>|]'` after edits
+- `user-invokable` (with k), NOT `user-invocable`, if it's a skill (not
+  applicable here, but verify)
+- LF line endings (run `sed -i 's/\r$//' <file>` after each edit on WSL2)
+
+#### 5.3 — Validation, changeset, submit
+
+- [ ] 5.3.1: Run `pnpm validate:agents && pnpm validate:schemas`.
+- [ ] 5.3.2: `pnpm changeset` — patch bumps on all five plugins:
+  yellow-core, yellow-review, yellow-research, yellow-codex, yellow-linear.
+- [ ] 5.3.3: Normalize line endings on all 13 modified `.md` files.
+- [ ] 5.3.4: Commit with `feat(agents): pin opus on deep reviewers + restrict tools on read-only research agents (A-01, A-02 P1)`.
+- [ ] 5.3.5: `gt submit` → PR 5.
+
+**Acceptance criteria:**
+- All 5 A-01 agents have `model: <opus-id>` (matching existing pinned
+  pattern — read one to confirm exact string).
+- All 8 A-02 P1 agents have a narrowed `tools:` field.
+- `pnpm validate:agents` passes clean.
+- No agent regressions: each restricted agent still has the tools it
+  actually uses (verified by reading agent body before editing).
+
+---
+
+### Phase 6 — PR 6: M-01 preventive — `validate-doc-counts.js`
+
+**Branch:** `audit/m-01-doc-counts-lint`
+**Stacks on:** `main` (independent; can land after PR 2)
+**Plugins touched:** none (scripts/, root docs/, package.json)
+**Changeset required:** no (scripts and root docs only)
+
+- [ ] 6.1: Create `scripts/validate-doc-counts.js` (~50 lines) that:
+  - Reads `.claude-plugin/marketplace.json` → `plugins.length` is the
+    canonical count
+  - Greps `CLAUDE.md`, `README.md`, and all root-level `.md` files (not
+    inside `plugins/`, `docs/solutions/`, or `node_modules/`) for these
+    patterns:
+    - `\d+ plugins` (case-insensitive)
+    - `\d+ marketplace plugins`
+    - `\d+ consumers` (audit also tracks consumer count drift)
+  - For each match, parse the integer and compare to canonical
+  - Mismatch → `process.exit(1)` with a message naming the file, line
+    number, found count, and expected count
+  - Match → silent success
+  - `console.error` for tooling output (stderr); reserve stdout for
+    machine-readable mode if needed
+- [ ] 6.2: Add unit test at `tests/integration/validate-doc-counts.test.ts`
+  (vitest watches `tests/integration` per package.json line 19; fixture path
+  in earlier draft was wrong):
+  - Describe block: `describe('validate-doc-counts', ...)` matching the
+    convention in `tests/integration/validate-plugin.test.ts`
+  - Fixture: temp file with `"15 plugins"` when canonical is 18 → expect
+    exit 1 with the file/line/expected/found in stderr
+  - Fixture: temp file with `"18 plugins"` → expect exit 0
+  - Fixture: temp file with no count claim → expect exit 0
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Current `release:check` (package.json line 29):
+> ```text
+> "release:check": "pnpm run validate:schemas && pnpm run validate:versions && pnpm run typecheck"
+> ```
+> Insert `validate:doc-counts` after `validate:versions`, before `typecheck`:
+> ```text
+> "release:check": "pnpm run validate:schemas && pnpm run validate:versions && pnpm run validate:doc-counts && pnpm run typecheck"
+> ```
+> The `&&` chaining pattern is used consistently in the package.json scripts
+> block. Test convention from `tests/integration/validate-plugin.test.ts`:
+> describe-block named for the script, vitest auto-discovers from
+> `--dir tests/integration`.
+<!-- /deepen-plan -->
+- [ ] 6.3: Wire into `package.json`:
+  - Add script: `"validate:doc-counts": "node scripts/validate-doc-counts.js"`
+  - Add to `release:check`: chain after `validate:versions` (so the
+    full chain becomes `validate:schemas && validate:versions && validate:doc-counts && typecheck`)
+- [ ] 6.4: Manual sanity check:
+  - Run `pnpm validate:doc-counts` on the post-PR-2 tree → expect exit 0
+    (PR 2 already fixed CLAUDE.md and README.md)
+  - Temporarily edit CLAUDE.md to `"17 plugins"` → run again → expect exit 1
+  - Restore CLAUDE.md
+- [ ] 6.5: Run full `pnpm release:check` → confirm clean.
+- [ ] 6.6: Normalize line endings on the new script: `sed -i 's/\r$//' scripts/validate-doc-counts.js`.
+- [ ] 6.7: Commit with `feat(scripts): add validate-doc-counts.js to catch narrative-doc count drift`.
+- [ ] 6.8: `gt submit` → PR 6.
+
+**Acceptance criteria:**
+- `pnpm validate:doc-counts` exists as a standalone npm script.
+- `pnpm release:check` invokes it and fails fast on any mismatch.
+- Unit tests cover positive, negative (mismatch), and absent-claim cases.
+- Adding a fake `"99 plugins"` to any root narrative doc fails the check
+  with file/line context.
+
+---
+
+## Technical Specifications
+
+### Files to Modify
+
+| Phase | File | Change |
+|---|---|---|
+| 1 | `scripts/validate-agent-authoring.js` | Frontmatter-only matching for `subagent_type:` rule |
+| 2 | `plugins/yellow-core/commands/workflows/plan.md` | Lines 90, 98, 132: 2-segment → 3-segment |
+| 2 | `CLAUDE.md` | Line 8: `14` → `18` |
+| 2 | `README.md` | Line 3: `17` → `18` |
+| 2 | `plugins/yellow-morph/hooks/scripts/prewarm-morph.sh` | `chmod +x` |
+| 2 | `plugins/gt-workflow/CLAUDE.md` | Append `## Namespace exception` section |
+| 3 | `plugins/yellow-morph/hooks/scripts/prewarm-morph.sh` | Fork-and-disown refactor |
+| 3 | `plugins/yellow-morph/.claude-plugin/plugin.json` | `timeout: 30` → `5` |
+| 4 | `schemas/plugin.schema.json` | Add optional `dependencies` field |
+| 4 | `scripts/validate-plugin.js` | Add cross-marketplace dep check (warn) |
+| 4 | `plugins/yellow-debt/.claude-plugin/plugin.json` | Declare `yellow-linear` dep |
+| 4 | `plugins/yellow-ci/.claude-plugin/plugin.json` | Declare `yellow-linear` dep |
+| 4 | `plugins/yellow-chatprd/.claude-plugin/plugin.json` | Declare `yellow-linear` dep |
+| 5 | 5× review agent `.md` files | `model: inherit` → `model: <opus>` |
+| 5 | 8× research agent `.md` files | Narrow `tools:` field |
+| 6 | `package.json` | Add `validate:doc-counts` script; chain into `release:check` |
+
+### Files to Create
+
+- `scripts/validate-doc-counts.js` — narrative-doc count lint (~50 lines)
+- `tests/validate-doc-counts.test.ts` — unit tests for the lint
+- `tests/validate-agent-authoring/changelog-prose.fixture.md` — regression
+  fixture for X-02
+
+### Dependencies
+
+None added. All work uses existing tooling (Node, jq for shell, AJV for
+schema, vitest for tests).
+
+### API Changes
+
+**`schemas/plugin.schema.json`** gains an optional top-level `dependencies`
+array. Existing manifests without the field validate unchanged.
+
+```json
+// Before
+{
+  "name": "yellow-debt",
+  "version": "1.x.x"
+  // ...
+}
+
+// After (optional)
+{
+  "name": "yellow-debt",
+  "version": "1.x.x",
+  "dependencies": [
+    { "plugin": "yellow-linear", "reason": "debt:sync uses ..." }
+  ]
+}
+```
+
+**Validator output** gains a new WARNING category (not ERROR) for
+declared deps missing from marketplace — does not break any existing
+gate. PR 4 must verify Claude Code's remote validator accepts the new
+field via fresh-install smoke test.
+
+### Database Changes
+
+None.
+
+## Testing Strategy
+
+### Per-PR validation gates
+
+| PR | Required gates |
+|---|---|
+| 1 | `pnpm test:unit && pnpm validate:schemas && pnpm release:check` |
+| 2 | `pnpm validate:schemas && pnpm validate:agents` |
+| 3 | Manual smoke (parent <1s, no zombies) + `pnpm validate:schemas` |
+| 4 | `pnpm validate:schemas && pnpm test:unit` + ⚠️ fresh-install smoke |
+| 5 | `pnpm validate:agents && pnpm validate:schemas` |
+| 6 | `pnpm release:check` (now includes `validate:doc-counts`) |
+
+### Regression fixtures
+
+- **X-02 fixture (PR 1):** prose mention of a deprecated subagent_type
+  inside `tests/validate-agent-authoring/changelog-prose.fixture.md` →
+  must NOT trigger the validator
+- **X-01 fixtures (PR 4):** unit-test fixture with a fictional dep →
+  must trigger WARNING; positive fixture with valid dep → must pass
+- **M-01 fixtures (PR 6):** three fixtures (mismatch, match, absent
+  claim) covering exit codes 1/0/0
+
+### Manual checks
+
+- **PR 3 H-01:** time `bash plugins/yellow-morph/hooks/scripts/prewarm-morph.sh`
+  → parent must exit in <1s; check `ps -ef | grep prewarm` after parent
+  exits → background subshell may still run, but no zombies (`Z` in `ps`).
+- **PR 4 X-01 smoke gate:** fresh `claude plugin install yellow-debt`
+  on a clean Claude Code install. Confirm install succeeds and the
+  remote validator does not reject the new `dependencies` field.
+
+## Acceptance Criteria
+
+1. **X-02 fixed:** `pnpm release:check` exits 0 on the post-PR-1 tree;
+   the fixture-based regression test is in place.
+2. **C-02 fixed:** `pnpm validate:agents` shows zero INFO warnings on
+   `yellow-core/commands/workflows/plan.md`.
+3. **H-01 fixed:** parent process of `prewarm-morph.sh` exits in <1s;
+   SessionStart timeout in `plugin.json` is 5; trade-off comment present
+   in script.
+4. **X-01 fixed:** all three consumer plugins declare `yellow-linear` as
+   a dep with human-readable reasons; validator warns on missing deps;
+   fresh-install smoke test passes.
+5. **A-01 fixed:** all 5 deep-analysis reviewers have explicit `model:`
+   pinning (opus); none on `inherit`.
+6. **A-02 P1 fixed:** all 8 read-only research agents have a narrowed
+   `tools:` field; none inherit `Edit`/`Write` they don't use.
+7. **M-01 fixed:** `CLAUDE.md` and `README.md` reflect 18 plugins;
+   `validate-doc-counts.js` lint catches future drift; wired into
+   `release:check`.
+8. **M-02 fixed:** `prewarm-morph.sh` is executable; no validator WARNING.
+9. **C-01 documented:** `plugins/gt-workflow/CLAUDE.md` has the three-point
+   namespace exception block.
+
+## Edge Cases & Error Handling
+
+- **PR 1 — frontmatter detection edge case:** files without frontmatter
+  (CHANGELOG.md, README.md) must be skipped, not treated as "frontmatter
+  with empty content." Test with a fixture that has a YAML-like block
+  inside fenced code (` ```yaml … ``` `) — must not be parsed as
+  frontmatter.
+- **PR 3 — fork race:** if the parent exits before `disown` completes,
+  the subshell may receive SIGHUP. The standard pattern handles this:
+  `( prewarm_work ) & disown` runs `disown` synchronously before the
+  parent returns. Verify with `ps` after a manual run.
+- **PR 3 — stdout corruption:** background subshell must NEVER write to
+  stdout (the parent's `{"continue": true}` line is the only stdout
+  output Claude Code reads). Redirect all background output: `( prewarm_work
+  >&2 2>&1 ) & disown` or similar.
+- **PR 4 — schema rejection by remote:** if Claude Code's remote
+  validator rejects the new `dependencies` field, do NOT silently strip
+  it. Document the rejection in `docs/solutions/build-errors/` and
+  rework the field shape (e.g., move under a custom namespace or escape
+  via `metadata`).
+- **PR 4 — circular declaration:** validator must not treat self-reference
+  as a dep (a plugin declaring itself as a dep). Add fixture if not
+  already covered.
+- **PR 5 — agent body uses tools not in restricted set:** before editing
+  each agent's `tools:` field, read the body and confirm no tool not in
+  the new list is invoked. Specifically check `Bash`, `Edit`, `Write`,
+  `WebFetch`, `WebSearch`, `Task` invocations in the prompt body.
+- **PR 6 — false positive on legitimate count claim:** if a doc says
+  `"34 consumers"` (different metric, see PR #785 history), the lint must
+  not fail. Limit pattern to specific phrases listed in 6.1, not bare
+  `\d+`.
+
+## Performance Considerations
+
+- **H-01 expected impact:** session start latency drops from ~30s
+  (synchronous prewarm) to <1s (parent only) for users with morph
+  installed. Measured via the manual smoke gate; an empirical baseline
+  belongs in a separate project (Risk 7 — deferred).
+- **Validator changes (PRs 1, 4, 6):** add a few file scans + a few
+  cross-references. Negligible impact on `pnpm release:check` runtime
+  (already O(n) over manifests).
+
+## Security Considerations
+
+- **PR 5 A-02 P1:** restricting tools is a least-privilege improvement,
+  not a regression. Read-only agents that previously inherited `Edit`/`Write`
+  could not have legitimately needed them; restriction blocks accidental
+  workspace mutation by these agents.
+- **PR 4 X-01:** dependency declaration does not introduce code execution.
+  The validator only reads and compares strings.
+- **No new external surface:** all changes are local to scripts, schemas,
+  manifests, and agent metadata. No new MCP servers, no new userConfig,
+  no new userland-facing input parsing.
+
+## Migration & Rollback
+
+- **PR 1:** scripts-only change. Rollback = revert commit. No user data
+  affected.
+- **PR 2:** mechanical edits. Rollback = revert. No user data affected.
+- **PR 3:** if the async pattern misbehaves in the wild, rollback restores
+  synchronous prewarm with `timeout: 30`. Communicate via plugin.json
+  changelog if revert ships.
+- **PR 4:** ⚠️ migration step — fresh-install smoke test BEFORE tagging.
+  If remote validator rejects, rollback to `main` and rework field shape
+  before re-attempting. Document in `docs/solutions/build-errors/` per
+  project memory pattern.
+- **PR 5:** model pins and tool restrictions are reversible by reverting
+  the agent `.md` files. No state migration.
+- **PR 6:** lint addition. Rollback = revert. No effect on existing
+  release pipeline beyond removing the new gate.
+
+## Stack Decomposition
+<!-- stack-topology: parallel -->
+<!-- stack-trunk: main -->
+
+PRs 2-6 are mutually independent off `main`. PR 1 is the recommended anchor
+because it clears the active `pnpm release:check` blocker, but no PR
+formally depends on another. Topology is `parallel` — each branch is created
+from trunk, not stacked.
+
+### 1. agent/audit/x-02-validator-frontmatter-only
+- **Type:** fix
+- **Description:** restrict subagent_type validator to YAML frontmatter
+- **Scope:** scripts/validate-agent-authoring.js, tests/integration/validate-agent-authoring/changelog-prose.fixture.md, AUDIT_REPORT.md, docs/brainstorms/2026-05-07-audit-followups-brainstorm.md, plans/audit-followups-2026-05-07.md
+- **Tasks:** 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7
+- **Depends on:** (none)
+
+### 2. agent/audit/c-02-m-01-m-02-mechanical
+- **Type:** chore
+- **Description:** apply mechanical audit followups (C-02, M-01 reactive, M-02, C-01 doc note)
+- **Scope:** plugins/yellow-core/commands/workflows/plan.md, CLAUDE.md, README.md, plugins/yellow-morph/hooks/scripts/prewarm-morph.sh, plugins/gt-workflow/CLAUDE.md
+- **Tasks:** 2.1.1, 2.1.2, 2.2.1, 2.2.2, 2.3.1, 2.3.2, 2.4.1, 2.4.2, 2.5.1, 2.5.2, 2.5.3, 2.5.4, 2.5.5
+- **Depends on:** (none)
+
+### 3. agent/audit/h-01-morph-async-prewarm
+- **Type:** perf
+- **Description:** run yellow-morph prewarm in detached background to unblock session start
+- **Scope:** plugins/yellow-morph/hooks/scripts/prewarm-morph.sh, plugins/yellow-morph/.claude-plugin/plugin.json
+- **Tasks:** 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10
+- **Depends on:** (none)
+
+### 4. agent/audit/x-01-cross-plugin-dependencies
+- **Type:** feat
+- **Description:** declare cross-plugin MCP dependencies via existing schema dependencies field
+- **Scope:** schemas/plugin.schema.json, scripts/validate-plugin.js, plugins/yellow-debt/.claude-plugin/plugin.json, plugins/yellow-ci/.claude-plugin/plugin.json, plugins/yellow-chatprd/.claude-plugin/plugin.json
+- **Tasks:** 4.1.1, 4.1.2, 4.2.1, 4.2.2, 4.2.3, 4.3.1, 4.3.2, 4.3.3, 4.4.1, 4.4.2, 4.4.3, 4.4.4, 4.4.5, 4.4.6
+- **Depends on:** (none) — ⚠️ external gate: do NOT tag a release until fresh `claude plugin install` smoke test passes
+
+### 5. agent/audit/a-01-model-pins-a-02-tool-restrictions
+- **Type:** feat
+- **Description:** pin opus on deep-analysis review personas + audit tools on read-only research agents
+- **Scope:** plugins/yellow-core/agents/review/security-sentinel.md, plugins/yellow-core/agents/review/performance-oracle.md, plugins/yellow-review/agents/review/adversarial-reviewer.md, plugins/yellow-review/agents/review/agent-cli-readiness-reviewer.md, plugins/yellow-review/agents/review/agent-native-reviewer.md, plugins/yellow-core/agents/research/, plugins/yellow-core/agents/workflow/spec-flow-analyzer.md, plugins/yellow-research/agents/research/code-researcher.md, plugins/yellow-codex/agents/research/codex-analyst.md, plugins/yellow-linear/agents/research/linear-explorer.md
+- **Tasks:** 5.1.1, 5.1.2, 5.1.3, 5.1.4, 5.1.5, 5.1.6, 5.2.1, 5.2.2, 5.2.3, 5.2.4, 5.2.5, 5.2.6, 5.2.7, 5.2.8, 5.3.1, 5.3.2, 5.3.3, 5.3.4, 5.3.5
+- **Depends on:** (none)
+
+### 6. agent/audit/m-01-doc-counts-lint
+- **Type:** feat
+- **Description:** add validate-doc-counts.js to catch narrative-doc plugin-count drift
+- **Scope:** scripts/validate-doc-counts.js, tests/integration/validate-doc-counts.test.ts, package.json
+- **Tasks:** 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8
+- **Depends on:** (none) — works best after item 2 lands so the lint passes its baseline check
+
+## References
+
+### Source documents
+- `docs/brainstorms/2026-05-07-audit-followups-brainstorm.md` — decisions
+- `AUDIT_REPORT.md` — full audit + executive summary
+
+### Project docs
+- `CLAUDE.md` — repository purpose, validator chain, release flow
+- `AGENTS.md` — critical agent authoring rules (referenced by PR 5)
+- `docs/solutions/build-errors/userconfig-type-title-remote-validator-drift.md`
+  — precedent for "local CI ≠ remote validation" (PR 4 smoke gate)
+- `docs/solutions/code-quality/skill-frontmatter-attribute-and-format-requirements.md`
+  — single-line description rule (PR 5 on-touch)
+
+### Schemas + scripts
+- `schemas/plugin.schema.json` — modified by PR 4
+- `scripts/validate-agent-authoring.js` — modified by PR 1
+- `scripts/validate-plugin.js` — modified by PR 4
+- `scripts/validate-doc-counts.js` — created by PR 6
+
+### Existing pinned-model agents (reference for PR 5 A-01)
+- `plugins/yellow-core/agents/review/architecture-strategist.md` (opus) ← **confirmed precedent; uses `model: opus` bare**
+- `plugins/yellow-research/agents/research/research-conductor.md` (opus)
+- `plugins/yellow-docs/agents/review/coherence-reviewer.md` (haiku)
+- ~~`plugins/yellow-core/agents/synthesis/audit-synthesizer.md`~~ — **does not exist** (corrected by codebase research)
+
+<!-- deepen-plan: external -->
+> **External research sources** (used in PR 3 and PR 4 annotations above):
+> - npm `peerDependencies` + `peerDependenciesMeta` semantics (npm 7+ — canonical
+>   "annotate without splitting" pattern for optional peer deps)
+> - VS Code Extension Manifest reference — `extensionDependencies` shape
+>   (string-array, no optionality, no reason field)
+>   <https://code.visualstudio.com/api/references/extension-manifest>
+> - JetBrains plugin.xml — `<depends optional="true" config-file="...">`:
+>   closest precedent for optional-with-structured-consequence
+> - Chrome Extensions Manifest V3 — confirms absence of cross-extension dep field
+> - bash(1) man page — `disown`, job control, SIGHUP signal forwarding behavior
+> - POSIX signal semantics — zombie reaping via PID 1 (init/launchd) reparenting
+>
+> Ceramic and Tavily MCP sources returned no useful results for these queries
+> (Ceramic: 0 hits for plugin dep schemas; Tavily: API key absent). Synthesis
+> from training data on stable specifications.
+<!-- /deepen-plan -->
+
+### Items NOT addressed in this cycle
+- A-02 Phase 2 (write-capable agent restrictions) — separate brainstorm
+- S-01 (`create-agent-skills` SKILL.md line count) — soft-cap, no proven duplication
+- Risk 6 (changeset enforcement gap) — separate audit topic
+- Risk 7 (empirical hook latency baseline) — separate validation project

--- a/plans/audit-followups-2026-05-07.md
+++ b/plans/audit-followups-2026-05-07.md
@@ -209,12 +209,15 @@ only one with an explicit external gate.
   `docs/solutions/build-errors/validate-agent-authoring-changelog-skip.md`.
 - [ ] 1.3: Run `pnpm release:check` — verify the false-positive ERROR on
   `plugins/yellow-review/CHANGELOG.md` no longer fires.
-- [ ] 1.4: Add a regression test:
-  - `tests/validate-agent-authoring/changelog-prose.fixture.md` containing
-    a `yellow-review:review:code-reviewer` reference inside a Markdown bullet
-  - Test asserts the validator does NOT flag this fixture
-  - Pair fixture: a real `agent.md` with a broken `subagent_type:` in
-    frontmatter → must still be flagged
+- [ ] 1.4: Add regression coverage at
+  `tests/integration/validate-agent-authoring-changelog-skip.test.ts`
+  (Vitest integration test, not a static fixture). Three cases:
+  1. CHANGELOG.md containing a deleted-agent `subagent_type:` reference →
+     validator does NOT flag it.
+  2. Non-CHANGELOG markdown (e.g., a command file) with the same reference →
+     validator STILL flags it.
+  3. Both files present → only the non-CHANGELOG file is flagged; CHANGELOG
+     remains silent.
 - [ ] 1.5: Run `pnpm test:unit && pnpm validate:schemas`.
 - [ ] 1.6: Commit with `fix(scripts): restrict subagent_type validator to frontmatter`.
 - [ ] 1.7: `gt submit` → PR 1.
@@ -767,7 +770,7 @@ were checked for least-privilege; current tools are correct."
 
 | Phase | File | Change |
 |---|---|---|
-| 1 | `scripts/validate-agent-authoring.js` | Frontmatter-only matching for `subagent_type:` rule |
+| 1 | `scripts/validate-agent-authoring.js` | Skip `CHANGELOG.md` files in the `markdownFiles` walk predicate (revised from the brainstormed frontmatter-only approach — see Phase 1 / step 1.2 for rationale) |
 | 2 | `plugins/yellow-core/commands/workflows/plan.md` | Lines 90, 98, 132: 2-segment → 3-segment |
 | 2 | `CLAUDE.md` | Line 8: `14` → `18` |
 | 2 | `README.md` | Line 3: `17` → `18` |
@@ -814,7 +817,7 @@ array. Existing manifests without the field validate unchanged.
   "name": "yellow-debt",
   "version": "1.x.x",
   "dependencies": [
-    { "plugin": "yellow-linear", "reason": "debt:sync uses ..." }
+    { "name": "yellow-linear", "version": "*", "optional": true, "reason": "debt:sync uses ..." }
   ]
 }
 ```

--- a/scripts/validate-agent-authoring.js
+++ b/scripts/validate-agent-authoring.js
@@ -141,7 +141,15 @@ const agentFiles = walk(
     filePath.includes(`${path.sep}agents${path.sep}`) &&
     filePath.endsWith('.md')
 );
-const markdownFiles = walk(PLUGINS_DIR, (filePath) => filePath.endsWith('.md'));
+// Skip CHANGELOG.md files: they document history including agents that have
+// since been deleted/renamed, so subagent_type references in CHANGELOG prose
+// are not live dispatches and must not be validated against the current
+// agent registry. See `docs/solutions/build-errors/` for context.
+const markdownFiles = walk(
+  PLUGINS_DIR,
+  (filePath) =>
+    filePath.endsWith('.md') && path.basename(filePath) !== 'CHANGELOG.md'
+);
 const commandFiles = walk(
   PLUGINS_DIR,
   (filePath) =>

--- a/scripts/validate-agent-authoring.js
+++ b/scripts/validate-agent-authoring.js
@@ -148,7 +148,8 @@ const agentFiles = walk(
 const markdownFiles = walk(
   PLUGINS_DIR,
   (filePath) =>
-    filePath.endsWith('.md') && path.basename(filePath) !== 'CHANGELOG.md'
+    filePath.endsWith('.md') &&
+    path.basename(filePath).toUpperCase() !== 'CHANGELOG.MD'
 );
 const commandFiles = walk(
   PLUGINS_DIR,

--- a/tests/integration/validate-agent-authoring-changelog-skip.test.ts
+++ b/tests/integration/validate-agent-authoring-changelog-skip.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Integration test for CHANGELOG.md skip in `scripts/validate-agent-authoring.js`.
+ *
+ * Verifies that:
+ *   1. A CHANGELOG.md containing a `subagent_type:` reference to a deleted
+ *      agent is NOT flagged (CHANGELOGs document history including
+ *      deletions; their references are not live dispatches).
+ *   2. A non-CHANGELOG markdown file (e.g., a command file) referencing the
+ *      same deleted agent IS still flagged.
+ *
+ * Regression context: prior to this fix, the validator's `markdownFiles`
+ * walk included every `.md` file under `plugins/`, including CHANGELOG.md.
+ * That produced a hard ERROR on legitimate CHANGELOG entries that documented
+ * deprecated agents — blocking `pnpm release:check` indefinitely.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const VALIDATOR = resolve(__dirname, '..', '..', 'scripts', 'validate-agent-authoring.js');
+
+interface ValidatorRun {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runValidator(pluginsDir: string): ValidatorRun {
+  try {
+    const stdout = execFileSync('node', [VALIDATOR], {
+      env: { ...process.env, VALIDATE_PLUGINS_DIR: pluginsDir },
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { status: 0, stdout, stderr: '' };
+  } catch (err) {
+    const e = err as { status: number; stdout?: string; stderr?: string };
+    return {
+      status: e.status,
+      stdout: e.stdout ?? '',
+      stderr: e.stderr ?? '',
+    };
+  }
+}
+
+function writeFile(
+  pluginsDir: string,
+  pluginRelative: string,
+  body: string
+): void {
+  const fullPath = join(pluginsDir, pluginRelative);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, body, 'utf8');
+}
+
+const REAL_AGENT = `---
+name: real-agent
+description: "Test fixture. Use when verifying CHANGELOG skip rule."
+model: inherit
+tools:
+  - Read
+  - Grep
+  - Glob
+---
+
+Real agent body.
+`;
+
+const CHANGELOG_WITH_DELETED_REF = `# Changelog
+
+## [1.0.0] - 2026-01-01
+
+- Removed deprecated agent. Callers using
+  \`subagent_type: "yellow-test:review:deleted-agent"\` must migrate.
+`;
+
+const COMMAND_WITH_DELETED_REF = `---
+name: broken-command
+description: "Test fixture referencing a deleted agent."
+---
+
+\`\`\`text
+Task: deleted-agent
+subagent_type: "yellow-test:review:deleted-agent"
+\`\`\`
+`;
+
+describe('validate-agent-authoring CHANGELOG.md skip', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'yellow-validate-changelog-'));
+    // Every fixture needs at least one declared agent so subagent_type
+    // references can be cross-checked against pluginAgents.
+    writeFile(tmpRoot, 'yellow-test/agents/review/real-agent.md', REAL_AGENT);
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('does NOT flag a deleted-agent reference inside CHANGELOG.md', () => {
+    writeFile(
+      tmpRoot,
+      'yellow-test/CHANGELOG.md',
+      CHANGELOG_WITH_DELETED_REF
+    );
+
+    const { status, stderr } = runValidator(tmpRoot);
+
+    expect(status).toBe(0);
+    expect(stderr).not.toMatch(/CHANGELOG\.md/);
+    expect(stderr).not.toMatch(/deleted-agent/);
+  });
+
+  it('STILL flags a deleted-agent reference inside a non-CHANGELOG file', () => {
+    writeFile(
+      tmpRoot,
+      'yellow-test/commands/broken/broken-command.md',
+      COMMAND_WITH_DELETED_REF
+    );
+
+    const { status, stderr } = runValidator(tmpRoot);
+
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/broken-command\.md/);
+    expect(stderr).toMatch(/deleted-agent/);
+  });
+
+  it('does NOT flag CHANGELOG.md even when both files are present', () => {
+    // Only the non-CHANGELOG file should trigger the error; CHANGELOG.md
+    // must remain silent regardless of what it contains.
+    writeFile(
+      tmpRoot,
+      'yellow-test/CHANGELOG.md',
+      CHANGELOG_WITH_DELETED_REF
+    );
+    writeFile(
+      tmpRoot,
+      'yellow-test/commands/broken/broken-command.md',
+      COMMAND_WITH_DELETED_REF
+    );
+
+    const { status, stderr } = runValidator(tmpRoot);
+
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/broken-command\.md/);
+    expect(stderr).not.toMatch(/CHANGELOG\.md/);
+  });
+});

--- a/tests/integration/validate-agent-authoring-changelog-skip.test.ts
+++ b/tests/integration/validate-agent-authoring-changelog-skip.test.ts
@@ -14,7 +14,7 @@
  * deprecated agents — blocking `pnpm release:check` indefinitely.
  */
 
-import { execFileSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
@@ -30,21 +30,18 @@ interface ValidatorRun {
 }
 
 function runValidator(pluginsDir: string): ValidatorRun {
-  try {
-    const stdout = execFileSync('node', [VALIDATOR], {
-      env: { ...process.env, VALIDATE_PLUGINS_DIR: pluginsDir },
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    return { status: 0, stdout, stderr: '' };
-  } catch (err) {
-    const e = err as { status: number; stdout?: string; stderr?: string };
-    return {
-      status: e.status,
-      stdout: e.stdout ?? '',
-      stderr: e.stderr ?? '',
-    };
-  }
+  // spawnSync (not execFileSync) so stderr is captured on success too —
+  // the assertions below check stderr regardless of exit code.
+  const result = spawnSync('node', [VALIDATOR], {
+    env: { ...process.env, VALIDATE_PLUGINS_DIR: pluginsDir },
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
 }
 
 function writeFile(


### PR DESCRIPTION
The validator's markdownFiles walk scanned every .md file under
plugins/, including CHANGELOG.md. CHANGELOG entries that documented
deprecated/deleted agents (e.g., yellow-review:review:code-reviewer)
were matched by pluginSubagentPattern, looked up against the current
agent registry (where the deleted agent is absent), and produced a
hard ERROR — blocking pnpm release:check.

Fix: filter CHANGELOG.md from the markdownFiles walk. CHANGELOGs
document history including deletions; their references are not live
dispatches and must not be validated against the current registry.

Body-code-block validation, inline Task(subagent_type=...) validation
in command/CLAUDE files, and frontmatter validation are all preserved.

Tests: 3 regression cases at
tests/integration/validate-agent-authoring-changelog-skip.test.ts
covering (a) deleted-agent ref in CHANGELOG.md NOT flagged,
(b) same ref in non-CHANGELOG STILL flagged,
(c) both files present — only non-CHANGELOG flagged.

Bundles audit meta-artifacts (AUDIT_REPORT.md, brainstorm doc, plan
file) for full context. Solutions doc at
docs/solutions/build-errors/validate-agent-authoring-changelog-skip.md
captures the design decision (frontmatter-only would have lost
~11 inline Task(subagent_type=...) usages; CHANGELOG-only filter is
strictly more targeted).

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed validator to exclude changelog history from agent-type validation, eliminating false positives when changelog text references deprecated agents.

* **Documentation**
  * Added comprehensive audit report documenting repository structure and findings.
  * Added audit follow-up brainstorm with prioritized decisions and implementation details.
  * Added implementation plan for audit improvements across multiple phases.
  * Added solution documentation for changelog validation behavior.

* **Tests**
  * Added integration test suite validating changelog handling in agent-authoring validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a false-positive in `scripts/validate-agent-authoring.js` where `CHANGELOG.md` files were included in the `markdownFiles` walk, causing the validator to flag deleted-agent references in changelog prose as hard errors and blocking `pnpm release:check`.

- **Core fix** (`scripts/validate-agent-authoring.js`, line 152): adds a single case-insensitive predicate — `path.basename(filePath).toUpperCase() !== 'CHANGELOG.MD'` — to the `markdownFiles` walk. All other validation surfaces (agent frontmatter, command `BASH_SOURCE`, inline `Task(subagent_type=...)` in non-changelog files) are fully preserved.
- **Tests** (`tests/integration/validate-agent-authoring-changelog-skip.test.ts`): three regression cases using `spawnSync` to capture both stdout and stderr; covers CHANGELOG-only skip, non-CHANGELOG still-flagged, and the combined-files scenario.
- **Documentation**: a solution doc at `docs/solutions/build-errors/validate-agent-authoring-changelog-skip.md` records the three approaches considered and why frontmatter-only and anchored-regex alternatives were rejected.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-predicate filter addition with no effect on other validation paths.

The change touches a single walk predicate, leaves all other validation loops (agentFiles, commandFiles, frontmatter, inline dispatch checks) completely unmodified, and is covered by three regression tests that correctly capture stderr via spawnSync. The case-insensitive .toUpperCase() guard is already present. No new risks introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/validate-agent-authoring.js | Single-predicate change to markdownFiles walk: adds path.basename(filePath).toUpperCase() !== 'CHANGELOG.MD' filter. Case-insensitive guard is intentional and correct. All other validation surfaces (agentFiles, commandFiles, frontmatter, inline Task references) are unaffected. |
| tests/integration/validate-agent-authoring-changelog-skip.test.ts | Three regression tests using spawnSync (captures stdout and stderr on both success and failure paths). Covers: CHANGELOG-only skipped, non-CHANGELOG still flagged, and both-files-present combination. Test fixtures are well-isolated with tmpdir scaffolding. |
| docs/solutions/build-errors/validate-agent-authoring-changelog-skip.md | Solution doc clearly documents root cause, three alternatives considered (frontmatter-only, anchored regex, CHANGELOG skip), chosen approach rationale, and acceptable trade-offs. No code issues. |
| AUDIT_REPORT.md | Audit meta-artifact bundled for context; documents the false-positive root cause and broader marketplace health findings. |
| docs/brainstorms/2026-05-07-audit-followups-brainstorm.md | Brainstorm artifact listing follow-up improvements; no executable code changes. |
| plans/audit-followups-2026-05-07.md | Implementation plan artifact for future audit work; no executable code changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[walk PLUGINS_DIR] --> B{ends with .md?}
    B -->|No| X[skip]
    B -->|Yes| C{basename is CHANGELOG.MD?}
    C -->|Yes| X
    C -->|No| D[markdownFiles]
    D --> E[scan with pluginSubagentPattern]
    E --> F{match found?}
    F -->|No| G[OK]
    F -->|Yes| H{pluginName known?}
    H -->|No| G
    H -->|Yes| I{agent in registry?}
    I -->|Yes| J{2-segment form?}
    J -->|Yes| K[INFO: prefer 3-segment]
    J -->|No| G
    I -->|No| L[ERROR: unknown agent]
```

<sub>Reviews (2): Last reviewed commit: ["fix(scripts): address PR #436 review fee..."](https://github.com/kinginyellows/yellow-plugins/commit/7aed45736e2da81aed6a19deb07e2a2cf30314fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31257343)</sub>

<!-- /greptile_comment -->