### PR TITLE
feat(agents): tier yellow-core personas + yellow-docs reviewers (M-A-03b)

### DIFF
--- a/.changeset/model-explicit-phase-3b.md
+++ b/.changeset/model-explicit-phase-3b.md
@@ -1,0 +1,35 @@
+---
+"yellow-core": patch
+"yellow-docs": patch
+---
+
+Tier yellow-core review/research/workflow personas + 2 yellow-docs reviewers
+to explicit `model:` frontmatter (Phase 3b of M-A-01).
+
+**yellow-core (8 files)** — single-axis review and structured analysis;
+Sonnet is the quality ceiling:
+- Review personas: code-simplicity-reviewer, pattern-recognition-specialist,
+  test-coverage-analyst, polyglot-reviewer, security-lens, security-reviewer,
+  performance-reviewer
+- Workflow: spec-flow-analyzer (UX flow analysis with defined axes)
+
+`security-sentinel`, `performance-oracle`, and `architecture-strategist`
+stay on `opus` (no change) — primary discovery agents and architectural
+judgment.
+
+**yellow-docs (2 files)**:
+- `feasibility-reviewer`: `model: sonnet` — structured feasibility assessment
+  matching the sibling pattern (design-lens, scope-guardian,
+  security-lens-reviewer, coherence-reviewer are all already explicitly
+  tiered)
+- `adversarial-document-reviewer`: `model: sonnet` + `effort: high` — applies
+  a structured challenge protocol; the adversarial angle benefits from
+  extended chain-of-thought, but the protocol is structured enough that Sonnet
+  is the appropriate ceiling
+
+**Already-correct (no edit) yellow-docs siblings** confirmed via grep:
+`design-lens-reviewer`, `scope-guardian-reviewer`, `security-lens-reviewer`
+all carry `model: sonnet` already — closes the documentation gap surfaced
+during planning.
+
+Per docs/research/model-selection-token-context-optimization.md.

--- a/.changeset/model-explicit-phase-3b.md
+++ b/.changeset/model-explicit-phase-3b.md
@@ -3,7 +3,7 @@
 "yellow-docs": patch
 ---
 
-Tier yellow-core review/research/workflow personas + 2 yellow-docs reviewers
+Tier yellow-core review/workflow personas + 2 yellow-docs reviewers
 to explicit `model:` frontmatter (Phase 3b of M-A-01).
 
 **yellow-core (8 files)** — single-axis review and structured analysis;

--- a/plugins/yellow-core/agents/review/code-simplicity-reviewer.md
+++ b/plugins/yellow-core/agents/review/code-simplicity-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: code-simplicity-reviewer
 description: "YAGNI enforcement and simplification analysis (pre-fix pass). Use when running full review passes to ensure code is minimal, removing unnecessary abstractions, premature optimizations, and unused features. For post-fix simplification, see code-simplifier (yellow-review)."
-model: inherit
+model: sonnet
 background: true
 memory: project
 tools:

--- a/plugins/yellow-core/agents/review/pattern-recognition-specialist.md
+++ b/plugins/yellow-core/agents/review/pattern-recognition-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: pattern-recognition-specialist
 description: "Code pattern analysis specialist detecting anti-patterns, naming convention violations, duplication, and inconsistency across codebases. Use when reviewing PRs that introduce new patterns, new directories, new file type conventions, checking codebase consistency, or when changes touch agents/*.md, commands/*.md, skills/*/SKILL.md, or plugin.json files (plugin authoring convention checks)."
-model: inherit
+model: sonnet
 background: true
 memory: project
 tools:

--- a/plugins/yellow-core/agents/review/performance-reviewer.md
+++ b/plugins/yellow-core/agents/review/performance-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: performance-reviewer
 description: "Conditional review persona for runtime performance and scalability. Use when reviewing PRs that touch database queries, loop-heavy data transforms, caching layers, or I/O-intensive paths — adds anchored confidence calibration on top of performance-oracle's deeper analysis."
-model: inherit
+model: sonnet
 memory: project
 tools:
   - Read

