### PR TITLE
feat(yellow-review): tier 13 reviewer agents to sonnet (M-A-03a)

### DIFF
--- a/.changeset/model-explicit-phase-3a.md
+++ b/.changeset/model-explicit-phase-3a.md
@@ -1,0 +1,24 @@
+---
+"yellow-review": patch
+---
+
+Tier 13 yellow-review reviewer-tier agents to `model: sonnet` (Phase 3a of
+M-A-01).
+
+These agents apply a defined review lens (single axis) with no cross-domain
+synthesis — Sonnet is the quality ceiling for structured code review with
+well-defined evaluation criteria.
+
+Agents downgraded from `inherit` to `sonnet`:
+- Always-on personas: correctness-reviewer, maintainability-reviewer,
+  project-standards-reviewer, project-compliance-reviewer
+- Conditional personas: reliability-reviewer, silent-failure-hunter,
+  pr-test-analyzer, comment-analyzer, type-design-analyzer, code-simplifier,
+  plugin-contract-reviewer, cli-readiness-reviewer
+- Workflow: pr-comment-resolver (in-context fix reconciliation)
+
+Agents that stay on `opus` (no change in this PR): adversarial-reviewer,
+agent-cli-readiness-reviewer, agent-native-reviewer — these construct novel
+failure scenarios or do compound multi-axis architectural judgment.
+
+Per docs/research/model-selection-token-context-optimization.md.

--- a/plugins/yellow-review/agents/review/cli-readiness-reviewer.md
+++ b/plugins/yellow-review/agents/review/cli-readiness-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: cli-readiness-reviewer
 description: "Conditional code-review persona, selected when the diff touches CLI command definitions, argument parsing, or command handler implementations. Reviews CLI code for agent readiness — how well the CLI serves autonomous agents, not just human users. Use when reviewing PRs that introduce or modify CLI commands, flag handlers, output formatters, or interactive prompts."
-model: inherit
+model: sonnet
 background: true
 tools:
   - Read

--- a/plugins/yellow-review/agents/review/code-simplifier.md
+++ b/plugins/yellow-review/agents/review/code-simplifier.md
@@ -1,7 +1,7 @@
 ---
 name: code-simplifier
 description: "Post-fix simplification pass (pass 2) preserving all functionality. Use when reviewing PRs after other review agents have applied fixes, to identify remaining unnecessary complexity, redundant abstractions, and YAGNI violations. Runs as the final review pass. For pre-fix complexity analysis, see code-simplicity-reviewer (yellow-core)."
-model: inherit
+model: sonnet
 background: true
 memory: project
 tools:

--- a/plugins/yellow-review/agents/review/comment-analyzer.md
+++ b/plugins/yellow-review/agents/review/comment-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: comment-analyzer
 description: "Code comment accuracy and rot detection. Use when reviewing PRs that add or modify documentation comments, docstrings, JSDoc, or inline comments to verify they accurately reflect the code they describe."
-model: inherit
+model: sonnet
 background: true
 memory: project
 tools:

--- a/plugins/yellow-review/agents/review/correctness-reviewer.md
+++ b/plugins/yellow-review/agents/review/correctness-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: correctness-reviewer
 description: "Always-on code-review persona. Reviews code for logic errors, edge cases, state-management bugs, error propagation failures, and intent-vs-implementation mismatches. Use when reviewing any PR — selected automatically by review:pr alongside the other always-on personas."
-model: inherit
+model: sonnet
 background: true
 tools:
   - Read

--- a/plugins/yellow-review/agents/review/maintainability-reviewer.md
+++ b/plugins/yellow-review/agents/review/maintainability-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: maintainability-reviewer
 description: "Always-on code-review persona. Reviews code for premature abstraction, unnecessary indirection, dead code, coupling between unrelated modules, and naming that obscures intent. Use when reviewing any PR — selected automatically by review:pr alongside the other always-on personas."
-model: inherit
+model: sonnet
 background: true
 tools:
   - Read

--- a/plugins/yellow-review/agents/review/plugin-contract-reviewer.md
+++ b/plugins/yellow-review/agents/review/plugin-contract-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: plugin-contract-reviewer
 description: "Conditional code-review persona, selected when the diff touches plugin manifest fields (plugin.json), agent/command/skill frontmatter, MCP tool registrations, hook contracts, or any other surface a downstream installation depends on. Reviews for breaking changes to the plugin's public surface — subagent_type renames, command/skill name renames, MCP tool name changes, plugin.json schema field changes, hook output contract changes, frontmatter field renames. Use when reviewing PRs touching `plugins/*/.claude-plugin/plugin.json`, `plugins/*/agents/**/*.md`, `plugins/*/commands/**/*.md`, `plugins/*/skills/**/SKILL.md`, or `plugins/*/hooks/`."
-model: inherit
+model: sonnet
 background: true
 tools:
   - Read

