### PR TITLE
feat: add $schema pointer to remaining 17 plugin manifests + CONTRIBUTING

### DIFF
--- a/.changeset/plugin-json-schema-pointer-rollout.md
+++ b/.changeset/plugin-json-schema-pointer-rollout.md
@@ -1,0 +1,34 @@
+---
+"gt-workflow": patch
+"yellow-browser-test": patch
+"yellow-chatprd": patch
+"yellow-ci": patch
+"yellow-codex": patch
+"yellow-composio": patch
+"yellow-council": patch
+"yellow-debt": patch
+"yellow-devin": patch
+"yellow-docs": patch
+"yellow-linear": patch
+"yellow-mempalace": patch
+"yellow-morph": patch
+"yellow-research": patch
+"yellow-review": patch
+"yellow-ruvector": patch
+"yellow-semgrep": patch
+---
+
+Add `$schema` pointer to all remaining plugin manifests:
+`https://json.schemastore.org/claude-code-plugin-manifest.json`
+
+Per https://code.claude.com/docs/en/plugins-reference, Claude Code's
+plugin loader ignores this field at load time, but editors and IDEs
+use it for autocomplete and inline validation against the official
+remote validator schema. yellow-core received the pointer earlier in
+the stack as a single-plugin probe; this PR extends it to the other 17.
+
+Also documents local vs remote validator divergence in CONTRIBUTING.md
+with a recipe for empirical install testing (`claude plugin validate`,
+`claude --plugin-url`, fresh-install probe). The `claude plugin validate`
+CI integration is deferred to a follow-up PR pending CI runtime
+evaluation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -345,6 +345,38 @@ a version bump.
 - Constants: `UPPER_SNAKE_CASE`
 - Plugin names: `kebab-case`
 