--- a/plugins/yellow-core/agents/review/polyglot-reviewer.md
+++ b/plugins/yellow-core/agents/review/polyglot-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: polyglot-reviewer
 description: "Language-idiomatic code reviewer for TypeScript, Python, Rust, and Go. Ensures code follows language-specific best practices, idioms, and conventions. Use when reviewing code in multi-language codebases or checking language-specific patterns."
-model: inherit
+model: sonnet
 background: true
 memory: project
 tools:

--- a/plugins/yellow-core/agents/review/security-lens.md
+++ b/plugins/yellow-core/agents/review/security-lens.md
@@ -1,7 +1,7 @@
 ---
 name: security-lens
 description: "Plan-level security architect. Use when reviewing planning documents, brainstorms, or architecture proposals — evaluates whether the plan accounts for security at the planning level (auth/authz assumptions, data exposure, attack surface) before implementation begins."
-model: inherit
+model: sonnet
 memory: project
 tools:
   - Read

--- a/plugins/yellow-core/agents/review/security-reviewer.md
+++ b/plugins/yellow-core/agents/review/security-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: security-reviewer
 description: "Conditional review persona for exploitable security vulnerabilities. Use when reviewing PRs that touch auth middleware, public endpoints, user input handling, or permission checks — adds anchored confidence calibration on top of security-sentinel's broad audit."
-model: inherit
+model: sonnet
 memory: project
 tools:
   - Read

--- a/plugins/yellow-core/agents/review/test-coverage-analyst.md
+++ b/plugins/yellow-core/agents/review/test-coverage-analyst.md
@@ -1,7 +1,7 @@
 ---
 name: test-coverage-analyst
 description: "Test quality and coverage analysis specialist for full test suite audits. Evaluates test structure, naming conventions, edge case coverage, mock usage, and assertion quality. Use when auditing test suites, identifying coverage gaps, or improving test strategy. For PR-scoped test analysis, use pr-test-analyzer (yellow-review) instead."
-model: inherit
+model: sonnet
 background: true
 memory: project
 tools:

--- a/plugins/yellow-core/agents/workflow/spec-flow-analyzer.md
+++ b/plugins/yellow-core/agents/workflow/spec-flow-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: spec-flow-analyzer
 description: "User experience flow analyst and requirements engineer. Examines specifications through the lens of the end user. Use when reviewing requirements, identifying gaps in specifications, or validating user journey completeness."
-model: inherit
+model: sonnet
 background: true
 memory: project
 tools:

--- a/plugins/yellow-docs/agents/review/adversarial-document-reviewer.md
+++ b/plugins/yellow-docs/agents/review/adversarial-document-reviewer.md
@@ -1,7 +1,8 @@
 ---
 name: adversarial-document-reviewer
 description: "Conditional document-review persona, selected when the document has more than 5 requirements, makes significant architectural decisions, covers high-stakes domains (auth, payments, migrations, compliance), or proposes new abstractions. Challenges premises, surfaces unstated assumptions, and stress-tests decisions rather than evaluating document quality. Use when reviewing high-stakes plans where premise validation matters via /docs:review."
-model: inherit
+model: sonnet
+effort: high
 background: true
 tools:
   - Read

--- a/plugins/yellow-docs/agents/review/feasibility-reviewer.md
+++ b/plugins/yellow-docs/agents/review/feasibility-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: feasibility-reviewer
 description: "Evaluates whether proposed technical approaches in planning documents will survive contact with reality — architecture conflicts, dependency gaps, migration risks, performance feasibility, and implementability. Uses shadow path tracing (happy/nil/empty/error) for new data flows. Use when reviewing technical plans, ADRs, or specs that propose new architecture or significant migrations via /docs:review."
-model: inherit
+model: sonnet
 background: true
 tools:
   - Read


### PR DESCRIPTION
Phase 3b of M-A-01 5-PR stack. Per docs/research/model-selection-token-context-optimization.md.

yellow-core (8 files, model: sonnet):
- Review: code-simplicity-reviewer, pattern-recognition-specialist, test-coverage-analyst, polyglot-reviewer, security-lens, security-reviewer, performance-reviewer
- Workflow: spec-flow-analyzer

yellow-docs (2 files):
- feasibility-reviewer: model: sonnet (matches sibling pattern)
- adversarial-document-reviewer: model: sonnet + effort: high (structured challenge protocol)

