### PR TITLE
feat(agents): close model/effort coverage gaps for 9 agents (M-A-05)

### DIFF
--- a/.changeset/model-explicit-coverage-gaps.md
+++ b/.changeset/model-explicit-coverage-gaps.md
@@ -37,7 +37,8 @@ avoid in agents that ship across Opus versions). The decision rule is now
 documented in `docs/solutions/code-quality/subagent-frontmatter-field-catalog.md`
 as part of this PR.
 
-V3/V4 validator inapplicable to all 9 agents: none are in `agents/scanners/`
-or `agents/ci/` (V3 inert), and none of their `name:` fields match the
+Once PR #477 (V3/V4 model/effort validation rules) lands, all 9 agents will
+be inapplicable to those rules: none are in `agents/scanners/` or `agents/ci/`
+(V3 inert), and none of their `name:` fields match the
 synthesizer/orchestrator/conductor/aggregator/compounder pattern (V4 inert).
-No allowlist updates required.
+No allowlist updates will be required when PR #477 merges.

--- a/.changeset/model-explicit-coverage-gaps.md
+++ b/.changeset/model-explicit-coverage-gaps.md
@@ -1,0 +1,43 @@
+---
+'yellow-core': patch
+'yellow-docs': patch
+'yellow-review': patch
+---
+
+feat(agents): close model/effort coverage gaps for 9 agents (M-A-05)
+
+Closes the three coverage gaps identified during M-A-01..M-A-04 review (PRs
+#467/469/470/471/477) that fell outside the original five-PR rollout scope.
+
+**6 agents downgraded `inherit` → `sonnet`** (no `effort:` — caller-flexible):
+
+- `yellow-core/agents/research/best-practices-researcher.md`
+- `yellow-core/agents/research/git-history-analyzer.md` (note: no
+  `subagent_type` callers in commands or skills today; tier change is for
+  consistency and future direct invocations)
+- `yellow-core/agents/research/repo-research-analyst.md`
+- `yellow-docs/agents/analysis/doc-auditor.md`
+- `yellow-docs/agents/generation/diagram-architect.md`
+- `yellow-docs/agents/generation/doc-generator.md`
+
+**3 yellow-review agents retain `model: opus` and gain explicit `effort:`**:
+
+- `agent-cli-readiness-reviewer` — `effort: high` (7-principle structured
+  rubric, multi-axis but bounded)
+- `agent-native-reviewer` — `effort: high` (parity-matrix reasoning,
+  structured)
+- `adversarial-reviewer` — `effort: xhigh` (constructs novel failure
+  scenarios; no rubric ceiling — additional CoT directly expands the
+  failure-mode search space rather than re-applying the same axes)
+
+**Establishes `xhigh` vs `high` vs `max` convention.** This PR is the first
+use of `xhigh` in the repo; `max` remains unused (community sources indicate
+it may be Opus 4.6-exclusive and return API errors on other model versions —
+avoid in agents that ship across Opus versions). The decision rule is now
+documented in `docs/solutions/code-quality/subagent-frontmatter-field-catalog.md`
+as part of this PR.
+
+V3/V4 validator inapplicable to all 9 agents: none are in `agents/scanners/`
+or `agents/ci/` (V3 inert), and none of their `name:` fields match the
+synthesizer/orchestrator/conductor/aggregator/compounder pattern (V4 inert).
+No allowlist updates required.

--- a/docs/solutions/code-quality/subagent-frontmatter-field-catalog.md
+++ b/docs/solutions/code-quality/subagent-frontmatter-field-catalog.md
@@ -54,6 +54,31 @@ Sources: [docs.anthropic.com/en/docs/claude-code/sub-agents](https://docs.anthro
 | `initialPrompt` | string | none | SDK-level |
 | `color` | `red`/`blue`/`green`/`yellow`/`purple`/`orange`/`pink`/`cyan` | none | undocumented until GH #19292 |
 
+### `effort` tier-selection rule (high vs xhigh vs max)
+
+The official Anthropic docs list the `effort` enum but do not document
+operational distinctions between `high`, `xhigh`, and `max`. Community
+precedent and yellow-plugins convention (established M-A-05, 2026-05-08):
+
+| Tier | Use when | Avoid when |
+|---|---|---|
+| `low` | CLI relay agents, narrow taxonomy scanners, deterministic agents that follow a fixed procedural script | The agent does any synthesis or scoring across candidates |
+| `medium` | Default for caller-flexible agents — let the calling session's context decide depth | The agent has compound reasoning that should override caller defaults |
+| `high` | Agent applies a **bounded structured rubric** (n principles, n axes, n criteria) where each axis is itself bounded; multi-axis but bounded analysis | The agent is open-ended and additional CoT mostly redoes the same axes |
+| `xhigh` | Open-ended reasoning with **no rubric ceiling** — adversarial scenario construction, novel-pattern detection, agents that *generate* failure modes rather than check against them. Effective ceiling on Opus 4.7+ | Agent is sonnet/haiku-tier (xhigh on lower models is pointless — model ceiling already constrains output before effort would) |
+| `max` | Deepest single-pass synthesis on the largest documents, when wall-clock cost is acceptable | The deployed model is not pinned to a specific Opus version that supports `max` — community sources indicate `max` may be Opus 4.6-exclusive and returns API errors on other models. Avoid in plugin agents that ship across Opus versions |
+
+**Pairing with `model:`:** `xhigh`/`max` are most impactful with `model: opus`.
+On `sonnet` or `haiku`, the model's ceiling constrains output quality before
+the effort budget would; pair lower-tier models with `low`/`medium`/`high`
+or omit `effort:` entirely to inherit caller context.
+
+**No published cost/latency multipliers.** Anthropic does not document the
+token-budget ratio between tiers. Order-of-magnitude proxies based on the
+underlying API extended-thinking parameter: `high` ≈ 2-4× a non-thinking
+call; `xhigh` adds further latency on complex prompts; `max` reportedly
+approaches 5-10× a non-thinking call. Treat as best-guess only.
+
 ### `permissionMode` enum and inheritance
 
 | Value | Behavior |

--- a/plans/model-explicit-coverage-gaps.md
+++ b/plans/model-explicit-coverage-gaps.md
@@ -1,0 +1,303 @@
+# Feature: Close Model/Effort Tier Coverage Gaps (M-A-05)
+
+## Problem Statement
+
+The M-A-01 through M-A-04 stack (PRs #467, #469, #470, #471, #477) tiered 39
+agents with explicit `model:` and `effort:` frontmatter and shipped the V1–V4
+validator that lints them. During PR #471 review, the maintainability and
+correctness reviewers surfaced three coverage gaps that fell outside the
+original five-PR rollout scope:
+
+1. **3 `yellow-core/research` agents still on `model: inherit`** —
+   `best-practices-researcher`, `git-history-analyzer`, `repo-research-analyst`.
+   Not covered by any prior phase; they remain in the inheritance trap the
+   M-A series was designed to escape.
+2. **3 `yellow-docs` analysis/generation agents still on `model: inherit`** —
+   `doc-auditor` (analysis/), `diagram-architect` and `doc-generator`
+   (generation/). Phases 3a/3b only addressed `yellow-docs/agents/review/`.
+3. **3 `yellow-review` reviewers retain `model: opus` but lack `effort:`** —
+   `adversarial-reviewer`, `agent-cli-readiness-reviewer`,
+   `agent-native-reviewer`. Plan-time rationale for keeping them on opus
+   ("compound multi-axis architectural judgment") is the exact use case
+   `effort: high` (or `xhigh` for the adversarial case) was designed to support.
+
+These gaps are non-blocking — the validator passes — but they leave 9 agents
+silently inheriting the calling session's model or running with default effort
+on bodies of work the M-A series explicitly identified as benefiting from
+deeper chain-of-thought.
+
+## Linear Issues
+
+(none — this is an internal cleanup PR; track via this plan)
+
+## Current State
+
+Frontmatter snapshot as of this plan's creation:
+
+| Plugin | Agent | Path | Current `model` | Current `effort` |
+|---|---|---|---|---|
+| yellow-core | best-practices-researcher | agents/research/ | `inherit` | (none) |
+| yellow-core | git-history-analyzer | agents/research/ | `inherit` | (none) |
+| yellow-core | repo-research-analyst | agents/research/ | `inherit` | (none) |
+| yellow-docs | doc-auditor | agents/analysis/ | `inherit` | (none) |
+| yellow-docs | diagram-architect | agents/generation/ | `inherit` | (none) |
+| yellow-docs | doc-generator | agents/generation/ | `inherit` | (none) |
+| yellow-review | adversarial-reviewer | agents/review/ | `opus` | (none) |
+| yellow-review | agent-cli-readiness-reviewer | agents/review/ | `opus` | (none) |
+| yellow-review | agent-native-reviewer | agents/review/ | `opus` | (none) |
+
+V3/V4 validator implications: none of these agents are in `scanners/` or
+`ci/` subdirs (V3 inapplicable), and none of their `name:` fields match the
+synthesizer/orchestrator/conductor/aggregator/compounder pattern (V4
+inapplicable). No allowlist updates needed.
+
+## Proposed Solution
+
+### Tier assignments
+
+| Agent | Target `model` | Target `effort` | Rationale |
+|---|---|---|---|
+| best-practices-researcher | `sonnet` | (none) | Web/code lookup + light synthesis. Caller-supplied effort context is appropriate; pinning a default reduces flexibility. |
+| git-history-analyzer | `sonnet` | (none) | Structured `git log` / `git blame` interpretation. Bounded I/O, no compound reasoning. |
+| repo-research-analyst | `sonnet` | (none) | Read + grep exploration + structured synthesis. Same caller-flexibility argument. |
+| doc-auditor | `sonnet` | (none) | Audit scan with structured rubric. Single-axis taxonomy work — sonnet at default effort is the established pattern (matches yellow-debt scanners' tier choice modulo `effort: low`, but this isn't a parallel-fanout role). |
+| diagram-architect | `sonnet` | (none) | Diagram type selection from code analysis. Bounded decision; structured. |
+| doc-generator | `sonnet` | (none) | Doc generation with explicit human review gates. The gates do the quality control; the agent itself doesn't need extended thinking. |
+| adversarial-reviewer | `opus` (no change) | **`xhigh`** | "Actively constructs failure scenarios to break the implementation rather than checking against known patterns" — this is the compound novel reasoning case. `xhigh` (vs `high`) is justified because adversarial reasoning has no rubric ceiling: the model's job is to expand the failure-mode search space, and additional CoT directly broadens that search. |
+| agent-cli-readiness-reviewer | `opus` (no change) | `high` | 7-principle severity-based rubric (Blocker/Friction/Optimization). Multi-axis but each principle is bounded; `high` provides extended thinking without `xhigh`'s diminishing returns. |
+| agent-native-reviewer | `opus` (no change) | `high` | Parity-matrix reasoning across UI/agent/system-prompt surfaces. Structured matrix, multi-axis but bounded — `high` matches the agent-cli-readiness peer pattern. |
+
+### `xhigh` vs `high` decision rule (for future tiers)
+
+Use `xhigh` when:
+- The agent's task has **no rubric ceiling** (open-ended adversarial work,
+  novel-pattern detection)
+- Additional CoT directly **expands the search space** rather than
+  re-applying the same axes
+- The agent is opus-tier (xhigh on sonnet/haiku is pointless — the model's
+  ceiling already constrains output before effort would)
+
+Use `high` when:
+- The agent applies a **bounded structured rubric** (n principles, n axes,
+  n criteria) where each axis is itself bounded
+- Additional CoT mostly redoes the same axes more carefully
+
+Reserve `max` for cases where wall-clock cost is acceptable in exchange for
+the most thorough deliberation possible (none of the M-A-05 agents qualify).
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** The local subagent frontmatter catalog at
+> `docs/solutions/code-quality/subagent-frontmatter-field-catalog.md:46`
+> documents the `effort:` enum (`low|medium|high|xhigh|max`) but provides
+> **no semantic distinction between `high`, `xhigh`, and `max`**. The plan's
+> "no rubric ceiling" framing is authorial — not a confirmation of an
+> existing convention. The validator (`scripts/validate-agent-authoring.js:52`)
+> treats all three as equivalent for V4 satisfiability via
+> `HIGH_EFFORT = new Set(['high', 'xhigh', 'max'])`. **Action:** as part of
+> Phase 4.1, add this decision rule to the catalog so future tiers have a
+> documented reference rather than re-deriving it. This PR is the first to
+> use either `xhigh` or `max` in the repo (verified: `rg 'effort: xhigh'`
+> and `rg 'effort: max'` return zero hits).
+<!-- /deepen-plan -->
+
+<!-- deepen-plan: external -->
+> **Research:** Community precedent strongly supports the plan's
+> `high` vs `xhigh` split. The most detailed public spec
+> ([modu-ai/moai-adk SPEC-OPUS47-COMPAT-001](https://github.com/modu-ai/moai-adk/blob/main/.moai/specs/SPEC-OPUS47-COMPAT-001/spec.md))
+> assigns `xhigh` to "manager" agents that do open-ended planning and
+> orchestration with no fixed rubric, and `high` to evaluator agents that
+> apply known criteria — exactly the rubric-vs-no-rubric criterion this
+> plan uses. moai-adk also documents that **`xhigh` is the effective
+> ceiling for Opus 4.7+** (other models default to `high` as internal
+> fallback). Anthropic's official subagent docs list the enum but provide
+> no per-level semantics, so the convention is community-derived rather
+> than vendor-specified.
+<!-- /deepen-plan -->
+
+<!-- deepen-plan: external -->
+> **Research:** **`effort: max` carries model-version risk.** A community
+> source ([FlorianBruniaux/claude-code-ultimate-guide quiz](https://github.com/FlorianBruniaux/claude-code-ultimate-guide/blob/main/quiz/questions/09-advanced-patterns.yaml))
+> states `effort: max` is Opus 4.6-exclusive and returns an API error on
+> other models. The Anthropic SDK has a `caps["effort"]["max"]["supported"]`
+> capability flag confirming `max` availability is per-model. The plan
+> correctly avoids `max` — preserve that decision; do not "upgrade"
+> adversarial-reviewer to `max` as a follow-up unless the agent is also
+> pinned to a specific Opus version where `max` is verified supported.
+<!-- /deepen-plan -->
+
+<!-- deepen-plan: external -->
+> **Research:** **No published cost/latency multipliers.** Anthropic does
+> not document the token-budget ratio between `high`/`xhigh`/`max`.
+> Order-of-magnitude proxies from the API's extended-thinking parameter:
+> `high` ≈ 2-4× a non-thinking call; `xhigh` adds further latency on
+> complex prompts; `max` reportedly approaches 5-10× but no authoritative
+> figure exists. Treat the Performance Considerations section's "1.5-2x /
+> 2-3x" estimates as best-guess only.
+<!-- /deepen-plan -->
+
+## Implementation Plan
+
+### Phase 1: Foundation
+
+- [ ] 1.1: `gt branch create agent/feat/model-explicit-coverage-gaps`
+  (stacks on `main`, NOT on the M-A-01..M-A-04 stack — all five upstream
+  PRs are merge-pending)
+- [ ] 1.2: Confirm none of the 9 agents have changed since this plan was
+  written: `git diff main -- <9 paths>`. If any have changed, refresh the
+  Current State table before edits.
+
+### Phase 2: Edit 9 agent frontmatter blocks
+
+Each edit inserts `model:` (and optionally `effort:`) immediately after
+`description:`, preserving existing field order for `background:`, `memory:`,
+`skills:`, `tools:` etc. Canonical convention (description → model → effort
+→ background → other fields) is now codified in
+`docs/solutions/code-quality/subagent-frontmatter-field-catalog.md`; the
+M-A-01..M-A-04 rollout plan that originated it has been archived.
+
+- [ ] 2.1: `plugins/yellow-core/agents/research/best-practices-researcher.md`
+  — replace `model: inherit` with `model: sonnet` (no `effort:` added)
+- [ ] 2.2: `plugins/yellow-core/agents/research/git-history-analyzer.md`
+  — `model: inherit` → `model: sonnet`
+
+  <!-- deepen-plan: codebase -->
+  > **Codebase:** `git-history-analyzer` has **no `subagent_type` callers
+  > in `commands/` or `skills/`** — only descriptive references in
+  > CLAUDE.md and READMEs. The tier change still has value (frontmatter
+  > consistency, future direct invocations, agent-discovery surface), but
+  > impact on running workflows is zero today. Document this in the
+  > changeset so reviewers don't expect runtime behavior changes.
+  <!-- /deepen-plan -->
+
+- [ ] 2.3: `plugins/yellow-core/agents/research/repo-research-analyst.md`
+  — `model: inherit` → `model: sonnet`
+- [ ] 2.4: `plugins/yellow-docs/agents/analysis/doc-auditor.md`
+  — `model: inherit` → `model: sonnet`
+- [ ] 2.5: `plugins/yellow-docs/agents/generation/diagram-architect.md`
+  — `model: inherit` → `model: sonnet`
+- [ ] 2.6: `plugins/yellow-docs/agents/generation/doc-generator.md`
+  — `model: inherit` → `model: sonnet`
+- [ ] 2.7: `plugins/yellow-review/agents/review/adversarial-reviewer.md`
+  — keep `model: opus`; add `effort: xhigh` directly after the `model:` line
+- [ ] 2.8: `plugins/yellow-review/agents/review/agent-cli-readiness-reviewer.md`
+  — keep `model: opus`; add `effort: high`
+- [ ] 2.9: `plugins/yellow-review/agents/review/agent-native-reviewer.md`
+  — keep `model: opus`; add `effort: high`
+
+### Phase 3: Validation
+
+- [ ] 3.1: Run `pnpm validate:agents` — must exit 0 with no warnings.
+  Expected: V3 inapplicable (none in scanners/ or ci/), V4 inapplicable
+  (none match the synthesizer regex). If any warning fires, the assumption
+  in the Current State section is wrong; re-evaluate.
+- [ ] 3.2: Run `pnpm validate:schemas` — must pass.
+- [ ] 3.3: Run `pnpm test:unit` — must pass.
+- [ ] 3.4: Run `pnpm typecheck && pnpm lint` — must pass.
+
+### Phase 4: Plan-doc update + changeset
+
+- [x] 4.1: Update `docs/solutions/code-quality/subagent-frontmatter-field-catalog.md`
+  with the `xhigh` vs `high` vs `max` decision rule and the 9 tier
+  assignments from this PR. The catalog is the canonical source of truth;
+  the prior `plans/model-selection-frontmatter-rollout.md` was archived,
+  so its "Per-Agent Assignment Table" responsibility has migrated here.
+
+- [ ] 4.2: `pnpm changeset` — patch bumps for `yellow-core`, `yellow-docs`,
+  `yellow-review`. Include the `xhigh` rationale paragraph in the changeset
+  body so future tiers have a precedent reference.
+- [ ] 4.3: Normalize CRLF on edited files: `for f in <9 paths>; do sed -i
+  's/\r$//' "$f"; done`
+
+### Phase 5: Commit + submit
+
+- [ ] 5.1: `gt commit create -m "feat(agents): close model/effort coverage
+  gaps for 9 agents (M-A-05)"` with a body summarizing the 3-plugin patch
+  bumps + `xhigh` precedent rationale
+- [ ] 5.2: `gt stack submit` (creates a new PR off `main`, independent of
+  the M-A-01..M-A-04 stack)
+
+## Technical Specifications
+
+### Files to Modify (9 agents + 1 plan + 1 changeset)
+
+- `plugins/yellow-core/agents/research/best-practices-researcher.md`
+- `plugins/yellow-core/agents/research/git-history-analyzer.md`
+- `plugins/yellow-core/agents/research/repo-research-analyst.md`
+- `plugins/yellow-docs/agents/analysis/doc-auditor.md`
+- `plugins/yellow-docs/agents/generation/diagram-architect.md`
+- `plugins/yellow-docs/agents/generation/doc-generator.md`
+- `plugins/yellow-review/agents/review/adversarial-reviewer.md`
+- `plugins/yellow-review/agents/review/agent-cli-readiness-reviewer.md`
+- `plugins/yellow-review/agents/review/agent-native-reviewer.md`
+- `docs/solutions/code-quality/subagent-frontmatter-field-catalog.md`
+  (effort tier-selection rule + per-agent assignment migration target;
+  replaces the archived `plans/model-selection-frontmatter-rollout.md`)
+
+### Files to Create
+
+- `.changeset/model-explicit-coverage-gaps.md` (3-plugin patch bumps)
+
+### Dependencies
+
+None.
+
+## Acceptance Criteria
+
+1. `grep -L "^model: " plugins/{yellow-core/agents/research,yellow-docs/agents/{analysis,generation},yellow-review/agents/review}/<9 files>` returns empty (every target file declares an explicit model).
+2. `grep -c "^model: inherit" plugins/yellow-core/agents/research/*.md plugins/yellow-docs/agents/{analysis,generation}/*.md` returns 0 (no remaining inheritance in the targeted directories).
+3. `grep -l "^effort: xhigh" plugins/yellow-review/agents/review/*.md` returns exactly `adversarial-reviewer.md` (and only that file).
+4. `pnpm validate:agents` exits 0 with no V3/V4 warnings on the live tree.
+5. CI baseline gate (`pnpm validate:schemas && pnpm test:unit && pnpm lint && pnpm typecheck`) passes.
+6. Changeset present at `.changeset/model-explicit-coverage-gaps.md` with three patch bumps.
+
+## Edge Cases
+
+- **One of the 9 agents gains a new `effort:` field upstream before this
+  PR ships.** Mitigation: Phase 1.2 re-checks frontmatter before editing.
+  If a conflict surfaces, defer that file's edit and document why in the
+  changeset.
+- **Future ImportError on `xhigh`.** If Claude Code's frontmatter parser
+  rejects `xhigh` (which would also break PR #477's V1 enum), that's a
+  framework regression unrelated to this PR — escalate, do not work around.
+- **adversarial-reviewer at `effort: xhigh` runs noticeably slower in CI.**
+  This is the intended trade-off — the agent only fires on large/high-risk
+  diffs (>200 changed lines or auth/payment/data-mutation domains), so the
+  wall-clock cost is bounded. If it becomes a problem, downgrade to `high`
+  in a follow-up.
+
+## Performance Considerations
+
+- The 6 sonnet downgrades (research/ and analysis/generation/) are *cost
+  reductions* — they exit the inheritance trap that was silently using
+  opus when the calling session was opus.
+- The 3 opus + effort additions are *cost increases* — `effort: high`
+  roughly 1.5–2x token use vs default; `effort: xhigh` ~2–3x (best-guess
+  proxies; Anthropic does not publish per-tier multipliers — see the
+  catalog's "No published cost/latency multipliers" note). These run
+  conditionally (adversarial only on large/high-risk PRs), so the
+  per-PR-review impact is bounded.
+
+## Security Considerations
+
+None directly — frontmatter changes don't affect tool surfaces, MCP access,
+or the W1.5 read-only-reviewer rule. The 3 yellow-review agents already had
+their tools constrained pre-existing.
+
+## Migration & Rollback
+
+- **Rollback:** revert the single commit. No state migration; pure
+  frontmatter changes.
+- **Downstream impact:** all 9 agents are spawned via `Task` from
+  command/skill bodies that pin `subagent_type` strings. The 9 `name:`
+  fields are unchanged, so no caller breaks.
+
+## References
+
+- Source plan: `plans/model-selection-frontmatter-rollout.md` *(archived
+  during plan-lifecycle cleanup; canonical tier rule and per-agent
+  assignments migrated to the catalog below)*
+- Source brainstorm: [`docs/brainstorms/2026-05-08-research-integration-model-selection-context-optimization-brainstorm.md`](../docs/brainstorms/2026-05-08-research-integration-model-selection-context-optimization-brainstorm.md)
+- Subagent frontmatter catalog: [`docs/solutions/code-quality/subagent-frontmatter-field-catalog.md`](../docs/solutions/code-quality/subagent-frontmatter-field-catalog.md) (canonical source for `effort:` enum, including `xhigh` semantics)
+- Validator implementation: [`scripts/validate-agent-authoring.js`](../scripts/validate-agent-authoring.js) (V1-V4 rules from PR #477)
+- M-A-01 through M-A-04 PRs (merged or in flight): #467, #469, #470, #471, #477
+- PR #471 review surfaced these gaps — see review-all run summary

--- a/plans/model-explicit-coverage-gaps.md
+++ b/plans/model-explicit-coverage-gaps.md
@@ -91,9 +91,11 @@ the most thorough deliberation possible (none of the M-A-05 agents qualify).
 > documents the `effort:` enum (`low|medium|high|xhigh|max`) but provides
 > **no semantic distinction between `high`, `xhigh`, and `max`**. The plan's
 > "no rubric ceiling" framing is authorial — not a confirmation of an
-> existing convention. The validator (`scripts/validate-agent-authoring.js:52`)
-> treats all three as equivalent for V4 satisfiability via
-> `HIGH_EFFORT = new Set(['high', 'xhigh', 'max'])`. **Action:** as part of
+> existing convention. Once PR #477 (M-A-01..M-A-04 upstream, not yet merged
+> on this branch) lands, the validator (`scripts/validate-agent-authoring.js`)
+> will treat all three as equivalent for V4 satisfiability via a
+> `HIGH_EFFORT = new Set(['high', 'xhigh', 'max'])` constant — but that
+> check does not exist on this branch today. **Action:** as part of
 > Phase 4.1, add this decision rule to the catalog so future tiers have a
 > documented reference rather than re-deriving it. This PR is the first to
 > use either `xhigh` or `max` in the repo (verified: `rg 'effort: xhigh'`
@@ -187,9 +189,12 @@ M-A-01..M-A-04 rollout plan that originated it has been archived.
 ### Phase 3: Validation
 
 - [ ] 3.1: Run `pnpm validate:agents` — must exit 0 with no warnings.
-  Expected: V3 inapplicable (none in scanners/ or ci/), V4 inapplicable
-  (none match the synthesizer regex). If any warning fires, the assumption
-  in the Current State section is wrong; re-evaluate.
+  On the current branch (PR #477 not merged), the validator checks tool
+  allowlists and `subagent_type` references only — no V3/V4 model/effort
+  warnings are emitted. After PR #477 lands: V3 will fire as inapplicable
+  (none in scanners/ or ci/), V4 will fire as inapplicable (none match the
+  synthesizer regex). If any warning fires post-merge, the assumption in the
+  Current State section is wrong; re-evaluate.
 - [ ] 3.2: Run `pnpm validate:schemas` — must pass.
 - [ ] 3.3: Run `pnpm test:unit` — must pass.
 - [ ] 3.4: Run `pnpm typecheck && pnpm lint` — must pass.

--- a/plugins/yellow-core/agents/research/best-practices-researcher.md
+++ b/plugins/yellow-core/agents/research/best-practices-researcher.md
@@ -1,7 +1,7 @@
 ---
 name: best-practices-researcher
 description: "Technology researcher specializing in discovering and synthesizing best practices from authoritative sources. Use when implementing new features, evaluating libraries, or establishing architectural patterns."
-model: inherit
+model: sonnet
 background: true
 memory: project
 tools:

--- a/plugins/yellow-core/agents/research/git-history-analyzer.md
+++ b/plugins/yellow-core/agents/research/git-history-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: git-history-analyzer
 description: 'Git archaeology specialist. Traces the origins and evolution of code changes. Use when investigating why code exists, identifying experts for code areas, or understanding change patterns.'
-model: inherit
+model: sonnet
 background: true
 memory: project
 tools:

--- a/plugins/yellow-core/agents/research/repo-research-analyst.md
+++ b/plugins/yellow-core/agents/research/repo-research-analyst.md
@@ -1,7 +1,7 @@
 ---
 name: repo-research-analyst
 description: "Expert repository research analyst. Analyzes repository structure, documentation, conventions, and implementation patterns. Use when exploring unfamiliar codebases or auditing existing projects."
-model: inherit
+model: sonnet
 background: true
 memory: project
 tools:

--- a/plugins/yellow-docs/agents/analysis/doc-auditor.md
+++ b/plugins/yellow-docs/agents/analysis/doc-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: doc-auditor
 description: "Documentation audit specialist — scan repos for doc gaps, staleness, and coverage. Use when auditing documentation health."
-model: inherit
+model: sonnet
 background: true
 memory: project
 skills:

--- a/plugins/yellow-docs/agents/generation/diagram-architect.md
+++ b/plugins/yellow-docs/agents/generation/diagram-architect.md
@@ -1,7 +1,7 @@
 ---
 name: diagram-architect
 description: "Context-aware Mermaid diagram generator — auto-selects diagram type from code analysis. Use when generating architecture, dependency, or sequence diagrams."
-model: inherit
+model: sonnet
 background: true
 memory: project
 skills:

--- a/plugins/yellow-docs/agents/generation/doc-generator.md
+++ b/plugins/yellow-docs/agents/generation/doc-generator.md
@@ -1,7 +1,7 @@
 ---
 name: doc-generator
 description: "AI-assisted documentation generator with human review gates. Use when generating READMEs, API references, architecture docs, or module documentation."
-model: inherit
+model: sonnet
 background: true
 memory: project
 skills:

--- a/plugins/yellow-review/agents/review/adversarial-reviewer.md
+++ b/plugins/yellow-review/agents/review/adversarial-reviewer.md
@@ -2,6 +2,7 @@
 name: adversarial-reviewer
 description: "Conditional code-review persona, selected when the diff is large (>200 changed lines) or touches high-risk domains like auth, payments, data mutations, external APIs, or trust boundaries. Use when reviewing PRs that pass the size/risk threshold — review:pr selects this automatically. Actively constructs failure scenarios to break the implementation rather than checking against known patterns."
 model: opus
+effort: xhigh
 background: true
 tools:
   - Read

--- a/plugins/yellow-review/agents/review/agent-cli-readiness-reviewer.md
+++ b/plugins/yellow-review/agents/review/agent-cli-readiness-reviewer.md
@@ -2,6 +2,7 @@
 name: agent-cli-readiness-reviewer
 description: "Reviews CLI source code, plans, or specs for AI agent readiness using a 7-principle severity-based rubric (Blocker / Friction / Optimization). Distinguishes whether a CLI is merely usable by agents or genuinely optimized for them: non-interactive defaults, structured output, actionable errors, safe retries, bounded output, composability, and pipeline-friendly behavior. Use when reviewing PRs that touch CLI command surface, argument parsers, output formatters, or design documents proposing a CLI."
 model: opus
+effort: high
 background: true
 tools:
   - Read

--- a/plugins/yellow-review/agents/review/agent-native-reviewer.md
+++ b/plugins/yellow-review/agents/review/agent-native-reviewer.md
@@ -2,6 +2,7 @@
 name: agent-native-reviewer
 description: "Reviews code to ensure agent-native parity — any action a user can take, an agent can also take. Reviews UI/agent action parity, context parity, shared workspace patterns, primitive-vs-workflow tool design, and dynamic context injection in system prompts. Use when reviewing PRs that introduce or modify UI features, agent tool definitions, system prompts, or LLM-integration scaffolding."
 model: opus
+effort: high
 background: true
 tools:
   - Read


### PR DESCRIPTION
(PRs #467/469/470/471/477) that fell outside the original five-PR rollout
scope.

Six inherit-on-research/analysis/generation agents downgraded to model: sonnet
(no effort:, caller-flexible):
- yellow-core: best-practices-researcher, git-history-analyzer,
  repo-research-analyst
- yellow-docs: doc-auditor, diagram-architect, doc-generator

Three opus-tier yellow-review agents gain explicit effort:
- agent-cli-readiness-reviewer: effort: high (7-principle bounded rubric)
- agent-native-reviewer: effort: high (parity-matrix structured analysis)
- adversarial-reviewer: effort: xhigh (constructs novel failure scenarios;
  no rubric ceiling - additional CoT directly expands the failure-mode
  search space rather than re-applying the same axes)

Establishes xhigh vs high vs max convention. First use of xhigh in repo;
max remains unused (community sources indicate Opus 4.6-exclusive behavior
with API errors on other versions). Decision rule documented in
docs/solutions/code-quality/subagent-frontmatter-field-catalog.md.

V3/V4 validator inapplicable to all 9 agents: none in agents/scanners/ or
agents/ci/ subdirs, none of their name: fields match the
synthesizer/orchestrator/conductor/aggregator/compounder pattern. No
allowlist updates required.

Stacks on main, not on the M-A-01..M-A-04 stack. The rollout plan at
plans/model-selection-frontmatter-rollout.md will be synced with the
M-A-05 entries after the upstream stack merges.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes nine model/effort coverage gaps that fell outside the original M-A-01..M-A-04 rollout scope: six research/analysis/generation agents in yellow-core and yellow-docs move from `model: inherit` to `model: sonnet` (no `effort:`, caller-flexible), and three opus-tier yellow-review agents gain explicit `effort:` (`xhigh` for the open-ended adversarial reviewer, `high` for the two rubric-bounded reviewers). The accompanying catalog update establishes the `high` vs `xhigh` vs `max` decision rule as convention.

- Six `model: inherit` agents across yellow-core/research and yellow-docs/analysis+generation are pinned to `model: sonnet` with no `effort:` — exiting the inheritance trap while keeping them caller-flexible.
- Three yellow-review opus agents (`adversarial-reviewer`, `agent-cli-readiness-reviewer`, `agent-native-reviewer`) gain `effort: xhigh` or `effort: high` respectively, with rationale grounded in the rubric-ceiling/no-ceiling distinction now codified in the catalog.
- `docs/solutions/code-quality/subagent-frontmatter-field-catalog.md` gains the `effort` tier-selection table, `xhigh`/`max` pairing guidance, and a best-guess cost/latency note.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are frontmatter-only with no runtime tool-surface, permission-mode, or schema impact.

Every changed file is either an agent frontmatter field addition/swap or documentation. The frontmatter values (sonnet, opus, high, xhigh) are all valid enum values per the catalog, field ordering follows the canonical convention, and none of the nine agents are in the subdirs or match the name patterns that would trigger the pending V3/V4 validator rules.

docs/solutions/code-quality/subagent-frontmatter-field-catalog.md — plan phase 4.1 committed to adding a per-agent assignment table alongside the decision rule, but only the rule was included.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .changeset/model-explicit-coverage-gaps.md | New patch-bump changeset for yellow-core, yellow-docs, yellow-review; accurately describes the 6 sonnet downgrades and 3 effort additions, including the xhigh precedent rationale. |
| docs/solutions/code-quality/subagent-frontmatter-field-catalog.md | Adds effort tier-selection rule section with high/xhigh/max decision table; missing the per-agent assignment table that phase 4.1 of the plan committed to migrating here from the archived rollout plan. |
| plans/model-explicit-coverage-gaps.md | Well-structured M-A-05 plan with thorough rationale and codebase/external research notes; phase checkboxes for 2.1–2.9, 4.2, 4.3, and 5.x remain unchecked despite the work being completed. |
| plugins/yellow-review/agents/review/adversarial-reviewer.md | Gains effort: xhigh after model: opus; field ordering follows canonical convention (description → model → effort → background). Rationale (no-rubric-ceiling adversarial construction) is well-justified and consistent with catalog definition. |
| plugins/yellow-review/agents/review/agent-cli-readiness-reviewer.md | Gains effort: high after model: opus; correct for its 7-principle bounded rubric. Field ordering and formatting match canonical convention. |
| plugins/yellow-review/agents/review/agent-native-reviewer.md | Gains effort: high after model: opus; correct for its parity-matrix structured analysis. Consistent with agent-cli-readiness-reviewer peer pattern. |
| plugins/yellow-core/agents/research/best-practices-researcher.md | model: inherit → model: sonnet; no effort added (caller-flexible). Clean single-line change. |
| plugins/yellow-core/agents/research/git-history-analyzer.md | model: inherit → model: sonnet; changeset correctly notes this agent has no subagent_type callers today so runtime impact is zero. |
| plugins/yellow-core/agents/research/repo-research-analyst.md | model: inherit → model: sonnet; no effort added (caller-flexible). Clean single-line change. |
| plugins/yellow-docs/agents/analysis/doc-auditor.md | model: inherit → model: sonnet; existing memory: project without disallowedTools guard is pre-existing and not introduced by this PR. |
| plugins/yellow-docs/agents/generation/diagram-architect.md | model: inherit → model: sonnet; no effort added. Clean single-line change. |
| plugins/yellow-docs/agents/generation/doc-generator.md | model: inherit → model: sonnet; agent has human review gates (AskUserQuestion) for all writes, making the no-effort choice appropriate. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph M-A-05["M-A-05: 9 Agent Frontmatter Updates"]
        direction TB

        subgraph inherit_to_sonnet["6 agents: model inherit → sonnet (no effort)"]
            BPR["best-practices-researcher\nyellow-core/research"]
            GHA["git-history-analyzer\nyellow-core/research"]
            RRA["repo-research-analyst\nyellow-core/research"]
            DA["doc-auditor\nyellow-docs/analysis"]
            DARCH["diagram-architect\nyellow-docs/generation"]
            DG["doc-generator\nyellow-docs/generation"]
        end

        subgraph opus_effort["3 agents: model opus + gain effort"]
            ADVR["adversarial-reviewer\nopus + effort: xhigh\n(no rubric ceiling)"]
            ACLIR["agent-cli-readiness-reviewer\nopus + effort: high\n(7-principle bounded rubric)"]
            ANR["agent-native-reviewer\nopus + effort: high\n(parity-matrix bounded)"]
        end

        subgraph catalog["Catalog Update"]
            RULE["effort tier-selection rule\nhigh vs xhigh vs max\ncodified in frontmatter catalog"]
        end
    end

    ADVR -. "xhigh: open-ended,\nno rubric ceiling" .-> RULE
    ACLIR -. "high: bounded\nstructured rubric" .-> RULE
    ANR -. "high: bounded\nstructured rubric" .-> RULE
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Ffeat%2Fmodel-explicit-coverage-gaps%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffeat%2Fmodel-explicit-coverage-gaps%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fsolutions%2Fcode-quality%2Fsubagent-frontmatter-field-catalog.md%3A57-80%0A**Per-agent%20assignment%20table%20missing%20from%20catalog**%0A%0APhase%204.1%20of%20the%20accompanying%20plan%20%28%60plans%2Fmodel-explicit-coverage-gaps.md%60%29%20is%20marked%20%60%5Bx%5D%60%20complete%20and%20explicitly%20states%20the%20catalog%20update%20should%20include%20%22the%209%20tier%20assignments%20from%20this%20PR%22%20in%20addition%20to%20the%20decision%20rule.%20The%20plan%20notes%3A%20%22The%20catalog%20is%20the%20canonical%20source%20of%20truth%3B%20the%20prior%20%60plans%2Fmodel-selection-frontmatter-rollout.md%60%20was%20archived%2C%20so%20its%20'Per-Agent%20Assignment%20Table'%20responsibility%20has%20migrated%20here.%22%0A%0AThe%20diff%20adds%20the%20%60high%60%2F%60xhigh%60%2F%60max%60%20decision%20rule%20correctly%2C%20but%20the%20per-agent%20assignment%20table%20%28agent%20%E2%86%92%20target%20model%20%E2%86%92%20target%20effort%20%E2%86%92%20rationale%29%20from%20the%20plan's%20Proposed%20Solution%20section%20was%20not%20ported%20to%20the%20catalog.%20A%20future%20tier%20review%20working%20from%20the%20catalog%20alone%20won't%20find%20the%20M-A-05%20assignments%20without%20cross-referencing%20the%20plan%20file.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
docs/solutions/code-quality/subagent-frontmatter-field-catalog.md:57-80
**Per-agent assignment table missing from catalog**

Phase 4.1 of the accompanying plan (`plans/model-explicit-coverage-gaps.md`) is marked `[x]` complete and explicitly states the catalog update should include "the 9 tier assignments from this PR" in addition to the decision rule. The plan notes: "The catalog is the canonical source of truth; the prior `plans/model-selection-frontmatter-rollout.md` was archived, so its 'Per-Agent Assignment Table' responsibility has migrated here."

The diff adds the `high`/`xhigh`/`max` decision rule correctly, but the per-agent assignment table (agent → target model → target effort → rationale) from the plan's Proposed Solution section was not ported to the catalog. A future tier review working from the catalog alone won't find the M-A-05 assignments without cross-referencing the plan file.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(plans): gate V3/V4 validator referen..."](https://github.com/kinginyellows/yellow-plugins/commit/b1cdefd54fba974c2b123dda459996bff3c87540) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31410515)</sub>

<!-- /greptile_comment -->