### PR TITLE
feat(plugins): declare cross-plugin MCP dependencies (X-01)

### DIFF
--- a/.changeset/audit-cross-plugin-deps.md
+++ b/.changeset/audit-cross-plugin-deps.md
@@ -1,0 +1,37 @@
+---
+"yellow-debt": patch
+"yellow-ci": patch
+"yellow-chatprd": patch
+---
+
+X-01 (audit 2026-05-07): declare cross-plugin MCP dependencies in three
+consumer manifests that silently require yellow-linear's MCP at runtime.
+Surfaces install-time coupling that previously failed opaquely as
+"MCP tool not found".
+
+**yellow-debt:** `/debt:sync` uses
+`mcp__plugin_yellow-linear_linear__create_issue` to push debt findings
+to Linear as issues.
+
+**yellow-ci:** `/ci:report-linear` uses the same Linear MCP tool to
+create issues from CI failure diagnoses.
+
+**yellow-chatprd:** `/chatprd:link-linear` uses it to bridge ChatPRD
+documents to Linear issues.
+
+All three deps are declared `optional: true` (matches npm
+`peerDependenciesMeta` semantics: declared as soft deps for
+audit/documentation purposes; consumers degrade gracefully when
+yellow-linear is absent — the Linear-specific commands surface "plugin
+not installed" rather than crashing).
+
+The schema extension (`schemas/plugin.schema.json`) and validator
+addition (RULE 11 in `scripts/validate-plugin.js`) ship in the same PR
+but do not require a changeset (root-level files, no plugin touches).
+
+⚠️ External smoke gate: do NOT tag a release until a fresh
+`claude plugin install` smoke test confirms Claude Code's remote
+validator accepts the new `optional` and `reason` fields. Local CI
+passing does NOT guarantee remote validator acceptance — see
+`docs/solutions/build-errors/userconfig-type-title-remote-validator-drift.md`
+for the precedent on local-vs-remote validator drift.

--- a/plugins/yellow-chatprd/.claude-plugin/plugin.json
+++ b/plugins/yellow-chatprd/.claude-plugin/plugin.json
@@ -21,5 +21,13 @@
       "type": "http",
       "url": "https://app.chatprd.ai/mcp"
     }
-  }
+  },
+  "dependencies": [
+    {
+      "name": "yellow-linear",
+      "version": "*",
+      "optional": true,
+      "reason": "chatprd:link-linear uses mcp__plugin_yellow-linear_linear__create_issue"
+    }
+  ]
 }

--- a/plugins/yellow-ci/.claude-plugin/plugin.json
+++ b/plugins/yellow-ci/.claude-plugin/plugin.json
@@ -29,5 +29,13 @@
         ]
       }
     ]
-  }
+  },
+  "dependencies": [
+    {
+      "name": "yellow-linear",
+      "version": "*",
+      "optional": true,
+      "reason": "ci:report-linear uses mcp__plugin_yellow-linear_linear__create_issue"
+    }
+  ]
 }

--- a/plugins/yellow-debt/.claude-plugin/plugin.json
+++ b/plugins/yellow-debt/.claude-plugin/plugin.json
@@ -27,5 +27,13 @@
         ]
       }
     ]
-  }
+  },
+  "dependencies": [
+    {
+      "name": "yellow-linear",
+      "version": "*",
+      "optional": true,
+      "reason": "debt:sync uses mcp__plugin_yellow-linear_linear__create_issue"
+    }
+  ]
 }

--- a/schemas/plugin.schema.json
+++ b/schemas/plugin.schema.json
@@ -325,7 +325,7 @@
               "reason": {
                 "type": "string",
                 "minLength": 1,
-                "description": "Informational free-text explaining why this plugin is required — typically the specific MCP tool, command, or capability the consumer relies on. Not validated; intended as an audit trail readable by humans and AI reviewers. No equivalent field exists in npm/VS Code/JetBrains plugin schemas; this is a yellow-plugins extension."
+                "description": "Informational free-text explaining why this plugin is required — typically the specific MCP tool, command, or capability the consumer relies on. Content is not semantically validated (any non-empty string is accepted; minLength: 1 rejects only \"\"); intended as an audit trail readable by humans and AI reviewers. No equivalent field exists in npm/VS Code/JetBrains plugin schemas; this is a yellow-plugins extension."
               }
             },
             "additionalProperties": false

