### PR TITLE
feat(validator): add V1-V4 model/effort lint rules (M-A-04)

### DIFF
--- a/plans/model-selection-frontmatter-rollout.md
+++ b/plans/model-selection-frontmatter-rollout.md
@@ -304,7 +304,8 @@ Branch: `agent/feat/model-effort-validator-rules` (stacked on PR 4)
 - All 5 test groups pass (V1, V2, V3, V4, exit-code semantics).
 - `pnpm validate:agents` against the live `plugins/` tree exits 0 with
   warnings printed but no errors (Phases 1–4 already landed correct values).
-- Allowlist documents the 3 intentional exemptions.
+- Allowlist documents the 4 intentional exemptions (failure-analyst,
+  workflow-optimizer, devin-orchestrator, knowledge-compounder).
 
 ## Technical Specifications
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,8 @@ importers:
 
   plugins/yellow-core: {}
 
+  plugins/yellow-council: {}
+
   plugins/yellow-debt: {}
 
   plugins/yellow-devin: {}
@@ -131,6 +133,8 @@ importers:
   plugins/yellow-docs: {}
 
   plugins/yellow-linear: {}
+
+  plugins/yellow-mempalace: {}
 
   plugins/yellow-morph:
     dependencies:

--- a/scripts/validate-agent-authoring.js
+++ b/scripts/validate-agent-authoring.js
@@ -37,11 +37,51 @@ const REVIEW_AGENT_ALLOWLIST = new Set([
   'yellow-council/agents/review/opencode-reviewer.md',
 ]);
 
