### PR TITLE
feat(agents): tier yellow-debt scanners + yellow-core workflow agents (M-A-02)

### DIFF
--- a/.changeset/model-explicit-phase-2.md
+++ b/.changeset/model-explicit-phase-2.md
@@ -1,0 +1,28 @@
+---
+"yellow-debt": patch
+"yellow-core": patch
+---
+
+Tier yellow-debt scanners and yellow-core workflow agents to explicit
+sonnet/effort frontmatter (Phase 2 of M-A-01).
+
+**yellow-debt scanners + remediation** — taxonomy-driven single-pass analysis;
+Sonnet is the quality ceiling. `effort: low` for the parallel scanner tier.
+
+- `ai-pattern-scanner`, `complexity-scanner`, `duplication-scanner`,
+  `architecture-scanner`, `security-debt-scanner`: `model: sonnet` +
+  `effort: low`
+- `debt-fixer`: `model: sonnet` (no `effort:` change). Spot-check passed —
+  `isolation: worktree` is model-agnostic and tools list contains no
+  Opus-tier-only entries.
+
+**yellow-core workflow** — sophisticated retrieval/orchestration without
+Opus-level synthesis (sub-agents handle the actual writing):
+
+- `knowledge-compounder`: `model: sonnet` — orchestrates dispatch and
+  novelty detection; sub-agents do the synthesis.
+- `session-historian`: `model: sonnet` — BM25 + cosine + RRF retrieval
+  with secret redaction. Ranking-and-returning is a Sonnet-ceiling task.
+
+Distinguished from `security-sentinel` (Opus, active vulnerability audit)
+which stays unchanged.

--- a/plugins/yellow-core/agents/workflow/knowledge-compounder.md
+++ b/plugins/yellow-core/agents/workflow/knowledge-compounder.md
@@ -1,7 +1,7 @@
 ---
 name: knowledge-compounder
 description: 'Extract and document recently solved engineering problems using parallel subagents. Use when spawned by /workflows:compound to capture solutions, or after /review:pr to compound review findings into docs/solutions/ and MEMORY.md.'
-model: inherit
+model: sonnet
 memory: project
 tools:
   - Task

--- a/plugins/yellow-core/agents/workflow/session-historian.md
+++ b/plugins/yellow-core/agents/workflow/session-historian.md
@@ -1,7 +1,7 @@
 ---
 name: session-historian
 description: "Cross-vendor session historian. Searches prior sessions across Claude Code (local JSONL), Devin (REST API via MCP), and Codex (local directory-per-session) for the same problem or topic, returns timestamped per-vendor results merged by relevance, with secret redaction. Use when the dispatching skill or workflow needs to surface prior decisions or attempted approaches that the current session cannot see — typically dispatched by /yellow-core:session-history."
-model: inherit
+model: sonnet
 memory: project
 tools:
   - Read

--- a/plugins/yellow-debt/agents/remediation/debt-fixer.md
+++ b/plugins/yellow-debt/agents/remediation/debt-fixer.md
@@ -1,7 +1,7 @@
 ---
 name: debt-fixer
 description: "Implement fixes for specific technical debt findings with human approval. Use when remediating accepted debt items."
-model: inherit
+model: sonnet
 isolation: worktree
 skills:
   - debt-conventions

--- a/plugins/yellow-debt/agents/scanners/ai-pattern-scanner.md
+++ b/plugins/yellow-debt/agents/scanners/ai-pattern-scanner.md
@@ -1,7 +1,8 @@
 ---
 name: ai-pattern-scanner
 description: "AI-specific anti-pattern detection. Use when auditing code for excessive comments, boilerplate, over-specification, or other AI-generated debt patterns."
-model: inherit
+model: sonnet
+effort: low
 background: true
 skills:
   - debt-conventions

--- a/plugins/yellow-debt/agents/scanners/architecture-scanner.md
+++ b/plugins/yellow-debt/agents/scanners/architecture-scanner.md
@@ -1,7 +1,8 @@
 ---
 name: architecture-scanner
 description: "Architecture and module design analysis. Use when auditing code for circular dependencies, god modules, boundary violations, or structural issues."
-model: inherit
+model: sonnet
+effort: low
 background: true
 skills:
   - debt-conventions

--- a/plugins/yellow-debt/agents/scanners/complexity-scanner.md
+++ b/plugins/yellow-debt/agents/scanners/complexity-scanner.md
@@ -1,7 +1,8 @@
 ---
 name: complexity-scanner
 description: "Cyclomatic and cognitive complexity analysis. Use when auditing code for high complexity, deep nesting, and god functions."
-model: inherit
+model: sonnet
+effort: low
 background: true
 skills:
   - debt-conventions

--- a/plugins/yellow-debt/agents/scanners/duplication-scanner.md
+++ b/plugins/yellow-debt/agents/scanners/duplication-scanner.md
@@ -1,7 +1,8 @@
 ---
 name: duplication-scanner
 description: "Code duplication and near-duplicate detection. Use when auditing code for repeated patterns, copy-paste code, or duplicate logic."
-model: inherit
+model: sonnet
+effort: low
 background: true
 skills:
   - debt-conventions

--- a/plugins/yellow-debt/agents/scanners/security-debt-scanner.md
+++ b/plugins/yellow-debt/agents/scanners/security-debt-scanner.md
@@ -1,7 +1,8 @@
 ---
 name: security-debt-scanner
 description: "Security tech debt detection (deprecated crypto, missing validation, hardcoded config — NOT active vulnerabilities). Use when auditing code for debt patterns that could become vulnerabilities. For active/exploitable vulnerability audits, use security-sentinel (yellow-core)."
-model: inherit
+model: sonnet
+effort: low
 background: true
 skills:
   - debt-conventions


