### PR TITLE
feat(yellow-research): support shell env fallback for MCP API keys

### DIFF
--- a/.changeset/yellow-research-mcp-key-shell-env-fallback.md
+++ b/.changeset/yellow-research-mcp-key-shell-env-fallback.md
@@ -1,0 +1,22 @@
+---
+"yellow-research": minor
+---
+
+feat(yellow-research): MCP API keys now fall back to shell env when userConfig is unset
+
+Each of the perplexity, tavily, and exa MCP servers now launches via a thin
+wrapper script (`bin/start-<server>.sh`) that resolves its API key with the
+following precedence:
+
+1. `userConfig` value (preferred — keychain-encrypted via Claude Code)
+2. Shell env fallback: `PERPLEXITY_API_KEY`, `TAVILY_API_KEY`, `EXA_API_KEY`
+
+Power users who already export these keys in their shell rc no longer have
+to re-enter them through the plugin config UI. If both sources are set,
+`userConfig` wins. If neither is set, the wrapper unsets the empty value so
+the MCP package sees "absent" rather than "explicitly empty"; behavior on
+the no-key path is unchanged.
+
+The wrapper pattern matches the existing `plugins/yellow-morph/bin/start-morph.sh`
+precedent. `--` separator added before forwarded args defends against future
+flag-injection if Claude Code ever passes args to MCP servers.

--- a/plugins/yellow-research/.claude-plugin/plugin.json
+++ b/plugins/yellow-research/.claude-plugin/plugin.json
@@ -42,35 +42,28 @@
   },
   "mcpServers": {
     "perplexity": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@perplexity-ai/mcp-server@0.8.2"
-      ],
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/start-perplexity.sh",
+      "args": [],
       "env": {
-        "PERPLEXITY_API_KEY": "${user_config.perplexity_api_key}",
+        "PERPLEXITY_API_KEY_USERCONFIG": "${user_config.perplexity_api_key}",
+        "PERPLEXITY_API_KEY": "${PERPLEXITY_API_KEY:-}",
         "PERPLEXITY_TIMEOUT_MS": "${PERPLEXITY_TIMEOUT_MS:-600000}"
       }
     },
     "tavily": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "tavily-mcp@0.2.17"
-      ],
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/start-tavily.sh",
+      "args": [],
       "env": {
-        "TAVILY_API_KEY": "${user_config.tavily_api_key}"
+        "TAVILY_API_KEY_USERCONFIG": "${user_config.tavily_api_key}",
+        "TAVILY_API_KEY": "${TAVILY_API_KEY:-}"
       }
     },
     "exa": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "exa-mcp-server@3.1.8",
-        "tools=web_search_exa,get_code_context_exa,company_research_exa,web_search_advanced_exa,crawling_exa,deep_researcher_start,deep_researcher_check"
-      ],
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/start-exa.sh",
+      "args": [],
       "env": {
-        "EXA_API_KEY": "${user_config.exa_api_key}"
+        "EXA_API_KEY_USERCONFIG": "${user_config.exa_api_key}",
+        "EXA_API_KEY": "${EXA_API_KEY:-}"
       }
     },
     "parallel": {

--- a/plugins/yellow-research/CLAUDE.md
+++ b/plugins/yellow-research/CLAUDE.md
@@ -150,10 +150,12 @@ that resolves the API key with the following precedence:
 This means power users who already export the keys in their shell rc do
 not have to re-enter them via `userConfig`. If both are set, `userConfig`
 wins. If neither is set, the wrapper unsets the empty value so the MCP
-package sees "absent" not "explicitly empty"; tool calls then return
-runtime errors. `CERAMIC_API_KEY` remains a shell-only env var because
-it gates the REST live-probe in `/research:setup`, not the MCP server
-(which uses OAuth).
+package sees "absent" not "explicitly empty"; behavior then differs by
+server. Perplexity's MCP hard-fails at startup so its tools are
+unavailable, while Tavily and EXA start successfully and surface a
+runtime error on the first tool call. `CERAMIC_API_KEY` remains a
+shell-only env var because it gates the REST live-probe in
+`/research:setup`, not the MCP server (which uses OAuth).
 
 **Scope note (security):** the resolved API key is exported into the MCP
 process environment and is therefore visible to any subprocess the MCP

--- a/plugins/yellow-research/CLAUDE.md
+++ b/plugins/yellow-research/CLAUDE.md
@@ -139,18 +139,29 @@ an optional sensitive `userConfig` field in `plugin.json`.
 On first enable (or after `claude plugin update yellow-research`), Claude
 Code prompts for each key. Answer the prompts for the sources you want;
 dismiss the others. Values are stored in the system keychain (or
-`~/.claude/.credentials.json` at 0600 perms on minimal Linux) and
-substituted into each MCP's env block via
-`${user_config.<name>_api_key}` — no Claude Code restart needed when a
-key changes.
+`~/.claude/.credentials.json` at 0600 perms on minimal Linux).
 