--- a/plugins/yellow-review/agents/review/pr-test-analyzer.md
+++ b/plugins/yellow-review/agents/review/pr-test-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: pr-test-analyzer
 description: "Test coverage and behavioral completeness analysis. Use when reviewing PRs that include test files or add testable business logic to verify tests cover critical paths, edge cases, and failure modes."
-model: inherit
+model: sonnet
 background: true
 memory: project
 tools:

--- a/plugins/yellow-review/agents/review/project-compliance-reviewer.md
+++ b/plugins/yellow-review/agents/review/project-compliance-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: project-compliance-reviewer
 description: "Reviews PRs against project-specific conventions defined in CLAUDE.md and AGENTS.md — naming patterns, repo-defined commit conventions, plugin-authoring rules, and project-pattern adherence. Use when reviewing any PR — selected automatically by review:pr alongside the other always-on personas. Distinct from project-standards-reviewer (frontmatter, references, portability) and from correctness-reviewer (general logic bugs)."
-model: inherit
+model: sonnet
 background: true
 memory: project
 tools:

--- a/plugins/yellow-review/agents/review/project-standards-reviewer.md
+++ b/plugins/yellow-review/agents/review/project-standards-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: project-standards-reviewer
 description: "Always-on code-review persona. Audits changes against the project's own CLAUDE.md and AGENTS.md standards — frontmatter rules, reference inclusion, naming conventions, cross-platform portability, and tool-selection policies. Use when reviewing any PR — selected automatically by review:pr alongside the other always-on personas; complements project-compliance-reviewer (general convention adherence)."
-model: inherit
+model: sonnet
 background: true
 tools:
   - Read

--- a/plugins/yellow-review/agents/review/reliability-reviewer.md
+++ b/plugins/yellow-review/agents/review/reliability-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: reliability-reviewer
 description: "Conditional code-review persona, selected when the diff touches error handling, retries, circuit breakers, timeouts, health checks, background jobs, or async handlers. Use when reviewing any PR with I/O, async, or production-reliability-relevant code — review:pr selects this automatically based on diff content."
-model: inherit
+model: sonnet
 background: true
 tools:
   - Read

--- a/plugins/yellow-review/agents/review/silent-failure-hunter.md
+++ b/plugins/yellow-review/agents/review/silent-failure-hunter.md
@@ -1,7 +1,7 @@
 ---
 name: silent-failure-hunter
 description: "Silent failure and error handling analysis. Use when reviewing PRs that contain try-catch blocks, error handling, fallback logic, or any code that could potentially suppress errors to ensure failures are visible and actionable."
-model: inherit
+model: sonnet
 background: true
 memory: project
 tools:

--- a/plugins/yellow-review/agents/review/type-design-analyzer.md
+++ b/plugins/yellow-review/agents/review/type-design-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: type-design-analyzer
 description: "Type design, encapsulation, and invariant analysis. Use when reviewing PRs that introduce or modify type definitions (interfaces, classes, structs, enums, models) in TypeScript, Python, Rust, or Go to ensure strong invariants and proper encapsulation."
-model: inherit
+model: sonnet
 background: true
 memory: project
 tools:

--- a/plugins/yellow-review/agents/workflow/pr-comment-resolver.md
+++ b/plugins/yellow-review/agents/workflow/pr-comment-resolver.md
@@ -1,7 +1,7 @@
 ---
 name: pr-comment-resolver
 description: "Implements a single coherent fix for a cluster of related PR review comments (same file region). Use when spawned in parallel by /review:resolve to reconcile a cluster of unresolved review threads by reading the file region, understanding each comment, and applying one consolidated edit."
-model: inherit
+model: sonnet
 background: true
 tools:
   - Read


### PR DESCRIPTION
Phase 3a of M-A-01 5-PR stack. Per docs/research/model-selection-token-context-optimization.md.

Single-axis review tier — Sonnet is the quality ceiling for structured code review with well-defined evaluation criteria.

Always-on personas: correctness-reviewer, maintainability-reviewer, project-standards-reviewer, project-compliance-reviewer.
Conditional personas: reliability-reviewer, silent-failure-hunter, pr-test-analyzer, comment-analyzer, type-design-analyzer, code-simplifier, plugin-contract-reviewer, cli-readiness-reviewer.
Workflow: pr-comment-resolver.

adversarial-reviewer, agent-cli-readiness-reviewer, agent-native-reviewer stay on opus (novel failure-scenario construction and compound multi-axis judgment).

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR downgrades 13 `yellow-review` agent definitions from `model: inherit` to `model: sonnet` as Phase 3a of M-A-01, based on the rationale that single-axis reviewers with well-defined evaluation criteria don't require Opus-level reasoning. Three agents (`adversarial-reviewer`, `agent-cli-readiness-reviewer`, `agent-native-reviewer`) are intentionally left on Opus.

