### PR TITLE
feat(agents): pin opus on deep-analysis reviewers (A-01)

### DIFF
--- a/.changeset/audit-model-pins-a01.md
+++ b/.changeset/audit-model-pins-a01.md
@@ -1,0 +1,42 @@
+---
+"yellow-core": patch
+"yellow-review": patch
+---
+
+A-01 (audit 2026-05-07): pin `model: opus` on five deep-analysis review
+personas that previously inherited the parent's model. Establishes
+deterministic quality on the most analytically demanding agents in the
+review surface, completing the existing pinning convention
+(`architecture-strategist`, `research-conductor` are already pinned to
+opus).
+
+**yellow-core:**
+- `agents/review/security-sentinel.md`: `model: inherit` → `model: opus`
+- `agents/review/performance-oracle.md`: `model: inherit` → `model: opus`
+
+**yellow-review:**
+- `agents/review/adversarial-reviewer.md`: `model: inherit` → `model: opus`
+- `agents/review/agent-cli-readiness-reviewer.md`: `model: inherit` → `model: opus`
+- `agents/review/agent-native-reviewer.md`: `model: inherit` → `model: opus`
+
+Identifier `opus` (bare string) matches existing precedent in
+`plugins/yellow-core/agents/review/architecture-strategist.md`.
+
+**A-02 Phase 1 (audit pass):** the brainstorm proposed restricting
+`tools:` on eight read-only research agents but per-body verification
+(deepen-plan codebase research) shows all 8 already have correct narrowed
+scope — no edits needed:
+
+| Agent | Status |
+|---|---|
+| `learnings-researcher` | already `[Read, Grep, Glob]` |
+| `repo-research-analyst` | `[Read, Grep, Glob, Bash]` — Bash needed |
+| `best-practices-researcher` | `[WebSearch, WebFetch, Read, Glob, Grep]` — keep |
+| `git-history-analyzer` | `[Bash, Read, Grep, Glob]` — Bash needed |
+| `spec-flow-analyzer` | `[Read, Grep, Glob, Bash]` — Bash needed |
+| `code-researcher` | full set with ToolSearch + MCP tools — far too narrow to restrict |
+| `codex-analyst` | `[Bash, Read, Grep, Glob]` — Bash needed |
+| `linear-explorer` | `[Bash, ToolSearch, 5× MCP]` — verified |
+
+Audit confirms least-privilege precedent is already in place for these
+eight agents. No `Edit`/`Write` inheritance found.

--- a/.changeset/audit-model-pins-a01.md
+++ b/.changeset/audit-model-pins-a01.md
@@ -34,7 +34,7 @@ scope — no edits needed:
 | `best-practices-researcher` | `[WebSearch, WebFetch, Read, Glob, Grep]` — keep |
 | `git-history-analyzer` | `[Bash, Read, Grep, Glob]` — Bash needed |
 | `spec-flow-analyzer` | `[Read, Grep, Glob, Bash]` — Bash needed |
-| `code-researcher` | full set with ToolSearch + MCP tools — far too narrow to restrict |
+| `code-researcher` | broad toolset by design (Read, Grep, Glob, Bash, ToolSearch + 11 MCP tools) — keep; restricting would break inline research |
 | `codex-analyst` | `[Bash, Read, Grep, Glob]` — Bash needed |
 | `linear-explorer` | `[Bash, ToolSearch, 5× MCP]` — verified |
 

--- a/plugins/yellow-core/agents/review/performance-oracle.md
+++ b/plugins/yellow-core/agents/review/performance-oracle.md
@@ -1,7 +1,7 @@
 ---
 name: performance-oracle
 description: "Performance bottleneck analysis specialist. Identifies algorithmic complexity issues, database query problems (N+1), memory management concerns, caching opportunities, and network optimization. Use when reviewing code for performance issues or optimizing hot paths."
-model: inherit
+model: opus
 background: true
 memory: project
 tools:

--- a/plugins/yellow-core/agents/review/security-sentinel.md
+++ b/plugins/yellow-core/agents/review/security-sentinel.md
@@ -1,7 +1,7 @@
 ---
 name: security-sentinel
 description: "Active security vulnerability audit specialist (OWASP top 10, injection attacks, XSS, hardcoded secrets, auth/authz flaws). Use when auditing code for exploitable issues or reviewing changes that touch auth, input handling, or data access. For security tech debt (not active vulnerabilities), use security-debt-scanner (yellow-debt)."
-model: inherit
+model: opus
 background: true
 memory: project
 tools:

--- a/plugins/yellow-review/agents/review/adversarial-reviewer.md
+++ b/plugins/yellow-review/agents/review/adversarial-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: adversarial-reviewer
 description: "Conditional code-review persona, selected when the diff is large (>200 changed lines) or touches high-risk domains like auth, payments, data mutations, external APIs, or trust boundaries. Use when reviewing PRs that pass the size/risk threshold — review:pr selects this automatically. Actively constructs failure scenarios to break the implementation rather than checking against known patterns."
-model: inherit
+model: opus
 background: true
 tools:
   - Read

--- a/plugins/yellow-review/agents/review/agent-cli-readiness-reviewer.md
+++ b/plugins/yellow-review/agents/review/agent-cli-readiness-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: agent-cli-readiness-reviewer
 description: "Reviews CLI source code, plans, or specs for AI agent readiness using a 7-principle severity-based rubric (Blocker / Friction / Optimization). Distinguishes whether a CLI is merely usable by agents or genuinely optimized for them: non-interactive defaults, structured output, actionable errors, safe retries, bounded output, composability, and pipeline-friendly behavior. Use when reviewing PRs that touch CLI command surface, argument parsers, output formatters, or design documents proposing a CLI."