-If you prefer shell env vars, that path no longer feeds the MCPs as of
-2.0.0 (the plugin.json references `${user_config.*}`, not `${*_API_KEY}`).
-Either answer the prompt or, for a fully shell-driven setup, add a thin
-wrapper per MCP (see `plugins/yellow-morph/bin/start-morph.sh` for a
-reference pattern). `CERAMIC_API_KEY` remains a shell-only env var because
-it gates the REST live-probe in `/research:setup`, not the MCP server (which
-uses OAuth).
+Each MCP server is launched via a thin wrapper in `bin/start-<server>.sh`
+that resolves the API key with the following precedence:
+
+1. `userConfig` value (preferred — keychain-encrypted)
+2. Shell env fallback: `PERPLEXITY_API_KEY`, `TAVILY_API_KEY`, `EXA_API_KEY`
+
+This means power users who already export the keys in their shell rc do
+not have to re-enter them via `userConfig`. If both are set, `userConfig`
+wins. If neither is set, the wrapper unsets the empty value so the MCP
+package sees "absent" not "explicitly empty"; tool calls then return
+runtime errors. `CERAMIC_API_KEY` remains a shell-only env var because
+it gates the REST live-probe in `/research:setup`, not the MCP server
+(which uses OAuth).
+
+**Scope note (security):** the resolved API key is exported into the MCP
+process environment and is therefore visible to any subprocess the MCP
+server spawns (e.g., a `node` child or a tool that shells out). This
+matches the morph and other-MCP precedent, but consumers handling
+high-sensitivity keys should prefer the `userConfig` keychain path over
+shell exports — the keychain isolates the value to Claude Code's
+substitution engine and keeps it out of generic shell-process leaks.
 
 The **parallel** server uses OAuth — Claude Code handles authentication
 automatically (no API key needed). You'll be prompted to authorize on first use.

--- a/plugins/yellow-research/README.md
+++ b/plugins/yellow-research/README.md
@@ -35,8 +35,10 @@ precedence:
 2. Shell env fallback: `EXA_API_KEY`, `TAVILY_API_KEY`, `PERPLEXITY_API_KEY`
 
 If both are set, `userConfig` wins. If neither is set, the wrapper
-unsets the empty value and the MCP starts but tool calls return runtime
-errors (Perplexity hard-fails at startup; Tavily/EXA error on first call).
+unsets the empty value before exec; behavior then differs by server.
+Perplexity's MCP hard-fails at startup so its tools are unavailable,
+while Tavily and EXA start successfully and surface a runtime error
+on the first tool call.
 
 Recommended path (one-time per workstation, no restart needed):
 

--- a/plugins/yellow-research/README.md
+++ b/plugins/yellow-research/README.md
@@ -26,11 +26,17 @@ manually: `npm install -g @ast-grep/cli`.
 
 ## API Key Setup
 
-As of v2.0.0, EXA / Tavily / Perplexity API keys are stored in `userConfig`
-(system keychain), NOT shell environment variables. The MCPs read from
-`${user_config.<key>}` — exporting `*_API_KEY` in `~/.zshrc` no longer feeds
-the MCP and the Perplexity MCP will hard-fail at startup without a valid
-userConfig value.
+EXA / Tavily / Perplexity API keys are read from `userConfig` (system
+keychain) by default. As of v3.1.0, each MCP server is launched via a
+small wrapper in `bin/start-<server>.sh` that resolves the key with this
+precedence:
+
+1. `userConfig` value (preferred — keychain-encrypted)
+2. Shell env fallback: `EXA_API_KEY`, `TAVILY_API_KEY`, `PERPLEXITY_API_KEY`
+
+If both are set, `userConfig` wins. If neither is set, the wrapper
+unsets the empty value and the MCP starts but tool calls return runtime
+errors (Perplexity hard-fails at startup; Tavily/EXA error on first call).
 
 Recommended path (one-time per workstation, no restart needed):
 
@@ -62,10 +68,10 @@ The **Parallel Task** and **Ceramic** MCP servers use OAuth — Claude Code
 handles authentication automatically. You'll be prompted to authorize on
 first use (no API key needed).
 
-Power users who insist on shell-env-driven auth can bridge with a per-MCP
-wrapper script (see `plugins/yellow-morph/bin/start-morph.sh` for the
-canonical pattern). `plugin.json` no longer reads shell `*_API_KEY` vars
-directly.
+Power users who already export `EXA_API_KEY`, `TAVILY_API_KEY`, and/or
+`PERPLEXITY_API_KEY` in their shell rc do not need to re-enter them via
+`userConfig` — the bundled `bin/start-<server>.sh` wrappers pick up shell
+env values automatically when no `userConfig` value is set.
 
 ## Usage
 

