### PR TITLE
docs: explain skill listing budget knobs in README + CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -345,6 +345,21 @@ a version bump.
 - Constants: `UPPER_SNAKE_CASE`
 - Plugin names: `kebab-case`
 
+## Skill Description Budget
+
+Plugin skill descriptions are subject to Claude Code's session-level
+[skill listing budget](https://code.claude.com/docs/en/skills) (default 1%
+of context, 8,000-char fallback). Each individual skill's combined
+`description` + `when_to_use` is officially capped at **1,536 characters**;
+yellow-plugins skill descriptions are all well under that limit.
+
+Authors should not artificially trim descriptions to fit the budget — that
+hurts auto-invocation accuracy. Instead, document per-user knobs in the
+README for downstream installs that hit the budget. See [`claude doctor`
+says "descriptions dropped"](README.md#claude-doctor-says-descriptions-dropped)
+for the user-side workaround (`skillListingBudgetFraction`,
+`SLASH_COMMAND_TOOL_CHAR_BUDGET`).
+
 ## Questions?
 
 - Browse each plugin's README for usage

--- a/README.md
+++ b/README.md
@@ -284,6 +284,47 @@ yellow-plugins/
 └── docs/                      # Validation guides, operational docs, and solutions
 ```
 
+## Troubleshooting
+
+### `claude doctor` says "descriptions dropped"
+
+If `claude doctor` shows a warning like
+`157 descriptions dropped (4.9%/1% of context)`, your skill listing budget
+is too small for the total skill descriptions installed across all your
+plugins. This is a **per-user Claude Code setting**, not a plugin problem
+— yellow-plugins skill descriptions are well under the official 1,536-char
+per-skill cap (per [code.claude.com/docs/en/skills](https://code.claude.com/docs/en/skills)).
+
+The default budget is 1% of the context window, with an 8,000-character
+fallback. Two ways to give Claude Code more room:
+
+1. **Raise `skillListingBudgetFraction`** — edit `~/.claude/settings.json`:
+
+   ```jsonc
+   {
+     "skillListingBudgetFraction": 0.04
+   }
+   ```
+
+   `0.04` (4%) is enough to fit the full yellow-plugins marketplace plus
+   typical adjacent installs, at the cost of roughly 8K extra characters
+   reserved from the per-session context window. Note: this setting is
+   community-discovered (decompiled from Claude Code 2.1.129) and not yet
+   in the official docs — it may be renamed before public documentation.
+
+2. **Set `SLASH_COMMAND_TOOL_CHAR_BUDGET`** as an environment variable for
+   a one-off raise without editing settings. Default is 15,000 characters;
+   set higher (e.g. `SLASH_COMMAND_TOOL_CHAR_BUDGET=40000`) to fit larger
+   skill listings.
+
+(Disabling skills via `/skills` or `skillOverrides` is intentionally
+omitted: those knobs apply to user-scoped skills, not plugin-provided
+skills, and would not reduce yellow-plugins' contribution to the
+budget.)
+
+The warning is informational — Claude Code drops the lowest-priority
+descriptions first. Critical skills you use frequently stay listed.
+
 ## License
 
 MIT


### PR DESCRIPTION
`claude doctor` warns "skill descriptions dropped" when the combined
skill listing across all installed plugins exceeds the per-user
budget (default 1% of context / 8000-char fallback). This is a
per-user Claude Code setting, not a plugin authoring problem —
yellow-plugins skill descriptions are well under the official 1,536-
char per-skill cap.

Adds:
- README.md "Troubleshooting" section with three workarounds:
  raise skillListingBudgetFraction, set
  SLASH_COMMAND_TOOL_CHAR_BUDGET env var, disable rarely-used skills
  via /skills or skillOverrides: name-only.
- CONTRIBUTING.md "Skill Description Budget" section telling
  authors NOT to artificially trim descriptions to fit the budget
  (hurts auto-invocation accuracy); link to the README workaround.

No skill descriptions are modified. No plugin files touched —
no changeset required.

Plan: plans/2026-05-08-doctor-fix-rollback-userconfig-pattern.md

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds user-facing documentation to address the `claude doctor` "descriptions dropped" warning when the cumulative skill listing exceeds Claude Code's per-session budget. No plugin code or skill descriptions are modified.

- **README.md** gains a "Troubleshooting" section with two concrete workarounds (`skillListingBudgetFraction` in `settings.json` and the `SLASH_COMMAND_TOOL_CHAR_BUDGET` env var), including a community-discovered caveat on the settings key and example values for both options.
- **CONTRIBUTING.md** gains a "Skill Description Budget" section telling authors not to artificially trim descriptions, with a link to the new README section for per-user remediation.

<h3>Confidence Score: 5/5</h3>

Documentation-only change; no plugin code, skill descriptions, or configuration files are modified, so there is no runtime risk.

Both changed files add purely informational prose. The undocumented-setting caveat and concrete SLASH_COMMAND_TOOL_CHAR_BUDGET=40000 example correctly incorporate the feedback from prior review threads. The anchor link in CONTRIBUTING.md resolves correctly against the new README heading. Nothing here can break runtime behavior.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Adds a Troubleshooting section with two clearly scoped workarounds; the undocumented-setting caveat and concrete env-var example both address prior review feedback. |
| CONTRIBUTING.md | Adds a Skill Description Budget section that correctly directs authors away from artificial trimming and links to the new README troubleshooting anchor. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["claude doctor warns\n'descriptions dropped'"] --> B{Is it a\nplugin problem?}
    B -- "No – yellow-plugins\nall under 1,536 chars" --> C[Per-user Claude Code\nsetting needs adjustment]
    C --> D[Option 1: Raise skillListingBudgetFraction\nin ~/.claude/settings.json\ne.g. 0.04]
    C --> E[Option 2: Set SLASH_COMMAND_TOOL_CHAR_BUDGET\nenv var e.g. 40000]
    D --> F[Community-discovered setting\nnot yet in official docs]
    E --> G[Officially documented\ndefault 15,000 chars]
    F --> H[Warning resolved]
    G --> H
```

<sub>Reviews (3): Last reviewed commit: ["fix: address PR #459 review comments"](https://github.com/kinginyellows/yellow-plugins/commit/ee713e2ce2ba1a9efbc4a12c55d76662acf23a79) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31360882)</sub>

<!-- /greptile_comment -->