+// V1/V2/V3/V4 — model/effort frontmatter lint rules (see M-A-01 plan).
+// V1: effort: enum (low|medium|high|xhigh|max) — hard error
+// V2: model: enum (haiku|sonnet|opus|inherit, optionally versioned) — hard error
+// V3: model: inherit on a scanner/CI agent — non-blocking warning
+// V4: synthesizer/orchestrator name without effort: high — non-blocking warning
+// `inherit` is a bare keyword (no version suffix). Real model IDs (haiku,
+// sonnet, opus) accept an optional one- or two-segment numeric suffix
+// (e.g., `sonnet-4-6`).
+const MODEL_VALUE_PATTERN = /^(haiku|sonnet|opus)(-\d+(-\d+)?)?$|^inherit$/;
+const EFFORT_VALUES = new Set(['low', 'medium', 'high', 'xhigh', 'max']);
+// Effort tiers that satisfy V4's "extended chain-of-thought" requirement.
+// Subset of EFFORT_VALUES — keep in sync if EFFORT_VALUES grows.
+const HIGH_EFFORT = new Set(['high', 'xhigh', 'max']);
+const SYNTHESIZER_NAME_PATTERN =
+  /(synthesizer|orchestrator|conductor|aggregator|compounder)/i;
+
+// Files exempt from V3/V4 advisory warnings — intentional inheritance
+// or intentional default-effort. Each entry must be a plugins-relative
+// POSIX path. Adding a file here is a documented decision that the
+// agent's role does NOT match the rule's intent (e.g., failure-analyst
+// in agents/ci/ is a workflow integration agent, not a scanner).
+const MODEL_RULE_ALLOWLIST = new Set([
+  // failure-analyst is a CI failure diagnosis orchestrator that delegates
+  // to runner-diagnostics for deep work — its model: inherit is intentional.
+  'yellow-ci/agents/ci/failure-analyst.md',
+  // workflow-optimizer is a CI workflow analysis agent whose output quality
+  // scales with the parent session's model — intentional inherit.
+  'yellow-ci/agents/ci/workflow-optimizer.md',
+  // devin-orchestrator coordinates Devin V3 sessions; its name matches V4's
+  // synthesizer/orchestrator pattern but the effort default is intentional —
+  // sub-sessions run independently in Devin.
+  'yellow-devin/agents/workflow/devin-orchestrator.md',
+  // knowledge-compounder dispatches sub-agents that handle synthesis;
+  // its own role is orchestration without Opus-level reasoning. The name
+  // matches V4's pattern but the brainstorm explicitly decided no
+  // effort: high because the heavy work happens in sub-agents.
+  'yellow-core/agents/workflow/knowledge-compounder.md',
+]);
+
 const colors = {
   reset: '\x1b[0m',
   red: '\x1b[31m',
   green: '\x1b[32m',
   blue: '\x1b[34m',
+  yellow: '\x1b[33m',
 };
 
 function walk(dir, predicate = () => true) {
@@ -124,6 +164,10 @@ function logError(message) {
   console.error(`${colors.red}✗ ERROR:${colors.reset} ${message}`);
 }
 
+function logWarning(message) {
+  console.log(`${colors.yellow}⚠ WARN:${colors.reset} ${message}`);
+}
+
 function logSuccess(message) {
   console.log(`${colors.green}✓ PASS:${colors.reset} ${message}`);
 }
@@ -161,6 +205,7 @@ const commandFiles = walk(
 logInfo(`Validating ${agentFiles.length} agents and ${markdownFiles.length} markdown files...`);
 
 const errors = [];
+const warnings = [];
 const pluginAgents = new Set();
 const skillReferencePattern = /`([a-z0-9][a-z0-9-]*)`\s+skill\b/gi;
 const pluginSubagentPattern =
@@ -181,8 +226,71 @@ for (const filePath of agentFiles) {
   const relPath = path.relative(PLUGINS_DIR, filePath);
   const relSegments = relPath.split(path.sep);
   const pluginName = relSegments[0];
+  // Hoist segment computations used by V3/V4 + W1.5 + 3-segment registration.
+  // POSIX-form path keeps allowlist matching consistent across platforms.
+  const agentsIdx = relSegments.indexOf('agents');
+  const subdir = agentsIdx >= 0 ? relSegments[agentsIdx + 1] : null;
+  const pluginsRelPath = relSegments.join('/');
+  const allowlisted = MODEL_RULE_ALLOWLIST.has(pluginsRelPath);
 
+  // V1: effort: enum (low | medium | high | xhigh | max). Hard error.
+  // Catches typos (e.g., effort: hight) that would otherwise silently fall
+  // back to the default and make the assignment a no-op.
+  const effortVal = parseScalar(frontmatter, 'effort');
+  const effortValid = effortVal === null || EFFORT_VALUES.has(effortVal);
+  if (effortVal !== null && !EFFORT_VALUES.has(effortVal)) {
+    errors.push(
+      `${relative(filePath)}: invalid effort: '${effortVal}' ` +
+        `(must be one of low|medium|high|xhigh|max)`
+    );
+  }
+
+  // V2: model: enum (haiku | sonnet | opus | inherit, optionally with a
+  // version suffix like sonnet-4-5). Hard error. Catches typos and invalid
+  // model IDs that would otherwise fall back to the session default.
+  const modelVal = parseScalar(frontmatter, 'model');
+  if (modelVal !== null && !MODEL_VALUE_PATTERN.test(modelVal)) {
+    errors.push(
+      `${relative(filePath)}: invalid model: '${modelVal}' ` +
+        `(must match ^(haiku|sonnet|opus)(-\\d+(-\\d+)?)?$|^inherit$)`
+    );
+  }
+
+  // V3: model: inherit on a scanner/CI agent — non-blocking warning.
+  // Nudge authors to make an explicit model choice for narrow-role agents
+  // where inheritance is usually wasteful (Opus session → scanner doing
+  // taxonomy matching).
+  if (
+    modelVal === 'inherit' &&
+    !allowlisted &&
+    (subdir === 'scanners' || subdir === 'ci')
+  ) {
+    warnings.push(
+      `[V3 advisory] ${relative(filePath)}: model: inherit on a ` +
+        `${subdir}/ agent — consider explicit model: sonnet or model: ` +
+        `haiku based on task complexity.`
+    );
+  }
+
+  // V4: synthesizer/orchestrator agents without effort: high — non-blocking
+  // warning. Matches against the name field (not description) to reduce
+  // false positives on integration agents that mention "synthesize" or
+  // "merge" in passing. Skipped when V1 already errors on effortVal so
+  // authors get one clear message instead of two.
   const name = parseScalar(frontmatter, 'name');
+  if (
+    name &&
+    SYNTHESIZER_NAME_PATTERN.test(name) &&
+    effortValid &&
+    !HIGH_EFFORT.has(effortVal) &&
+    !allowlisted
+  ) {
+    warnings.push(
+      `[V4 advisory] ${relative(filePath)}: synthesizer/orchestrator ` +
+        `agent without effort: high — consider extended chain-of-thought.`
+    );
+  }
+
   if (!name) {
     errors.push(`${relative(filePath)}: missing agent name`);
   } else {
@@ -195,10 +303,8 @@ for (const filePath of agentFiles) {
     // markdown-scan loop below emits a warning when a 2-segment hit has
     // an available 3-segment equivalent — turning silent runtime
     // failures into loud CI signal for new code.
-    const agentsIdx = relSegments.indexOf('agents');
     if (agentsIdx >= 0 && relSegments.length > agentsIdx + 2) {
-      const dir = relSegments[agentsIdx + 1];
-      pluginAgents.add(`${pluginName}:${dir}:${name}`);
+      pluginAgents.add(`${pluginName}:${subdir}:${name}`);
     }
   }
 
@@ -214,16 +320,12 @@ for (const filePath of agentFiles) {
     }
 
     // W1.5 — Rule X: review/ agents must be read-only (no Bash, Write, Edit)
-    // unless explicitly allowlisted with a documented exception. Reuse the
-    // PLUGINS_DIR-relative path computed above. Tool comparison is
-    // case-insensitive so lowercase variants (e.g., `bash`) cannot bypass
-    // the security check.
-    const agentsIdx = relSegments.indexOf('agents');
-    const isReviewAgent =
-      agentsIdx >= 0 && relSegments[agentsIdx + 1] === 'review';
-    if (isReviewAgent) {
-      const pluginsRel = relSegments.join('/');
-      if (!REVIEW_AGENT_ALLOWLIST.has(pluginsRel)) {
+    // unless explicitly allowlisted with a documented exception. Tool
+    // comparison is case-insensitive so lowercase variants (e.g., `bash`)
+    // cannot bypass the security check. Reuses subdir/pluginsRelPath
+    // computed once at the top of the loop body.
+    if (subdir === 'review') {
+      if (!REVIEW_AGENT_ALLOWLIST.has(pluginsRelPath)) {
         const deniedLower = REVIEW_AGENT_DENIED_TOOLS.map((t) =>
           t.toLowerCase()
         );
@@ -316,6 +418,12 @@ for (const filePath of commandFiles) {
       `${relative(filePath)}: markdown command sources plugin files via BASH_SOURCE; use \${CLAUDE_PLUGIN_ROOT} or a real script path`
     );
   }
+}
+
+// Print warnings first so they remain visible above the trailing
+// success/error block. Warnings do NOT affect exit code; only errors do.
+for (const warning of warnings) {
+  logWarning(warning);
 }
 
 if (errors.length > 0) {

--- a/tests/integration/helpers/validator-harness.ts
+++ b/tests/integration/helpers/validator-harness.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared test harness for spawning `scripts/validate-agent-authoring.js` as a
+ * child process against a fixture plugins/ tree.
+ *
+ * Each integration test in this directory drives the validator the same way:
+ * write fixture agent files to a temp dir, pass the dir via the
+ * `VALIDATE_PLUGINS_DIR` env var, capture stdout / stderr / exit status. This
+ * module owns that machinery so individual test files can focus on their
+ * rule-specific fixtures and assertions.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+
+const VALIDATOR = resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'scripts',
+  'validate-agent-authoring.js'
+);
+
+export interface ValidatorRun {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+export function runValidator(pluginsDir: string): ValidatorRun {
+  try {
+    const stdout = execFileSync('node', [VALIDATOR], {
+      env: { ...process.env, VALIDATE_PLUGINS_DIR: pluginsDir },
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { status: 0, stdout, stderr: '' };
+  } catch (err) {
+    const e = err as { status: number; stdout?: string; stderr?: string };
+    return {
+      status: e.status,
+      stdout: e.stdout ?? '',
+      stderr: e.stderr ?? '',
+    };
+  }
+}
+
+export function writeAgent(
+  pluginsDir: string,
+  pluginRelative: string,
+  body: string
+): void {
+  const fullPath = join(pluginsDir, pluginRelative);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, body, 'utf8');
+}

--- a/tests/integration/validate-agent-authoring-model-effort-rules.test.ts
+++ b/tests/integration/validate-agent-authoring-model-effort-rules.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Integration tests for the V1–V4 model/effort lint rules in
+ * `scripts/validate-agent-authoring.js`.
+ *
+ * V1: effort: enum (low|medium|high|xhigh|max) — hard error
+ * V2: model: enum (haiku|sonnet|opus|inherit, optionally versioned) — hard error
+ * V3: model: inherit on agents/scanners/ or agents/ci/ — non-blocking warning
+ * V4: synthesizer/orchestrator name without effort: high — non-blocking warning
+ *
+ * The test parameterizes the validator via `VALIDATE_PLUGINS_DIR` and runs it
+ * as a child process against fixture trees in `os.tmpdir()`. Mirrors the
+ * pattern in `validate-agent-authoring-review-rule.test.ts`.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { runValidator, writeAgent } from './helpers/validator-harness';
+
+function agentBody(opts: {
+  name: string;
+  model?: string;
+  effort?: string;
+  description?: string;
+}): string {
+  const lines = ['---', `name: ${opts.name}`];
+  lines.push(
+    `description: "${opts.description ?? 'Test fixture. Use when verifying lint rules.'}"`
+  );
+  if (opts.model !== undefined) lines.push(`model: ${opts.model}`);
+  if (opts.effort !== undefined) lines.push(`effort: ${opts.effort}`);
+  lines.push('tools:', '  - Read', '  - Grep', '  - Glob', '---', '', 'Body.');
+  return lines.join('\n') + '\n';
+}
+
+describe('validate-agent-authoring V1: effort enum', () => {
+  let tmpRoot: string;
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'yellow-validate-v1-'));
+  });
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('passes a valid effort: low', () => {
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/workflow/clean.md',
+      agentBody({ name: 'clean', model: 'sonnet', effort: 'low' })
+    );
+    const { status } = runValidator(tmpRoot);
+    expect(status).toBe(0);
+  });
+
+  it('passes a valid effort: xhigh (canonical enum includes it)', () => {
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/workflow/xh.md',
+      agentBody({ name: 'xh', model: 'opus', effort: 'xhigh' })
+    );
+    const { status } = runValidator(tmpRoot);
+    expect(status).toBe(0);
+  });
+
+  it('errors on invalid effort: hight (typo)', () => {
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/workflow/typo.md',
+      agentBody({ name: 'typo', model: 'sonnet', effort: 'hight' })
+    );
+    const { status, stderr } = runValidator(tmpRoot);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/invalid effort: 'hight'/);
+  });
+
+  it('passes when effort: is absent', () => {
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/workflow/nodefault.md',
+      agentBody({ name: 'nodefault', model: 'sonnet' })
+    );
+    const { status } = runValidator(tmpRoot);
+    expect(status).toBe(0);
+  });
+});
+
+describe('validate-agent-authoring V2: model enum', () => {
+  let tmpRoot: string;
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'yellow-validate-v2-'));
+  });
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('passes valid bare models (haiku, sonnet, opus, inherit)', () => {
+    for (const m of ['haiku', 'sonnet', 'opus', 'inherit']) {
+      writeAgent(
+        tmpRoot,
+        `yellow-test/agents/workflow/${m}.md`,
+        agentBody({ name: m, model: m })
+      );
+    }
+    const { status } = runValidator(tmpRoot);
+    expect(status).toBe(0);
+  });
+
+  it('passes a versioned model: sonnet-4-5', () => {
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/workflow/v.md',
+      agentBody({ name: 'v', model: 'sonnet-4-5' })
+    );
+    const { status } = runValidator(tmpRoot);
+    expect(status).toBe(0);
+  });
+
+  it('errors on model: gpt-4 (foreign provider)', () => {
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/workflow/foreign.md',
+      agentBody({ name: 'foreign', model: 'gpt-4' })
+    );
+    const { status, stderr } = runValidator(tmpRoot);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/invalid model: 'gpt-4'/);
+  });
+
+  it('errors on model: sonnet-invalid (bad version suffix)', () => {
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/workflow/bad.md',
+      agentBody({ name: 'bad', model: 'sonnet-invalid' })
+    );
+    const { status, stderr } = runValidator(tmpRoot);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/invalid model: 'sonnet-invalid'/);
+  });
+
+  it('passes when model: is absent', () => {
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/workflow/nomodel.md',
+      agentBody({ name: 'nomodel' })
+    );
+    const { status } = runValidator(tmpRoot);
+    expect(status).toBe(0);
+  });
+});
+
+describe('validate-agent-authoring V3: scanner/CI inheritance advisory', () => {
+  let tmpRoot: string;
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'yellow-validate-v3-'));
+  });
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('warns on a scanner with model: inherit (status 0, advisory in stdout)', () => {
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/scanners/test-scanner.md',
+      agentBody({ name: 'test-scanner', model: 'inherit' })
+    );
+    const { status, stdout } = runValidator(tmpRoot);
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/\[V3 advisory\]/);
+    expect(stdout).toMatch(/test-scanner\.md/);
+  });
+
+  it('does NOT warn on a scanner with explicit model: sonnet', () => {
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/scanners/explicit-scanner.md',
+      agentBody({ name: 'explicit-scanner', model: 'sonnet' })
+    );
+    const { status, stdout } = runValidator(tmpRoot);
+    expect(status).toBe(0);
+    expect(stdout).not.toMatch(/V3 advisory/);
+  });
+
+  it('warns on agents/ci/ with model: inherit', () => {
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/ci/some-ci-agent.md',
+      agentBody({ name: 'some-ci-agent', model: 'inherit' })
+    );
+    const { status, stdout } = runValidator(tmpRoot);
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/\[V3 advisory\]/);
+  });
+
+  it('does NOT warn on agents/workflow/ with model: inherit (V3 is scoped)', () => {
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/workflow/wf.md',
+      agentBody({ name: 'wf', model: 'inherit' })
+    );
+    const { status, stdout } = runValidator(tmpRoot);
+    expect(status).toBe(0);
+    expect(stdout).not.toMatch(/V3 advisory/);
+  });
+
+  it('honors MODEL_RULE_ALLOWLIST for failure-analyst.md', () => {
+    writeAgent(
+      tmpRoot,
+      'yellow-ci/agents/ci/failure-analyst.md',
+      agentBody({ name: 'failure-analyst', model: 'inherit' })
+    );
+    const { status, stdout } = runValidator(tmpRoot);
+    expect(status).toBe(0);
+    expect(stdout).not.toMatch(/V3 advisory/);
+  });
+
+  it('honors MODEL_RULE_ALLOWLIST for workflow-optimizer.md', () => {
+    writeAgent(
+      tmpRoot,
+      'yellow-ci/agents/ci/workflow-optimizer.md',
+      agentBody({ name: 'workflow-optimizer', model: 'inherit' })
+    );
+    const { status, stdout } = runValidator(tmpRoot);
+    expect(status).toBe(0);
+    expect(stdout).not.toMatch(/V3 advisory/);
+  });
+});
+
+describe('validate-agent-authoring V4: synthesizer effort:high advisory', () => {
+  let tmpRoot: string;
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'yellow-validate-v4-'));
+  });
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('warns on a name matching synthesizer pattern without effort: high', () => {
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/workflow/test-synthesizer.md',
+      agentBody({ name: 'test-synthesizer', model: 'sonnet' })
+    );
+    const { status, stdout } = runValidator(tmpRoot);
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/\[V4 advisory\]/);
+    expect(stdout).toMatch(/test-synthesizer\.md/);
+  });
+
+  it('does NOT warn when effort: high is set', () => {
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/workflow/synthesizer-effort.md',
+      agentBody({ name: 'test-synthesizer', model: 'sonnet', effort: 'high' })
+    );
+    const { status, stdout } = runValidator(tmpRoot);
+    expect(status).toBe(0);
+    expect(stdout).not.toMatch(/V4 advisory/);
+  });
+
+  it('does NOT warn when effort: max is set', () => {
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/workflow/synthesizer-max.md',
+      agentBody({ name: 'test-orchestrator', model: 'sonnet', effort: 'max' })
+    );
+    const { status, stdout } = runValidator(tmpRoot);
+    expect(status).toBe(0);
+    expect(stdout).not.toMatch(/V4 advisory/);
+  });
+
+  it('does NOT warn when effort: xhigh is set', () => {
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/workflow/synthesizer-xhigh.md',
+      agentBody({ name: 'test-conductor', model: 'sonnet', effort: 'xhigh' })
+    );
+    const { status, stdout } = runValidator(tmpRoot);
+    expect(status).toBe(0);
+    expect(stdout).not.toMatch(/V4 advisory/);
+  });
+
+  it('does NOT warn on a non-synthesizer name even if its description mentions synthesize', () => {
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/research/plain-researcher.md',
+      agentBody({
+        name: 'plain-researcher',
+        model: 'sonnet',
+        description: 'A researcher that may synthesize info from sources.',
+      })
+    );
+    const { status, stdout } = runValidator(tmpRoot);
+    expect(status).toBe(0);
+    expect(stdout).not.toMatch(/V4 advisory/);
+  });
+
+  it('honors MODEL_RULE_ALLOWLIST for devin-orchestrator.md', () => {
+    writeAgent(
+      tmpRoot,
+      'yellow-devin/agents/workflow/devin-orchestrator.md',
+      agentBody({ name: 'devin-orchestrator', model: 'inherit' })
+    );
+    const { status, stdout } = runValidator(tmpRoot);
+    expect(status).toBe(0);
+    expect(stdout).not.toMatch(/V4 advisory/);
+  });
+
+  it('honors MODEL_RULE_ALLOWLIST for knowledge-compounder.md', () => {
+    writeAgent(
+      tmpRoot,
+      'yellow-core/agents/workflow/knowledge-compounder.md',
+      agentBody({ name: 'knowledge-compounder', model: 'sonnet' })
+    );
+    const { status, stdout } = runValidator(tmpRoot);
+    expect(status).toBe(0);
+    expect(stdout).not.toMatch(/V4 advisory/);
+  });
+
+  it('does NOT fire spuriously when V1 already errors on a typo effort', () => {
+    // Synthesizer name + invalid effort: V1 must error, V4 must NOT also
+    // fire (the author should see one clear message about the typo, not a
+    // second confusing advisory about effort: high).
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/workflow/synthesizer-typo.md',
+      agentBody({
+        name: 'test-aggregator',
+        model: 'sonnet',
+        effort: 'hight',
+      })
+    );
+    const { status, stderr, stdout } = runValidator(tmpRoot);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/invalid effort: 'hight'/);
+    expect(stdout).not.toMatch(/V4 advisory/);
+  });
+});
+
+describe('validate-agent-authoring exit-code semantics: errors vs warnings', () => {
+  let tmpRoot: string;
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'yellow-validate-exit-'));
+  });
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('exits nonzero when V1 error AND V3 warning both fire (errors win)', () => {
+    // V1 error: invalid effort
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/scanners/error-and-warn.md',
+      agentBody({ name: 'error-and-warn', model: 'inherit', effort: 'hight' })
+    );
+    const { status, stderr, stdout } = runValidator(tmpRoot);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/invalid effort: 'hight'/);
+    expect(stdout).toMatch(/\[V3 advisory\]/);
+  });
+
+  it('exits 0 when only warnings fire (no errors)', () => {
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/scanners/warn-only.md',
+      agentBody({ name: 'warn-only', model: 'inherit' })
+    );
+    const { status, stdout } = runValidator(tmpRoot);
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/\[V3 advisory\]/);
+  });
+});