--- a/schemas/plugin.schema.json
+++ b/schemas/plugin.schema.json
@@ -316,6 +316,16 @@
                 "pattern": "^[~^>=<*xXvV0-9]",
                 "semverRange": true,
                 "description": "Semver range constraint such as ^1.2.0, ~2.1.0, >=3.0.0, or v1.2.3. Two-layer validation: the `pattern` is a lightweight structural gate that rejects unsupported leading characters before the keyword runs; `semverRange` then calls semver.validRange() for full semantic correctness. minLength: 1 guards the empty-string case — semver.validRange(\"\") returns \"*\" (truthy) so the keyword alone would accept it."
+              },
+              "optional": {
+                "type": "boolean",
+                "default": false,
+                "description": "When true, the validator does not warn if this dep is missing from .claude-plugin/marketplace.json. Mirrors npm peerDependenciesMeta `optional: true` semantics: declared as a soft dep for documentation/audit purposes, not hard-required at install time. Hard deps (default `false` or omitted) trigger a WARNING (not ERROR) when missing from the catalog."
+              },
+              "reason": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Informational free-text explaining why this plugin is required — typically the specific MCP tool, command, or capability the consumer relies on. Not validated; intended as an audit trail readable by humans and AI reviewers. No equivalent field exists in npm/VS Code/JetBrains plugin schemas; this is a yellow-plugins extension."
               }
             },
             "additionalProperties": false
@@ -323,7 +333,7 @@
         ]
       },
       "minItems": 1,
-      "description": "Other plugins this plugin requires, optionally with semver version constraints."
+      "description": "Other plugins this plugin requires, optionally with semver version constraints. Each entry may also declare `optional: true` (soft dep — no warning if missing from marketplace catalog) and `reason: \"<text>\"` (audit trail explaining the specific MCP tool, command, or capability the consumer uses from this dep)."
     }
   },
   "additionalProperties": false