--- a/plugins/yellow-research/bin/start-exa.sh
+++ b/plugins/yellow-research/bin/start-exa.sh
@@ -12,6 +12,6 @@ unset EXA_API_KEY_USERCONFIG
 # string so the MCP package sees "absent" not "explicitly empty".
 [ -z "${EXA_API_KEY:-}" ] && unset EXA_API_KEY
 
-exec npx -y exa-mcp-server@3.1.8 \
+exec npx -y "exa-mcp-server@3.1.8" \
   "tools=web_search_exa,get_code_context_exa,company_research_exa,web_search_advanced_exa,crawling_exa,deep_researcher_start,deep_researcher_check" \
-  -- "$@"
+  ${1+-- "$@"}

--- a/plugins/yellow-research/bin/start-exa.sh
+++ b/plugins/yellow-research/bin/start-exa.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# yellow-research exa MCP wrapper.
+# Resolves EXA_API_KEY from userConfig (preferred) or shell env fallback.
+set -euo pipefail
+
+if [ -n "${EXA_API_KEY_USERCONFIG:-}" ]; then
+  export EXA_API_KEY="$EXA_API_KEY_USERCONFIG"
+fi
+unset EXA_API_KEY_USERCONFIG
+
+# If neither userConfig nor shell env supplied a value, unset the empty
+# string so the MCP package sees "absent" not "explicitly empty".
+[ -z "${EXA_API_KEY:-}" ] && unset EXA_API_KEY
+
+exec npx -y exa-mcp-server@3.1.8 \
+  "tools=web_search_exa,get_code_context_exa,company_research_exa,web_search_advanced_exa,crawling_exa,deep_researcher_start,deep_researcher_check" \
+  -- "$@"

--- a/plugins/yellow-research/bin/start-perplexity.sh
+++ b/plugins/yellow-research/bin/start-perplexity.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# yellow-research perplexity MCP wrapper.
+# Resolves PERPLEXITY_API_KEY from userConfig (preferred) or shell env fallback.
+# PERPLEXITY_TIMEOUT_MS is passed through from plugin.json env unchanged.
+set -euo pipefail
+
+if [ -n "${PERPLEXITY_API_KEY_USERCONFIG:-}" ]; then
+  export PERPLEXITY_API_KEY="$PERPLEXITY_API_KEY_USERCONFIG"
+fi
+unset PERPLEXITY_API_KEY_USERCONFIG
+
+# If neither userConfig nor shell env supplied a value, unset the empty
+# string so the MCP package sees "absent" not "explicitly empty".
+[ -z "${PERPLEXITY_API_KEY:-}" ] && unset PERPLEXITY_API_KEY
+
+exec npx -y "@perplexity-ai/mcp-server@0.8.2" -- "$@"

--- a/plugins/yellow-research/bin/start-perplexity.sh
+++ b/plugins/yellow-research/bin/start-perplexity.sh
@@ -13,4 +13,4 @@ unset PERPLEXITY_API_KEY_USERCONFIG
 # string so the MCP package sees "absent" not "explicitly empty".
 [ -z "${PERPLEXITY_API_KEY:-}" ] && unset PERPLEXITY_API_KEY
 
-exec npx -y "@perplexity-ai/mcp-server@0.8.2" -- "$@"
+exec npx -y "@perplexity-ai/mcp-server@0.8.2" ${1+-- "$@"}

--- a/plugins/yellow-research/bin/start-tavily.sh
+++ b/plugins/yellow-research/bin/start-tavily.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# yellow-research tavily MCP wrapper.
+# Resolves TAVILY_API_KEY from userConfig (preferred) or shell env fallback.
+set -euo pipefail
+
+if [ -n "${TAVILY_API_KEY_USERCONFIG:-}" ]; then
+  export TAVILY_API_KEY="$TAVILY_API_KEY_USERCONFIG"
+fi
+unset TAVILY_API_KEY_USERCONFIG
+
+# If neither userConfig nor shell env supplied a value, unset the empty
+# string so the MCP package sees "absent" not "explicitly empty".
+[ -z "${TAVILY_API_KEY:-}" ] && unset TAVILY_API_KEY
+
+exec npx -y tavily-mcp@0.2.17 -- "$@"

--- a/plugins/yellow-research/bin/start-tavily.sh
+++ b/plugins/yellow-research/bin/start-tavily.sh
@@ -12,4 +12,4 @@ unset TAVILY_API_KEY_USERCONFIG
 # string so the MCP package sees "absent" not "explicitly empty".
 [ -z "${TAVILY_API_KEY:-}" ] && unset TAVILY_API_KEY
 