--- a/tests/integration/validate-agent-authoring-review-rule.test.ts
+++ b/tests/integration/validate-agent-authoring-review-rule.test.ts
@@ -17,49 +17,13 @@
  * process.
  */
 
-import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, resolve, dirname } from 'node:path';
+import { join } from 'node:path';
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
-const VALIDATOR = resolve(__dirname, '..', '..', 'scripts', 'validate-agent-authoring.js');
-
-interface ValidatorRun {
-  status: number;
-  stdout: string;
-  stderr: string;
-}
-
-function runValidator(pluginsDir: string): ValidatorRun {
-  try {
-    const stdout = execFileSync('node', [VALIDATOR], {
-      env: { ...process.env, VALIDATE_PLUGINS_DIR: pluginsDir },
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    return { status: 0, stdout, stderr: '' };
-  } catch (err) {
-    const e = err as { status: number; stdout?: string; stderr?: string };
-    return {
-      status: e.status,
-      stdout: e.stdout ?? '',
-      stderr: e.stderr ?? '',
-    };
-  }
-}
-
-function writeAgent(
-  pluginsDir: string,
-  pluginRelative: string,
-  body: string
-): void {
-  const fullPath = join(pluginsDir, pluginRelative);
-  const dir = dirname(fullPath);
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(fullPath, body, 'utf8');
-}
+import { runValidator, writeAgent } from './helpers/validator-harness';
 
 const REVIEW_AGENT_BASH_VIOLATOR = `---
 name: synth-violator


### PR DESCRIPTION
Phase 5 of M-A-01 5-PR stack. Validator-only PR — no changeset.

V1: effort enum (low|medium|high|xhigh|max) — hard error. Catches typos.
V2: model enum (haiku|sonnet|opus|inherit, optionally versioned like sonnet-4-5) — hard error.
V3: model: inherit on agents/scanners/ or agents/ci/ — non-blocking warning. Nudges authors toward explicit assignment for narrow-role agents.
V4: synthesizer/orchestrator name without effort: high — non-blocking warning. Matches against name field (not description) to avoid false positives on integration agents.

Warnings infrastructure scaffolded: yellow color constant, logWarning helper, warnings array. Final reporting block prints warnings before checking errors; exit 0 when only warnings present.

MODEL_RULE_ALLOWLIST exempts intentional-inherit agents from V3/V4: failure-analyst, workflow-optimizer (yellow-ci/ci/), devin-orchestrator (yellow-devin/workflow/), knowledge-compounder (yellow-core/workflow/).

21 new tests in tests/integration/validate-agent-authoring-model-effort-rules.test.ts across 5 describe blocks. Full CI baseline gate green: pnpm validate:schemas && pnpm test:unit && pnpm lint && pnpm typecheck.

Lockfile sync: yellow-council and yellow-mempalace registered as workspace members (existing plugins missing from lockfile).

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds four model/effort frontmatter lint rules (V1–V4) to `scripts/validate-agent-authoring.js` along with a warnings infrastructure (yellow color, `logWarning`, warnings array) and 21 integration tests. Hard errors on invalid `effort`/`model` values (V1/V2) and advisory non-blocking warnings for scanner/CI agents using `model: inherit` (V3) or synthesizer-named agents without `effort: high` (V4).

- **V1/V2 (hard errors):** The `MODEL_VALUE_PATTERN` alternation form correctly rejects `inherit-1` and other versioned-inherit nonsense; `effortValid` is computed once and reused by V4 to suppress double-diagnostic noise when a typo triggers V1.
- **V3/V4 (advisory warnings):** `MODEL_RULE_ALLOWLIST` exempts four intentional-inherit agents; `subdir` hoisting cleans up the loop by removing repeated `agentsIdx` lookups.
- **Test harness refactor:** `validator-harness.ts` extracts the shared child-process machinery so the existing review-rule test and the new model-effort test both use the same `runValidator`/`writeAgent` helpers.

<h3>Confidence Score: 5/5</h3>

Safe to merge — validator-only change with no plugin file modifications and a comprehensive integration test suite.

The four lint rules are implemented correctly: the MODEL_VALUE_PATTERN alternation form rejects inherit with version suffixes, effortValid cleanly suppresses V4 when V1 already fires, allowlist lookups use consistent POSIX-joined paths on all platforms, and all 21 tests cover the expected pass/fail/warning states. The one stale section in the plan document does not affect runtime behavior.

The step 5.5 implementation sketch in plans/model-selection-frontmatter-rollout.md should be updated to match what was actually shipped.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/validate-agent-authoring.js | Adds V1–V4 model/effort lint rules, warnings infrastructure, and MODEL_RULE_ALLOWLIST; logic is correct and well-commented, hoisting of agentsIdx/subdir/pluginsRelPath cleans up the loop. |
| tests/integration/helpers/validator-harness.ts | Extracts runValidator/writeAgent into a shared harness; VALIDATOR path resolution is correct (3 levels up from helpers/ to repo root). |
| tests/integration/validate-agent-authoring-model-effort-rules.test.ts | 21 new integration tests covering V1–V4 and exit-code semantics; fixtures use correct plugin-relative paths, allowlist entries match implementation, and the V4 double-diagnostic suppression is explicitly tested. |
| tests/integration/validate-agent-authoring-review-rule.test.ts | Refactored to import runValidator/writeAgent from the shared harness; no behavioral changes to the W1.5 review-rule tests. |
| plans/model-selection-frontmatter-rollout.md | Acceptance criteria updated to document 4 exemptions, but step 5.5 code snippet retains wrong plugin name for devin-orchestrator, wrong path prefix, and is missing knowledge-compounder. |
| pnpm-lock.yaml | Registers yellow-council and yellow-mempalace as workspace members; no new external dependencies introduced. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent .md file] --> B{Has frontmatter?}
    B -- No --> ERR0[ERROR: missing frontmatter]
    B -- Yes --> V1

    subgraph V1 [V1: effort enum]
        C{effort present?} -- No --> V1OK[skip]
        C -- Yes --> D{in EFFORT_VALUES?}
        D -- No --> ERR1[ERROR: invalid effort]
        D -- Yes --> V1OK
    end

    V1 --> V2

    subgraph V2 [V2: model enum]
        E{model present?} -- No --> V2OK[skip]
        E -- Yes --> F{matches MODEL_VALUE_PATTERN?}
        F -- No --> ERR2[ERROR: invalid model]
        F -- Yes --> V2OK
    end

    V2 --> V3

    subgraph V3 [V3: scanner/CI inherit advisory]
        G{model == inherit AND subdir in scanners/ci AND NOT allowlisted?}
        G -- Yes --> WARN1[WARN: V3 advisory]
        G -- No --> V3OK[skip]
    end

    V3 --> V4

    subgraph V4 [V4: synthesizer effort advisory]
        H{name matches SYNTHESIZER pattern AND effortValid AND NOT high-effort AND NOT allowlisted?}
        H -- Yes --> WARN2[WARN: V4 advisory]
        H -- No --> V4OK[skip]
    end

    V4 --> REPORT

    subgraph REPORT [Reporting]
        WARN1 & WARN2 --> WPRINT[Print warnings to stdout]
        ERR1 & ERR2 --> EPRINT[Print errors to stderr]
        EPRINT --> EXIT1[exit 1]
        WPRINT --> EXIT0[exit 0 if no errors]
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Fmodel-effort-validator-rules%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Fmodel-effort-validator-rules%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aplans%2Fmodel-selection-frontmatter-rollout.md%3A239-246%0A**Stale%20allowlist%20snippet%20in%20step%205.5**%0A%0AThe%20code%20example%20in%20step%205.5%20no%20longer%20matches%20what%20was%20actually%20implemented.%20Three%20divergences%3A%20%281%29%20%60devin-orchestrator%60%20is%20listed%20under%20%60yellow-core%60%20here%20but%20lives%20in%20%60yellow-devin%60%20in%20the%20real%20%60MODEL_RULE_ALLOWLIST%60%3B%20%282%29%20%60knowledge-compounder%60%20is%20absent%20%28it%20was%20added%20as%20the%20fourth%20exemption%29%3B%20%283%29%20every%20path%20is%20prefixed%20with%20%60plugins%2F%60%20but%20the%20validator%20resolves%20paths%20relative%20to%20%60PLUGINS_DIR%60%2C%20so%20the%20correct%20entries%20omit%20that%20prefix.%20If%20a%20future%20developer%20follows%20this%20snippet%20to%20add%20a%20fifth%20exemption%2C%20the%20entry%20would%20be%20silently%20ignored%20%28wrong%20prefix%20%E2%9F%B9%20allowlist%20lookup%20never%20matches%29%20and%20the%20V3%2FV4%20warning%20would%20still%20fire.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
plans/model-selection-frontmatter-rollout.md:239-246
**Stale allowlist snippet in step 5.5**

The code example in step 5.5 no longer matches what was actually implemented. Three divergences: (1) `devin-orchestrator` is listed under `yellow-core` here but lives in `yellow-devin` in the real `MODEL_RULE_ALLOWLIST`; (2) `knowledge-compounder` is absent (it was added as the fourth exemption); (3) every path is prefixed with `plugins/` but the validator resolves paths relative to `PLUGINS_DIR`, so the correct entries omit that prefix. If a future developer follows this snippet to add a fifth exemption, the entry would be silently ignored (wrong prefix ⟹ allowlist lookup never matches) and the V3/V4 warning would still fire.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(validator): add V1-V4 model/effort ..."](https://github.com/kinginyellows/yellow-plugins/commit/a75f2e48e013eef11aee366b9155739d062e01f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31396708)</sub>

<!-- /greptile_comment -->