+## Local vs Remote Validator Divergence
+
+Yellow-plugins runs two local validation passes: `pnpm validate:plugins`
+checks plugin-specific rules in `scripts/validate-plugin.js` (path existence,
+hook script sanity, userConfig allowlist, hooks.json drift), and
+`pnpm validate:schemas` runs AJV against `schemas/plugin.schema.json`. CI
+runs both. **Neither passing guarantees the plugin will install successfully
+via `claude doctor`.** Claude Code's remote validator can reject keys our
+local schemas permit — recent examples:
+
+| Field | Status | Symptom on `claude doctor` |
+|---|---|---|
+| `userConfig.<key>.pattern` | rejected | `Unrecognized key: "pattern"` (PR #409 → reverted 2026-05-08) |
+| `plugin.changelog` | rejected | unknown root key |
+| `repository: {type, url}` (npm-style) | rejected | invalid type, expects string |
+| `userConfig.<key>` missing `type` or `title` | rejected | required fields per official schema |
+
+**Always test schema-affecting changes on a fresh install before merging:**
+
+1. Run `claude plugin validate` (official local CLI) — catches more than AJV.
+2. Optional: bundle plugin to a zip + serve via HTTPS, then test load in a
+   disposable session via `claude --plugin-url <https-artifact-url>`. This
+   exercises the client-side load path (still not the marketplace remote
+   validator, but closest available).
+3. Most reliable: check out the PR branch on a clean machine, install the
+   marketplace, and run `claude doctor` to confirm zero plugin errors.
+
+The canonical official schema reference is
+`https://json.schemastore.org/claude-code-plugin-manifest.json`. All plugins
+in this marketplace declare it via `"$schema": "..."` in `plugin.json` for
+editor autocomplete and inline validation.
+
 ## Skill Description Budget
 
 Plugin skill descriptions are subject to Claude Code's session-level

--- a/plugins/gt-workflow/.claude-plugin/plugin.json
+++ b/plugins/gt-workflow/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "gt-workflow",
   "version": "1.5.1",
   "description": "Graphite-native workflow commands for stacked PR development. Provides smart commit-and-submit with parallel audit agents, stack planning, sync, and navigation — all through the gt CLI.",

--- a/plugins/yellow-browser-test/.claude-plugin/plugin.json
+++ b/plugins/yellow-browser-test/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "yellow-browser-test",
   "version": "1.1.1",
   "description": "Autonomous web app testing with agent-browser — auto-discovery, structured flows, exploratory testing, and bug reporting",

--- a/plugins/yellow-chatprd/.claude-plugin/plugin.json
+++ b/plugins/yellow-chatprd/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "yellow-chatprd",
   "version": "1.3.1",
   "description": "ChatPRD MCP integration with document management workflows and Linear bridging for Claude Code",

--- a/plugins/yellow-ci/.claude-plugin/plugin.json
+++ b/plugins/yellow-ci/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "yellow-ci",
   "version": "1.4.1",
   "description": "CI failure diagnosis, workflow linting, and runner health management for self-hosted GitHub Actions runners",

--- a/plugins/yellow-codex/.claude-plugin/plugin.json
+++ b/plugins/yellow-codex/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "yellow-codex",
   "version": "0.2.2",
   "description": "OpenAI Codex CLI wrapper with review, rescue, and analysis agents for workflow integration",

--- a/plugins/yellow-composio/.claude-plugin/plugin.json
+++ b/plugins/yellow-composio/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "yellow-composio",
   "version": "1.2.2",
   "description": "Optional Composio accelerator for batch workflows with usage tracking",

--- a/plugins/yellow-council/.claude-plugin/plugin.json
+++ b/plugins/yellow-council/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "yellow-council",
   "version": "0.2.0",
   "description": "On-demand cross-lineage code review fanning out to Codex, Gemini, and OpenCode CLIs in parallel for advisory consensus",

--- a/plugins/yellow-debt/.claude-plugin/plugin.json
+++ b/plugins/yellow-debt/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "yellow-debt",
   "version": "1.6.3",
   "description": "Technical debt audit and remediation with parallel scanner agents. Use when you need to assess codebase health, identify AI-generated debt patterns, prioritize findings, and systematically remediate technical debt.",

--- a/plugins/yellow-devin/.claude-plugin/plugin.json
+++ b/plugins/yellow-devin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "yellow-devin",
   "version": "2.3.1",
   "description": "Devin.AI V3 API integration — delegate tasks, manage sessions, review and remediate PRs, research codebases via DeepWiki, orchestrate plan-implement-review chains",

--- a/plugins/yellow-docs/.claude-plugin/plugin.json
+++ b/plugins/yellow-docs/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "yellow-docs",
   "version": "1.3.0",
   "description": "Documentation audit, generation, and Mermaid diagram creation for any repository",

--- a/plugins/yellow-linear/.claude-plugin/plugin.json
+++ b/plugins/yellow-linear/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "yellow-linear",
   "version": "1.3.0",
   "description": "Linear MCP integration with PM workflows for issues, projects, initiatives, cycles, and documents",

--- a/plugins/yellow-mempalace/.claude-plugin/plugin.json
+++ b/plugins/yellow-mempalace/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "yellow-mempalace",
   "version": "1.1.1",
   "description": "Structured long-term memory with temporal knowledge graph via MemPalace",

--- a/plugins/yellow-morph/.claude-plugin/plugin.json
+++ b/plugins/yellow-morph/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "yellow-morph",
   "version": "1.2.3",
   "description": "Intelligent code editing and search via Morph Fast Apply and WarpGrep",

--- a/plugins/yellow-research/.claude-plugin/plugin.json
+++ b/plugins/yellow-research/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "yellow-research",
   "version": "3.1.0",
   "description": "Deep research plugin with Ceramic, Perplexity, Tavily, EXA, Parallel Task, and ast-grep MCP servers. Code research inline; deep research saved to docs/research/.",

--- a/plugins/yellow-review/.claude-plugin/plugin.json
+++ b/plugins/yellow-review/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "yellow-review",
   "version": "3.1.1",
   "description": "Multi-agent PR review with adaptive agent selection, parallel comment resolution, and sequential stack review. Graphite-native workflow.",

--- a/plugins/yellow-ruvector/.claude-plugin/plugin.json
+++ b/plugins/yellow-ruvector/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "yellow-ruvector",
   "version": "1.1.2",
   "description": "Persistent vector memory and semantic code search for Claude Code agents via ruvector",

--- a/plugins/yellow-semgrep/.claude-plugin/plugin.json
+++ b/plugins/yellow-semgrep/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "yellow-semgrep",
   "version": "4.0.3",
   "description": "Semgrep security finding remediation — fetch, fix, and verify 'to fix' findings from the Semgrep AppSec Platform",

--- a/schemas/plugin.schema.json
+++ b/schemas/plugin.schema.json
@@ -94,6 +94,11 @@
     }
   },
   "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "description": "Optional pointer to the official Claude Code plugin manifest schema (https://json.schemastore.org/claude-code-plugin-manifest.json). Claude Code's plugin loader ignores this field at load time per the official docs; editors and IDEs use it for autocomplete and inline validation. Declared here so additionalProperties:false at root does not reject it if AJV is later wired against real plugin manifests."
+    },
     "name": {
       "type": "string",
       "pattern": "^[a-z0-9-]+$",


### PR DESCRIPTION
Extends the yellow-core $schema probe (previous stack PR) to the
other 17 plugins in the marketplace:

  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json"

Per https://code.claude.com/docs/en/plugins-reference, Claude Code's
plugin loader ignores this field at load time, but editors and IDEs
use it for autocomplete and inline validation against the official
remote validator schema.

Plugins updated (17): gt-workflow, yellow-browser-test, yellow-chatprd,
yellow-ci, yellow-codex, yellow-composio, yellow-council, yellow-debt,
yellow-devin, yellow-docs, yellow-linear, yellow-mempalace, yellow-morph,
yellow-research, yellow-review, yellow-ruvector, yellow-semgrep.

CONTRIBUTING.md adds a "Local vs Remote Validator Divergence" section
with the empirical install-test recipe:

1. claude plugin validate (official local CLI)
2. claude --plugin-url <https-artifact-url> (closest to install probe)
3. Fresh-install + claude doctor (most reliable)

NOTE: The claude plugin validate CI integration is DEFERRED to a
follow-up PR. Local vs remote validator drift remains a manual gate
for now; this PR codifies the documentation while the CI tooling
question is evaluated separately.

Plan: plans/2026-05-08-doctor-fix-rollback-userconfig-pattern.md

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `"$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json"` as the first field in all 17 remaining plugin manifests (yellow-core received the pointer in the previous stack PR as a probe), and updates the local AJV schema and CONTRIBUTING.md to match.

- **17 plugin manifests** each get one new line; the changes are mechanically identical and the URL is consistent across all files.
- **`schemas/plugin.schema.json`** gains an explicit `$schema` property definition so `additionalProperties: false` at the root does not reject the pointer field when AJV is run against real manifests.
- **CONTRIBUTING.md** gains a \"Local vs Remote Validator Divergence\" section with a divergence table and a three-step empirical install-test recipe; the changeset correctly lists all 17 packages as patch bumps.

<h3>Confidence Score: 5/5</h3>

This is a mechanical, additive-only change — one new line per manifest, one new property in the local AJV schema — with no logic altered and no existing fields touched.

Every manifest receives exactly the same one-line addition in the same position, the local schema is updated to permit the field, and the CONTRIBUTING.md documents the divergence risk explicitly. The yellow-core probe PR already validated that the remote validator accepts this field, and the plugin loader is documented to ignore it at load time. Nothing here can break an existing install.

No files require special attention. All 17 manifest edits are structurally identical and the schema update is a straightforward allowlist addition.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .changeset/plugin-json-schema-pointer-rollout.md | Changeset correctly lists all 17 modified plugins as patch bumps; description is accurate. |
| CONTRIBUTING.md | Adds a 'Local vs Remote Validator Divergence' section with a divergence table and a three-step empirical install-test recipe; content is accurate and well-placed. |
| schemas/plugin.schema.json | Adds $schema as an explicit property (type:string, format:uri) so additionalProperties:false at root does not reject the pointer field when AJV is run against real manifests. |
| plugins/gt-workflow/.claude-plugin/plugin.json | Adds $schema as first property, consistent with all other updated manifests. |
| plugins/yellow-semgrep/.claude-plugin/plugin.json | Adds $schema as first property; change is identical in structure to all 16 other modified manifests. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[plugin.json with $schema pointer] --> B{Validation path}
    B --> C[Local: pnpm validate:schemas]
    B --> D[Editor/IDE tooling]
    B --> E[Claude Code plugin loader]
    C --> F[AJV against schemas/plugin.schema.json now allows $schema field]
    D --> G[Fetches SchemaStore for autocomplete + inline validation]
    E --> H[Ignores $schema at load time per official docs]
    F --> I{CI passes?}
    I -- yes --> J[Merge safe]
    I -- no --> K[Fix schema]
    J --> L[Fresh-install gate via claude doctor still manual]
```

<sub>Reviews (4): Last reviewed commit: ["fix: address PR #461 review comment"](https://github.com/kinginyellows/yellow-plugins/commit/b5cb014e238c36653df590444859475a5b8f72ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31360918)</sub>

<!-- /greptile_comment -->