### PR TITLE
feat(agents): add explicit model/effort to 8 phase-1 agents (M-A-01)

### DIFF
--- a/.changeset/model-explicit-phase-1.md
+++ b/.changeset/model-explicit-phase-1.md
@@ -1,0 +1,28 @@
+---
+"yellow-docs": patch
+"yellow-council": patch
+"yellow-core": patch
+"yellow-ci": patch
+"yellow-debt": patch
+"yellow-research": patch
+---
+
+Add explicit `model:` and `effort:` frontmatter to 8 phase-1 agents to escape
+the inheritance trap on narrow-role agents and add chain-of-thought depth to
+synthesizers/orchestrators.
+
+- `product-lens-reviewer` (yellow-docs): `model: sonnet` (matches sibling
+  reviewers' explicit tiering)
+- `gemini-reviewer`, `opencode-reviewer` (yellow-council): `model: haiku` +
+  `effort: low` — CLI relay agents that do no reasoning
+- `learnings-researcher` (yellow-core): `model: haiku` + `effort: low` — BM25
+  retrieval, no synthesis; called on every `/review:pr` and `/workflows:plan`
+- `runner-assignment` (yellow-ci): `model: haiku` + `effort: low` —
+  deterministic label-matching against fixed runner taxonomy
+- `audit-synthesizer` (yellow-debt): `effort: high` (model already `opus`) —
+  cross-scanner deduplication and confidence gating benefit from extended CoT
+- `research-conductor` (yellow-research): `effort: high` (model already
+  `opus`) — multi-source fan-out routing involves ambiguous decomposition
+- `brainstorm-orchestrator` (yellow-core): `model: sonnet` + `effort: high` —
+  iterative dialogue with research integration; Sonnet is the structured-
+  orchestration ceiling

--- a/docs/brainstorms/2026-05-08-research-integration-model-selection-context-optimization-brainstorm.md
+++ b/docs/brainstorms/2026-05-08-research-integration-model-selection-context-optimization-brainstorm.md
@@ -190,12 +190,12 @@ frontmatter scalars via `parseScalar()`.
 
 #### Rule V1: `effort:` enum validation
 
-If `effort:` is present in agent frontmatter, its value must be one of `low | medium | high | max`.
+If `effort:` is present in agent frontmatter, its value must be one of `low | medium | high | xhigh | max`.
 Any other value is a hard error. This prevents typos (`hight`, `lo`) from silently falling
 back to default behavior.
 
 **Implementation:** Add `parseScalar(frontmatter, 'effort')` → if not null, check against
-`['low', 'medium', 'high', 'max']` → push error on mismatch.
+`['low', 'medium', 'high', 'xhigh', 'max']` → push error on mismatch.
 
 #### Rule V2: `model:` enum validation
 
@@ -221,9 +221,9 @@ nudge behavior until the pattern is established. Escalation to error is a follow
 
 #### Rule V4: `effort: high` advisory for synthesizer/orchestrator agents (warning, not error)
 
-Agents whose description contains keywords `synthesize`, `orchestrat`, `deduplicate`, or
-`merge` that lack `effort: high` or `effort: max` produce a non-blocking advisory. This
-surfaces the recommendation without blocking.
+Agents whose `name:` field matches keywords `synthesizer`, `orchestrator`, `conductor`,
+`aggregator`, or `compounder` that lack `effort: high`, `effort: xhigh`, or `effort: max`
+produce a non-blocking advisory. This surfaces the recommendation without blocking.
 
 **Note:** Rules V3 and V4 produce warnings via a new `warnings` array (alongside the existing
 `errors` array). The exit code remains 0 if only warnings are present. CI output prints

--- a/docs/brainstorms/2026-05-08-research-integration-model-selection-context-optimization-brainstorm.md
+++ b/docs/brainstorms/2026-05-08-research-integration-model-selection-context-optimization-brainstorm.md
@@ -1,0 +1,299 @@
+# Brainstorm: Model Selection and Token/Context Optimization Research Integration
+
+**Date:** 2026-05-08
+**Source research:** `docs/research/model-selection-token-context-optimization.md`
+**Status:** Decisions resolved — ready for `/workflows:plan`
+
+---
+
+## What We're Building
+
+Incorporate the model-selection and token/context-optimization research findings into
+the yellow-plugins system by assigning explicit `model:` and `effort:` frontmatter values
+to every agent where `model: inherit` is either wasteful or wrong, and by extending
+`validate-agent-authoring.js` with lint rules that prevent the inheritance trap from
+silently reappearing in future agents.
+
+The work is delivered across 5 Graphite-stackable PRs so `/workflows:plan` can peel off
+one stage at a time. The staging is ordered by risk and coordination cost — not by value,
+which is roughly equal across phases.
+
+---
+
+## Why This Approach
+
+**The inheritance trap is real and measurable.** 71 of 79 agents (90%) use `model: inherit`.
+When a user runs `/review:pr` from an Opus session, all dispatched reviewers inherit Opus
+at ~5-8x the cost of an equivalent Sonnet invocation — for pattern-matching tasks that have
+no quality ceiling above Sonnet. The yellow-docs plugin already demonstrates the correct
+pattern (explicit haiku/sonnet tiering across 6 of 7 reviewers); the rest of the system
+should converge to that pattern.
+
+**Code quality is preserved by:**
+1. Keeping all agents that require genuine synthesis, adversarial reasoning, or
+   cross-domain orchestration on `model: opus` (no downgrades for those).
+2. Adding `effort: high` to synthesizers and orchestrators, not reducing it from default.
+3. Extending the validator so future agents authored without explicit `model:` on
+   narrow-role agents produce a CI warning rather than silently inheriting.
+4. No schema changes required — `model:` and `effort:` are already valid recognized
+   frontmatter fields per the subagent frontmatter catalog.
+
+---
+
+## Key Decisions
+
+1. **No golden-set testing gates.** Model assignments are made on the basis of the
+   research doc's evidence and each agent's documented role. The right assignment is
+   chosen up front, not validated experimentally before merge.
+
+2. **`model: inherit` is retained where correct** — CLI wrappers for external tools
+   (yellow-codex, yellow-devin, yellow-composio, yellow-morph, yellow-ruvector, yellow-mempalace)
+   where the parent's model choice should flow through, and integration-only agents
+   whose quality is bounded by the external API they call.
+
+3. **`effort:` is only set where there's a clear behavioral reason** — `effort: low`
+   for single-pass mechanical tasks, `effort: high` for synthesizers and orchestrators
+   that benefit from extended chain-of-thought. Agents at the default (`effort: medium`
+   implicit) are left unset to avoid noise.
+
+4. **Validator additions are warning-not-error for `model: inherit` on narrow agents**
+   initially, to avoid blocking existing external contributors. Strict error level is a
+   follow-on decision after Phase 4 is in and patterns are established.
+
+5. **Staging — 5 Graphite-stackable PRs:**
+   - **PR 1 (Phase 1):** ~8 agents across yellow-docs, yellow-council, yellow-core, yellow-ci, yellow-debt, yellow-research — no-risk frontmatter additions only.
+   - **PR 2 (Phase 2):** All 5 yellow-debt scanners + `debt-fixer` + `knowledge-compounder` + `session-historian` — single PR, single changeset for the yellow-debt and yellow-core plugins touched.
+   - **PR 3 (Phase 3a):** yellow-review reviewer-tier agents (~13 agents) — scoped to yellow-review plugin only.
+   - **PR 4 (Phase 3b):** yellow-core review/research/workflow persona agents (~10 agents) — scoped to yellow-core plugin only. Keeps blast radius for the `/review:pr` pipeline split across two reviewable PRs.
+   - **PR 5 (Phase 4):** `validate-agent-authoring.js` V1–V4 rules + tests — tooling-only, no plugin file changes.
+
+---
+
+## Per-Agent Assignment Table
+
+All assignments approved. Legend: `(no change)` = current value is correct, explicitly confirming it.
+Agents not listed are `model: inherit` with no change recommended.
+
+---
+
+### Phase 1 — No-Risk, No-Schema-Change Wins
+
+These are single-line frontmatter additions with zero quality risk. Changeset per plugin.
+
+| Agent | File | Current | Proposed `model:` | Proposed `effort:` | Rationale |
+|---|---|---|---|---|---|
+| `product-lens-reviewer` | `plugins/yellow-docs/agents/review/product-lens-reviewer.md` | `inherit` | `sonnet` | — | Premise-challenging and strategic-consequence analysis — same job as `design-lens-reviewer` and `scope-guardian-reviewer` siblings which are already `model: sonnet`. Aligns to yellow-docs's own explicit tiering pattern. |
+| `gemini-reviewer` | `plugins/yellow-council/agents/review/gemini-reviewer.md` | `inherit` | `haiku` | `low` | CLI relay agent — constructs a `gemini -p "..."` shell invocation and fences the output. Does zero reasoning. Haiku + effort:low is correct for relay tasks. |
+| `opencode-reviewer` | `plugins/yellow-council/agents/review/opencode-reviewer.md` | `inherit` | `haiku` | `low` | Identical reasoning to gemini-reviewer: invokes `opencode run --format json` and parses the JSON event stream. The agent itself does not analyze code. |
+| `learnings-researcher` | `plugins/yellow-core/agents/research/learnings-researcher.md` | `inherit` | `haiku` | `low` | BM25-style keyword search over `docs/solutions/` using Read/Grep/Glob only — structured retrieval with no multi-step reasoning. Called on every `/review:pr` and `/workflows:plan` invocation, making this one of the highest-frequency agents in the system. |
+| `runner-assignment` | `plugins/yellow-ci/agents/ci/runner-assignment.md` | `inherit` | `haiku` | `low` | Deterministic label-matching: workflow job labels → runner capability → `runs-on` recommendation. Fixed taxonomy, no ambiguous judgment. |
+| `audit-synthesizer` | `plugins/yellow-debt/agents/synthesis/audit-synthesizer.md` | `opus` (no change) | `opus` | `high` | Correctly Opus (no model change). Add `effort: high` — cross-scanner deduplication, confidence gating, and multi-axis severity scoring benefit from extended chain-of-thought. Pure quality improvement with no cost regression. |
+| `research-conductor` | `plugins/yellow-research/agents/research/research-conductor.md` | `opus` (no change) | `opus` | `high` | Correctly Opus (no model change). Add `effort: high` — complexity triage and multi-source fan-out decisions involve ambiguous decomposition problems where extended reasoning reduces routing errors. |
+| `brainstorm-orchestrator` | `plugins/yellow-core/agents/workflow/brainstorm-orchestrator.md` | `inherit` | `sonnet` | `high` | Iterative dialogue with research integration, AskUserQuestion orchestration, approach synthesis, and doc write. Sonnet is the quality ceiling for this structured orchestration task; effort:high adds deliberation for approach exploration. |
+
+---
+
+### Phase 2 — Parallel Scanner Tier + yellow-debt Remediation + yellow-core Workflow Agents
+
+One PR covering all files in this phase (yellow-debt scanners + debt-fixer + yellow-core workflow agents).
+
+#### yellow-debt scanners + remediation agent
+
+All five scanners are single-pass, taxonomy-driven analysis agents using Read/Grep only.
+They are dispatched in parallel by `/debt:audit` and their output is fed to `audit-synthesizer`.
+The research doc's finding: Sonnet is the quality ceiling for fixed-taxonomy pattern matching;
+there is no creative synthesis and no multi-domain cross-referencing in these agents.
+
+| Agent | File | Current | Proposed `model:` | Proposed `effort:` | Rationale |
+|---|---|---|---|---|---|
+| `ai-pattern-scanner` | `plugins/yellow-debt/agents/scanners/ai-pattern-scanner.md` | `inherit` | `sonnet` | `low` | Matches AI-generated code patterns (excessive comments, boilerplate, over-specification) against a fixed taxonomy. Structured single-pass scan. |
+| `complexity-scanner` | `plugins/yellow-debt/agents/scanners/complexity-scanner.md` | `inherit` | `sonnet` | `low` | Cyclomatic/cognitive complexity analysis via Grep/Bash against defined thresholds. Deterministic metric extraction. |
+| `duplication-scanner` | `plugins/yellow-debt/agents/scanners/duplication-scanner.md` | `inherit` | `sonnet` | `low` | Near-duplicate detection over defined code blocks. Pattern-matching task with no synthesis requirement. |
+| `architecture-scanner` | `plugins/yellow-debt/agents/scanners/architecture-scanner.md` | `inherit` | `sonnet` | `low` | Circular dependency and boundary violation detection — structural graph analysis against declared module boundaries. |
+| `security-debt-scanner` | `plugins/yellow-debt/agents/scanners/security-debt-scanner.md` | `inherit` | `sonnet` | `low` | Security tech debt patterns (deprecated crypto, missing validation, hardcoded config) — NOT active vulnerabilities. Taxonomy application, not adversarial reasoning. Distinguished from `security-sentinel` which stays on Opus for active vulnerability audits. |
+| `debt-fixer` | `plugins/yellow-debt/agents/remediation/debt-fixer.md` | `inherit` | `sonnet` | — | Implements concrete code edits from an accepted debt-item spec in an isolated worktree. Real code editing from a structured spec — Sonnet is the appropriate model for well-bounded implementation tasks. |
+
+#### yellow-core workflow agents
+
+| Agent | File | Current | Proposed `model:` | Proposed `effort:` | Rationale |
+|---|---|---|---|---|---|
+| `knowledge-compounder` | `plugins/yellow-core/agents/workflow/knowledge-compounder.md` | `inherit` | `sonnet` | — | Orchestration logic for deciding what to document, detecting novelty, and dispatching sub-agents. Requires reasoning but not Opus-level synthesis — sub-agents handle the writing. |
+| `session-historian` | `plugins/yellow-core/agents/workflow/session-historian.md` | `inherit` | `sonnet` | — | Cross-vendor session search with BM25 + cosine + RRF fusion. Sophisticated retrieval with ranking logic, but no creative synthesis — ranking and returning is a Sonnet-ceiling task. |
+
+---
+
+### Phase 3 — yellow-review and yellow-core Reviewer Tier
+
+This is the highest file-count change (12+ agents) and the most user-visible pipeline.
+The research doc's analysis: `architecture-strategist` and `adversarial-reviewer` are
+correctly Opus; the pattern-matching and single-axis review agents should be Sonnet.
+
+Split into two PRs (PR 3 and PR 4) for blast-radius management:
+- **PR 3 (Phase 3a):** yellow-review plugin agents only
+- **PR 4 (Phase 3b):** yellow-core review/research/workflow persona agents + yellow-docs feasibility/adversarial reviewers
+
+#### Agents to downgrade from `inherit` to `sonnet`
+
+These agents apply a defined review lens (single axis) with no cross-domain synthesis.
+The research doc's rationale: Sonnet reliably catches real issues within each agent's scope.
+
+| Agent | File | Current | Proposed `model:` | Proposed `effort:` | Rationale |
+|---|---|---|---|---|---|
+| `correctness-reviewer` | `plugins/yellow-review/agents/review/correctness-reviewer.md` | `inherit` | `sonnet` | — | Always-on logic-error and edge-case reviewer. Single-axis analysis (correctness) against a defined review lens. Sonnet is the quality ceiling for structured code review with well-defined evaluation criteria. |
+| `maintainability-reviewer` | `plugins/yellow-review/agents/review/maintainability-reviewer.md` | `inherit` | `sonnet` | — | Always-on dead code, coupling, and naming reviewer. Pattern-matching against maintainability anti-patterns — defined taxonomy, single axis. |
+| `project-standards-reviewer` | `plugins/yellow-review/agents/review/project-standards-reviewer.md` | `inherit` | `sonnet` | — | Always-on CLAUDE.md/AGENTS.md compliance reviewer. Rule-application against documented project standards — no judgment beyond what the standards docs say. |
+| `project-compliance-reviewer` | `plugins/yellow-review/agents/review/project-compliance-reviewer.md` | `inherit` | `sonnet` | — | Always-on naming and convention adherence reviewer. Complements project-standards-reviewer; same reasoning applies. |
+| `reliability-reviewer` | `plugins/yellow-review/agents/review/reliability-reviewer.md` | `inherit` | `sonnet` | — | Conditional error-handling, retries, and async-safety reviewer. Structured review of error propagation and reliability patterns — Sonnet-ceiling task. |
+| `silent-failure-hunter` | `plugins/yellow-review/agents/review/silent-failure-hunter.md` | `inherit` | `sonnet` | — | try-catch and error-suppression detector. Pattern-matching for identifiable silent-failure antipatterns — single-pass structured scan. |
+| `pr-test-analyzer` | `plugins/yellow-review/agents/review/pr-test-analyzer.md` | `inherit` | `sonnet` | — | Test coverage and behavioral completeness analysis scoped to the PR diff. Coverage gap detection against defined criteria. |
+| `comment-analyzer` | `plugins/yellow-review/agents/review/comment-analyzer.md` | `inherit` | `sonnet` | — | Comment accuracy and rot detection. Structural comparison of comments to adjacent code — pattern-matching, no synthesis. |
+| `type-design-analyzer` | `plugins/yellow-review/agents/review/type-design-analyzer.md` | `inherit` | `sonnet` | — | Type invariant and encapsulation analysis. Well-defined evaluation criteria per language (TS/Py/Rust/Go). |
+| `code-simplifier` | `plugins/yellow-review/agents/review/code-simplifier.md` | `inherit` | `sonnet` | — | Post-fix YAGNI and simplification pass. Rule-application (YAGNI) against code that has already been reviewed — Sonnet is sufficient for identifying unnecessary abstractions in-context. |
+| `plugin-contract-reviewer` | `plugins/yellow-review/agents/review/plugin-contract-reviewer.md` | `inherit` | `sonnet` | — | Plugin manifest breaking-change detector. Structured comparison of before/after frontmatter and plugin.json surface — defined schema rules, no ambiguous judgment. |
+| `cli-readiness-reviewer` | `plugins/yellow-review/agents/review/cli-readiness-reviewer.md` | `inherit` | `sonnet` | — | Conditional CLI agent-readiness reviewer. Applies the 7-principle rubric from `agent-cli-readiness-reviewer` to CLI code diffs — rule-application task. |
+| `pr-comment-resolver` | `plugins/yellow-review/agents/workflow/pr-comment-resolver.md` | `inherit` | `sonnet` | — | Implements a single coherent fix for a cluster of PR review comments in the same file region. Localized edit with clear constraints — Sonnet is sufficient for in-context reconciliation. |
+| `code-simplicity-reviewer` | `plugins/yellow-core/agents/review/code-simplicity-reviewer.md` | `inherit` | `sonnet` | — | YAGNI enforcement pre-fix pass. Same reasoning as code-simplifier — rule-application against defined YAGNI criteria. |
+| `pattern-recognition-specialist` | `plugins/yellow-core/agents/review/pattern-recognition-specialist.md` | `inherit` | `sonnet` | — | Anti-pattern, naming, and convention inconsistency detector. Pattern-matching against codebase conventions — defined taxonomy, no creative synthesis. |
+| `test-coverage-analyst` | `plugins/yellow-core/agents/review/test-coverage-analyst.md` | `inherit` | `sonnet` | — | Full test-suite audit for coverage gaps and assertion quality. Structured analysis against test quality criteria — Sonnet-ceiling task. |
+| `polyglot-reviewer` | `plugins/yellow-core/agents/review/polyglot-reviewer.md` | `inherit` | `sonnet` | — | Language-idiomatic review (TS/Py/Rust/Go). Sonnet has reliable coverage of language idioms across all four target languages. Research doc confirms this as a Sonnet-ceiling task. |
+| `spec-flow-analyzer` | `plugins/yellow-core/agents/workflow/spec-flow-analyzer.md` | `inherit` | `sonnet` | — | User experience flow analysis and requirements review. Structured evaluation of UX flows against completeness criteria — analysis with defined axes, not open-ended synthesis. |
+| `security-lens` | `plugins/yellow-core/agents/review/security-lens.md` | `inherit` | `sonnet` | — | Plan-level security architect reviewing auth/authz assumptions and attack surface in planning docs. Plan-level review with defined threat-model dimensions — Sonnet is the quality ceiling for this structured assessment. |
+| `security-reviewer` | `plugins/yellow-core/agents/review/security-reviewer.md` | `inherit` | `sonnet` | — | Conditional persona adding calibrated confidence on top of security-sentinel's broader audit. This agent synthesizes security-sentinel output — it does not independently discover vulnerabilities. Sonnet is appropriate for this synthesis/calibration role. |
+| `performance-reviewer` | `plugins/yellow-core/agents/review/performance-reviewer.md` | `inherit` | `sonnet` | — | Conditional performance persona that adds anchored confidence calibration on top of `performance-oracle`'s deeper analysis. Calibration/synthesis role, not primary discovery. |
+| `feasibility-reviewer` | `plugins/yellow-docs/agents/review/feasibility-reviewer.md` | `inherit` | `sonnet` | — | Evaluates whether proposed technical approaches survive contact with reality — architecture conflicts, migration risks, implementability. Structured feasibility assessment with defined evaluation criteria, matching the yellow-docs sibling pattern. |
+| `adversarial-document-reviewer` | `plugins/yellow-docs/agents/review/adversarial-document-reviewer.md` | `inherit` | `sonnet` | `high` | Premise-challenging and stress-testing of high-stakes planning documents (5+ requirements, auth/payments/migrations/compliance). The adversarial angle requires deliberation — `effort: high` adds reasoning depth. Sonnet rather than Opus because this reviewer applies a structured challenge protocol, not open-ended novel synthesis. |
+
+#### Agents that stay on `opus` (confirming existing or implicit assignments)
+
+| Agent | File | Current | Proposed `model:` | Rationale |
+|---|---|---|---|---|
+| `architecture-strategist` | `plugins/yellow-core/agents/review/architecture-strategist.md` | `opus` | `opus` (no change) | SOLID, dependency direction, API contract stability — architectural judgment is the canonical Opus use case. Cross-domain synthesis with high downstream cost if wrong. |
+| `security-sentinel` | `plugins/yellow-core/agents/review/security-sentinel.md` | `opus` | `opus` (no change) | Active vulnerability audit (OWASP top 10, injection, XSS, auth/authz flaws). Adversarial reasoning requiring deep multi-step inference — false negatives here are high-cost. Opus is correct. |
+| `performance-oracle` | `plugins/yellow-core/agents/review/performance-oracle.md` | `opus` | `opus` (no change) | Primary performance bottleneck analysis — algorithmic complexity, N+1, memory management. This is the discovery agent (not the calibration persona); Opus earns its cost for novel complexity reasoning. |
+| `adversarial-reviewer` | `plugins/yellow-review/agents/review/adversarial-reviewer.md` | `opus` | `opus` (no change) | Constructs failure scenarios to break the implementation rather than checking patterns. Active adversarial reasoning is Opus territory — this agent's value is in finding failures that pattern-matching misses. |
+| `agent-cli-readiness-reviewer` | `plugins/yellow-review/agents/review/agent-cli-readiness-reviewer.md` | `opus` | `opus` (no change) | 7-principle severity rubric including nuanced distinctions (Blocker vs. Friction vs. Optimization) and architectural CLI design judgment. Opus is defensible for this level of compound judgment. |
+| `agent-native-reviewer` | `plugins/yellow-review/agents/review/agent-native-reviewer.md` | `opus` | `opus` (no change) | Agent-native parity review: UI/agent action parity, context parity, primitive-vs-workflow tool design, dynamic context injection in system prompts. Multi-axis novel reasoning — correctly Opus. |
+
+---
+
+### Phase 4 — Validator Layer
+
+> **Note (2026-05-08):** This section captures the brainstorm-time sketch of V1–V4. The
+> canonical implementation spec — including the final `effort:` enum (which adds `xhigh`)
+> and V4's match on the agent `name:` field rather than `description:` keywords — lives
+> in `plans/model-selection-frontmatter-rollout.md` Phase 5. Refer to the plan, not this
+> section, when implementing or auditing the validator rules.
+
+Add lint rules to `validate-agent-authoring.js` that make the inheritance trap a CI signal
+rather than a silent default. No schema changes required — the validator already parses
+frontmatter scalars via `parseScalar()`.
+
+#### Rule V1: `effort:` enum validation
+
+If `effort:` is present in agent frontmatter, its value must be one of `low | medium | high | max`.
+Any other value is a hard error. This prevents typos (`hight`, `lo`) from silently falling
+back to default behavior.
+
+**Implementation:** Add `parseScalar(frontmatter, 'effort')` → if not null, check against
+`['low', 'medium', 'high', 'max']` → push error on mismatch.
+
+#### Rule V2: `model:` enum validation
+
+If `model:` is present, its value must be one of `inherit | haiku | sonnet | opus` (or a
+versioned form like `sonnet-4-5`, `opus-4-6`). Any other value is a hard error. This catches
+misspellings and invalid model IDs before they silently fall back to the session default.
+
+**Implementation:** Add `parseScalar(frontmatter, 'model')` → validate against known enum
+(allow prefix match for versioned IDs like `haiku-4-5`).
+
+#### Rule V3: `model: inherit` warning for narrow-role agents (warning, not error)
+
+Agents in the following subdirectory patterns that use `model: inherit` produce a
+non-blocking CI warning (not error) to nudge authors toward explicit assignment:
+- `agents/scanners/` — single-pass taxonomy scanners
+- `agents/ci/` — CI analysis agents
+
+The warning message: `[V3 advisory] {file}: model: inherit on a scanner/CI agent — consider
+explicit model: sonnet or model: haiku based on task complexity.`
+
+**Rationale for warning-not-error:** External contributors shouldn't be blocked; this is
+nudge behavior until the pattern is established. Escalation to error is a follow-on decision.
+
+#### Rule V4: `effort: high` advisory for synthesizer/orchestrator agents (warning, not error)
+
+Agents whose description contains keywords `synthesize`, `orchestrat`, `deduplicate`, or
+`merge` that lack `effort: high` or `effort: max` produce a non-blocking advisory. This
+surfaces the recommendation without blocking.
+
+**Note:** Rules V3 and V4 produce warnings via a new `warnings` array (alongside the existing
+`errors` array). The exit code remains 0 if only warnings are present. CI output prints
+warnings in yellow, errors in red.
+
+---
+
+## Agents with No Change Recommended
+
+The following agents correctly use `model: inherit` because:
+- They are pure CLI/API wrappers for external tools where the parent model choice
+  should flow through (`yellow-codex`, `yellow-devin`, `yellow-composio`, `yellow-morph`)
+- They are integration agents whose output quality is bounded by the external service
+  (`yellow-linear`, `yellow-mempalace`, `yellow-ruvector`, `yellow-chatprd`)
+- They are runner/diagnostic agents where inherit is appropriate (`yellow-browser-test`,
+  yellow-ci `runner-diagnostics`, `workflow-optimizer`, `failure-analyst`)
+- Their role is primarily workflow orchestration that benefits from the parent session's
+  full model quality (e.g., `devin-orchestrator`, `repo-research-analyst`,
+  `best-practices-researcher`, `git-history-analyzer`, `code-researcher`)
+- They are generation agents (doc-generator, diagram-architect) where output quality
+  scales with model capability and inherit is intentional
+- They are the yellow-docs `doc-auditor` (scanning, but within a docs-generation context
+  where inherit from the parent session is appropriate)
+
+Specific no-change list:
+`app-discoverer`, `test-reporter`, `test-runner`, `document-assistant`, `document-reviewer`,
+`linear-prd-bridge`, `project-dashboard`, `failure-analyst`, `workflow-optimizer`,
+`runner-diagnostics`, `codex-analyst`, `codex-reviewer`, `codex-executor`,
+`best-practices-researcher`, `git-history-analyzer`, `repo-research-analyst`,
+`devin-orchestrator`, `doc-auditor`, `diagram-architect`, `doc-generator`,
+`linear-explorer`, `linear-issue-loader`, `linear-pr-linker`, `memory-archivist`,
+`palace-navigator`, `code-researcher`, `ruvector-memory-manager`, `ruvector-semantic-search`,
+`finding-fixer`, `coherence-reviewer` (already `model: haiku`, no change).
+
+`scan-verifier` (yellow-semgrep) is already `model: sonnet` — no change.
+
+---
+
+## Resolved Decisions
+
+These questions were raised during the brainstorm and answered by the user. Recorded here
+for traceability by future readers and `/workflows:plan`.
+
+1. **`adversarial-document-reviewer`: `sonnet` + `effort: high` confirmed.**
+   This reviewer challenges document premises using a structured protocol (defined challenge
+   axes, conditional triggers). `adversarial-reviewer` in yellow-review constructs novel
+   failure scenarios for code — open-ended adversarial reasoning that warrants Opus. The
+   structured-vs-novel-failure-scenarios distinction is the rationale for the split.
+
+2. **`performance-oracle` stays on `opus` confirmed.**
+   Primary performance discovery agent — algorithmic complexity, N+1, memory management.
+   This is the reasoning agent (not the calibration persona `performance-reviewer`); Opus
+   earns its cost here.
+
+3. **`security-reviewer` and `security-lens` both `sonnet` confirmed.**
+   Both are calibration/synthesis personas that layer on top of `security-sentinel` (Opus).
+   The sentinel handles discovery at Opus depth; the calibration step does not need to
+   duplicate that cost. Defense in depth is preserved by keeping `security-sentinel` on Opus.
+
+4. **`debt-fixer` added to Phase 2 as `model: sonnet`.**
+   The agent implements concrete code edits from an accepted debt-item spec in an isolated
+   worktree. Real code editing from a structured spec is a Sonnet-ceiling task. Added to
+   the Phase 2 table alongside the scanner tier.
+
+5. **Validator severity: V1 and V2 are hard errors; V3 and V4 remain warnings.**
+   V1 (`effort:` enum) and V2 (`model:` enum) validate values that are already present —
+   a typo here is unambiguously wrong and should block CI. V3 (inheritance advisory for
+   scanner/CI agents) and V4 (effort advisory for synthesizers) are inference-based nudges
+   where external contributors shouldn't be blocked. No escalation path planned.
+
+6. **5 Graphite-stackable PRs (option A') confirmed.** See staging structure in Key Decisions.
+   Phase 3 split into 3a (yellow-review) and 3b (yellow-core + yellow-docs) for blast-radius
+   scoping. Phase 4 (validator tooling) stands alone as a tooling-only PR.

--- a/plans/model-selection-frontmatter-rollout.md
+++ b/plans/model-selection-frontmatter-rollout.md
@@ -34,7 +34,7 @@ Five Graphite-stackable PRs, ordered by risk and coordination cost:
 3. **PR 3 (Phase 3a):** yellow-review reviewer-tier downgrades (13 agents).
 4. **PR 4 (Phase 3b):** yellow-core review/research/workflow personas + 2
    yellow-docs reviewers (10 files).
-5. **PR 5 (Phase 4):** Validator V1–V4 rules + tests (tooling-only, no plugin
+5. **PR 5 (Phase 5):** Validator V1–V4 rules + tests (tooling-only, no plugin
    files, no changeset).
 
 Code quality is preserved because:
@@ -70,7 +70,7 @@ Branch: `agent/feat/model-explicit-phase-1`
 - [ ] 1.9: Edit
   `plugins/yellow-core/agents/workflow/brainstorm-orchestrator.md` — add
   `model: sonnet` and `effort: high`
-- [ ] 1.10: Run `pnpm validate:agents && pnpm validate:plugins`
+- [ ] 1.10: Run `pnpm validate:schemas && pnpm validate:agents && pnpm validate:plugins`
 - [ ] 1.11: WSL2 normalize: `for f in <edited files>; do sed -i 's/\r$//' "$f"; done`
 - [ ] 1.12: `pnpm changeset` — single file, `patch` bumps for `yellow-docs`,
   `yellow-council`, `yellow-core`, `yellow-ci`, `yellow-debt`, `yellow-research`
@@ -100,7 +100,7 @@ Branch: `agent/feat/model-explicit-phase-2` (stacked on PR 1)
   add `model: sonnet`
 - [ ] 2.5: Edit `plugins/yellow-core/agents/workflow/session-historian.md` —
   add `model: sonnet`
-- [ ] 2.6: Run `pnpm validate:agents && pnpm validate:plugins`
+- [ ] 2.6: Run `pnpm validate:schemas && pnpm validate:agents && pnpm validate:plugins`
 - [ ] 2.7: WSL2 normalize edited files
 - [ ] 2.8: `pnpm changeset` — **one file**, `patch` bumps for **both**
   `yellow-debt` AND `yellow-core` (mirrors PR A-01 precedent from 2026-05-07)
@@ -134,7 +134,7 @@ Branch: `agent/feat/model-explicit-phase-3a` (stacked on PR 2)
   - `plugin-contract-reviewer.md`
   - `cli-readiness-reviewer.md`
   - `agents/workflow/pr-comment-resolver.md`
-- [ ] 3.3: Run `pnpm validate:agents && pnpm validate:plugins`
+- [ ] 3.3: Run `pnpm validate:schemas && pnpm validate:agents && pnpm validate:plugins`
 - [ ] 3.4: WSL2 normalize edited files
 - [ ] 3.5: `pnpm changeset` — single `patch` bump for `yellow-review`
 - [ ] 3.6: `gt commit create -m "feat(yellow-review): tier 13 reviewer agents to sonnet"`
@@ -171,7 +171,7 @@ confirmations, not edits.
 - [ ] 4.4: Edit
   `plugins/yellow-docs/agents/review/adversarial-document-reviewer.md` — add
   `model: sonnet` and `effort: high`
-- [ ] 4.5: Run `pnpm validate:agents && pnpm validate:plugins`
+- [ ] 4.5: Run `pnpm validate:schemas && pnpm validate:agents && pnpm validate:plugins`
 - [ ] 4.6: WSL2 normalize edited files
 - [ ] 4.7: `pnpm changeset` — one file, `patch` bumps for `yellow-core` AND
   `yellow-docs`
@@ -382,8 +382,9 @@ PR 5 (validator-only) requires NO changeset.
 
 1. Each PR's per-phase acceptance criteria (above) met.
 2. After PR 5 lands, `pnpm validate:agents` against the live plugin tree
-   exits 0 with optional V3/V4 warnings only on allowlisted files (none
-   expected since allowlist excludes those).
+   exits 0 and emits zero V3/V4 warnings, because every file that would
+   otherwise trigger them is either explicitly tiered (Phases 1–4) or
+   listed in `MODEL_RULE_ALLOWLIST` (the 3 intentional-inherit exemptions).
 3. After all 5 PRs land, `grep -rn '^model:' plugins/*/agents/ | wc -l`
    shows the expected count of explicit assignments (~30 + the 8 already
    on opus/sonnet pre-rollout = ~38).

--- a/plans/model-selection-frontmatter-rollout.md
+++ b/plans/model-selection-frontmatter-rollout.md
@@ -1,0 +1,473 @@
+# Feature: Model Selection & Effort Frontmatter Rollout
+
+## Overview
+
+Add explicit `model:` and `effort:` frontmatter to ~30 yellow-plugins agents,
+delivered as a 5-PR Graphite stack, plus 4 lint rules (V1–V4) in
+`scripts/validate-agent-authoring.js` to prevent the inheritance trap from
+silently reappearing. No schema changes required — all fields are already in
+the canonical subagent frontmatter catalog.
+
+**Source brainstorm:**
+`docs/brainstorms/2026-05-08-research-integration-model-selection-context-optimization-brainstorm.md`
+
+**Source research:**
+`docs/research/model-selection-token-context-optimization.md`
+
+## Problem Statement
+
+71 of 79 agents (90%) use `model: inherit`. When a user runs `/review:pr` from
+an Opus session, all dispatched reviewers inherit Opus at ~5–8× the cost of
+an equivalent Sonnet invocation — for pattern-matching tasks that have no
+quality ceiling above Sonnet. The yellow-docs plugin already demonstrates the
+correct pattern (explicit haiku/sonnet tiering across 6 of 7 reviewers); the
+rest of the system should converge on it. Without a validator gate, future
+agents revert to silent inheritance.
+
+## Proposed Solution
+
+Five Graphite-stackable PRs, ordered by risk and coordination cost:
+
+1. **PR 1 (Phase 1):** No-risk frontmatter additions across 6 plugins (8 agents).
+2. **PR 2 (Phase 2):** yellow-debt scanners + `debt-fixer` + 2 yellow-core
+   workflow agents (8 files, 2 plugins).
+3. **PR 3 (Phase 3a):** yellow-review reviewer-tier downgrades (13 agents).
+4. **PR 4 (Phase 3b):** yellow-core review/research/workflow personas + 2
+   yellow-docs reviewers (10 files).
+5. **PR 5 (Phase 4):** Validator V1–V4 rules + tests (tooling-only, no plugin
+   files, no changeset).
+
+Code quality is preserved because:
+- Architectural reasoning, adversarial code analysis, and primary security
+  discovery agents stay on Opus.
+- Synthesizers and orchestrators get `effort: high` (added behavior, not
+  reduced).
+- The validator's V1/V2 enum checks are hard errors; V3/V4 advisory rules are
+  warnings with exit code 0 to avoid blocking external contributors.
+
+## Implementation Plan
+
+### Phase 1 — PR 1: No-Risk Frontmatter Additions
+
+Branch: `agent/feat/model-explicit-phase-1`
+
+- [ ] 1.1: `gt branch create agent/feat/model-explicit-phase-1`
+- [ ] 1.2: Edit `plugins/yellow-docs/agents/review/product-lens-reviewer.md` —
+  add `model: sonnet` (insert between `description:` and `background:`)
+- [ ] 1.3: Edit `plugins/yellow-council/agents/review/gemini-reviewer.md` —
+  add `model: haiku` and `effort: low`
+- [ ] 1.4: Edit `plugins/yellow-council/agents/review/opencode-reviewer.md` —
+  add `model: haiku` and `effort: low`
+- [ ] 1.5: Edit `plugins/yellow-core/agents/research/learnings-researcher.md` —
+  add `model: haiku` and `effort: low`
+- [ ] 1.6: Edit `plugins/yellow-ci/agents/ci/runner-assignment.md` — add
+  `model: haiku` and `effort: low`
+- [ ] 1.7: Edit `plugins/yellow-debt/agents/synthesis/audit-synthesizer.md` —
+  add `effort: high` (model already `opus`)
+- [ ] 1.8: Edit
+  `plugins/yellow-research/agents/research/research-conductor.md` — add
+  `effort: high` (model already `opus`)
+- [ ] 1.9: Edit
+  `plugins/yellow-core/agents/workflow/brainstorm-orchestrator.md` — add
+  `model: sonnet` and `effort: high`
+- [ ] 1.10: Run `pnpm validate:agents && pnpm validate:plugins`
+- [ ] 1.11: WSL2 normalize: `for f in <edited files>; do sed -i 's/\r$//' "$f"; done`
+- [ ] 1.12: `pnpm changeset` — single file, `patch` bumps for `yellow-docs`,
+  `yellow-council`, `yellow-core`, `yellow-ci`, `yellow-debt`, `yellow-research`
+- [ ] 1.13: `gt commit create -m "feat: add explicit model/effort to 8 phase-1 agents"`
+- [ ] 1.14: `gt stack submit`
+
+**Acceptance criteria for PR 1:**
+- 8 agent files modified; 0 other plugin files touched.
+- `pnpm validate:agents` passes.
+- `pnpm validate:plugins` passes.
+- Changeset declares 6 plugin patches in one file.
+- `grep -L 'model:' <edited files>` returns empty (every edited file has
+  `model:`).
+
+### Phase 2 — PR 2: Scanners + debt-fixer + yellow-core workflow
+
+Branch: `agent/feat/model-explicit-phase-2` (stacked on PR 1)
+
+- [ ] 2.1: `gt branch create agent/feat/model-explicit-phase-2`
+- [ ] 2.2: Edit 5 `plugins/yellow-debt/agents/scanners/{ai-pattern,complexity,duplication,architecture,security-debt}-scanner.md` —
+  add `model: sonnet` and `effort: low` to each
+- [ ] 2.3: Edit `plugins/yellow-debt/agents/remediation/debt-fixer.md` —
+  add `model: sonnet`. Spot-check first: confirm frontmatter has no
+  `isolation:` or `permissionMode:` value that would interact with the
+  downgrade. (No effort field added.)
+- [ ] 2.4: Edit `plugins/yellow-core/agents/workflow/knowledge-compounder.md` —
+  add `model: sonnet`
+- [ ] 2.5: Edit `plugins/yellow-core/agents/workflow/session-historian.md` —
+  add `model: sonnet`
+- [ ] 2.6: Run `pnpm validate:agents && pnpm validate:plugins`
+- [ ] 2.7: WSL2 normalize edited files
+- [ ] 2.8: `pnpm changeset` — **one file**, `patch` bumps for **both**
+  `yellow-debt` AND `yellow-core` (mirrors PR A-01 precedent from 2026-05-07)
+- [ ] 2.9: `gt commit create -m "feat: tier yellow-debt scanners and yellow-core workflow agents"`
+- [ ] 2.10: `gt stack submit`
+
+**Acceptance criteria for PR 2:**
+- 8 files modified across 2 plugins.
+- Changeset declares both `yellow-debt: patch` and `yellow-core: patch`.
+- `validate-versions.js` passes (would fail if either changeset entry
+  missing).
+- `debt-fixer` frontmatter spot-check: tools list is `[Read, Edit, Write,
+  Bash, AskUserQuestion]`-compatible; no Opus-tier-only tools present.
+
+### Phase 3 — PR 3 (Phase 3a): yellow-review reviewer tier
+
+Branch: `agent/feat/model-explicit-phase-3a` (stacked on PR 2)
+
+- [ ] 3.1: `gt branch create agent/feat/model-explicit-phase-3a`
+- [ ] 3.2: Edit 13 yellow-review agents — add `model: sonnet`:
+  - `correctness-reviewer.md`
+  - `maintainability-reviewer.md`
+  - `project-standards-reviewer.md`
+  - `project-compliance-reviewer.md`
+  - `reliability-reviewer.md`
+  - `silent-failure-hunter.md`
+  - `pr-test-analyzer.md`
+  - `comment-analyzer.md`
+  - `type-design-analyzer.md`
+  - `code-simplifier.md`
+  - `plugin-contract-reviewer.md`
+  - `cli-readiness-reviewer.md`
+  - `agents/workflow/pr-comment-resolver.md`
+- [ ] 3.3: Run `pnpm validate:agents && pnpm validate:plugins`
+- [ ] 3.4: WSL2 normalize edited files
+- [ ] 3.5: `pnpm changeset` — single `patch` bump for `yellow-review`
+- [ ] 3.6: `gt commit create -m "feat(yellow-review): tier 13 reviewer agents to sonnet"`
+- [ ] 3.7: `gt stack submit`
+
+**Acceptance criteria for PR 3:**
+- 13 files modified, all in `plugins/yellow-review/agents/`.
+- Changeset declares `yellow-review: patch` only.
+- Verification: `grep -c 'model: sonnet' plugins/yellow-review/agents/review/*.md`
+  returns 12; `grep -c 'model: sonnet' plugins/yellow-review/agents/workflow/*.md`
+  returns 1 (pr-comment-resolver).
+
+### Phase 4 — PR 4 (Phase 3b): yellow-core personas + yellow-docs reviewers
+
+Branch: `agent/feat/model-explicit-phase-3b` (stacked on PR 3)
+
+**Actual file-touch count: 10 files** (8 yellow-core + 2 yellow-docs). The
+brainstorm's Phase 3 table additionally lists 3 yellow-core "stays on opus"
+rows and 3 yellow-docs already-correct siblings — those are documentation
+confirmations, not edits.
+
+- [ ] 4.1: `gt branch create agent/feat/model-explicit-phase-3b`
+- [ ] 4.2: Edit 8 yellow-core agents — add `model: sonnet`:
+  - `agents/review/code-simplicity-reviewer.md`
+  - `agents/review/pattern-recognition-specialist.md`
+  - `agents/review/test-coverage-analyst.md`
+  - `agents/review/polyglot-reviewer.md`
+  - `agents/review/security-lens.md`
+  - `agents/review/security-reviewer.md`
+  - `agents/review/performance-reviewer.md`
+  - `agents/workflow/spec-flow-analyzer.md`
+- [ ] 4.3: Edit `plugins/yellow-docs/agents/review/feasibility-reviewer.md` —
+  add `model: sonnet`
+- [ ] 4.4: Edit
+  `plugins/yellow-docs/agents/review/adversarial-document-reviewer.md` — add
+  `model: sonnet` and `effort: high`
+- [ ] 4.5: Run `pnpm validate:agents && pnpm validate:plugins`
+- [ ] 4.6: WSL2 normalize edited files
+- [ ] 4.7: `pnpm changeset` — one file, `patch` bumps for `yellow-core` AND
+  `yellow-docs`
+- [ ] 4.8: PR description must include "Already-correct (no edit) siblings:
+  `design-lens-reviewer`, `scope-guardian-reviewer`, `security-lens-reviewer`
+  in `plugins/yellow-docs/agents/review/`" — closes the documentation gap
+  surfaced in spec-flow analysis.
+- [ ] 4.9: `gt commit create -m "feat: tier yellow-core personas and yellow-docs reviewers"`
+- [ ] 4.10: `gt stack submit`
+
+**Acceptance criteria for PR 4:**
+- 10 files modified across 2 plugins.
+- Changeset declares both `yellow-core: patch` and `yellow-docs: patch`.
+- PR description acknowledges 3 yellow-docs siblings as already-correct.
+
+### Phase 5 — PR 5: Validator V1–V4 + tests
+
+Branch: `agent/feat/model-effort-validator-rules` (stacked on PR 4)
+
+**No changeset required** — modifies only `scripts/` and
+`tests/integration/`, not under `plugins/[^/]+/`.
+
+- [ ] 5.1: `gt branch create agent/feat/model-effort-validator-rules`
+
+#### 5a: Warnings infrastructure scaffold
+
+- [ ] 5.2: Edit `scripts/validate-agent-authoring.js`:
+  - Add `yellow: '\x1b[33m'` to the `colors` object (currently lines 40–45)
+  - Add `logWarning(msg)` helper paralleling `logError`/`logInfo` — yellow
+    color + `⚠ WARN:` prefix
+  - Add `const warnings = [];` parallel to `const errors = [];`
+  - Final reporting block: print `warnings.length` warnings (yellow) before
+    `errors.length` check; exit code stays 0 if `warnings.length > 0` and
+    `errors.length === 0`
+
+#### 5b: V1 effort enum (hard error)
+
+- [ ] 5.3: Add inside the main per-file loop:
+  ```js
+  const effortVal = parseScalar(frontmatter, 'effort');
+  if (effortVal !== null && !['low','medium','high','xhigh','max'].includes(effortVal)) {
+    errors.push(`${relPath}: invalid effort: '${effortVal}' (must be one of low|medium|high|xhigh|max)`);
+  }
+  ```
+  **Note:** `xhigh` is included (per the canonical subagent frontmatter
+  catalog, `docs/solutions/code-quality/subagent-frontmatter-field-catalog.md`
+  line 46) — omitting it creates a false-error trap for any agent legitimately
+  using `xhigh`.
+
+#### 5c: V2 model enum (hard error)
+
+- [ ] 5.4: Add inside the main per-file loop:
+  ```js
+  const modelVal = parseScalar(frontmatter, 'model');
+  if (modelVal !== null && !/^(haiku|sonnet|opus|inherit)(-\d+(-\d+)?)?$/.test(modelVal)) {
+    errors.push(`${relPath}: invalid model: '${modelVal}' (must match ^(haiku|sonnet|opus|inherit)(-\\d+(-\\d+)?)?$)`);
+  }
+  ```
+  Versioned IDs like `sonnet-4-5`, `opus-4-7`, `haiku-4-5` are valid;
+  arbitrary suffixes like `sonnet-invalid` are rejected.
+
+#### 5d: V3 inheritance advisory (warning) — with shared allowlist
+
+- [ ] 5.5: Add a `MODEL_RULE_ALLOWLIST` constant near the top of the file:
+  ```js
+  // Files exempt from V3/V4 advisory warnings — intentional inheritance.
+  const MODEL_RULE_ALLOWLIST = new Set([
+    'plugins/yellow-ci/agents/ci/failure-analyst.md',
+    'plugins/yellow-ci/agents/ci/workflow-optimizer.md',
+    'plugins/yellow-core/agents/workflow/devin-orchestrator.md',
+  ]);
+  ```
+- [ ] 5.6: Inside the main per-file loop, after V2:
+  ```js
+  if (modelVal === 'inherit' && !MODEL_RULE_ALLOWLIST.has(relPath)) {
+    const isScannerOrCi = relSegments.includes('scanners') ||
+                          (relSegments.includes('agents') &&
+                           relSegments[relSegments.indexOf('agents') + 1] === 'ci');
+    if (isScannerOrCi) {
+      warnings.push(`[V3 advisory] ${relPath}: model: inherit on a scanner/CI agent — consider explicit model: sonnet or model: haiku based on task complexity.`);
+    }
+  }
+  ```
+
+#### 5e: V4 effort:high advisory (warning) — name-field match + shared allowlist
+
+- [ ] 5.7: Inside the main per-file loop, after V3:
+  ```js
+  const nameVal = parseScalar(frontmatter, 'name') || '';
+  const effortHigh = effortVal === 'high' || effortVal === 'max' || effortVal === 'xhigh';
+  const synthesizerName = /(synthesizer|orchestrator|conductor|aggregator|compounder)/i.test(nameVal);
+  if (synthesizerName && !effortHigh && !MODEL_RULE_ALLOWLIST.has(relPath)) {
+    warnings.push(`[V4 advisory] ${relPath}: synthesizer/orchestrator agent without effort: high — consider extended chain-of-thought.`);
+  }
+  ```
+  Matches `name:` field instead of `description:` to reduce false positives
+  on integration agents that mention "synthesize" or "merge" in passing.
+
+#### 5f: Tests
+
+- [ ] 5.8: Create `tests/integration/validate-agent-authoring-model-effort-rules.test.ts`
+  with one `describe` block per rule. Pattern mirrors
+  `tests/integration/validate-agent-authoring-review-rule.test.ts` —
+  `VALIDATE_PLUGINS_DIR` env var, temp fixture trees, child-process
+  invocation via `execFileSync`, asserts on `status` and `stdout`/`stderr`.
+  Test matrix:
+  - **V1:** `effort: low` passes (status 0). `effort: hight` errors (status
+    nonzero, stderr contains `invalid effort`). Missing `effort:` passes.
+  - **V2:** `model: sonnet` passes. `model: sonnet-4-5` passes. `model: gpt-4`
+    errors. `model: sonnet-invalid` errors. Missing `model:` passes.
+  - **V3:** Scanner agent with `model: inherit` → status 0, stdout contains
+    `[V3 advisory]`. Scanner agent with `model: sonnet` → no V3 warning.
+    `agents/ci/foo.md` with `model: inherit` → V3 warning. Allowlisted file
+    (`failure-analyst.md` fixture in `agents/ci/`) → no V3 warning.
+  - **V4:** Agent named `*-synthesizer` without `effort: high` → V4 warning.
+    Same agent with `effort: high` → no warning. Agent with synthesizer-y
+    description but plain name → no warning. Allowlisted name →
+    no warning.
+  - **Exit-code semantics:** Fixture with V1 error AND V3 warning → status
+    nonzero (errors win), both messages appear in output.
+
+- [ ] 5.9: Run `pnpm test:integration -- validate-agent-authoring-model-effort-rules`
+- [ ] 5.10: Run full CI baseline: `pnpm validate:schemas && pnpm test:unit && pnpm lint && pnpm typecheck`
+- [ ] 5.11: WSL2 normalize: `sed -i 's/\r$//' scripts/validate-agent-authoring.js tests/integration/validate-agent-authoring-model-effort-rules.test.ts`
+- [ ] 5.12: `gt commit create -m "feat(validator): add V1-V4 model/effort lint rules"`
+- [ ] 5.13: `gt stack submit`
+
+**Acceptance criteria for PR 5:**
+- No changeset file (validator-only PR).
+- All 5 test groups pass (V1, V2, V3, V4, exit-code semantics).
+- `pnpm validate:agents` against the live `plugins/` tree exits 0 with
+  warnings printed but no errors (Phases 1–4 already landed correct values).
+- Allowlist documents the 3 intentional exemptions.
+
+## Technical Specifications
+
+### Files to Modify
+
+**Phase 1 (8 files):**
+- `plugins/yellow-docs/agents/review/product-lens-reviewer.md`
+- `plugins/yellow-council/agents/review/gemini-reviewer.md`
+- `plugins/yellow-council/agents/review/opencode-reviewer.md`
+- `plugins/yellow-core/agents/research/learnings-researcher.md`
+- `plugins/yellow-ci/agents/ci/runner-assignment.md`
+- `plugins/yellow-debt/agents/synthesis/audit-synthesizer.md`
+- `plugins/yellow-research/agents/research/research-conductor.md`
+- `plugins/yellow-core/agents/workflow/brainstorm-orchestrator.md`
+
+**Phase 2 (8 files):**
+- `plugins/yellow-debt/agents/scanners/ai-pattern-scanner.md`
+- `plugins/yellow-debt/agents/scanners/complexity-scanner.md`
+- `plugins/yellow-debt/agents/scanners/duplication-scanner.md`
+- `plugins/yellow-debt/agents/scanners/architecture-scanner.md`
+- `plugins/yellow-debt/agents/scanners/security-debt-scanner.md`
+- `plugins/yellow-debt/agents/remediation/debt-fixer.md`
+- `plugins/yellow-core/agents/workflow/knowledge-compounder.md`
+- `plugins/yellow-core/agents/workflow/session-historian.md`
+
+**Phase 3 (13 files):** All in `plugins/yellow-review/agents/`.
+**Phase 4 (10 files):** 8 in `plugins/yellow-core/agents/`, 2 in
+`plugins/yellow-docs/agents/review/`.
+
+**Phase 5:**
+- `scripts/validate-agent-authoring.js` (extend, ~50 added lines)
+- `tests/integration/validate-agent-authoring-model-effort-rules.test.ts` (new)
+
+### Frontmatter Insertion Convention
+
+Per yellow-docs precedent
+(`plugins/yellow-docs/agents/review/design-lens-reviewer.md` etc.), the field
+order is:
+
+```
+---
+name: <agent-name>
+description: <single-line>
+model: <haiku|sonnet|opus|inherit>
+effort: <low|medium|high|xhigh|max>     # optional, only when set
+background: <true|false>                # optional
+tools: [...]
+---
+```
+
+`model:` goes immediately after `description:`. `effort:` goes immediately
+after `model:` (before `background:` or `tools:`).
+
+### Dependencies
+
+None added.
+
+### Changeset Format
+
+Single multi-plugin changeset per phase that touches plugin files:
+
+```
+---
+"yellow-debt": patch
+"yellow-core": patch
+---
+
+Tier yellow-debt scanners and yellow-core workflow agents to explicit
+sonnet/effort frontmatter.
+```
+
+PR 5 (validator-only) requires NO changeset.
+
+## Acceptance Criteria
+
+1. Each PR's per-phase acceptance criteria (above) met.
+2. After PR 5 lands, `pnpm validate:agents` against the live plugin tree
+   exits 0 with optional V3/V4 warnings only on allowlisted files (none
+   expected since allowlist excludes those).
+3. After all 5 PRs land, `grep -rn '^model:' plugins/*/agents/ | wc -l`
+   shows the expected count of explicit assignments (~30 + the 8 already
+   on opus/sonnet pre-rollout = ~38).
+4. No agent in the brainstorm's "no change recommended" list has been
+   inadvertently modified.
+
+## Edge Cases & Resolutions Already Decided
+
+1. **`xhigh` effort value.** Included in V1's enum (per subagent frontmatter
+   catalog). Without this, agents legitimately using `xhigh` would trigger a
+   false hard-error.
+2. **V2 versioned model IDs.** Validated via the regex
+   `^(haiku|sonnet|opus|inherit)(-\d+(-\d+)?)?$` — accepts `sonnet-4-5`,
+   `opus-4-7`, `haiku-4-5`; rejects `sonnet-invalid`, `gpt-4`, etc.
+3. **V3 false positives on `failure-analyst` and `workflow-optimizer`.**
+   Resolved via shared `MODEL_RULE_ALLOWLIST` — both files exempted.
+4. **V4 false positives on intentional-inherit synthesizer-named agents.**
+   Resolved by matching `name:` field instead of `description:`, plus
+   `MODEL_RULE_ALLOWLIST` for `devin-orchestrator` (the lone post-name-narrowing
+   false positive).
+5. **PR ordering.** PRs 1–4 land before PR 5. Graphite stacking enforces this
+   implicitly. If PR 5 were to land first, V1/V2 (hard errors) would still
+   pass because pre-existing `model: inherit` and absent `effort:` are valid;
+   V3/V4 (warnings) would fire on more files but exit 0 — not a CI blocker.
+6. **Tool-capability risk for downgraded agents.** `debt-fixer` spot-check
+   in PR 2 verifies no Opus-tier-only tool dependency. Other downgrades
+   (Phase 3, Phase 4) are reviewer agents with read-only tool surfaces —
+   no capability risk.
+7. **Sub-agent dispatch model inheritance.** When a downgraded agent (e.g.,
+   `correctness-reviewer` at sonnet) dispatches sub-agents, those sub-agents
+   inherit from the dispatching agent's session, not the original parent.
+   This is per-design — sub-agent assignments in this rollout are
+   intentional and not affected.
+
+## Testing Strategy
+
+- **Per-PR:** `pnpm validate:agents && pnpm validate:plugins` after each
+  edit batch.
+- **PR 5:** `pnpm test:integration -- validate-agent-authoring-model-effort-rules`
+  covers all 5 test groups (V1, V2, V3, V4, exit-code semantics).
+- **Post-merge spot-check:** After each plugin-touching PR merges, run
+  `grep -c 'model:' plugins/<plugin>/agents/**/*.md` against expected count.
+
+**No golden-set behavioral testing.** Per brainstorm decision, model
+assignments are evidence-based from the research doc. Empirical validation
+of model behavior is out of scope.
+
+## Documentation Updates
+
+- Each plugin's `CLAUDE.md` "Known Limitations" section: NO updates required
+  (model tiering is a positive default, not a limitation).
+- `docs/research/model-selection-token-context-optimization.md`:
+  cross-reference unchanged — already exists as the source-of-truth research
+  doc.
+- The 3 yellow-docs siblings (`design-lens-reviewer`,
+  `scope-guardian-reviewer`, `security-lens-reviewer`) are explicitly
+  acknowledged as already-correct in PR 4's description (Step 4.8) — no
+  code change needed.
+
+## Migration & Rollback
+
+- **Migration:** None required for end users. Plugin updates flow through
+  the marketplace install/update path; changes are frontmatter-only and
+  take effect on next agent dispatch.
+- **Rollback:** Each PR is independently revertable via `gt downstack edit` +
+  delete branch, or `git revert <commit>` for landed commits. Rolling back
+  any one PR restores `model: inherit` for that PR's files; no data
+  migration needed.
+
+## References
+
+- Brainstorm:
+  `docs/brainstorms/2026-05-08-research-integration-model-selection-context-optimization-brainstorm.md`
+- Research:
+  `docs/research/model-selection-token-context-optimization.md`
+- Subagent frontmatter catalog:
+  `docs/solutions/code-quality/subagent-frontmatter-field-catalog.md`
+- yellow-docs tiering precedent:
+  `plugins/yellow-docs/agents/review/{design-lens,scope-guardian,security-lens}-reviewer.md`
+- Validator current state:
+  `scripts/validate-agent-authoring.js` (parseScalar at lines 67–71;
+  errors-only at line 163; exit gate at line 325)
+- Test pattern:
+  `tests/integration/validate-agent-authoring-review-rule.test.ts`
+- Multi-plugin changeset precedent (PR A-01, 2026-05-07): see
+  `plugins/yellow-review/CHANGELOG.md` lines 1–27 and
+  `plugins/yellow-core/CHANGELOG.md` lines 1–20

--- a/plugins/yellow-ci/agents/ci/runner-assignment.md
+++ b/plugins/yellow-ci/agents/ci/runner-assignment.md
@@ -1,7 +1,8 @@
 ---
 name: runner-assignment
 description: 'GitHub Actions runner assignment specialist. Analyzes workflow jobs against available self-hosted runner inventory to recommend optimal runs-on values. Use when spawned by ci:setup-self-hosted with a fenced runner inventory.'
-model: inherit
+model: haiku
+effort: low
 color: yellow
 skills:
   - ci-conventions

--- a/plugins/yellow-core/agents/research/learnings-researcher.md
+++ b/plugins/yellow-core/agents/research/learnings-researcher.md
@@ -1,7 +1,8 @@
 ---
 name: learnings-researcher
 description: "Searches docs/solutions/ for past learnings relevant to a PR diff or planning context, returning a fenced advisory block of distilled findings. Use when running review:pr, /workflows:plan, or /workflows:brainstorm — surfaces prior bugs, architecture patterns, design decisions, and conventions so institutional knowledge carries forward into the current work."
-model: inherit
+model: haiku
+effort: low
 tools:
   - Read
   - Grep

--- a/plugins/yellow-core/agents/workflow/brainstorm-orchestrator.md
+++ b/plugins/yellow-core/agents/workflow/brainstorm-orchestrator.md
@@ -1,7 +1,8 @@
 ---
 name: brainstorm-orchestrator
 description: 'Iterative brainstorm dialogue — questions, research, approaches, doc write. Input: feature topic or empty string. Output: docs/brainstorms/<date>-<topic>-brainstorm.md. Use when running /workflows:brainstorm.'
-model: inherit
+model: sonnet
+effort: high
 memory: project
 skills:
   - brainstorming

--- a/plugins/yellow-council/agents/review/gemini-reviewer.md
+++ b/plugins/yellow-council/agents/review/gemini-reviewer.md
@@ -1,7 +1,8 @@
 ---
 name: gemini-reviewer
 description: "Cross-lineage code reviewer that invokes the Google Gemini CLI for an independent verdict. Spawned by /council via Task. Returns structured findings with Verdict / Confidence / Findings / Summary."
-model: inherit
+model: haiku
+effort: low
 tools:
   - Bash
   - Read

--- a/plugins/yellow-council/agents/review/opencode-reviewer.md
+++ b/plugins/yellow-council/agents/review/opencode-reviewer.md
@@ -1,7 +1,8 @@
 ---
 name: opencode-reviewer
 description: "Cross-lineage code reviewer that invokes the OpenCode CLI for an independent verdict. Spawned by /council via Task. Returns structured findings with Verdict / Confidence / Findings / Summary."
-model: inherit
+model: haiku
+effort: low
 tools:
   - Bash
   - Read

--- a/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
+++ b/plugins/yellow-debt/agents/synthesis/audit-synthesizer.md
@@ -2,6 +2,7 @@
 name: audit-synthesizer
 description: "Merge scanner outputs, deduplicate findings, score severity, and generate reports. Use when synthesizing results from multiple debt scanners."
 model: opus
+effort: high
 background: true
 skills:
   - debt-conventions

--- a/plugins/yellow-docs/agents/review/product-lens-reviewer.md
+++ b/plugins/yellow-docs/agents/review/product-lens-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: product-lens-reviewer
 description: "Reviews planning documents as a senior product leader — challenges premise claims, assesses strategic consequences (trajectory, identity, adoption, opportunity cost), and surfaces goal-work misalignment. Domain-agnostic: users may be end users, developers, operators, or any audience. Use when reviewing PRDs, OKRs, strategy docs, or feature plans where premise validation matters via /docs:review."
-model: inherit
+model: sonnet
 background: true
 tools:
   - Read

--- a/plugins/yellow-research/agents/research/research-conductor.md
+++ b/plugins/yellow-research/agents/research/research-conductor.md
@@ -2,6 +2,7 @@
 name: research-conductor
 description: "Routes /research:deep queries across multiple MCP sources. Use when deep research needs multi-source investigation. Triages complexity and dispatches parallel fan-out -- simple queries try Ceramic first (keyword-tight) and fall back to Perplexity; moderate runs Ceramic plus 2-3 parallel sources; complex topics trigger full fan-out including Parallel Task MCP for async reports."
 model: opus
+effort: high
 background: true
 memory: project
 tools:


### PR DESCRIPTION
Escapes the inheritance trap on narrow-role agents (haiku/sonnet) and adds chain-of-thought depth to synthesizers/orchestrators (effort: high). Per docs/research/model-selection-token-context-optimization.md.

Phase 1 of a 5-PR Graphite stack. See plans/model-selection-frontmatter-rollout.md for the full sequence.

- product-lens-reviewer (yellow-docs): model: sonnet
- gemini-reviewer, opencode-reviewer (yellow-council): haiku + effort: low
- learnings-researcher (yellow-core): haiku + effort: low
- runner-assignment (yellow-ci): haiku + effort: low
- audit-synthesizer (yellow-debt): effort: high (model already opus)
- research-conductor (yellow-research): effort: high (model already opus)
- brainstorm-orchestrator (yellow-core): sonnet + effort: high

No schema changes. validate:schemas, validate:agents, validate:plugins all pass.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added research integration and model selection planning documents

* **Chores**
  * Updated agent configurations with explicit model assignments and effort level specifications across multiple plugins to replace inherited defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Phase 1 of a 5-PR Graphite stack that adds explicit `model:` and `effort:` frontmatter to 8 agents across 6 plugins, escaping the inheritance trap for narrow-role agents and adding chain-of-thought depth to synthesizers and orchestrators. No schema changes are introduced; all assigned values are already valid per the subagent frontmatter catalog.

- Four agents (`gemini-reviewer`, `opencode-reviewer`, `learnings-researcher`, `runner-assignment`) are downgraded from inherited model to `model: haiku + effort: low` to reduce cost on tasks characterized as relay/retrieval/deterministic routing work.
- Two existing Opus agents (`audit-synthesizer`, `research-conductor`) gain `effort: high` to deepen chain-of-thought for synthesis and fan-out routing.
- Two agents (`product-lens-reviewer`, `brainstorm-orchestrator`) are promoted from `model: inherit` to `model: sonnet` (with `effort: high` on the orchestrator), matching sibling agents' tiering patterns.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the Sonnet/Opus-tier changes; the four Haiku + effort:low assignments are the only area warranting attention, already tracked in open review threads.

The audit-synthesizer, research-conductor, brainstorm-orchestrator, and product-lens-reviewer assignments are well-matched to each agent's documented workflow. The four effort: low assignments (gemini-reviewer, opencode-reviewer, learnings-researcher, runner-assignment) are applied to agents whose internal bodies contain multi-step branching, scored routing, and distillation passes — tasks where minimal chain-of-thought allocation risks abbreviated outputs. Those concerns are already captured in open prior-review threads and have not been addressed by the current diff.

The four effort: low agents in plugins/yellow-council/agents/review/ and plugins/yellow-ci/agents/ci/runner-assignment.md and plugins/yellow-core/agents/research/learnings-researcher.md warrant a second look against the prior review thread feedback before merge.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/yellow-docs/agents/review/product-lens-reviewer.md | Upgrades model: inherit to model: sonnet, aligning with the sibling design-lens-reviewer and scope-guardian-reviewer agents in the same plugin. Frontmatter ordering is correct per convention. |
| plugins/yellow-council/agents/review/gemini-reviewer.md | Assigns model: haiku + effort: low; prior review threads flag a potential mismatch with the agent's 9-step orchestration workflow including multi-case bash heredoc generation and AWK credential-redaction. |
| plugins/yellow-council/agents/review/opencode-reviewer.md | Same model: haiku + effort: low assignment as gemini-reviewer; prior review thread notes an additional CRITICAL session-cleanup step that must execute on every code path. |
| plugins/yellow-core/agents/research/learnings-researcher.md | Assigns model: haiku + effort: low; prior thread notes the agent has a 7-step workflow including scoring/ranking and distillation that may benefit from more than minimal CoT on a high-frequency call path. |
| plugins/yellow-core/agents/workflow/brainstorm-orchestrator.md | Assigns model: sonnet + effort: high, matching the iterative-dialogue + AskUserQuestion orchestration role. Frontmatter order (model -> effort -> memory -> skills) is correct. |
| plugins/yellow-ci/agents/ci/runner-assignment.md | Assigns model: haiku + effort: low; prior review thread flags a mismatch with the agent's 9-step scored-routing workflow involving tiered semantic scoring, JIT pool materialization, and multi-case re-prompt logic. |
| plugins/yellow-debt/agents/synthesis/audit-synthesizer.md | Adds effort: high to an existing model: opus agent — clearly appropriate for an 8-step synthesis workflow with confidence-rubric gating, deduplication, severity scoring, and path-traversal guards. |
| plugins/yellow-research/agents/research/research-conductor.md | Adds effort: high to an existing model: opus agent — appropriate for a multi-source fan-out conductor with complexity triage, parallel async polling, and per-source fallback logic. |
| plans/model-selection-frontmatter-rollout.md | New planning doc for the 5-PR stack. An existing outside-diff comment flags that knowledge-compounder (Phase 2) matches the V4 regex but is not in MODEL_RULE_ALLOWLIST and has no effort: field, which would cause Phase 5's acceptance criterion to fail. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent Model Assignment Decision] --> B{Existing explicit model?}
    B -- "Already opus" --> C{Synthesizer / Orchestrator / Conductor?}
    C -- Yes --> D[Add effort: high\naudit-synthesizer\nresearch-conductor]
    C -- No --> E[No change]
    B -- "model: inherit" --> F{Agent role classification}
    F -- "CLI relay / pure retrieval\n/ deterministic routing" --> G[model: haiku + effort: low\ngemini-reviewer\nopencode-reviewer\nlearnings-researcher\nrunner-assignment]
    F -- "Pattern-match review\n/ strategic analysis" --> H[model: sonnet\nproduct-lens-reviewer]
    F -- "Iterative orchestration\nwith synthesis" --> I[model: sonnet + effort: high\nbrainstorm-orchestrator]
    G -.->|"Prior threads: body complexity\nmay exceed effort: low allocation"| G
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `plans/model-selection-frontmatter-rollout.md`, line 606-614 ([link](https://github.com/kinginyellows/yellow-plugins/blob/9794a19eb2e6b444b3640d31498886ecfcfa8759/plans/model-selection-frontmatter-rollout.md#L606-L614)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`knowledge-compounder` triggers V4 but is not guarded by the allowlist**

   The V4 regex `/(synthesizer|orchestrator|conductor|aggregator|compounder)/i` matches the name `knowledge-compounder`. Phase 2 assigns it `model: sonnet` with no `effort:` field, and the `MODEL_RULE_ALLOWLIST` contains only three entries — none of which is `knowledge-compounder`. When Phase 5 lands, `pnpm validate:agents` would emit a V4 advisory for that agent, failing the stated acceptance criterion ("emits zero V3/V4 warnings").

   Fix before Phase 5: either add `effort: high` to `knowledge-compounder` in Phase 2, add `plugins/yellow-core/agents/workflow/knowledge-compounder.md` to `MODEL_RULE_ALLOWLIST`, or remove `compounder` from the V4 keyword set.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: plans/model-selection-frontmatter-rollout.md
   Line: 606-614

   Comment:
   **`knowledge-compounder` triggers V4 but is not guarded by the allowlist**

   The V4 regex `/(synthesizer|orchestrator|conductor|aggregator|compounder)/i` matches the name `knowledge-compounder`. Phase 2 assigns it `model: sonnet` with no `effort:` field, and the `MODEL_RULE_ALLOWLIST` contains only three entries — none of which is `knowledge-compounder`. When Phase 5 lands, `pnpm validate:agents` would emit a V4 advisory for that agent, failing the stated acceptance criterion ("emits zero V3/V4 warnings").

   Fix before Phase 5: either add `effort: high` to `knowledge-compounder` in Phase 2, add `plugins/yellow-core/agents/workflow/knowledge-compounder.md` to `MODEL_RULE_ALLOWLIST`, or remove `compounder` from the V4 keyword set.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Fmodel-explicit-phase-1%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Fmodel-explicit-phase-1%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plans%2Fmodel-selection-frontmatter-rollout.md%0ALine%3A%20606-614%0A%0AComment%3A%0A**%60knowledge-compounder%60%20triggers%20V4%20but%20is%20not%20guarded%20by%20the%20allowlist**%0A%0AThe%20V4%20regex%20%60%2F%28synthesizer%7Corchestrator%7Cconductor%7Caggregator%7Ccompounder%29%2Fi%60%20matches%20the%20name%20%60knowledge-compounder%60.%20Phase%202%20assigns%20it%20%60model%3A%20sonnet%60%20with%20no%20%60effort%3A%60%20field%2C%20and%20the%20%60MODEL_RULE_ALLOWLIST%60%20contains%20only%20three%20entries%20%E2%80%94%20none%20of%20which%20is%20%60knowledge-compounder%60.%20When%20Phase%205%20lands%2C%20%60pnpm%20validate%3Aagents%60%20would%20emit%20a%20V4%20advisory%20for%20that%20agent%2C%20failing%20the%20stated%20acceptance%20criterion%20%28%22emits%20zero%20V3%2FV4%20warnings%22%29.%0A%0AFix%20before%20Phase%205%3A%20either%20add%20%60effort%3A%20high%60%20to%20%60knowledge-compounder%60%20in%20Phase%202%2C%20add%20%60plugins%2Fyellow-core%2Fagents%2Fworkflow%2Fknowledge-compounder.md%60%20to%20%60MODEL_RULE_ALLOWLIST%60%2C%20or%20remove%20%60compounder%60%20from%20the%20V4%20keyword%20set.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (6): Last reviewed commit: ["Apply suggested changes"](https://github.com/kinginyellows/yellow-plugins/commit/3d01355ba39f597398bc7d7c9537ccc6dd06fe1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31395495)</sub>

<!-- /greptile_comment -->