### PR DESCRIPTION
Phase 2 of M-A-01 5-PR stack. Per docs/research/model-selection-token-context-optimization.md.

yellow-debt — taxonomy-driven single-pass analysis; Sonnet is the quality ceiling:
- ai-pattern-scanner, complexity-scanner, duplication-scanner, architecture-scanner, security-debt-scanner: model: sonnet + effort: low
- debt-fixer: model: sonnet (isolation: worktree preserved; tools list has no Opus-tier-only entries)

yellow-core — sophisticated retrieval/orchestration without Opus-level synthesis:
- knowledge-compounder: model: sonnet (sub-agents do the writing)
- session-historian: model: sonnet (BM25 + cosine + RRF retrieval)

security-sentinel stays on Opus (active vulnerability audit, distinguished from security-debt-scanner). validate:agents and validate:plugins pass.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR explicitly pins `model: sonnet` (and `effort: low` for the parallel scanner tier) across the `yellow-debt` scanner and remediation agents and the `yellow-core` workflow agents, replacing the previous `model: inherit` default. The rationale — taxonomy-driven single-pass analysis and ranking/orchestration tasks don't require Opus-level synthesis; `security-sentinel` (active vulnerability audit) is intentionally kept on Opus and is unaffected.

- **yellow-debt scanners** (`ai-pattern-scanner`, `complexity-scanner`, `duplication-scanner`, `architecture-scanner`, `security-debt-scanner`): `model: sonnet` + `effort: low` added; prompt bodies, security fencing, and output schemas are unchanged.
- **yellow-debt remediation** (`debt-fixer`): `model: sonnet` only — no `effort:` change, consistent with the worktree-isolated fix workflow that requires full context.
- **yellow-core workflow** (`knowledge-compounder`, `session-historian`): `model: sonnet` only — orchestration and retrieval logic, BM25+cosine+RRF ranking, and secret-redaction rules are all preserved.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are frontmatter-only additions to existing agent definitions; no prompt bodies, schemas, or tool lists were modified.

Every changed file adds one or two frontmatter keys (`model: sonnet`, optionally `effort: low`) to existing, otherwise untouched agent definitions. The underlying prompt logic, security fencing, output schemas, and tool lists are identical to before. The only open question is the changeset bump type (`patch` vs. `minor`), which is a convention call with no runtime impact.

`.changeset/model-explicit-phase-2.md` — bump type choice is worth a second look before merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .changeset/model-explicit-phase-2.md | Changeset records a `patch` bump for both plugins, but the changes alter observable agent behavior (model selection), which maps more naturally to `minor` per the project's bump-type guide. |
| plugins/yellow-debt/agents/scanners/security-debt-scanner.md | Adds `model: sonnet` + `effort: low`; PR description clearly distinguishes this from `security-sentinel` (Opus, active vulns), so the downgrade is intentional and scoped correctly. |
| plugins/yellow-debt/agents/remediation/debt-fixer.md | Adds `model: sonnet` only (no `effort:` change); `isolation: worktree` and full tools list are model-agnostic and preserved correctly. |
| plugins/yellow-core/agents/workflow/knowledge-compounder.md | Adds `model: sonnet`; orchestrates 5 parallel extraction subagents that handle synthesis, so Sonnet for the orchestrator tier is appropriate. |
| plugins/yellow-core/agents/workflow/session-historian.md | Adds `model: sonnet`; BM25+cosine+RRF retrieval and ranking logic unchanged; complex retrieval body remains intact. |

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Fmodel-explicit-phase-2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Fmodel-explicit-phase-2%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.changeset%2Fmodel-explicit-phase-2.md%3A1-4%0APer%20%60docs%2FCLAUDE.md%60%2C%20%60patch%60%20is%20defined%20as%20%22bug%20fix%20or%20documentation-only%20change%20inside%20a%20plugin%22%20and%20%60minor%60%20as%20%22new%20command%2C%20skill%2C%20or%20agent%20%28additive%20change%29%22.%20Changing%20%60model%3A%20inherit%60%20%E2%86%92%20%60model%3A%20sonnet%60%20%28and%20adding%20%60effort%3A%20low%60%29%20on%20existing%20agents%20modifies%20observable%20runtime%20behavior%20%E2%80%94%20callers%20that%20previously%20inherited%20an%20Opus%20parent%20will%20now%20get%20Sonnet%20regardless.%20That's%20closer%20to%20a%20%60minor%60%20bump%20than%20a%20%60patch%60.%20Arguably%20there's%20no%20clean%20enum%20slot%20for%20a%20non-additive%20behavioral%20change%2C%20but%20%60patch%60%20under-signals%20the%20impact%20to%20plugin%20consumers%20who%20track%20changelogs.%0A%0A%60%60%60suggestion%0A---%0A%22yellow-debt%22%3A%20minor%0A%22yellow-core%22%3A%20minor%0A---%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.changeset/model-explicit-phase-2.md:1-4
Per `docs/CLAUDE.md`, `patch` is defined as "bug fix or documentation-only change inside a plugin" and `minor` as "new command, skill, or agent (additive change)". Changing `model: inherit` → `model: sonnet` (and adding `effort: low`) on existing agents modifies observable runtime behavior — callers that previously inherited an Opus parent will now get Sonnet regardless. That's closer to a `minor` bump than a `patch`. Arguably there's no clean enum slot for a non-additive behavioral change, but `patch` under-signals the impact to plugin consumers who track changelogs.

```suggestion
---
"yellow-debt": minor
"yellow-core": minor
---
```

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["feat(agents): tier yellow-debt scanners ..."](https://github.com/kinginyellows/yellow-plugins/commit/3a86dd0357b5399d25aeaf22f2903de4ae26a1b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31395505)</sub>

<!-- /greptile_comment -->