Already-correct yellow-docs siblings (no edit needed): design-lens-reviewer, scope-guardian-reviewer, security-lens-reviewer, coherence-reviewer.

Stays on opus (no change): architecture-strategist, security-sentinel, performance-oracle.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Phase 3b of the M-A-01 model-explicit stack: pins `model: sonnet` on 8 yellow-core agents (7 review + 1 workflow) and 2 yellow-docs reviewers that previously inherited their model from the caller context, and adds `effort: high` to `adversarial-document-reviewer` for extended chain-of-thought.

- **yellow-core (8 files):** All changed agents receive `model: sonnet`; `security-lens` and `security-reviewer` already carry the required `disallowedTools: [Write, Edit, MultiEdit]` guard, but `performance-reviewer` — explicitly named in `plugins/yellow-core/CLAUDE.md` as requiring that guard — is still missing it (same gap present in the four agents flagged in the previous review cycle).
- **yellow-docs (2 files):** `feasibility-reviewer` and `adversarial-document-reviewer` neither use `memory: project` nor expose write-capable tools, so the model-only change is safe; `effort: high` on the adversarial reviewer is intentional and consistent with its structured challenge protocol.
- **Changeset:** The `coherence-reviewer` haiku discrepancy and `patch`-vs-`minor` bump questions raised in prior threads remain open.

<h3>Confidence Score: 4/5</h3>

Safe to merge once the disallowedTools gap in performance-reviewer is resolved; all other changes are correct model-pin updates.

performance-reviewer has memory: project — which auto-grants Write and Edit regardless of the tools allowlist — but no disallowedTools block. plugins/yellow-core/CLAUDE.md names it explicitly as one of the agents that must carry that runtime guard. Without it, the tools: [Read, Grep, Glob] restriction is not enforced at the runtime layer, leaving only the system prompt as the read-only contract. The correct pattern is demonstrated by security-reviewer and security-lens in this same PR.