-model: inherit
+model: opus
 background: true
 tools:
   - Read

--- a/plugins/yellow-review/agents/review/agent-native-reviewer.md
+++ b/plugins/yellow-review/agents/review/agent-native-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: agent-native-reviewer
 description: "Reviews code to ensure agent-native parity — any action a user can take, an agent can also take. Reviews UI/agent action parity, context parity, shared workspace patterns, primitive-vs-workflow tool design, and dynamic context injection in system prompts. Use when reviewing PRs that introduce or modify UI features, agent tool definitions, system prompts, or LLM-integration scaffolding."
-model: inherit
+model: opus
 background: true
 tools:
   - Read


### PR DESCRIPTION
A-01 (audit 2026-05-07): pin model: opus on the five deep-analysis review
personas that previously inherited the parent's model.

Affected agents:
- yellow-core/agents/review/security-sentinel.md
- yellow-core/agents/review/performance-oracle.md
- yellow-review/agents/review/adversarial-reviewer.md
- yellow-review/agents/review/agent-cli-readiness-reviewer.md
- yellow-review/agents/review/agent-native-reviewer.md

These five do the deepest analysis in the review surface (OWASP audit,
algorithmic complexity, adversarial failure construction, agent-native
parity, CLI readiness rubric). Pinning opus completes the convention
already established by architecture-strategist (yellow-core) and
research-conductor (yellow-research) which use the same identifier.

A-02 Phase 1 (read-only research agent tool restrictions): per-body
verification confirms all 8 candidate agents already have correct
narrowed `tools:` scope — no edits needed. The brainstorm overestimated
the restriction surface. See changeset for the per-agent audit table.

Note on CI: the X-02 false-positive ERROR on yellow-review/CHANGELOG.md
still fires on this branch (PR 5 branched off main; PR #436 fixes it).
After PR #436 merges, rebase onto main (gt sync) — release:check will
pass cleanly.

Companion to plans/audit-followups-2026-05-07.md.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR pins `model: opus` on five deep-analysis review agents that previously inherited their model from the parent, completing a pinning convention already established by `architecture-strategist` and `research-conductor`.

- **yellow-core:** `security-sentinel` and `performance-oracle` now explicitly use `model: opus`, matching the `architecture-strategist` precedent and consistent with their `memory: project` + read-only toolset structure.
- **yellow-review:** `adversarial-reviewer`, `agent-cli-readiness-reviewer`, and `agent-native-reviewer` likewise pinned to `model: opus`; these are conditionally selected agents (large/high-risk diffs, CLI surface, agent-native parity) where consistent model quality is most impactful.
- **Changeset:** correctly marks both `yellow-core` and `yellow-review` as patch bumps and documents the A-02 audit pass confirming no tool-scope edits were needed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are single-line frontmatter edits that pin a model identifier, with no logic, prompt body, or tool-scope modifications.

Each of the five files has exactly one changed line (model: inherit → model: opus), and the bare string opus matches the format already used by architecture-strategist and research-conductor. The changeset covers both affected packages at the correct bump level. No behavioral regressions are possible from this change.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .changeset/audit-model-pins-a01.md | New changeset marking both yellow-core and yellow-review as patch bumps; accurately documents all five model pin changes and includes the A-02 audit table. |
| plugins/yellow-core/agents/review/security-sentinel.md | Single-line change: model: inherit → model: opus; consistent with architecture-strategist precedent and the agent's OWASP deep-audit role. |
| plugins/yellow-core/agents/review/performance-oracle.md | Single-line change: model: inherit → model: opus; appropriate given the algorithmic-complexity and N+1 deep-analysis role. |
| plugins/yellow-review/agents/review/adversarial-reviewer.md | Single-line change: model: inherit → model: opus; appropriate for the failure-scenario construction role that activates on large/high-risk diffs. |
| plugins/yellow-review/agents/review/agent-cli-readiness-reviewer.md | Single-line change: model: inherit → model: opus; consistent with the deep rubric-based CLI audit responsibility of this agent. |
| plugins/yellow-review/agents/review/agent-native-reviewer.md | Single-line change: model: inherit → model: opus; appropriate for the agent-native parity audit role. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[review:pr triggered] --> B{Diff size / domain check}
    B -->|always selected| C[correctness-reviewer\nmodel: inherit]
    B -->|always selected| D[project-compliance-reviewer\nmodel: inherit]
    B -->|always selected| E[maintainability-reviewer\nmodel: inherit]
    B -->|diff > 200 lines\nor trust boundary| F[adversarial-reviewer\nmodel: opus ✨]
    B -->|CLI surface touched| G[agent-cli-readiness-reviewer\nmodel: opus ✨]
    B -->|UI / agent tools touched| H[agent-native-reviewer\nmodel: opus ✨]
    B -->|via yellow-core| I[security-sentinel\nmodel: opus ✨]
    B -->|via yellow-core| J[performance-oracle\nmodel: opus ✨]
    B -->|via yellow-core| K[architecture-strategist\nmodel: opus existing]
```

<sub>Reviews (1): Last reviewed commit: ["docs(changeset): clarify code-researcher..."](https://github.com/kinginyellows/yellow-plugins/commit/de7d9c9f70fa4b901cb5933efb24773a6ae8ee97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31258582)</sub>

<!-- /greptile_comment -->