- **13 agent frontmatter files** updated uniformly: 4 always-on review personas, 8 conditional review personas, and the `pr-comment-resolver` workflow agent all move from `inherit` to `sonnet`.
- **Changeset** (`model-explicit-phase-3a.md`) documents the change accurately, lists all affected agents, and explains the exclusion rationale for the three agents remaining on Opus.
- No prompt logic, tool lists, or behavioral content was modified — only the `model:` frontmatter field in each file.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a uniform one-field frontmatter update across 13 agent files with no logic modifications.

Every changed file has exactly one line modified (`model: inherit` → `model: sonnet`). No prompt logic, tool lists, security rules, or behavioral content was touched. The changeset accurately enumerates all changed agents and correctly identifies the three agents excluded from this PR. The agent count matches the CLAUDE.md inventory.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .changeset/model-explicit-phase-3a.md | New changeset file; accurately enumerates all 13 changed agents and the 3 excluded agents, with rationale matching the PR description. |
| plugins/yellow-review/agents/review/correctness-reviewer.md | Always-on review persona; model changed from `inherit` to `sonnet`. No other changes. |
| plugins/yellow-review/agents/review/maintainability-reviewer.md | Always-on review persona; model changed from `inherit` to `sonnet`. No other changes. |
| plugins/yellow-review/agents/review/project-standards-reviewer.md | Always-on review persona; model changed from `inherit` to `sonnet`. No other changes. |
| plugins/yellow-review/agents/review/project-compliance-reviewer.md | Always-on review persona; model changed from `inherit` to `sonnet`. No other changes. |
| plugins/yellow-review/agents/review/reliability-reviewer.md | Conditional review persona; model changed from `inherit` to `sonnet`. No other changes. |
| plugins/yellow-review/agents/review/silent-failure-hunter.md | Conditional review persona; model changed from `inherit` to `sonnet`. No other changes. |
| plugins/yellow-review/agents/review/pr-test-analyzer.md | Conditional review persona; model changed from `inherit` to `sonnet`. No other changes. |
| plugins/yellow-review/agents/review/comment-analyzer.md | Conditional review persona; model changed from `inherit` to `sonnet`. No other changes. |
| plugins/yellow-review/agents/review/type-design-analyzer.md | Conditional review persona; model changed from `inherit` to `sonnet`. No other changes. |
| plugins/yellow-review/agents/review/code-simplifier.md | Conditional review persona; model changed from `inherit` to `sonnet`. No other changes. |
| plugins/yellow-review/agents/review/plugin-contract-reviewer.md | Conditional review persona; model changed from `inherit` to `sonnet`. No other changes. |
| plugins/yellow-review/agents/review/cli-readiness-reviewer.md | Conditional review persona; model changed from `inherit` to `sonnet`. No other changes. |
| plugins/yellow-review/agents/workflow/pr-comment-resolver.md | Workflow agent for in-context comment resolution; model changed from `inherit` to `sonnet`. No behavioral changes; security rules, scope limits, and path deny list intact. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    ORC[review:pr orchestrator] --> AA[Always-on personas]
    ORC --> COND[Conditional personas]
    ORC --> WF[Workflow agents]

    AA --> CR["correctness-reviewer\n🔵 sonnet"]
    AA --> MR["maintainability-reviewer\n🔵 sonnet"]
    AA --> PSR["project-standards-reviewer\n🔵 sonnet"]
    AA --> PCR["project-compliance-reviewer\n🔵 sonnet"]

    COND --> RR["reliability-reviewer\n🔵 sonnet"]
    COND --> SFH["silent-failure-hunter\n🔵 sonnet"]
    COND --> PTA["pr-test-analyzer\n🔵 sonnet"]
    COND --> CA["comment-analyzer\n🔵 sonnet"]
    COND --> TDA["type-design-analyzer\n🔵 sonnet"]
    COND --> CS["code-simplifier\n🔵 sonnet"]
    COND --> PKCR["plugin-contract-reviewer\n🔵 sonnet"]
    COND --> CLR["cli-readiness-reviewer\n🔵 sonnet"]
    COND --> AR["adversarial-reviewer\n🟠 opus (unchanged)"]
    COND --> ACLR["agent-cli-readiness-reviewer\n🟠 opus (unchanged)"]
    COND --> ANR["agent-native-reviewer\n🟠 opus (unchanged)"]

    WF --> PCRes["pr-comment-resolver\n🔵 sonnet"]
```

<sub>Reviews (3): Last reviewed commit: ["feat(yellow-review): tier 13 reviewer ag..."](https://github.com/kinginyellows/yellow-plugins/commit/aa8c632f46344d3b2e7390f5d2a9005c643843e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31395524)</sub>

**Context used:**

- Context used - plugins/yellow-review/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=331e26fc-49a1-4e0b-b953-b2aaca8f4007))

<!-- /greptile_comment -->