plugins/yellow-core/agents/review/performance-reviewer.md — missing disallowedTools block despite being named in CLAUDE.md as requiring it.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .changeset/model-explicit-phase-3b.md | Changeset documenting model tiering for 10 agents; coherence-reviewer haiku discrepancy in justification text and patch-vs-minor bump question already flagged in previous threads. |
| plugins/yellow-core/agents/review/performance-reviewer.md | model: inherit → model: sonnet; has memory: project but is missing disallowedTools: [Write, Edit, MultiEdit] despite being explicitly named in CLAUDE.md as requiring that guard. |
| plugins/yellow-core/agents/review/security-lens.md | model: inherit → model: sonnet; already has correct disallowedTools: [Write, Edit, MultiEdit] guard. |
| plugins/yellow-core/agents/review/security-reviewer.md | model: inherit → model: sonnet; already has correct disallowedTools: [Write, Edit, MultiEdit] guard. |
| plugins/yellow-docs/agents/review/adversarial-document-reviewer.md | model: inherit → model: sonnet + effort: high added; no memory: project so tools allowlist restriction holds; change looks correct. |
| plugins/yellow-docs/agents/review/feasibility-reviewer.md | model: inherit → model: sonnet; no memory: project so tools allowlist restriction holds; change looks correct. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PR["Phase 3b: model: inherit → model: sonnet"]

    PR --> YC["yellow-core (8 agents)"]
    PR --> YD["yellow-docs (2 agents)"]

    YC --> RC["Review agents\ncode-simplicity-reviewer\npattern-recognition-specialist\ntest-coverage-analyst\npolyglot-reviewer\nperformance-reviewer"]
    YC --> RS["Review agents ✅\nsecurity-lens\nsecurity-reviewer"]
    YC --> WF["Workflow agent\nspec-flow-analyzer"]

    RC -->|memory: project| AG["Auto-grants Write + Edit\ntools allowlist bypassed"]
    AG -->|disallowedTools absent| RISK["❌ No runtime read-only enforcement"]
    RS -->|disallowedTools: Write, Edit, MultiEdit| OK["✅ Runtime guard in place"]

    YD --> FE["feasibility-reviewer\nmodel: sonnet"]
    YD --> AD["adversarial-document-reviewer\nmodel: sonnet + effort: high"]
    FE -->|no memory: project| SAFE1["✅ tools allowlist enforced"]
    AD -->|no memory: project| SAFE2["✅ tools allowlist enforced"]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `plugins/yellow-core/agents/review/code-simplicity-reviewer.md`, line 6-10 ([link](https://github.com/kinginyellows/yellow-plugins/blob/2db8604b5274758e83c65b9c7caf1052fd526d36/plugins/yellow-core/agents/review/code-simplicity-reviewer.md#L6-L10)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`disallowedTools` guard missing despite `memory: project`**

   `plugins/yellow-core/CLAUDE.md` explicitly states that all review agents — including `code-simplicity-reviewer`, `pattern-recognition-specialist`, `test-coverage-analyst`, and `polyglot-reviewer` — carry `disallowedTools: [Write, Edit, MultiEdit]` to enforce their read-only contract at the runtime layer. Per `docs/solutions/code-quality/subagent-frontmatter-field-catalog.md`, `memory: project` auto-grants `Read`, `Write`, and `Edit` **regardless of the `tools:` allowlist**, so the explicit `tools: [Read, Grep, Glob]` restriction provides no protection. The only guard then is the system prompt — exactly the condition the catalog warns against, since a prompt injection in reviewed code could instruct these agents to write files.

   `security-lens` and `security-reviewer` — also changed in this batch — already have the correct `disallowedTools: [Write, Edit, MultiEdit]` block. The same guard should be applied to the four agents above that are still missing it. The CLAUDE.md claim that the guard is universal is currently inaccurate for those four.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: plugins/yellow-core/agents/review/code-simplicity-reviewer.md
   Line: 6-10

   Comment:
   **`disallowedTools` guard missing despite `memory: project`**

   `plugins/yellow-core/CLAUDE.md` explicitly states that all review agents — including `code-simplicity-reviewer`, `pattern-recognition-specialist`, `test-coverage-analyst`, and `polyglot-reviewer` — carry `disallowedTools: [Write, Edit, MultiEdit]` to enforce their read-only contract at the runtime layer. Per `docs/solutions/code-quality/subagent-frontmatter-field-catalog.md`, `memory: project` auto-grants `Read`, `Write`, and `Edit` **regardless of the `tools:` allowlist**, so the explicit `tools: [Read, Grep, Glob]` restriction provides no protection. The only guard then is the system prompt — exactly the condition the catalog warns against, since a prompt injection in reviewed code could instruct these agents to write files.

   `security-lens` and `security-reviewer` — also changed in this batch — already have the correct `disallowedTools: [Write, Edit, MultiEdit]` block. The same guard should be applied to the four agents above that are still missing it. The CLAUDE.md claim that the guard is universal is currently inaccurate for those four.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Fmodel-explicit-phase-3b%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Fmodel-explicit-phase-3b%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plugins%2Fyellow-core%2Fagents%2Freview%2Fcode-simplicity-reviewer.md%0ALine%3A%206-10%0A%0AComment%3A%0A**%60disallowedTools%60%20guard%20missing%20despite%20%60memory%3A%20project%60**%0A%0A%60plugins%2Fyellow-core%2FCLAUDE.md%60%20explicitly%20states%20that%20all%20review%20agents%20%E2%80%94%20including%20%60code-simplicity-reviewer%60%2C%20%60pattern-recognition-specialist%60%2C%20%60test-coverage-analyst%60%2C%20and%20%60polyglot-reviewer%60%20%E2%80%94%20carry%20%60disallowedTools%3A%20%5BWrite%2C%20Edit%2C%20MultiEdit%5D%60%20to%20enforce%20their%20read-only%20contract%20at%20the%20runtime%20layer.%20Per%20%60docs%2Fsolutions%2Fcode-quality%2Fsubagent-frontmatter-field-catalog.md%60%2C%20%60memory%3A%20project%60%20auto-grants%20%60Read%60%2C%20%60Write%60%2C%20and%20%60Edit%60%20**regardless%20of%20the%20%60tools%3A%60%20allowlist**%2C%20so%20the%20explicit%20%60tools%3A%20%5BRead%2C%20Grep%2C%20Glob%5D%60%20restriction%20provides%20no%20protection.%20The%20only%20guard%20then%20is%20the%20system%20prompt%20%E2%80%94%20exactly%20the%20condition%20the%20catalog%20warns%20against%2C%20since%20a%20prompt%20injection%20in%20reviewed%20code%20could%20instruct%20these%20agents%20to%20write%20files.%0A%0A%60security-lens%60%20and%20%60security-reviewer%60%20%E2%80%94%20also%20changed%20in%20this%20batch%20%E2%80%94%20already%20have%20the%20correct%20%60disallowedTools%3A%20%5BWrite%2C%20Edit%2C%20MultiEdit%5D%60%20block.%20The%20same%20guard%20should%20be%20applied%20to%20the%20four%20agents%20above%20that%20are%20still%20missing%20it.%20The%20CLAUDE.md%20claim%20that%20the%20guard%20is%20universal%20is%20currently%20inaccurate%20for%20those%20four.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

2. `plugins/yellow-core/agents/review/performance-reviewer.md`, line 1-10 ([link](https://github.com/kinginyellows/yellow-plugins/blob/2c8e1c083f5e4e8d4a42e224980b0eef549bd668/plugins/yellow-core/agents/review/performance-reviewer.md#L1-L10)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`disallowedTools` guard absent despite explicit CLAUDE.md requirement**

   `plugins/yellow-core/CLAUDE.md` enumerates `performance-reviewer` by name in the list of review agents that "carry `memory: project` frontmatter, which auto-enables Read/Write/Edit" and for which "the runtime `disallowedTools: [Write, Edit, MultiEdit]` block on those agents enforces the read-only contract." This agent has `memory: project` but no `disallowedTools` block, so the `tools: [Read, Grep, Glob]` allowlist provides no runtime protection — `memory: project` grants Write/Edit regardless. The four other review agents in this same batch (`code-simplicity-reviewer`, `pattern-recognition-specialist`, `test-coverage-analyst`, `polyglot-reviewer`) have the same gap; `security-reviewer` and `security-lens` show the correct pattern with the block present.

   **Context Used:** plugins/yellow-core/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=6658476f-92f5-4e65-8778-caca9c592f68))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: plugins/yellow-core/agents/review/performance-reviewer.md
   Line: 1-10
   
   Comment:
   **`disallowedTools` guard absent despite explicit CLAUDE.md requirement**
   
   `plugins/yellow-core/CLAUDE.md` enumerates `performance-reviewer` by name in the list of review agents that "carry `memory: project` frontmatter, which auto-enables Read/Write/Edit" and for which "the runtime `disallowedTools: [Write, Edit, MultiEdit]` block on those agents enforces the read-only contract." This agent has `memory: project` but no `disallowedTools` block, so the `tools: [Read, Grep, Glob]` allowlist provides no runtime protection — `memory: project` grants Write/Edit regardless. The four other review agents in this same batch (`code-simplicity-reviewer`, `pattern-recognition-specialist`, `test-coverage-analyst`, `polyglot-reviewer`) have the same gap; `security-reviewer` and `security-lens` show the correct pattern with the block present.
   
   **Context Used:** plugins/yellow-core/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=6658476f-92f5-4e65-8778-caca9c592f68))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Fmodel-explicit-phase-3b%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Fmodel-explicit-phase-3b%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plugins%2Fyellow-core%2Fagents%2Freview%2Fperformance-reviewer.md%0ALine%3A%201-10%0A%0AComment%3A%0A**%60disallowedTools%60%20guard%20absent%20despite%20explicit%20CLAUDE.md%20requirement**%0A%0A%60plugins%2Fyellow-core%2FCLAUDE.md%60%20enumerates%20%60performance-reviewer%60%20by%20name%20in%20the%20list%20of%20review%20agents%20that%20%22carry%20%60memory%3A%20project%60%20frontmatter%2C%20which%20auto-enables%20Read%2FWrite%2FEdit%22%20and%20for%20which%20%22the%20runtime%20%60disallowedTools%3A%20%5BWrite%2C%20Edit%2C%20MultiEdit%5D%60%20block%20on%20those%20agents%20enforces%20the%20read-only%20contract.%22%20This%20agent%20has%20%60memory%3A%20project%60%20but%20no%20%60disallowedTools%60%20block%2C%20so%20the%20%60tools%3A%20%5BRead%2C%20Grep%2C%20Glob%5D%60%20allowlist%20provides%20no%20runtime%20protection%20%E2%80%94%20%60memory%3A%20project%60%20grants%20Write%2FEdit%20regardless.%20The%20four%20other%20review%20agents%20in%20this%20same%20batch%20%28%60code-simplicity-reviewer%60%2C%20%60pattern-recognition-specialist%60%2C%20%60test-coverage-analyst%60%2C%20%60polyglot-reviewer%60%29%20have%20the%20same%20gap%3B%20%60security-reviewer%60%20and%20%60security-lens%60%20show%20the%20correct%20pattern%20with%20the%20block%20present.%0A%0A**Context%20Used%3A**%20plugins%2Fyellow-core%2FCLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D6658476f-92f5-4e65-8778-caca9c592f68%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Fmodel-explicit-phase-3b%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Fmodel-explicit-phase-3b%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aplugins%2Fyellow-core%2Fagents%2Freview%2Fperformance-reviewer.md%3A1-10%0A**%60disallowedTools%60%20guard%20absent%20despite%20explicit%20CLAUDE.md%20requirement**%0A%0A%60plugins%2Fyellow-core%2FCLAUDE.md%60%20enumerates%20%60performance-reviewer%60%20by%20name%20in%20the%20list%20of%20review%20agents%20that%20%22carry%20%60memory%3A%20project%60%20frontmatter%2C%20which%20auto-enables%20Read%2FWrite%2FEdit%22%20and%20for%20which%20%22the%20runtime%20%60disallowedTools%3A%20%5BWrite%2C%20Edit%2C%20MultiEdit%5D%60%20block%20on%20those%20agents%20enforces%20the%20read-only%20contract.%22%20This%20agent%20has%20%60memory%3A%20project%60%20but%20no%20%60disallowedTools%60%20block%2C%20so%20the%20%60tools%3A%20%5BRead%2C%20Grep%2C%20Glob%5D%60%20allowlist%20provides%20no%20runtime%20protection%20%E2%80%94%20%60memory%3A%20project%60%20grants%20Write%2FEdit%20regardless.%20The%20four%20other%20review%20agents%20in%20this%20same%20batch%20%28%60code-simplicity-reviewer%60%2C%20%60pattern-recognition-specialist%60%2C%20%60test-coverage-analyst%60%2C%20%60polyglot-reviewer%60%29%20have%20the%20same%20gap%3B%20%60security-reviewer%60%20and%20%60security-lens%60%20show%20the%20correct%20pattern%20with%20the%20block%20present.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