--- a/scripts/validate-plugin.js
+++ b/scripts/validate-plugin.js
@@ -466,7 +466,7 @@ function getMarketplacePluginNames() {
   }
   try {
     const data = JSON.parse(fs.readFileSync(marketplacePath, 'utf8'));
-    if (Array.isArray(data.plugins)) {
+    if (data && Array.isArray(data.plugins)) {
       _marketplacePluginNames = new Set(
         data.plugins
           .filter((p) => p && typeof p.name === 'string')
@@ -1014,9 +1014,6 @@ function validatePlugin(pluginDir) {
   // surfacing install-time coupling that would otherwise fail opaquely at
   // runtime ("MCP tool not found"). Optional deps stay silent (matches
   // npm peerDependenciesMeta semantics: declared, not enforced).
-  //
-  // Loaded once per validate-plugin invocation; passed to validateManifest
-  // via the `marketplacePluginNames` parameter (see discoverPlugins).
   if (Array.isArray(manifest.dependencies) && marketplacePluginNames) {
     for (const dep of manifest.dependencies) {
       // String form: bare plugin name. Cannot be optional; cannot carry reason.

--- a/scripts/validate-plugin.js
+++ b/scripts/validate-plugin.js
@@ -450,8 +450,10 @@ function validateHookScriptPath(scriptPath, eventName, pluginDir, errors) {
 // Lazy-loaded set of plugin names declared in the marketplace catalog.
 // Populated on first call to `getMarketplacePluginNames()` and reused for
 // every subsequent plugin's RULE 11 cross-dep check. Returns null when
-// marketplace.json is absent or unparseable — RULE 11 skips silently in
-// that case rather than producing spurious warnings.
+// marketplace.json is absent (silent — single-plugin validation outside
+// the monorepo is a legitimate flow), unparseable, or has an unexpected
+// shape; the latter two cases also emit a WARNING so a broken catalog
+// doesn't quietly reduce validation coverage.
 let _marketplacePluginNames = undefined;
 function getMarketplacePluginNames() {
   if (_marketplacePluginNames !== undefined) return _marketplacePluginNames;
@@ -473,9 +475,15 @@ function getMarketplacePluginNames() {
           .map((p) => p.name)
       );
     } else {
+      logWarning(
+        'cannot parse .claude-plugin/marketplace.json (unexpected shape); skipping dependency cross-checks'
+      );
       _marketplacePluginNames = null;
     }
   } catch (_err) {
+    logWarning(
+      'cannot parse .claude-plugin/marketplace.json (invalid JSON); skipping dependency cross-checks'
+    );
     _marketplacePluginNames = null;
   }
   return _marketplacePluginNames;

--- a/scripts/validate-plugin.js
+++ b/scripts/validate-plugin.js
@@ -447,10 +447,45 @@ function validateHookScriptPath(scriptPath, eventName, pluginDir, errors) {
 /**
  * Validate a single plugin directory
  */
+// Lazy-loaded set of plugin names declared in the marketplace catalog.
+// Populated on first call to `getMarketplacePluginNames()` and reused for
+// every subsequent plugin's RULE 11 cross-dep check. Returns null when
+// marketplace.json is absent or unparseable — RULE 11 skips silently in
+// that case rather than producing spurious warnings.
+let _marketplacePluginNames = undefined;
+function getMarketplacePluginNames() {
+  if (_marketplacePluginNames !== undefined) return _marketplacePluginNames;
+  const marketplacePath = path.join(
+    PROJECT_ROOT,
+    '.claude-plugin',
+    'marketplace.json'
+  );
+  if (!fs.existsSync(marketplacePath)) {
+    _marketplacePluginNames = null;
+    return _marketplacePluginNames;
+  }
+  try {
+    const data = JSON.parse(fs.readFileSync(marketplacePath, 'utf8'));
+    if (Array.isArray(data.plugins)) {
+      _marketplacePluginNames = new Set(
+        data.plugins
+          .filter((p) => p && typeof p.name === 'string')
+          .map((p) => p.name)
+      );
+    } else {
+      _marketplacePluginNames = null;
+    }
+  } catch (_err) {
+    _marketplacePluginNames = null;
+  }
+  return _marketplacePluginNames;
+}
+
 function validatePlugin(pluginDir) {
   const manifestPath = path.join(pluginDir, '.claude-plugin', 'plugin.json');
   const dirName = path.basename(pluginDir);
   const errors = [];
+  const marketplacePluginNames = getMarketplacePluginNames();
 
   // Check manifest exists
   if (!fs.existsSync(manifestPath)) {
@@ -971,6 +1006,31 @@ function validatePlugin(pluginDir) {
         validateUserConfigEntries(ch.userConfig, `channels[${i}].userConfig`);
       }
     });
+  }
+
+  // RULE 11: cross-plugin dependency declarations.
+  // For each entry in `dependencies`, look up the dep's `name` in the
+  // marketplace catalog. Hard deps (`optional` not true) WARN if missing —
+  // surfacing install-time coupling that would otherwise fail opaquely at
+  // runtime ("MCP tool not found"). Optional deps stay silent (matches
+  // npm peerDependenciesMeta semantics: declared, not enforced).
+  //
+  // Loaded once per validate-plugin invocation; passed to validateManifest
+  // via the `marketplacePluginNames` parameter (see discoverPlugins).
+  if (Array.isArray(manifest.dependencies) && marketplacePluginNames) {
+    for (const dep of manifest.dependencies) {
+      // String form: bare plugin name. Cannot be optional; cannot carry reason.
+      const depName = typeof dep === 'string' ? dep : dep && dep.name;
+      const depOptional = typeof dep === 'object' && dep && dep.optional === true;
+      const depReason = typeof dep === 'object' && dep && dep.reason;
+      if (!depName || depOptional) continue;
+      if (!marketplacePluginNames.has(depName)) {
+        const reasonSuffix = depReason ? ` — reason: ${depReason}` : '';
+        logWarning(
+          `${manifest.name}: declared dependency "${depName}" is not present in marketplace.json catalog${reasonSuffix}`
+        );
+      }
+    }
   }
 
   // Summary


### PR DESCRIPTION
X-01 (audit 2026-05-07): extend the existing dependencies schema with
optional + reason fields and declare yellow-linear as a soft dep on the
three consumer plugins that silently require its MCP at runtime.

Schema extension (schemas/plugin.schema.json):
- Existing {name, version} item shape gains optional `optional: boolean`
  (default false) and optional `reason: string` fields
- Mirrors npm peerDependenciesMeta semantics: optional=true marks a
  declared-but-not-enforced soft dep
- `reason` is informational free-text for audit trail (not validated)

Validator extension (scripts/validate-plugin.js RULE 11):
- For each non-optional declared dep, look up `name` in
  .claude-plugin/marketplace.json
- WARNING (not ERROR) if missing — surfaces install-time coupling
  without blocking subset installs
- Optional deps (optional: true) stay silent when missing
- Lazy-loaded marketplace catalog cached at module scope

Manifest declarations (3 consumers, all optional: true):
- yellow-debt: debt:sync → mcp__plugin_yellow-linear_linear__create_issue
- yellow-ci: ci:report-linear → same MCP tool
- yellow-chatprd: chatprd:link-linear → same MCP tool

External smoke gate: DO NOT tag a release with this PR until a fresh
`claude plugin install` smoke test confirms Claude Code's remote
validator accepts the new optional + reason fields. See
docs/solutions/build-errors/userconfig-type-title-remote-validator-drift.md
for the precedent on local-vs-remote validator drift.

Note on CI: the X-02 false-positive ERROR on yellow-review/CHANGELOG.md
still fires on this branch (PR 4 branched off main; PR #436 fixes it).
After PR #436 merges, rebase onto main (gt sync) — release:check will
pass cleanly.

Companion to plans/audit-followups-2026-05-07.md (deepen-plan revised
the field shape from {plugin, reason} to extend the existing
{name, version} after the codebase research surfaced the conflict).

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced optional cross-plugin dependencies with audit metadata to support graceful degradation when dependencies are unavailable.
  * Three plugins (yellow-debt, yellow-ci, yellow-chatprd) now support Linear integration, enabling issue creation and management when the yellow-linear plugin is installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the plugin dependency schema with `optional` (boolean, default `false`) and `reason` (free-text string) fields, then uses them to declare `yellow-linear` as a soft dep in three consumer plugins (`yellow-debt`, `yellow-ci`, `yellow-chatprd`). A new RULE 11 in the validator warns — without blocking — when a hard (non-optional) dep is missing from `marketplace.json`, while optional deps remain silent.

- **Schema** (`schemas/plugin.schema.json`): `optional` and `reason` are added to the object form of dependency items only; `additionalProperties: false` is preserved, so no unknown keys can sneak through.
- **Validator** (`scripts/validate-plugin.js`): `getMarketplacePluginNames()` lazy-loads and caches the marketplace catalog at module scope; RULE 11 iterates `manifest.dependencies`, skips optional entries, and emits a `logWarning` (never `addError`) for hard deps absent from the catalog.
- **Plugin manifests**: All three new entries use `optional: true` and a `reason` string naming the exact MCP tool; they will be silently skipped by RULE 11 today, which is correct since `yellow-linear` is not guaranteed to be installed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive and backwards-compatible; the new fields are optional in the schema, the validator emits warnings not errors, and all three plugin manifests declare their deps as optional so no existing CI gate is affected.

The schema extension is non-breaking (new optional fields, additionalProperties: false maintained), the RULE 11 validator path is warn-only and correctly skips the three new optional deps, and the sentinel-cache pattern in getMarketplacePluginNames is sound for the CLI use case. No data paths are altered, no existing validations are removed.

No files require special attention. scripts/validate-plugin.js has one minor note about the module-scope cache lacking a reset path, relevant only if the script is ever required as a library rather than invoked as a CLI.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/validate-plugin.js | Adds getMarketplacePluginNames() lazy-loader and RULE 11 cross-dep check; module-scope mutable cache has minor test-isolation implications but is safe for CLI invocations. |
| schemas/plugin.schema.json | Adds optional boolean and reason string fields to the dependency item object shape; schema constraints are correct and consistent with the validator logic. |
| plugins/yellow-debt/.claude-plugin/plugin.json | Adds yellow-linear as optional: true dependency with audit reason; structure matches the new schema. |
| plugins/yellow-ci/.claude-plugin/plugin.json | Adds yellow-linear as optional: true dependency with audit reason; structure matches the new schema. |
| plugins/yellow-chatprd/.claude-plugin/plugin.json | Adds yellow-linear as optional: true dependency with audit reason; structure matches the new schema. |
| .changeset/audit-cross-plugin-deps.md | Changeset covering patch bumps for the three consumer plugins; includes external smoke-gate warning and clear explanation of the schema extension. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[validatePlugin called] --> B[getMarketplacePluginNames]
    B --> C{_marketplacePluginNames\ncached?}
    C -- "yes" --> D[return cached value]
    C -- "no" --> E{marketplace.json\nexists?}
    E -- "no" --> F[cache = null\nsilent skip]
    E -- "yes" --> G{Parse JSON\nvalid shape?}
    G -- "invalid JSON" --> H[logWarning\ncache = null]
    G -- "unexpected shape" --> I[logWarning\ncache = null]
    G -- "ok" --> J[cache = Set of plugin names]
    D --> K[RULE 11 check]
    F --> K
    H --> K
    I --> K
    J --> K
    K --> L{dependencies array\n& cache is a Set?}
    L -- "no" --> M[skip RULE 11]
    L -- "yes" --> N[for each dep]
    N --> O{dep is optional?}
    O -- "yes" --> P[silent, continue]
    O -- "no" --> Q{name in\nmarketplace catalog?}
    Q -- "yes" --> R[ok, continue]
    Q -- "no" --> S[logWarning with\noptional reason suffix]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Faudit%2Fx-01-cross-plugin-dependencies%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Faudit%2Fx-01-cross-plugin-dependencies%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fvalidate-plugin.js%3A457-489%0A**Module-scope%20cache%20has%20no%20reset%20mechanism**%0A%0A%60_marketplacePluginNames%60%20is%20initialised%20once%20per%20process%20and%20never%20cleared.%20For%20the%20normal%20CLI%20invocation%20this%20is%20fine%20%28each%20%60node%20scripts%2Fvalidate-plugin.js%60%20run%20is%20a%20fresh%20process%29%2C%20but%20if%20the%20script%20is%20ever%20%60require%28%29%60d%20from%20a%20test%20suite%20or%20another%20Node%20script%20and%20%60validatePlugin%60%20is%20called%20across%20multiple%20test%20cases%20that%20set%20up%20different%20marketplace%20fixtures%2C%20the%20first%20call%20wins%20and%20every%20subsequent%20call%20reuses%20its%20result%20regardless%20of%20which%20%60PROJECT_ROOT%60%20or%20marketplace%20file%20is%20in%20play.%20There's%20no%20exported%20reset%20function%20or%20way%20for%20callers%20to%20invalidate%20the%20cache.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
scripts/validate-plugin.js:457-489
**Module-scope cache has no reset mechanism**

`_marketplacePluginNames` is initialised once per process and never cleared. For the normal CLI invocation this is fine (each `node scripts/validate-plugin.js` run is a fresh process), but if the script is ever `require()`d from a test suite or another Node script and `validatePlugin` is called across multiple test cases that set up different marketplace fixtures, the first call wins and every subsequent call reuses its result regardless of which `PROJECT_ROOT` or marketplace file is in play. There's no exported reset function or way for callers to invalidate the cache.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(validate-plugin): warn instead of si..."](https://github.com/kinginyellows/yellow-plugins/commit/b7692c0dc604f8cb73fecef4fde357751fd1d46c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31259254)</sub>

<!-- /greptile_comment -->