-exec npx -y tavily-mcp@0.2.17 -- "$@"
+exec npx -y "tavily-mcp@0.2.17" ${1+-- "$@"}


### PR DESCRIPTION
Wrap perplexity, tavily, and exa MCP servers in thin launcher scripts
that resolve their API keys with userConfig (keychain) priority and
shell env (PERPLEXITY_API_KEY, TAVILY_API_KEY, EXA_API_KEY) fallback.

This restores the shell-env path that was lost when these MCPs moved to
userConfig substitution in 2.0.0 — power users with the keys already
exported no longer have to re-enter them via /plugin config. If both
sources are set, userConfig wins. If neither is set, the wrapper unsets
the empty value so the MCP package sees "absent" not "explicitly empty".

Pattern matches the existing yellow-morph/bin/start-morph.sh precedent.
Adds -- separator before forwarded args to defend against future
flag-injection if Claude Code ever passes args to MCP servers.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wraps the Perplexity, Tavily, and EXA MCP servers in thin shell launcher scripts (`bin/start-*.sh`) that restore the shell-env fallback path removed in v2.0.0, while preserving userConfig (keychain) priority. The `plugin.json` env block captures both sources and the wrapper selects between them at runtime.

- Three new launcher scripts implement identical key-resolution logic: userConfig value wins if present; shell env is used as fallback; if both are absent the variable is unset so the MCP package sees \"absent\" rather than an empty string.
- `plugin.json` is updated to invoke each wrapper via `${CLAUDE_PLUGIN_ROOT}/bin/start-*.sh`, and env blocks are restructured to pass both the `_USERCONFIG` helper variable and the raw shell-env value.
- Documentation in `README.md` and `CLAUDE.md` is updated to reflect the new v3.1.0 precedence rules, including a security scope note about key visibility in subprocess environments.

<h3>Confidence Score: 5/5</h3>

The wrappers correctly implement the described key-resolution logic across all four input combinations and are a faithful application of the start-morph.sh precedent.

The key-resolution logic in all three scripts handles every combination of set/unset userConfig and shell env correctly. The conditional-separator idiom is sound (expands to nothing when called with zero args, as plugin.json always does). The plugin.json env-block design correctly threads both sources into the wrapper without double-evaluation. The set -euo pipefail guard interacts correctly with the unset idiom. Documentation and changeset are accurate.

No files require special attention — the wrapper scripts, plugin.json changes, and documentation are all consistent with each other and with the morph precedent.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/yellow-research/bin/start-perplexity.sh | New wrapper script correctly resolves PERPLEXITY_API_KEY with userConfig-wins precedence, unsets the empty string, and exec's the MCP; key-resolution logic is sound across all four combinations of set/unset inputs. |
| plugins/yellow-research/bin/start-tavily.sh | Identical pattern to start-perplexity.sh applied to TAVILY_API_KEY; logic is correct and consistent. |
| plugins/yellow-research/bin/start-exa.sh | Same pattern applied to EXA_API_KEY; the tools=... positional arg is preserved in the exec call at the same relative position as the original plugin.json invocation. |
| plugins/yellow-research/.claude-plugin/plugin.json | Each of the three MCP servers now delegates to its wrapper script; env blocks correctly capture both the userConfig value (via _USERCONFIG suffix) and the shell env value (via default expansion), matching the design intent. |
| plugins/yellow-research/CLAUDE.md | Documentation updated to reflect the new shell-env fallback path; adds a security scope note about key visibility in subprocess environments. |
| plugins/yellow-research/README.md | README updated to correctly describe the v3.1.0 key-resolution precedence and removes the outdated 'shell env no longer works' note. |
| .changeset/yellow-research-mcp-key-shell-env-fallback.md | Changeset file correctly marks yellow-research as a minor bump with an accurate description of the new shell-env fallback behavior. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Claude Code launches MCP server] --> B[plugin.json evaluates env block]
    B --> C[_USERCONFIG var = keychain value or empty]
    B --> D[plain var = shell env value or empty]
    C --> E[wrapper script executes]
    D --> E
    E --> F{userConfig value non-empty?}
    F -- Yes --> G[override plain var with keychain value - userConfig wins]
    F -- No --> H{shell env value non-empty?}
    G --> I[unset _USERCONFIG helper var]
    H -- Yes --> I
    H -- No --> J[unset the var entirely - MCP sees absent not empty string]
    I --> K[exec npx MCP server process]
    J --> K
```

<sub>Reviews (3): Last reviewed commit: ["docs(yellow-research): split per-server ..."](https://github.com/kinginyellows/yellow-plugins/commit/74ef82c0da06ddbe4d1c7f2cac899a6f6af0e2f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31359552)</sub>

<!-- /greptile_comment -->