plugins/yellow-core/agents/review/performance-reviewer.md:1-10
**`disallowedTools` guard absent despite explicit CLAUDE.md requirement**

`plugins/yellow-core/CLAUDE.md` enumerates `performance-reviewer` by name in the list of review agents that "carry `memory: project` frontmatter, which auto-enables Read/Write/Edit" and for which "the runtime `disallowedTools: [Write, Edit, MultiEdit]` block on those agents enforces the read-only contract." This agent has `memory: project` but no `disallowedTools` block, so the `tools: [Read, Grep, Glob]` allowlist provides no runtime protection — `memory: project` grants Write/Edit regardless. The four other review agents in this same batch (`code-simplicity-reviewer`, `pattern-recognition-specialist`, `test-coverage-analyst`, `polyglot-reviewer`) have the same gap; `security-reviewer` and `security-lens` show the correct pattern with the block present.


`````

</details>

<sub>Reviews (5): Last reviewed commit: ["docs(changeset): correct phase-3b scope ..."](https://github.com/kinginyellows/yellow-plugins/commit/2c8e1c083f5e4e8d4a42e224980b0eef549bd668) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31395538)</sub>

**Context used:**

- Context used - plugins/yellow-core/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=6658476f-92f5-4e65-8778-caca9c592f68))
- Context used - docs/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=63ee1f64-4111-4591-a098-f5919bbd7dcf))

<!-- /greptile_comment -->