### PR TITLE
feat(yellow-core): add $schema pointer (single-plugin probe)

### DIFF
--- a/.changeset/yellow-core-schema-pointer-probe.md
+++ b/.changeset/yellow-core-schema-pointer-probe.md
@@ -1,0 +1,13 @@
+---
+"yellow-core": patch
+---
+
+Add `$schema` pointer to `https://json.schemastore.org/claude-code-plugin-manifest.json`
+in `plugin.json`. Single-plugin probe — IDE/editor JSON Schema autocomplete
+should now work, and Claude Code's plugin loader should silently ignore the
+field per official docs ("Claude Code ignores this field at load time"). If
+the remote validator unexpectedly rejects this key on install (similar to
+the recent `userConfig.pattern` rejection), this single bump can be reverted
+without affecting any other plugin.
+
+Gates the broader 17-plugin rollout in a follow-up PR.

--- a/plugins/yellow-core/.claude-plugin/plugin.json
+++ b/plugins/yellow-core/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "yellow-core",
   "version": "1.15.1",
   "description": "Dev toolkit with review agents, research agents, and workflow commands for TypeScript, Python, Rust, and Go",


### PR DESCRIPTION
Adds the canonical JSON Schema pointer to yellow-core's plugin.json:

  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json"

Per https://code.claude.com/docs/en/plugins-reference, Claude Code's
plugin loader ignores this field at load time, but editors and IDEs
use it for autocomplete and inline validation against the official
remote validator schema.

This is a single-plugin PROBE before rolling out to all 18 plugins.
The recent userConfig.pattern incident (PR1, this stack) confirmed
that local AJV validation does NOT match Claude Code's remote
validator. If $schema is unexpectedly rejected on a fresh install
(claude doctor), this single bump can be reverted without affecting
the rest of the marketplace. The bulk 17-plugin rollout in the next
stack PR is gated on a successful manual install probe of yellow-core.

Plan: plans/2026-05-08-doctor-fix-rollback-userconfig-pattern.md

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the canonical `$schema` pointer to `yellow-core`'s `plugin.json`, wiring it to the official SchemaStore schema (`https://json.schemastore.org/claude-code-plugin-manifest.json`). The change is deliberately scoped to a single plugin as a probe before rolling out to the remaining 17 plugins.

- **`plugins/yellow-core/.claude-plugin/plugin.json`**: Adds `"$schema"` as the first key; the SchemaStore URL is confirmed to exist and is the exact example cited in the official Claude Code plugins-reference docs. Claude Code ignores this field at load time, so there is no runtime impact.
- **`.changeset/yellow-core-schema-pointer-probe.md`**: Correctly records a `patch` bump for `yellow-core` and documents the single-plugin probe rationale and the gate for the follow-up 17-plugin rollout.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change adds a single ignored-at-runtime metadata field to one JSON file with no behavioral impact.

The only modified file is `plugin.json`, where a `$schema` field is added as the first key. The SchemaStore URL is confirmed live and is the exact example in the official Claude Code docs. Claude Code explicitly ignores this field at load time, so no install path, validation gate, or runtime behavior is affected. The changeset is correctly typed as a patch. There are no logic changes, no schema migrations, and no conditional paths introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/yellow-core/.claude-plugin/plugin.json | Adds `$schema` pointer to the official SchemaStore URL; JSON remains valid and correctly ordered. |
| .changeset/yellow-core-schema-pointer-probe.md | New changeset entry correctly marks yellow-core as a patch bump and documents the single-plugin probe rationale. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["plugin.json loaded by Claude Code"] --> B{"$schema field present?"}
    B -->|yes| C["Claude Code ignores $schema at load time"]
    B -->|no| C
    C --> D["Plugin loads normally"]
    A --> E["Editor / IDE reads plugin.json"]
    E --> F["Fetches schema from SchemaStore\nhttps://json.schemastore.org/\nclaude-code-plugin-manifest.json"]
    F --> G["Autocomplete + inline validation\nenabled in editor"]
```

<sub>Reviews (4): Last reviewed commit: ["feat(yellow-core): add $schema pointer (..."](https://github.com/kinginyellows/yellow-plugins/commit/15d9f14574e76a3215adc7832ea6ccfbabb3421c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31360895)</sub>

<!-- /greptile_comment -->