### PR TITLE
docs(plans): add plan-lifecycle-management brainstorm and plan

### DIFF
--- a/docs/brainstorms/2026-05-08-plan-lifecycle-management-brainstorm.md
+++ b/docs/brainstorms/2026-05-08-plan-lifecycle-management-brainstorm.md
@@ -1,0 +1,193 @@
+# Plan Lifecycle Management
+
+**Date:** 2026-05-08
+**Status:** Brainstorm — ready for planning
+
+## What We're Building
+
+A plan lifecycle management system living in yellow-core that gives the plugin
+system authoritative knowledge of which plans are open and which are complete,
+with validation that completion is real — not just a flag the user set.
+
+Two new commands extend the existing `/workflows:*` surface in yellow-core:
+
+- `/plan:status` — read-only dashboard: lists open plans (`plans/*.md`) and
+  archived plans (`plans/complete/*.md`), annotating each with checkbox
+  completion percentage and any known PR merge status
+- `/plan:complete <plan-filename>` — explicit archival command that runs two
+  validation gates before moving the file:
+  1. **Gate A (structural):** All `- [ ]` checkboxes in the plan are checked
+     off. Cheap pre-check; fails fast before the agent runs.
+  2. **Gate C (semantic):** A lightweight verification agent reads the plan,
+     queries `gh` for a merged PR associated with the plan's branch, checks
+     that files mentioned in the plan exist on disk, and confirms commits
+     referencing the plan landed on main. If all three pass, archival proceeds.
+
+A new `scripts/validate-plans.js` CI validator ensures no plan file in
+`plans/complete/` has unchecked boxes — catching manual archival that skipped
+the gate.
+
+## Why This Approach
+
+**Friction is real.** Six archival commits landed in two days
+(`6f883f7c`, `f056390c`, `3e9baf4d`, `0538866b` and peers), all manual
+`git mv` + commit cycles. That's the actual pain — not missing dashboards.
+
+**`/workflows:work` cannot own this.** Work executes during development, before
+merge. Completion validation requires post-merge state: a closed PR, commits on
+main, artifacts on disk. Splitting into a dedicated `/plan:complete` command
+respects that boundary cleanly.
+
+**Two gates, not one.** Checkbox coverage (Gate A) is a mechanical contract
+the plan author already made with themselves when writing tasks. The agent
+re-review (Gate C) adds semantic confidence: did the right files actually land,
+did a PR actually merge? Together they prevent both lazy checkbox-ticking and
+accidental archival of stalled work.
+
+**No new plugin needed.** Yellow-core already owns the planning surface
+(`/workflows:plan`, `/workflows:work`, `/workflows:brainstorm`). Adding
+`/plan:status` and `/plan:complete` under a `plan/` subdirectory of commands
+follows the same pattern as `workflows/` — zero new plugin manifest overhead.
+
+**Filesystem convention stays unchanged.** _(NOTE: The "no frontmatter required" position below was reversed during planning. See `docs/plans/plan-lifecycle-management.md`, which introduces a `slug:` + `created:` frontmatter convention as a stable per-plan identifier for Gate C and a `ci-skip-checkbox-check` escape hatch for the CI validator. Filesystem convention is still the lifecycle-state source of truth, but a small frontmatter block now exists for tooling.)_ Plans remain plain markdown files.
+No frontmatter required. The `plans/` vs `plans/complete/` directory split is
+the single source of truth for open vs archived — the same convention already
+in use, now enforced by CI.
+
+## Key Decisions
+
+### Command placement in yellow-core
+
+New directory: `plugins/yellow-core/commands/plan/`
+
+```
+plugins/yellow-core/commands/plan/
+  status.md      → /plan:status
+  complete.md    → /plan:complete
+```
+
+This mirrors how `commands/workflows/` is laid out and keeps the namespace
+intuitive (`/plan:*` = plan lifecycle, `/workflows:*` = execution flows).
+
+### Gate A: checkbox coverage (structural pre-check)
+
+Before spawning any agent, `/plan:complete` runs a Bash check:
+
+```bash
+UNCHECKED=$(grep -c '^\s*- \[ \]' "$PLAN_FILE" || true)
+[ "$UNCHECKED" -eq 0 ] || { printf '[plan:complete] %d unchecked tasks remain\n' "$UNCHECKED"; exit 1; }
+```
+
+This is instant and cannot be argued with. If it fails, the user sees exactly
+how many tasks are unfinished. No agent token spend until this passes.
+
+### Gate C: semantic evidence review (agent)
+
+A Task-spawned verification agent receives the plan content (injection-fenced
+as reference only) and performs three checks:
+
+1. **PR merge check:** `gh pr list --state merged --search "<plan-slug>"` — if
+   no merged PR found, the agent surfaces a warning and asks the user to
+   confirm override or provide a PR number manually.
+2. **File existence check:** The agent reads the plan, extracts file paths or
+   component names mentioned under "Proposed Solution" / task steps, and
+   verifies they exist on disk via Glob/Read.
+3. **Commit landing check:** `git log main --oneline --grep="<plan-slug>"` —
+   confirms at least one commit referencing the plan name landed on main.
+
+All three must pass for automatic archival. If any check is uncertain (e.g.,
+PR search returns ambiguous results), the agent presents findings and asks via
+`AskUserQuestion` before proceeding — never silently skips.
+
+### Archival mechanics
+
+On success, `/plan:complete` moves the file and creates the commit:
+
+```bash
+gt branch create "plan/archive-<slug>"
+mv "plans/<file>" "plans/complete/<file>"
+gt commit create -m "docs(plans): archive completed <slug> plan"
+gt stack submit
+```
+
+The user gets a Graphite PR for the archival — keeping the git history clean
+and the merge queue flow intact.
+
+### CI validator: validate-plans.js
+
+New script at `scripts/validate-plans.js`, invoked as `pnpm validate:plans`.
+
+Rules enforced:
+- Every file in `plans/complete/*.md` must have zero `- [ ]` occurrences
+  (unchecked boxes in an archived plan = bypassed gate)
+- Every file in `plans/*.md` (open) is valid by existence alone — no rules on
+  open plans except that they must be `.md` files
+
+Added to `pnpm release:check` alongside the existing `validate:schemas` chain.
+
+### /plan:status output format
+
+Plain text table, no external dependencies:
+
+```
+OPEN PLANS (3)
+  yellow-rtk-plugin.md              [ 4/12 tasks ]
+  yellow-symphony-plugin.md         [ 0/8 tasks  ]
+  ast-grep-integration.md           [ 11/11 tasks ] -- ready to complete
+
+ARCHIVED PLANS (14)
+  plans/complete/everyinc-merge-wave3.md
+  plans/complete/audit-followups-2026-05-07.md
+  ... (12 more)
+```
+
+Plans with 100% checkbox coverage get a `-- ready to complete` annotation as a
+nudge to run `/plan:complete`.
+
+## Open Questions
+
+1. **PR search heuristic:** The Gate C PR check uses the plan filename as a
+   search term. Plans named generically (e.g., `refactor.md`) may return
+   ambiguous results. Should `/workflows:plan` write the plan filename into the
+   plan body as a stable identifier, or should `/plan:complete` ask the user
+   for a PR number explicitly when the search is ambiguous?
+   **(Resolved in plan):** Plan introduces `slug:` frontmatter written by
+   `/workflows:plan` at creation; `/plan:complete` reads it via
+   `parsePlanFrontmatter` and uses it as the `gh` search term. Generic-slug
+   collision is addressed by post-filtering on PR branch name.
+
+2. **Multi-PR plans:** Large features (e.g., the everyinc merge wave series)
+   ship across multiple PRs. Gate C currently expects one merged PR. Should
+   the agent accept "any merged PR referencing this plan" or require a
+   user-supplied PR list?
+
+3. **validate-plans.js scope creep risk:** The validator could grow to check
+   for plan naming conventions, required sections, etc. Keep it to the one
+   rule above for now — unchecked boxes in complete/ only. Resist expansion
+   until a specific failure mode demands it.
+
+4. **Stale open plans:** `/plan:status` will surface plans that have been
+   sitting open for weeks with zero progress. Worth adding an age annotation
+   (last modified date) in a follow-up, but not in v1.
+
+## Considered Alternatives
+
+**Frontmatter-based status field** (`status: complete` in plan YAML): Rejected.
+User-settable flags are exactly what the C gate is designed to replace. A field
+the user writes is trivially wrong. Directory position is a stronger signal
+because it requires the archival command to have run.
+
+**Hooking into `/workflows:work` for automatic completion detection:**
+Rejected. `/workflows:work` runs during execution, before merge. It has no
+reliable way to know the branch merged. The explicit `/plan:complete` call
+respects the actual workflow boundary.
+
+**New dedicated plugin (yellow-plans):** Rejected as YAGNI. Yellow-core already
+owns the planning surface. A new plugin adds manifest overhead, a separate
+version track, and install friction for what is essentially two command files
+and one script.
+
+**Linear integration for plan tracking:** Deferred. Linear adds external
+dependency and sync complexity. The filesystem convention is self-contained and
+works offline. Revisit if the team grows beyond the current solo/small-team
+context.

--- a/docs/brainstorms/2026-05-08-plan-lifecycle-management-brainstorm.md
+++ b/docs/brainstorms/2026-05-08-plan-lifecycle-management-brainstorm.md
@@ -1,7 +1,7 @@
 # Plan Lifecycle Management
 
 **Date:** 2026-05-08
-**Status:** Brainstorm — ready for planning
+**Status:** Superseded for several decisions by `plans/plan-lifecycle-management.md`. Preserved for historical context only — do NOT delete (protected-artifact policy). The frontmatter convention discussed below was added during planning and then dropped after PR #484 review (issues #494 and #496); the final design uses runtime slug derivation from filename, a single-`gh`-call Gate C (no LLM agent), and a PR-touched-files validator scope. Annotations inline below mark the divergent decisions.
 
 ## What We're Building
 
@@ -22,6 +22,13 @@ Two new commands extend the existing `/workflows:*` surface in yellow-core:
      queries `gh` for a merged PR associated with the plan's branch, checks
      that files mentioned in the plan exist on disk, and confirms commits
      referencing the plan landed on main. If all three pass, archival proceeds.
+     **(Superseded — see plan):** the LLM verification agent and the
+     file-existence + commit-landing checks were dropped during PR #484
+     review (#496 YAGNI reduction). The final design uses a single
+     `gh pr list --search "in:title $SLUG" --state merged` call inside
+     the command itself; no agent, no file-existence check, no commit-log
+     scan. Squash-merge resilient because GitHub keeps PR titles regardless
+     of merge strategy.
 
 A new `scripts/validate-plans.js` CI validator ensures no plan file in
 `plans/complete/` has unchecked boxes — catching manual archival that skipped
@@ -44,12 +51,18 @@ re-review (Gate C) adds semantic confidence: did the right files actually land,
 did a PR actually merge? Together they prevent both lazy checkbox-ticking and
 accidental archival of stalled work.
 
+**(Superseded — see plan):** "agent re-review" is no longer accurate. Gate C
+collapsed to a single `gh pr list` call (no agent in the loop). The
+"semantic confidence" claim above survives in spirit — finding a merged PR
+whose title matches the slug is itself the semantic check — but no LLM
+runs and no on-disk file-existence audit happens.
+
 **No new plugin needed.** Yellow-core already owns the planning surface
 (`/workflows:plan`, `/workflows:work`, `/workflows:brainstorm`). Adding
 `/plan:status` and `/plan:complete` under a `plan/` subdirectory of commands
 follows the same pattern as `workflows/` — zero new plugin manifest overhead.
 
-**Filesystem convention stays unchanged.** _(NOTE: The "no frontmatter required" position below was reversed during planning. See `docs/plans/plan-lifecycle-management.md`, which introduces a `slug:` + `created:` frontmatter convention as a stable per-plan identifier for Gate C and a `ci-skip-checkbox-check` escape hatch for the CI validator. Filesystem convention is still the lifecycle-state source of truth, but a small frontmatter block now exists for tooling.)_ Plans remain plain markdown files.
+**Filesystem convention stays unchanged.** _(NOTE: The "no frontmatter required" position below was briefly reversed during planning, then restored in revision after PR #484 review (issues #494, #496). Final design: no frontmatter; the slug is derived at runtime from the filename via `basename "$PLAN" .md | sed 's/^[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-//'`. The directory split remains the single source of truth for state. See `plans/plan-lifecycle-management.md`.)_ Plans remain plain markdown files.
 No frontmatter required. The `plans/` vs `plans/complete/` directory split is
 the single source of truth for open vs archived — the same convention already
 in use, now enforced by CI.
@@ -125,6 +138,11 @@ Rules enforced:
 
 Added to `pnpm release:check` alongside the existing `validate:schemas` chain.
 
+**(Superseded — see plan):** `validate:plans` is wired as a separate
+top-level CI step, NOT into `release:check`. Different concern per
+project CLAUDE.md — release-readiness vs. plan-corpus health. See
+`plans/plan-lifecycle-management.md` Phase 1 for the final wiring.
+
 ### /plan:status output format
 
 Plain text table, no external dependencies:
@@ -151,15 +169,23 @@ nudge to run `/plan:complete`.
    ambiguous results. Should `/workflows:plan` write the plan filename into the
    plan body as a stable identifier, or should `/plan:complete` ask the user
    for a PR number explicitly when the search is ambiguous?
-   **(Resolved in plan):** Plan introduces `slug:` frontmatter written by
-   `/workflows:plan` at creation; `/plan:complete` reads it via
-   `parsePlanFrontmatter` and uses it as the `gh` search term. Generic-slug
-   collision is addressed by post-filtering on PR branch name.
+   **(Resolved in plan):** Slug is derived at runtime from the filename
+   (no frontmatter); the `--jq` post-filter requires a word-boundary match
+   on `headRefName` (`(^|[/_-])$SLUG($|[/_-])`) which mitigates generic-slug
+   collisions. When the search returns zero matches, `/plan:complete` prompts
+   the user via `AskUserQuestion` for explicit PR-number confirmation, and
+   captures the override in a `Plan-Verifier-Override:` commit trailer.
 
 2. **Multi-PR plans:** Large features (e.g., the everyinc merge wave series)
    ship across multiple PRs. Gate C currently expects one merged PR. Should
    the agent accept "any merged PR referencing this plan" or require a
    user-supplied PR list?
+   **(Resolved in plan):** Gate C PASSES when `COUNT >= 1` — any merged
+   PR whose title contains the slug is sufficient evidence the plan
+   shipped. Multi-PR plans are handled implicitly: the first matching
+   merged PR satisfies the gate, and the user can override via the
+   no-evidence path with an explicit PR number if the search is
+   ambiguous (Plan-Verifier-Override commit trailer).
 
 3. **validate-plans.js scope creep risk:** The validator could grow to check
    for plan naming conventions, required sections, etc. Keep it to the one

--- a/plans/plan-lifecycle-management.md
+++ b/plans/plan-lifecycle-management.md
@@ -1,30 +1,65 @@
 # Feature: Plan Lifecycle Management
 
 **Source brainstorm:** `docs/brainstorms/2026-05-08-plan-lifecycle-management-brainstorm.md`
-**Detail level:** STANDARD+ (validator + 2 commands + 1 agent + migration)
+**Detail level:** STANDARD (validator + 2 commands; no frontmatter, no agent, no migration)
 **Status:** Ready for `/workflows:work`
+
+> **Revision history:** First-pass plan introduced a `slug:`/`created:` frontmatter
+> convention, a 47-file backfill migration, a 3-check `plan-verifier` agent (with
+> an 8-row PR/commit/file truth table), and a 5-PR stack. PR #484 review (issues
+> #494, #496) collapsed all four. Frontmatter is dropped (slug derived at runtime
+> from filename), Gate C is a single `gh` call (no LLM in the loop), the validator
+> scopes to PR-touched files (no escape hatch needed), and the stack is two PRs.
+> The brainstorm references several artifacts that no longer exist in this plan;
+> treat the brainstorm as historical context only.
 
 ## Problem Statement
 
-Plans live as markdown in `plans/` (open) and `plans/complete/` (archived). Six manual `git mv` archival commits in two days (`6f883f7c`, `f056390c`, `3e9baf4d`, `0538866b`, peers) confirm this is real friction. The plugin system has no authoritative way to know which plans are open, which are complete, or whether the work a plan describes actually shipped.
+Plans live as markdown in `plans/` (open) and `plans/complete/` (archived). Six
+manual `git mv` archival commits in two days (`6f883f7c`, `f056390c`,
+`3e9baf4d`, `0538866b`, peers) confirm this is real friction. The plugin
+system has no authoritative way to know which plans are open, which are
+complete, or whether the work a plan describes actually shipped.
 
-We need: a status surface, an explicit archival command with completion validation, and a CI gate that catches premature archival — without changing the underlying filesystem convention.
+We need: a status surface, an explicit archival command with completion
+validation, and a CI gate that catches premature archival — without changing
+the underlying filesystem convention and without inventing a new metadata
+layer.
 
 ## Current State
 
-- 3 open plans in `plans/`, 44 archived in `plans/complete/` (counts as of this PR landing; the validator checks `plans/complete/` so the open count is informational only)
-- No frontmatter convention — plans are plain markdown starting with `# Feature: …`
-- 36% of archived plans (16/44) contain stray `- [ ]` lines from prose checklists, future-work sections, or quoted code — meaning a naive checkbox validator would block CI immediately
-- `/workflows:plan` writes plans but no stable per-plan identifier survives renames
+- 3 open plans in `plans/`, 44 archived in `plans/complete/` (counts as of
+  this PR's snapshot; the validator scopes to PR-touched files so absolute
+  counts are informational only and naturally drift as new PRs land)
+- No frontmatter convention — plans are plain markdown starting with
+  `# Feature: …`
+- 36% of archived plans (16/44) contain stray `- [ ]` lines from prose
+  checklists, future-work sections, or quoted code — meaning a naive
+  whole-corpus checkbox validator would block CI immediately. The
+  PR-touched-files scoping (Phase 1.1) sidesteps this entirely.
+- `/workflows:plan` writes plans named `plans/<slug>.md`; the filename slug
+  (with optional `YYYY-MM-DD-` prefix stripped) survives renames as long as
+  the file is renamed deliberately
 - Archival is `git mv` + commit; no machine-readable signal of completion
 
 ## Proposed Solution
 
-A small frontmatter convention plus two commands plus one CI validator, all in yellow-core. Three user-facing decisions already made (recorded here so future readers can skip the rationale):
+Two commands plus one CI validator, all in yellow-core. No new file format,
+no migration, no LLM agent. Three user-facing decisions already made
+(recorded so future readers can skip the rationale):
 
-1. **Frontmatter escape hatch** — Gate A respects `ci-skip-checkbox-check: true` on legacy plans rather than scoping to specific headings (avoids ambiguous structural rules).
-2. **`slug:` frontmatter** — `/workflows:plan` writes a stable slug at creation; Gate C reads it. Survives file renames.
-3. **Work-PR evidence** — Gate C confirms ≥1 PR referencing the slug merged to main (multi-PR plans like `everyinc-merge` work naturally).
+1. **No frontmatter convention** — Slug is derived at runtime from the
+   filename: `basename "$PLAN" .md | sed 's/^[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-//'`.
+   Plans/ vs plans/complete/ directory split is the single source of truth
+   for state.
+2. **Validator scopes to PR-touched files** — Legacy stray-checkbox files
+   are never re-touched, so the validator never sees them. No escape-hatch
+   flag needed. Only files added or modified in the current PR are checked.
+3. **Gate C is one `gh` query, no agent** — Run
+   `gh pr list --search "in:title <slug>" --state merged` and post-filter
+   on `headRefName` for word-boundary safety. PASS when at least one match
+   exists; otherwise prompt the user via `AskUserQuestion`. No three-check
+   verifier, no plan-body file-existence parsing, no token spend.
 
 ### Surface
 
@@ -33,135 +68,244 @@ plugins/yellow-core/
   commands/plan/
     status.md            → /plan:status         (read-only dashboard)
     complete.md          → /plan:complete <plan> (two-gate archival)
-  agents/plan/
-    plan-verifier.md     (Gate C verification agent)
 
 scripts/
-  validate-plans.js      (CI validator, runs in pnpm release:check)
-  backfill-plan-slugs.js (one-shot migration helper, deleted after use)
+  validate-plans.js      (CI validator, PR-diff-scoped)
 ```
 
-### Plan frontmatter (new)
+No new shared library, no agent, no backfill script.
 
-```yaml
----
-slug: plan-lifecycle-management
-created: 2026-05-08
-ci-skip-checkbox-check: false   # optional; defaults to false
----
-```
+### Namespace split (deliberate)
 
-`slug` is required for any plan that wants to use `/plan:complete` Gate C. `ci-skip-checkbox-check` is the legacy escape hatch — set to `true` only for already-archived plans whose stray `- [ ]` lines are not tasks.
+Plan creation lives under `/workflows:plan` (it is a workflow that produces
+plans alongside brainstorms, research, etc.). Archive and dashboard live
+under `/plan:complete` and `/plan:status` (they are plan-specific lifecycle
+operations, not general-purpose workflows). Future authors who want to add
+plan-related commands should put them under `/plan:*`. This split is
+documented in `plugins/yellow-core/CLAUDE.md` per Phase 5.2 below.
 
 ## Implementation Plan
 
-### Phase 1: Foundation — frontmatter parsing utility
+### Phase 1: CI validator (`scripts/validate-plans.js`)
 
 <!-- deepen-plan: codebase -->
-> **Codebase:** `scripts/validate-agent-authoring.js` already implements
-> `extractFrontmatter(text)` (≈line 62), `parseScalar(frontmatter, key)` (≈line 67), and
-> `parseList(frontmatter, key)` (≈line 73, ends just before `relative()` at line 115)
-> as module-private helpers. Refer to the function names rather than fixed line ranges
-> when implementing — the file is edited frequently and exact ranges drift. `scripts/lint-plugins.sh:74` has a bash-side `frontmatter()`
-> function. `scripts/backfill-solution-frontmatter.js` contains another independent parser.
-> Do **not** invent a fourth implementation — extract those three functions into the new
-> shared `scripts/lib/plan-frontmatter.js` and have `validate-agent-authoring.js` import from
-> it (or accept the duplication and copy verbatim if cross-script imports add complexity).
+> **Codebase:** `scripts/validate-marketplace.js` and `scripts/validate-plugin.js`
+> use the `logError`/`logWarning`/`logInfo`/`logSuccess` pattern with `process.exit(0|1)`.
+> Match that style. No `js-yaml` dependency is needed because the validator
+> only reads body content (`grep ^\\s*- \\[ \\]`), not frontmatter.
 <!-- /deepen-plan -->
 
-- [ ] 1.1: Add `parsePlanFrontmatter(filePath)` helper to `scripts/lib/plan-frontmatter.js` — reads first `---` block, returns `{slug, created, ciSkipCheckboxCheck}` plus a `_raw` field for the body. Pure regex (no js-yaml dep) — frontmatter is simple key:value only. Mirror the `extractFrontmatter` / `parseScalar` / `parseList` helpers in `scripts/validate-agent-authoring.js` (referenced by name, not line range, to avoid drift).
-- [ ] 1.2: Unit-test the helper in `tests/integration/plan-frontmatter.test.ts` against fixtures: missing frontmatter, malformed YAML, present-but-empty, all-fields-present.
-- [ ] 1.3: Document the schema in `docs/CLAUDE.md` (versioning section already exists) and `plugins/yellow-core/CLAUDE.md`.
+- [ ] 1.1: Implement `scripts/validate-plans.js`. Behaviour:
+  - Compute the PR-touched file set:
+    `git diff --no-renames --name-only --diff-filter=AM "$BASE_REF...HEAD"`
+    where `BASE_REF` defaults to `origin/main` and is overridable via the
+    `PLAN_VALIDATOR_BASE_REF` env var. `--no-renames` is mandatory: without
+    it, `git mv plans/foo.md plans/complete/foo.md` is reported as `R`
+    (rename), which the `AM` filter drops — silently bypassing the gate
+    on any machine where rename detection is enabled (`diff.renames=true`,
+    a common global default).
+  - Filter to paths matching `^plans/complete/.*\.md$`.
+  - For each, count `^\s*- \[ \]` lines. If non-zero, log error and set
+    failure flag.
+  - Exit 1 if any failures, exit 0 otherwise.
+  - **No-op cases (exit 0):**
+    - PR touches no files under `plans/complete/`.
+    - `BASE_REF` is unreachable (e.g., shallow clone) — emit a warning to
+      stderr and exit 0; CI is responsible for fetching the base. Document
+      the recipe in the validator's header comment.
+- [ ] 1.2: Add `"validate:plans": "node scripts/validate-plans.js"` to
+  `package.json` scripts. **Do NOT add to the `validate:schemas` chain.**
+  `validate:schemas` is the plugin schema gate (marketplace + plugin +
+  setup-all + agent-authoring); plan-lifecycle rules are a different concern
+  per `CLAUDE.md`. Wire `validate:plans` as a separate top-level step in
+  `.github/workflows/validate-schemas.yml` (or its sibling workflow) so it
+  runs alongside, not inside, `validate:schemas`.
+- [ ] 1.3: Vitest integration test in
+  `tests/integration/validate-plans.test.ts`. Match the temp-dir pattern in
+  `tests/integration/validate-plugin.test.ts`:
+  `mkdtempSync(join(tmpdir(), 'yellow-validate-plans-'))` per test, init a
+  bare git repo inside, commit fixtures, exercise the validator via
+  `spawnSync('node', [VALIDATOR], { cwd: tmpRoot, env: {...,
+  PLAN_VALIDATOR_BASE_REF: '<base-sha>'} })`, clean up via
+  `rmSync(tmpRoot, { recursive: true, force: true })` in `afterEach`.
+  Cases: PR adds clean file (PASS), PR adds dirty file with stray `- [ ]`
+  (FAIL), PR modifies file in `plans/complete/` to add stray boxes (FAIL),
+  PR touches files outside `plans/complete/` only (PASS), repository has
+  pre-existing dirty files in `plans/complete/` but PR doesn't touch them
+  (PASS — the core YAGNI behaviour).
 
-### Phase 2: `/workflows:plan` augmentation
+### Phase 2: `/plan:status` command
 
-<!-- deepen-plan: codebase -->
-> **Codebase:** Confirmed `plugins/yellow-core/commands/workflows/plan.md` Phase 4 Step 2
-> currently writes plain markdown starting with `# Feature: [Title]` — zero YAML frontmatter
-> in any of the three templates (MINIMAL/STANDARD/COMPREHENSIVE, lines 164-360). Phase 2.1
-> below is a real net-new addition, not a tweak. The `# Feature:` header line stays; the
-> frontmatter block prepends above it.
-<!-- /deepen-plan -->
+- [ ] 2.1: Create `plugins/yellow-core/commands/plan/status.md` with
+  frontmatter `name: plan:status`, single-line description with "Use when…"
+  trigger clause, `argument-hint: ''`, `allowed-tools: [Bash]`.
+- [ ] 2.2: Body: bash blocks that walk `plans/*.md` and
+  `plans/complete/*.md`, count `- [ ]` and `- [x]` per file, format as
+  plain-text table. Append `-- ready to complete` annotation when 100%
+  checked AND file is in `plans/` (not `plans/complete/`).
+- [ ] 2.3: Handle edge cases: zero-task plans render as `[ 0/0 ]` with no
+  annotation; missing `plans/complete/` reports `(0)`.
+- [ ] 2.4: Re-derive variables in each Bash block (every block is a fresh
+  subprocess — see `MEMORY.md` "$VAR in bash code blocks").
 
-- [ ] 2.1: Modify `plugins/yellow-core/commands/workflows/plan.md` Phase 4 Step 2: when writing plan file, prepend a YAML frontmatter block with `slug` (kebab-case from the plan title) and `created` (today's date in `YYYY-MM-DD`).
-- [ ] 2.2: Update plan templates (MINIMAL/STANDARD/COMPREHENSIVE) in the same file to show frontmatter as the first block.
-- [ ] 2.3: Verify that downstream commands (`/workflows:work`, `/gt-stack-plan`) ignore the frontmatter cleanly — no parser changes needed since they read body content.
+### Phase 3: `/plan:complete` command
 
-### Phase 3: Backfill migration
+- [ ] 3.1: Create `plugins/yellow-core/commands/plan/complete.md` with
+  `allowed-tools: [Bash, Read, AskUserQuestion]`, `argument-hint: '<plan-filename>'`.
+  Note: no `Task` tool — Gate C is a bash call, not an agent dispatch.
+- [ ] 3.2: Step 0 — idempotency guard: if `plans/complete/<arg>` already
+  exists, exit with explanatory message.
+- [ ] 3.3: Step 1 — filename validation:
+  ```bash
+  CLEAN_ARG="${ARG#plans/}"
+  printf '%s' "$CLEAN_ARG" | grep -qE '^[a-z0-9_][a-z0-9_.-]*\.md$'
+  ```
+  (strip `plans/` prefix to support tab-completion; reject `..`, `/`,
+  leading `-`, and uppercase letters). Lowercase-only is intentional:
+  the post-derivation regex in step 3.4 enforces lowercase, so accepting
+  mixed-case filenames here would create a parity gap (filename
+  validation passes, slug validation fails). Use `$CLEAN_ARG` in all
+  subsequent steps.
+- [ ] 3.4: Step 2 — derive slug from filename:
+  ```bash
+  SLUG=$(basename "$CLEAN_ARG" .md | sed 's/^[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-//')
+  printf '%s' "$SLUG" | grep -qE '^[a-z0-9]+(-[a-z0-9]+)*$' \
+    || { printf 'Slug %s contains invalid characters\n' "$SLUG" >&2; exit 1; }
+  ```
+  The post-derivation regex enforces lowercase alphanumeric + single
+  hyphens (no leading/trailing/consecutive hyphens). This guards
+  prompt-injection of any subsequent shell context — the slug is never
+  embedded in an LLM prompt, but it IS interpolated into `gh` and
+  `git` commands.
+- [ ] 3.5: Step 3 — Gate A:
+  ```bash
+  UNCHECKED=$(grep -c '^[[:space:]]*- \[ \]' "plans/$CLEAN_ARG" || true)
+  if [ "$UNCHECKED" -gt 0 ]; then
+    printf 'Gate A FAIL: %d unchecked boxes in plans/%s\n' "$UNCHECKED" "$CLEAN_ARG" >&2
+    exit 1
+  fi
+  ```
+  No frontmatter escape hatch — the validator's PR-scoped behaviour means
+  legacy stray-checkbox files never reach this gate (they were archived
+  before the gate existed, and the validator only inspects PR-touched
+  files going forward).
+- [ ] 3.6: Step 4 — Gate C: single `gh` call.
 
-- [ ] 3.1: Write `scripts/backfill-plan-slugs.js` — walks `plans/` and `plans/complete/`, prepends frontmatter to any file lacking it. Slug derived from filename minus `.md` minus optional `YYYY-MM-DD-` prefix. `ci-skip-checkbox-check: true` is set on archived plans that have unchecked boxes.
-- [ ] 3.2: Run the migration locally; verify diff is reasonable (47 file changes — 44 archived + 3 open, frontmatter only).
-- [ ] 3.3: Commit migration as a separate logical commit ("chore(plans): backfill slug + ci-skip frontmatter") so the validator change can be reviewed independently.
-- [ ] 3.4: Delete `scripts/backfill-plan-slugs.js` after migration commits land — one-shot tool.
+  ```bash
+  MERGED=$(gh pr list \
+    --search "in:title \"$SLUG\"" \
+    --state merged \
+    --limit 100 \
+    --json number,title,headRefName,url \
+    --jq '[.[] | select(.headRefName | test("(^|[/_-])'"$SLUG"'($|[/_-])"))]')
+  COUNT=$(printf '%s' "$MERGED" | jq 'length')
+  ```
 
-### Phase 4: CI validator
+  **Verdict logic:**
+  - **PASS** if `COUNT >= 1`. Squash-merged PRs are detected because the
+    PR title (kept by GitHub regardless of squash strategy) is searched
+    by `gh pr list`, not the synthesized commit message.
+  - **No-evidence** if `COUNT == 0`: `AskUserQuestion`
+    "No merged PR found whose title and branch contain the slug
+    `$SLUG`. Provide a PR number to confirm, or cancel."
+    Options: `Confirm with PR number` (Other → free-text), `Cancel`.
+    On confirmed PR-number override, store `OVERRIDE_PR_NUM` for the
+    commit trailer in step 3.10.
 
-- [ ] 4.1: Implement `scripts/validate-plans.js` matching the pattern in `validate-marketplace.js` (logError/logWarning/logInfo/logSuccess; exit 0/1). Rule: every `.md` in `plans/complete/` either (a) contains zero `^\s*- \[ \]` lines OR (b) has `ci-skip-checkbox-check: true` in frontmatter. Use `parsePlanFrontmatter` from Phase 1.
-- [ ] 4.2: Guard `plans/complete/` non-existence — `fs.existsSync` check returns success with no files validated.
-- [ ] 4.3: Add `"validate:plans": "node scripts/validate-plans.js"` to `package.json` scripts (the script entry only — do NOT append to `release:check` separately; see task 4.4).
-- [ ] 4.4: Add `&& node scripts/validate-plans.js` to the `validate:schemas` chain in `package.json` (CI baseline gate — blocks all PRs). Because `release:check` already calls `validate:schemas`, this single insertion covers both gates; no separate edit to `release:check` is needed.
+  Word-boundary protection: the `--jq` post-filter requires `$SLUG` to be
+  separated from surrounding characters by `^`, `$`, `/`, `_`, or `-`. This
+  prevents short or generic slugs (`refactor`, `fix`) from matching
+  unrelated PRs whose branch names contain the slug as a substring inside
+  another word.
 
-<!-- deepen-plan: codebase -->
-> **Codebase:** `package.json:20` chains `validate:schemas` as `marketplace → plugin → setup-all → agent-authoring`. The chain is `&&`-joined fail-fast; ordering is by scope (broadest to narrowest), not data-flow. Appending `&& node scripts/validate-plans.js` at the end is safe with no ordering constraint. `release:check` (`package.json:30`) already invokes `validate:schemas`, so adding `validate:plans` to the `validate:schemas` chain is sufficient — no duplicate entry in `release:check` is required.
-<!-- /deepen-plan -->
+  **Server-side `--state merged`** is preferred over reading `mergedAt`:
+  per `docs/solutions/integration-issues/merge-queue-closed-pr-null-mergedat-detection.md`,
+  `mergedAt` can be null for recently MQ-merged PRs during propagation
+  lag. `--state merged` filters on PR state, which is authoritative
+  once the upstream API has caught up; users archiving plans rarely race
+  with same-second merges, so propagation lag is not a practical concern.
+- [ ] 3.7: Step 5 — clean-tree check: warn (not block) if
+  `git status --porcelain` non-empty; AskUserQuestion to proceed.
+- [ ] 3.8: Step 6 — checkout trunk + sync before branch creation:
+  ```bash
+  git checkout main && gt repo sync
+  ```
+  Ensures the archival branch forks from `main`, not an in-progress
+  feature branch.
+- [ ] 3.9: Step 7 — archival branch + staged move:
+  ```bash
+  gt branch create "plan/archive-$SLUG"
+  mkdir -p plans/complete
+  git mv -- "plans/$CLEAN_ARG" "plans/complete/$CLEAN_ARG"
+  ```
+  `git mv` is required (not bare `mv`): a plain `mv` leaves the rename
+  unstaged, so the `gt commit create` in step 3.10 would either fail or
+  produce an empty commit. `git mv` records the rename in the index
+  immediately, ready to commit.
+- [ ] 3.10: Step 8 — commit with override audit trail. After building
+  the message body from one of the templates below, invoke
+  `gt commit create -m "<subject>" -m "<body>"` (the `-m` body flag
+  receives the multi-line body verbatim — heredoc-in-`$()` substitution
+  is a known footgun, see MEMORY.md "gt modify multi-line commit").
 
-- [ ] 4.5: Vitest integration test in `tests/integration/validate-plans.test.ts`: temp-dir fixtures for pass/fail/escape-hatch/no-frontmatter/missing-dir cases.
+  Default commit (Gate C PASS, no override):
+  ```
+  docs(plans): archive completed <slug> plan
 
-<!-- deepen-plan: codebase -->
-> **Codebase:** Match the pattern in `tests/integration/validate-plugin.test.ts` —
-> `mkdtempSync(join(tmpdir(), 'yellow-validate-plans-'))` in `beforeEach`, fixture files via
-> inline write helpers, validator invoked via `spawnSync('node', [VALIDATOR, tmpRoot])`,
-> cleanup via `rmSync(tmpRoot, { recursive: true, force: true })` in `afterEach`. The
-> "plugin directory basename must equal manifest name" constraint (RULE 2) does **not**
-> apply since plan files have no name field — temp dir basename is unconstrained.
-<!-- /deepen-plan -->
+  Verified by /plan:complete: <COUNT> merged PR(s) found.
+  ```
 
+  Override commit (Gate C found 0 PRs, user confirmed):
+  ```
+  docs(plans): archive completed <slug> plan
 
-### Phase 5: `/plan:status` command
+  Verified by /plan:complete: user-confirmed override.
 
-- [ ] 5.1: Create `plugins/yellow-core/commands/plan/status.md` with frontmatter `name: plan:status`, single-line description, `argument-hint: ''`, `allowed-tools: [Bash]`.
-- [ ] 5.2: Body: bash blocks that walk `plans/*.md` and `plans/complete/*.md`, count `- [ ]` and `- [x]` per file, format as plain-text table. Append `-- ready to complete` annotation when 100% checked AND file is in `plans/` (not `plans/complete/`).
-- [ ] 5.3: Handle edge cases: zero-task plans render as `[ 0/0 ]` with no annotation; missing `plans/complete/` reports `(0)`.
-- [ ] 5.4: Re-derive variables in each Bash block (every block is a fresh subprocess — see MEMORY.md).
+  Plan-Verifier-Override: user-confirmed-no-pr-evidence (pr=#<OVERRIDE_PR_NUM>)
+  ```
 
-### Phase 6: `/plan:complete` command + plan-verifier agent
+  The `Plan-Verifier-Override:` trailer is grep-discoverable via
+  `git log --grep='Plan-Verifier-Override'` for future audit. Document
+  the trailer in `docs/solutions/workflow/plan-lifecycle-management.md`
+  per Phase 5.3.
+- [ ] 3.11: Step 9 — submit:
+  ```bash
+  gt stack submit --no-interactive
+  ```
+  Print the resulting PR URL on success (parse `gt submit` output or
+  follow with `gh pr view --json url -q .url`).
 
-- [ ] 6.1: Create `plugins/yellow-core/agents/plan/plan-verifier.md` modeled on `repo-research-analyst` (frontmatter: `name: plan-verifier`, `model: inherit`, `background: true`, `memory: project`, `tools: [Bash, Read, Grep, Glob, AskUserQuestion]`). The `name:` field is required so `subagent_type: "yellow-core:plan:plan-verifier"` resolves at runtime — `validate-agent-authoring.js` emits `missing agent name` without it. Body instructs the agent to run three checks against a slug + plan body (provided injection-fenced) and return a structured pass/fail/uncertain verdict.
+### Phase 4: Tests
 
-<!-- deepen-plan: codebase -->
-> **Codebase:** Confirmed `plugins/yellow-core/agents/research/repo-research-analyst.md`
-> lines 1-11 use `background: true`, `memory: project`, plain-text narrative output (no
-> `run_dir` JSON protocol). Match exactly. Single-spawn dispatch from `/plan:complete` waits
-> via `TaskOutput`, identical to how `/workflows:plan` Phase 2 waits on its parallel research
-> agents. Plain-text output is parsed by the command via simple `grep`/`awk` looking for the
-> `VERDICT:`, `PR_EVIDENCE:` etc. line prefixes.
-<!-- /deepen-plan -->
+- [ ] 4.1: Vitest integration tests for `validate-plans.js` (covered in 1.3).
+- [ ] 4.2: Bats smoke tests in `plugins/yellow-core/tests/plan-commands.bats`:
+  exercise the slug derivation regex and the Gate A `grep -c` regex on
+  fixture files (smoke; not a full command-flow test). Mark with
+  `@test "skip on non-Linux"` guard if needed for cross-platform CI.
+- [ ] 4.3: Manual verification checklist in plan body (no automated test
+  for end-to-end command flow — too much shell + AskUserQuestion involved):
+  run `/plan:status`, run `/plan:complete` against this plan after merge.
 
-- [ ] 6.2: Create `plugins/yellow-core/commands/plan/complete.md` with `allowed-tools: [Bash, Read, Task, AskUserQuestion, ToolSearch]`, `argument-hint: '<plan-filename>'`.
-- [ ] 6.3: Step 0 — idempotency guard: if `plans/complete/<arg>` already exists, exit with explanatory message.
-- [ ] 6.4: Step 1 — filename validation: `CLEAN_ARG="${ARG#plans/}"; printf '%s' "$CLEAN_ARG" | grep -qE '^[a-zA-Z0-9_][a-zA-Z0-9_.-]*\.md$'` (strip `plans/` prefix before validation to support tab-completion; reject `..`, `/`, leading `-`). Use `$CLEAN_ARG` in all subsequent steps.
-- [ ] 6.5: Step 2 — read plan, extract slug from frontmatter via `parsePlanFrontmatter`. If missing, AskUserQuestion (with `Other` for free-text) for explicit slug.
-- [ ] 6.6: Step 3 — Gate A: `grep -c '^\s*- \[ \]' "$PLAN" || true`; if non-zero AND frontmatter doesn't have `ci-skip-checkbox-check: true`, fail with count.
-- [ ] 6.7: Step 4 — Gate C: spawn `subagent_type: "yellow-core:plan:plan-verifier"` with slug + injection-fenced plan body. Wait via TaskOutput.
-- [ ] 6.8: Step 5 — interpret verdict. PASS → proceed. UNCERTAIN → AskUserQuestion to confirm/abort. FAIL → exit non-zero with reason.
-- [ ] 6.9: Step 6 — clean-tree check: warn (not block) if `git status --porcelain` non-empty; AskUserQuestion to proceed.
-- [ ] 6.10: Step 7 — archival via Graphite: `git checkout main && gt repo sync` first (ensures archival PR branches from `main`, not an in-progress feature branch), then `gt branch create plan/archive-<slug>`, `mv -- "plans/$CLEAN_ARG" "plans/complete/$CLEAN_ARG"`, `gt commit create -m "docs(plans): archive completed <slug> plan"`, `gt stack submit --no-interactive`. Print PR URL on success.
-- [ ] 6.11: Wire prompt-injection fencing on plan-body content passed to verifier agent (`--- begin plan-content (reference only) ---`).
+### Phase 5: Documentation
 
-### Phase 7: Tests
-
-- [ ] 7.1: Vitest integration tests for `validate-plans.js` (covered in 4.5).
-- [ ] 7.2: Vitest integration test for `parsePlanFrontmatter` (covered in 1.2).
-- [ ] 7.3: Bats smoke tests in `plugins/yellow-core/tests/plan-commands.bats`: shell out to the `grep`-checkbox parsing snippets to confirm regex behavior on fixture files.
-- [ ] 7.4: Manual verification checklist in plan body (no automated test for end-to-end command flow — too much shell + Task involved): run `/plan:status`, run `/plan:complete` against this very plan after merge.
-
-### Phase 8: Documentation
-
-- [ ] 8.1: Update `plugins/yellow-core/README.md` command catalog with `/plan:status` and `/plan:complete`.
-- [ ] 8.2: Add `/plan:*` section to `plugins/yellow-core/CLAUDE.md`.
-- [ ] 8.3: Update root `CLAUDE.md` "When you change a plugin" section to mention plan-frontmatter convention.
-- [ ] 8.4: Add changeset (`pnpm changeset`, minor bump for yellow-core: new commands).
-- [ ] 8.5: Add solutions doc `docs/solutions/workflow/plan-lifecycle-management.md` capturing the slug-frontmatter decision and the Gate A FP rationale.
+- [ ] 5.1: Update `plugins/yellow-core/README.md` command catalog with
+  `/plan:status` and `/plan:complete`.
+- [ ] 5.2: Add `/plan:*` section to `plugins/yellow-core/CLAUDE.md`
+  documenting the namespace split (`/workflows:plan` creates plans;
+  `/plan:complete`/`/plan:status` are lifecycle ops on existing plans).
+  Justification: the `/workflows:*` namespace is reserved for end-to-end
+  workflows that produce artifacts; lifecycle ops on those artifacts get
+  their own namespace.
+- [ ] 5.3: Add solutions doc `docs/solutions/workflow/plan-lifecycle-management.md`
+  capturing:
+  - The runtime-slug-from-filename decision and why frontmatter was
+    rejected.
+  - Gate C verdict logic (PASS / no-evidence + override).
+  - The `Plan-Verifier-Override:` commit trailer convention.
+  - Word-boundary regex rationale (slug collision protection).
+  - PR-touched-files validator scope rationale (no whole-corpus scan).
+- [ ] 5.4: Add changeset (`pnpm changeset`, minor bump for yellow-core:
+  new commands).
 
 ## Technical Details
 
@@ -169,129 +313,109 @@ ci-skip-checkbox-check: false   # optional; defaults to false
 
 - `plugins/yellow-core/commands/plan/status.md`
 - `plugins/yellow-core/commands/plan/complete.md`
-- `plugins/yellow-core/agents/plan/plan-verifier.md`
 - `scripts/validate-plans.js`
-- `scripts/lib/plan-frontmatter.js`
-- `scripts/backfill-plan-slugs.js` (deleted post-migration)
 - `tests/integration/validate-plans.test.ts`
-- `tests/integration/plan-frontmatter.test.ts`
 - `plugins/yellow-core/tests/plan-commands.bats`
 - `docs/solutions/workflow/plan-lifecycle-management.md`
 
 ### Files to modify
 
-- `plugins/yellow-core/commands/workflows/plan.md` (add slug to written frontmatter)
 - `plugins/yellow-core/README.md` (command catalog)
-- `plugins/yellow-core/CLAUDE.md` (plan section)
-- `package.json` (add `validate:plans` script + chain into `validate:schemas` and `release:check`)
-- `plans/*.md` and `plans/complete/*.md` (62 files, frontmatter prepend via migration script)
+- `plugins/yellow-core/CLAUDE.md` (`/plan:*` section)
+- `package.json` (add `validate:plans` script entry — NOT in
+  `validate:schemas` chain)
+- `.github/workflows/validate-schemas.yml` or sibling (add separate
+  `validate:plans` step alongside `validate:schemas`)
+
+### Files NOT changed (deliberately, vs. the first-pass plan)
+
+- `plugins/yellow-core/commands/workflows/plan.md` — `/workflows:plan` does
+  not need to write frontmatter, since slug is derived at runtime from
+  filename.
+- All 47 plan files under `plans/` (3) and `plans/complete/` (44) — no backfill.
+- `scripts/lib/plan-frontmatter.js` — not created (no frontmatter to parse).
+- `scripts/backfill-plan-slugs.js` — not created (no migration needed).
+- `plugins/yellow-core/agents/plan/plan-verifier.md` — not created (Gate C
+  is a bash call).
 
 ### Dependencies
 
-No new packages. Frontmatter parsing is pure regex; `gh` and `git` and `gt` are already required by the repo.
-
-### Verification agent contract
-
-`plan-verifier` receives a slug and an injection-fenced plan body, returns:
-
-```
-VERDICT: PASS|FAIL|UNCERTAIN
-PR_EVIDENCE: <list of merged PRs found referencing slug, with branches and merge SHAs>
-COMMIT_EVIDENCE: <git log main --grep=slug count>
-FILE_EVIDENCE: <count of files mentioned in plan body that exist on disk>
-RATIONALE: <one short paragraph>
-```
-
-Three checks:
-1. `gh pr list --search "in:title <slug>" --state merged --limit 10 --json number,title,mergedAt,headRefName` then filter `mergedAt != null` AND `headRefName` contains the slug (post-filter in jq: `.[] | select(.mergedAt != null) | select(.headRefName | contains("<slug>"))`). Note merge-queue ambiguity (MEMORY.md): a closed-not-merged PR has `mergedAt: null` — must check this field, not just state. Bare-prose body matches are rejected — only title and branch-name matches count, to avoid false positives from generic slugs (e.g., `refactor`) matching unrelated PRs.
-2. `git log main --oneline --grep="$SLUG"` — at least one commit.
-3. Read plan body; for each `path/to/file.ts`-style reference under "Files to create" or "Files to modify" sections, check file exists. Report fraction.
-
-**Verdict precedence rule (covers all 8 PR/commit/file combinations deterministically):**
-
-1. **FAIL** if both PR evidence AND commit evidence are absent — regardless of file evidence. (Files alone never justify PASS; a plan can name files that exist for unrelated reasons.)
-2. **PASS** if all three checks have evidence.
-3. **UNCERTAIN** otherwise — i.e. any case where exactly one or two of the three checks has evidence and rule 1 doesn't fire. The verdict triggers an `AskUserQuestion` confirmation in `/plan:complete` Step 5.
-
-Explicit truth table (P=PR, C=commits, F=files; ✓=evidence found, ✗=empty):
-
-| P | C | F | Verdict   | Notes                                            |
-|---|---|---|-----------|--------------------------------------------------|
-| ✓ | ✓ | ✓ | PASS      | All three checks satisfied                       |
-| ✓ | ✓ | ✗ | UNCERTAIN | Files renamed/moved? Confirm                     |
-| ✓ | ✗ | ✓ | UNCERTAIN | Squash-merge with non-matching commit msg?       |
-| ✓ | ✗ | ✗ | UNCERTAIN | PR exists but no traces — confirm intentionality |
-| ✗ | ✓ | ✓ | UNCERTAIN | Direct-to-main commits, no PR — confirm          |
-| ✗ | ✓ | ✗ | UNCERTAIN | Commits but no files/PR — slug mismatch likely   |
-| ✗ | ✗ | ✓ | FAIL      | Files alone are insufficient evidence            |
-| ✗ | ✗ | ✗ | FAIL      | No evidence anywhere                             |
+No new packages. `gh`, `git`, and `gt` are already required by the repo.
 
 ## Acceptance Criteria
 
-1. Running `/workflows:plan` writes a plan with `slug:` and `created:` frontmatter.
-2. Running `/plan:status` produces a plain-text table listing 3 open + 44 archived plans (current corpus) with checkbox progress; 100%-complete open plans annotated `-- ready to complete`.
-3. Running `/plan:complete <plan>` against a plan whose work has merged passes Gate A and Gate C, runs the Graphite archival flow, and reports the PR URL.
-4. Running `/plan:complete <plan>` twice in a row: second invocation exits with "already archived" message.
-5. `pnpm validate:plans` passes against the current `plans/complete/` corpus after migration commit.
-6. `pnpm validate:plans` fails when a new file with unchecked boxes (and no `ci-skip-checkbox-check: true`) is introduced into `plans/complete/`.
-7. `pnpm release:check` and `pnpm validate:schemas` both include `validate:plans` in their chain.
+1. Running `/plan:status` produces a plain-text table listing the current
+   `plans/*.md` (open) and `plans/complete/*.md` (archived) corpus with
+   per-file checkbox progress; 100%-complete open plans annotated
+   `-- ready to complete`.
+2. Running `/plan:complete <plan>` against a plan whose work has merged
+   under a same-named PR title runs Gate A and Gate C cleanly, archives
+   via `gt`, and reports the resulting PR URL.
+3. Running `/plan:complete <plan>` against a plan with no matching merged
+   PR prompts via `AskUserQuestion` for confirmation and, on override,
+   appends `Plan-Verifier-Override: user-confirmed-no-pr-evidence` to
+   the archival commit.
+4. Running `/plan:complete <plan>` twice in a row: second invocation exits
+   with "already archived" message.
+5. `pnpm validate:plans` passes when no PR-touched files violate the
+   no-stray-checkbox rule, regardless of how many legacy
+   `plans/complete/*.md` files have stray boxes.
+6. `pnpm validate:plans` fails when a PR adds or modifies a file in
+   `plans/complete/` that contains `- [ ]` lines.
 
 ## Edge Cases
 
-- **Plan with no frontmatter:** `/plan:complete` prompts for slug via AskUserQuestion. `validate-plans.js` treats absence of frontmatter as `ci-skip-checkbox-check: false` (default), so legacy archived plans without frontmatter and with stray `- [ ]` lines fail until backfilled.
-- **Slug collision:** Multiple plans with the same slug in different states. Migration script must detect and warn; humans resolve. Out of scope for the runtime command.
-- **Dirty working tree at /plan:complete:** Warn, ask, proceed if confirmed. Don't block — the user may have unrelated WIP they want to keep.
-- **`gh pr list` returns nothing but commits exist:** Verifier returns UNCERTAIN; user confirms via AskUserQuestion. (Common for old plans archived before this workflow existed.)
-- **Plan with zero `- [ ]` and zero `- [x]`:** Status renders `[ 0/0 ]`, no annotation. `/plan:complete` Gate A trivially passes.
-- **`plans/complete/` doesn't exist on first run:** `/plan:complete` runs `mkdir -p plans/complete/` before mv. Validator no-ops gracefully.
+- **Slug collision at archival time:** Two plans with the same derived slug.
+  Detection: the directory split prevents two open plans from sharing a
+  slug at the same time; archival of a slug whose archived peer already
+  exists trips Step 0's idempotency guard.
+- **Slug too generic:** `refactor`, `fix`, `wip`. The word-boundary
+  post-filter on `headRefName` mitigates most false matches; if the
+  override path triggers anyway, the user resolves via the PR-number
+  prompt and the commit trailer captures the decision.
+- **Dirty working tree at /plan:complete:** Warn, ask, proceed if confirmed.
+  Don't block — the user may have unrelated WIP they want to keep.
+- **`gh pr list` returns nothing but the PR is in merge queue:** PR is not
+  yet in `--state merged`. User confirms via override path. (Edge case
+  for users who run `/plan:complete` before their own PR has merged out
+  of the queue.)
+- **Plan with zero `- [ ]` and zero `- [x]`:** Status renders `[ 0/0 ]`,
+  no annotation. `/plan:complete` Gate A trivially passes.
+- **`plans/complete/` doesn't exist on first run:** `/plan:complete` runs
+  `mkdir -p plans/complete/` before mv. Validator no-ops gracefully.
 - **Filename with traversal characters:** Step 1 regex rejects.
+- **Shallow clone in CI:** Validator emits a warning to stderr and exits 0
+  when `BASE_REF` is unreachable; CI workflow is responsible for
+  `actions/checkout@v4` `fetch-depth: 0` (or fetching the base ref
+  explicitly). Documented in the validator header comment.
 
 ## Stack Decomposition
 
 <!-- stack-topology: linear -->
 <!-- stack-trunk: main -->
 
-### 1. agent/feat/plan-frontmatter-parser
+### 1. agent/feat/validate-plans-pr-scoped
 - **Type:** feat
-- **Description:** Add scripts/lib/plan-frontmatter.js parser plus integration tests
-- **Scope:** scripts/lib/plan-frontmatter.js, tests/integration/plan-frontmatter.test.ts
+- **Description:** Add scripts/validate-plans.js (PR-diff-scoped, no frontmatter) plus integration tests and CI wiring as a separate top-level step
+- **Scope:** scripts/validate-plans.js, package.json, tests/integration/validate-plans.test.ts, .github/workflows/*.yml
 - **Tasks:** 1.1, 1.2, 1.3
 - **Depends on:** (none)
+- **Changeset:** none required (no `plugins/*` files touched)
 
-### 2. agent/feat/workflows-plan-writes-slug
+### 2. agent/feat/plan-commands
 - **Type:** feat
-- **Description:** /workflows:plan writes slug + created frontmatter on every new plan
-- **Scope:** plugins/yellow-core/commands/workflows/plan.md
-- **Tasks:** 2.1, 2.2, 2.3
+- **Description:** /plan:status read-only dashboard + /plan:complete two-gate archival (runtime slug, single-gh-call Gate C, override trailer) + docs + changeset
+- **Scope:** plugins/yellow-core/commands/plan/status.md, plugins/yellow-core/commands/plan/complete.md, plugins/yellow-core/README.md, plugins/yellow-core/CLAUDE.md, plugins/yellow-core/tests/plan-commands.bats, docs/solutions/workflow/plan-lifecycle-management.md, .changeset/*.md
+- **Tasks:** 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 4.2, 4.3, 5.1, 5.2, 5.3, 5.4
 - **Depends on:** #1
-
-### 3. agent/feat/validate-plans-and-backfill
-- **Type:** feat
-- **Description:** validate-plans.js CI gate + one-shot backfill of 62 existing plan files
-- **Scope:** scripts/validate-plans.js, scripts/backfill-plan-slugs.js, package.json, plans/*.md, plans/complete/*.md, tests/integration/validate-plans.test.ts
-- **Tasks:** 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 4.3, 4.4, 4.5
-- **Depends on:** #2
-
-### 4. agent/feat/plan-status-command
-- **Type:** feat
-- **Description:** /plan:status read-only dashboard with checkbox progress + ready-to-complete annotation
-- **Scope:** plugins/yellow-core/commands/plan/status.md, plugins/yellow-core/tests/plan-commands.bats
-- **Tasks:** 5.1, 5.2, 5.3, 5.4, 7.3
-- **Depends on:** #3
-
-### 5. agent/feat/plan-complete-command
-- **Type:** feat
-- **Description:** /plan:complete two-gate archival + plan-verifier agent + docs + changeset
-- **Scope:** plugins/yellow-core/commands/plan/complete.md, plugins/yellow-core/agents/plan/plan-verifier.md, plugins/yellow-core/README.md, plugins/yellow-core/CLAUDE.md, CLAUDE.md, .changeset/*.md, docs/solutions/workflow/plan-lifecycle-management.md
-- **Tasks:** 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, 6.9, 6.10, 6.11, 7.4, 8.1, 8.2, 8.3, 8.4, 8.5
-- **Depends on:** #4
+- **Changeset:** required (yellow-core, minor — new commands)
 
 ## References
 
-- Brainstorm: `docs/brainstorms/2026-05-08-plan-lifecycle-management-brainstorm.md`
+- Brainstorm (superseded for several decisions): `docs/brainstorms/2026-05-08-plan-lifecycle-management-brainstorm.md`
 - Validator pattern: `scripts/validate-marketplace.js`, `scripts/validate-plugin.js`
-- Verification agent precedent: `plugins/yellow-core/agents/research/repo-research-analyst.md`
 - Reference command: `plugins/yellow-core/commands/worktree/cleanup.md` (uses `gh pr list --head`)
-- Merge-queue gotcha: `docs/solutions/integration-issues/merge-queue-closed-pr-null-mergedat-detection.md`
+- Merge-queue / `mergedAt` gotcha: `docs/solutions/integration-issues/merge-queue-closed-pr-null-mergedat-detection.md`
 - Bash hardening: `MEMORY.md` "Bash Hook & Validation Patterns" section
 - Command anti-patterns: `docs/solutions/code-quality/claude-code-command-authoring-anti-patterns.md`
+- PR #484 review issues driving this revision: `#494` (P0/P1 design), `#496` (YAGNI scope reductions)

--- a/plans/plan-lifecycle-management.md
+++ b/plans/plan-lifecycle-management.md
@@ -12,7 +12,7 @@ We need: a status surface, an explicit archival command with completion validati
 
 ## Current State
 
-- 2 open plans in `plans/`, 44 archived in `plans/complete/`
+- 3 open plans in `plans/`, 44 archived in `plans/complete/` (counts as of this PR landing; the validator checks `plans/complete/` so the open count is informational only)
 - No frontmatter convention — plans are plain markdown starting with `# Feature: …`
 - 36% of archived plans (16/44) contain stray `- [ ]` lines from prose checklists, future-work sections, or quoted code — meaning a naive checkbox validator would block CI immediately
 - `/workflows:plan` writes plans but no stable per-plan identifier survives renames
@@ -58,16 +58,18 @@ ci-skip-checkbox-check: false   # optional; defaults to false
 ### Phase 1: Foundation — frontmatter parsing utility
 
 <!-- deepen-plan: codebase -->
-> **Codebase:** `scripts/validate-agent-authoring.js` lines 62-105 already implements
-> `extractFrontmatter(text)`, `parseScalar(frontmatter, key)`, and `parseList(frontmatter, key)`
-> as module-private helpers. `scripts/lint-plugins.sh:74` has a bash-side `frontmatter()`
+> **Codebase:** `scripts/validate-agent-authoring.js` already implements
+> `extractFrontmatter(text)` (≈line 62), `parseScalar(frontmatter, key)` (≈line 67), and
+> `parseList(frontmatter, key)` (≈line 73, ends just before `relative()` at line 115)
+> as module-private helpers. Refer to the function names rather than fixed line ranges
+> when implementing — the file is edited frequently and exact ranges drift. `scripts/lint-plugins.sh:74` has a bash-side `frontmatter()`
 > function. `scripts/backfill-solution-frontmatter.js` contains another independent parser.
 > Do **not** invent a fourth implementation — extract those three functions into the new
 > shared `scripts/lib/plan-frontmatter.js` and have `validate-agent-authoring.js` import from
 > it (or accept the duplication and copy verbatim if cross-script imports add complexity).
 <!-- /deepen-plan -->
 
-- [ ] 1.1: Add `parsePlanFrontmatter(filePath)` helper to `scripts/lib/plan-frontmatter.js` — reads first `---` block, returns `{slug, created, ciSkipCheckboxCheck}` plus a `_raw` field for the body. Pure regex (no js-yaml dep) — frontmatter is simple key:value only. Mirror the parser pattern in `scripts/validate-agent-authoring.js` lines 62-90.
+- [ ] 1.1: Add `parsePlanFrontmatter(filePath)` helper to `scripts/lib/plan-frontmatter.js` — reads first `---` block, returns `{slug, created, ciSkipCheckboxCheck}` plus a `_raw` field for the body. Pure regex (no js-yaml dep) — frontmatter is simple key:value only. Mirror the `extractFrontmatter` / `parseScalar` / `parseList` helpers in `scripts/validate-agent-authoring.js` (referenced by name, not line range, to avoid drift).
 - [ ] 1.2: Unit-test the helper in `tests/integration/plan-frontmatter.test.ts` against fixtures: missing frontmatter, malformed YAML, present-but-empty, all-fields-present.
 - [ ] 1.3: Document the schema in `docs/CLAUDE.md` (versioning section already exists) and `plugins/yellow-core/CLAUDE.md`.
 
@@ -205,7 +207,24 @@ Three checks:
 2. `git log main --oneline --grep="$SLUG"` — at least one commit.
 3. Read plan body; for each `path/to/file.ts`-style reference under "Files to create" or "Files to modify" sections, check file exists. Report fraction.
 
-UNCERTAIN if PR check has zero results but commit check has results (unusual — usually means slug mismatch). PASS if all three have evidence. FAIL if all three are empty.
+**Verdict precedence rule (covers all 8 PR/commit/file combinations deterministically):**
+
+1. **FAIL** if both PR evidence AND commit evidence are absent — regardless of file evidence. (Files alone never justify PASS; a plan can name files that exist for unrelated reasons.)
+2. **PASS** if all three checks have evidence.
+3. **UNCERTAIN** otherwise — i.e. any case where exactly one or two of the three checks has evidence and rule 1 doesn't fire. The verdict triggers an `AskUserQuestion` confirmation in `/plan:complete` Step 5.
+
+Explicit truth table (P=PR, C=commits, F=files; ✓=evidence found, ✗=empty):
+
+| P | C | F | Verdict   | Notes                                            |
+|---|---|---|-----------|--------------------------------------------------|
+| ✓ | ✓ | ✓ | PASS      | All three checks satisfied                       |
+| ✓ | ✓ | ✗ | UNCERTAIN | Files renamed/moved? Confirm                     |
+| ✓ | ✗ | ✓ | UNCERTAIN | Squash-merge with non-matching commit msg?       |
+| ✓ | ✗ | ✗ | UNCERTAIN | PR exists but no traces — confirm intentionality |
+| ✗ | ✓ | ✓ | UNCERTAIN | Direct-to-main commits, no PR — confirm          |
+| ✗ | ✓ | ✗ | UNCERTAIN | Commits but no files/PR — slug mismatch likely   |
+| ✗ | ✗ | ✓ | FAIL      | Files alone are insufficient evidence            |
+| ✗ | ✗ | ✗ | FAIL      | No evidence anywhere                             |
 
 ## Acceptance Criteria
 

--- a/plans/plan-lifecycle-management.md
+++ b/plans/plan-lifecycle-management.md
@@ -1,0 +1,278 @@
+# Feature: Plan Lifecycle Management
+
+**Source brainstorm:** `docs/brainstorms/2026-05-08-plan-lifecycle-management-brainstorm.md`
+**Detail level:** STANDARD+ (validator + 2 commands + 1 agent + migration)
+**Status:** Ready for `/workflows:work`
+
+## Problem Statement
+
+Plans live as markdown in `plans/` (open) and `plans/complete/` (archived). Six manual `git mv` archival commits in two days (`6f883f7c`, `f056390c`, `3e9baf4d`, `0538866b`, peers) confirm this is real friction. The plugin system has no authoritative way to know which plans are open, which are complete, or whether the work a plan describes actually shipped.
+
+We need: a status surface, an explicit archival command with completion validation, and a CI gate that catches premature archival — without changing the underlying filesystem convention.
+
+## Current State
+
+- 2 open plans in `plans/`, 44 archived in `plans/complete/`
+- No frontmatter convention — plans are plain markdown starting with `# Feature: …`
+- 36% of archived plans (16/44) contain stray `- [ ]` lines from prose checklists, future-work sections, or quoted code — meaning a naive checkbox validator would block CI immediately
+- `/workflows:plan` writes plans but no stable per-plan identifier survives renames
+- Archival is `git mv` + commit; no machine-readable signal of completion
+
+## Proposed Solution
+
+A small frontmatter convention plus two commands plus one CI validator, all in yellow-core. Three user-facing decisions already made (recorded here so future readers can skip the rationale):
+
+1. **Frontmatter escape hatch** — Gate A respects `ci-skip-checkbox-check: true` on legacy plans rather than scoping to specific headings (avoids ambiguous structural rules).
+2. **`slug:` frontmatter** — `/workflows:plan` writes a stable slug at creation; Gate C reads it. Survives file renames.
+3. **Work-PR evidence** — Gate C confirms ≥1 PR referencing the slug merged to main (multi-PR plans like `everyinc-merge` work naturally).
+
+### Surface
+
+```
+plugins/yellow-core/
+  commands/plan/
+    status.md            → /plan:status         (read-only dashboard)
+    complete.md          → /plan:complete <plan> (two-gate archival)
+  agents/plan/
+    plan-verifier.md     (Gate C verification agent)
+
+scripts/
+  validate-plans.js      (CI validator, runs in pnpm release:check)
+  backfill-plan-slugs.js (one-shot migration helper, deleted after use)
+```
+
+### Plan frontmatter (new)
+
+```yaml
+---
+slug: plan-lifecycle-management
+created: 2026-05-08
+ci-skip-checkbox-check: false   # optional; defaults to false
+---
+```
+
+`slug` is required for any plan that wants to use `/plan:complete` Gate C. `ci-skip-checkbox-check` is the legacy escape hatch — set to `true` only for already-archived plans whose stray `- [ ]` lines are not tasks.
+
+## Implementation Plan
+
+### Phase 1: Foundation — frontmatter parsing utility
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** `scripts/validate-agent-authoring.js` lines 62-105 already implements
+> `extractFrontmatter(text)`, `parseScalar(frontmatter, key)`, and `parseList(frontmatter, key)`
+> as module-private helpers. `scripts/lint-plugins.sh:74` has a bash-side `frontmatter()`
+> function. `scripts/backfill-solution-frontmatter.js` contains another independent parser.
+> Do **not** invent a fourth implementation — extract those three functions into the new
+> shared `scripts/lib/plan-frontmatter.js` and have `validate-agent-authoring.js` import from
+> it (or accept the duplication and copy verbatim if cross-script imports add complexity).
+<!-- /deepen-plan -->
+
+- [ ] 1.1: Add `parsePlanFrontmatter(filePath)` helper to `scripts/lib/plan-frontmatter.js` — reads first `---` block, returns `{slug, created, ciSkipCheckboxCheck}` plus a `_raw` field for the body. Pure regex (no js-yaml dep) — frontmatter is simple key:value only. Mirror the parser pattern in `scripts/validate-agent-authoring.js` lines 62-90.
+- [ ] 1.2: Unit-test the helper in `tests/integration/plan-frontmatter.test.ts` against fixtures: missing frontmatter, malformed YAML, present-but-empty, all-fields-present.
+- [ ] 1.3: Document the schema in `docs/CLAUDE.md` (versioning section already exists) and `plugins/yellow-core/CLAUDE.md`.
+
+### Phase 2: `/workflows:plan` augmentation
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Confirmed `plugins/yellow-core/commands/workflows/plan.md` Phase 4 Step 2
+> currently writes plain markdown starting with `# Feature: [Title]` — zero YAML frontmatter
+> in any of the three templates (MINIMAL/STANDARD/COMPREHENSIVE, lines 164-360). Phase 2.1
+> below is a real net-new addition, not a tweak. The `# Feature:` header line stays; the
+> frontmatter block prepends above it.
+<!-- /deepen-plan -->
+
+- [ ] 2.1: Modify `plugins/yellow-core/commands/workflows/plan.md` Phase 4 Step 2: when writing plan file, prepend a YAML frontmatter block with `slug` (kebab-case from the plan title) and `created` (today's date in `YYYY-MM-DD`).
+- [ ] 2.2: Update plan templates (MINIMAL/STANDARD/COMPREHENSIVE) in the same file to show frontmatter as the first block.
+- [ ] 2.3: Verify that downstream commands (`/workflows:work`, `/gt-stack-plan`) ignore the frontmatter cleanly — no parser changes needed since they read body content.
+
+### Phase 3: Backfill migration
+
+- [ ] 3.1: Write `scripts/backfill-plan-slugs.js` — walks `plans/` and `plans/complete/`, prepends frontmatter to any file lacking it. Slug derived from filename minus `.md` minus optional `YYYY-MM-DD-` prefix. `ci-skip-checkbox-check: true` is set on archived plans that have unchecked boxes.
+- [ ] 3.2: Run the migration locally; verify diff is reasonable (47 file changes — 44 archived + 3 open, frontmatter only).
+- [ ] 3.3: Commit migration as a separate logical commit ("chore(plans): backfill slug + ci-skip frontmatter") so the validator change can be reviewed independently.
+- [ ] 3.4: Delete `scripts/backfill-plan-slugs.js` after migration commits land — one-shot tool.
+
+### Phase 4: CI validator
+
+- [ ] 4.1: Implement `scripts/validate-plans.js` matching the pattern in `validate-marketplace.js` (logError/logWarning/logInfo/logSuccess; exit 0/1). Rule: every `.md` in `plans/complete/` either (a) contains zero `^\s*- \[ \]` lines OR (b) has `ci-skip-checkbox-check: true` in frontmatter. Use `parsePlanFrontmatter` from Phase 1.
+- [ ] 4.2: Guard `plans/complete/` non-existence — `fs.existsSync` check returns success with no files validated.
+- [ ] 4.3: Add `"validate:plans": "node scripts/validate-plans.js"` to `package.json` scripts (the script entry only — do NOT append to `release:check` separately; see task 4.4).
+- [ ] 4.4: Add `&& node scripts/validate-plans.js` to the `validate:schemas` chain in `package.json` (CI baseline gate — blocks all PRs). Because `release:check` already calls `validate:schemas`, this single insertion covers both gates; no separate edit to `release:check` is needed.
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** `package.json:20` chains `validate:schemas` as `marketplace → plugin → setup-all → agent-authoring`. The chain is `&&`-joined fail-fast; ordering is by scope (broadest to narrowest), not data-flow. Appending `&& node scripts/validate-plans.js` at the end is safe with no ordering constraint. `release:check` (`package.json:30`) already invokes `validate:schemas`, so adding `validate:plans` to the `validate:schemas` chain is sufficient — no duplicate entry in `release:check` is required.
+<!-- /deepen-plan -->
+
+- [ ] 4.5: Vitest integration test in `tests/integration/validate-plans.test.ts`: temp-dir fixtures for pass/fail/escape-hatch/no-frontmatter/missing-dir cases.
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Match the pattern in `tests/integration/validate-plugin.test.ts` —
+> `mkdtempSync(join(tmpdir(), 'yellow-validate-plans-'))` in `beforeEach`, fixture files via
+> inline write helpers, validator invoked via `spawnSync('node', [VALIDATOR, tmpRoot])`,
+> cleanup via `rmSync(tmpRoot, { recursive: true, force: true })` in `afterEach`. The
+> "plugin directory basename must equal manifest name" constraint (RULE 2) does **not**
+> apply since plan files have no name field — temp dir basename is unconstrained.
+<!-- /deepen-plan -->
+
+
+### Phase 5: `/plan:status` command
+
+- [ ] 5.1: Create `plugins/yellow-core/commands/plan/status.md` with frontmatter `name: plan:status`, single-line description, `argument-hint: ''`, `allowed-tools: [Bash]`.
+- [ ] 5.2: Body: bash blocks that walk `plans/*.md` and `plans/complete/*.md`, count `- [ ]` and `- [x]` per file, format as plain-text table. Append `-- ready to complete` annotation when 100% checked AND file is in `plans/` (not `plans/complete/`).
+- [ ] 5.3: Handle edge cases: zero-task plans render as `[ 0/0 ]` with no annotation; missing `plans/complete/` reports `(0)`.
+- [ ] 5.4: Re-derive variables in each Bash block (every block is a fresh subprocess — see MEMORY.md).
+
+### Phase 6: `/plan:complete` command + plan-verifier agent
+
+- [ ] 6.1: Create `plugins/yellow-core/agents/plan/plan-verifier.md` modeled on `repo-research-analyst` (frontmatter: `name: plan-verifier`, `model: inherit`, `background: true`, `memory: project`, `tools: [Bash, Read, Grep, Glob, AskUserQuestion]`). The `name:` field is required so `subagent_type: "yellow-core:plan:plan-verifier"` resolves at runtime — `validate-agent-authoring.js` emits `missing agent name` without it. Body instructs the agent to run three checks against a slug + plan body (provided injection-fenced) and return a structured pass/fail/uncertain verdict.
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Confirmed `plugins/yellow-core/agents/research/repo-research-analyst.md`
+> lines 1-11 use `background: true`, `memory: project`, plain-text narrative output (no
+> `run_dir` JSON protocol). Match exactly. Single-spawn dispatch from `/plan:complete` waits
+> via `TaskOutput`, identical to how `/workflows:plan` Phase 2 waits on its parallel research
+> agents. Plain-text output is parsed by the command via simple `grep`/`awk` looking for the
+> `VERDICT:`, `PR_EVIDENCE:` etc. line prefixes.
+<!-- /deepen-plan -->
+
+- [ ] 6.2: Create `plugins/yellow-core/commands/plan/complete.md` with `allowed-tools: [Bash, Read, Task, AskUserQuestion, ToolSearch]`, `argument-hint: '<plan-filename>'`.
+- [ ] 6.3: Step 0 — idempotency guard: if `plans/complete/<arg>` already exists, exit with explanatory message.
+- [ ] 6.4: Step 1 — filename validation: `CLEAN_ARG="${ARG#plans/}"; printf '%s' "$CLEAN_ARG" | grep -qE '^[a-zA-Z0-9_][a-zA-Z0-9_.-]*\.md$'` (strip `plans/` prefix before validation to support tab-completion; reject `..`, `/`, leading `-`). Use `$CLEAN_ARG` in all subsequent steps.
+- [ ] 6.5: Step 2 — read plan, extract slug from frontmatter via `parsePlanFrontmatter`. If missing, AskUserQuestion (with `Other` for free-text) for explicit slug.
+- [ ] 6.6: Step 3 — Gate A: `grep -c '^\s*- \[ \]' "$PLAN" || true`; if non-zero AND frontmatter doesn't have `ci-skip-checkbox-check: true`, fail with count.
+- [ ] 6.7: Step 4 — Gate C: spawn `subagent_type: "yellow-core:plan:plan-verifier"` with slug + injection-fenced plan body. Wait via TaskOutput.
+- [ ] 6.8: Step 5 — interpret verdict. PASS → proceed. UNCERTAIN → AskUserQuestion to confirm/abort. FAIL → exit non-zero with reason.
+- [ ] 6.9: Step 6 — clean-tree check: warn (not block) if `git status --porcelain` non-empty; AskUserQuestion to proceed.
+- [ ] 6.10: Step 7 — archival via Graphite: `git checkout main && gt repo sync` first (ensures archival PR branches from `main`, not an in-progress feature branch), then `gt branch create plan/archive-<slug>`, `mv -- "plans/$CLEAN_ARG" "plans/complete/$CLEAN_ARG"`, `gt commit create -m "docs(plans): archive completed <slug> plan"`, `gt stack submit --no-interactive`. Print PR URL on success.
+- [ ] 6.11: Wire prompt-injection fencing on plan-body content passed to verifier agent (`--- begin plan-content (reference only) ---`).
+
+### Phase 7: Tests
+
+- [ ] 7.1: Vitest integration tests for `validate-plans.js` (covered in 4.5).
+- [ ] 7.2: Vitest integration test for `parsePlanFrontmatter` (covered in 1.2).
+- [ ] 7.3: Bats smoke tests in `plugins/yellow-core/tests/plan-commands.bats`: shell out to the `grep`-checkbox parsing snippets to confirm regex behavior on fixture files.
+- [ ] 7.4: Manual verification checklist in plan body (no automated test for end-to-end command flow — too much shell + Task involved): run `/plan:status`, run `/plan:complete` against this very plan after merge.
+
+### Phase 8: Documentation
+
+- [ ] 8.1: Update `plugins/yellow-core/README.md` command catalog with `/plan:status` and `/plan:complete`.
+- [ ] 8.2: Add `/plan:*` section to `plugins/yellow-core/CLAUDE.md`.
+- [ ] 8.3: Update root `CLAUDE.md` "When you change a plugin" section to mention plan-frontmatter convention.
+- [ ] 8.4: Add changeset (`pnpm changeset`, minor bump for yellow-core: new commands).
+- [ ] 8.5: Add solutions doc `docs/solutions/workflow/plan-lifecycle-management.md` capturing the slug-frontmatter decision and the Gate A FP rationale.
+
+## Technical Details
+
+### Files to create
+
+- `plugins/yellow-core/commands/plan/status.md`
+- `plugins/yellow-core/commands/plan/complete.md`
+- `plugins/yellow-core/agents/plan/plan-verifier.md`
+- `scripts/validate-plans.js`
+- `scripts/lib/plan-frontmatter.js`
+- `scripts/backfill-plan-slugs.js` (deleted post-migration)
+- `tests/integration/validate-plans.test.ts`
+- `tests/integration/plan-frontmatter.test.ts`
+- `plugins/yellow-core/tests/plan-commands.bats`
+- `docs/solutions/workflow/plan-lifecycle-management.md`
+
+### Files to modify
+
+- `plugins/yellow-core/commands/workflows/plan.md` (add slug to written frontmatter)
+- `plugins/yellow-core/README.md` (command catalog)
+- `plugins/yellow-core/CLAUDE.md` (plan section)
+- `package.json` (add `validate:plans` script + chain into `validate:schemas` and `release:check`)
+- `plans/*.md` and `plans/complete/*.md` (62 files, frontmatter prepend via migration script)
+
+### Dependencies
+
+No new packages. Frontmatter parsing is pure regex; `gh` and `git` and `gt` are already required by the repo.
+
+### Verification agent contract
+
+`plan-verifier` receives a slug and an injection-fenced plan body, returns:
+
+```
+VERDICT: PASS|FAIL|UNCERTAIN
+PR_EVIDENCE: <list of merged PRs found referencing slug, with branches and merge SHAs>
+COMMIT_EVIDENCE: <git log main --grep=slug count>
+FILE_EVIDENCE: <count of files mentioned in plan body that exist on disk>
+RATIONALE: <one short paragraph>
+```
+
+Three checks:
+1. `gh pr list --search "in:title <slug>" --state merged --limit 10 --json number,title,mergedAt,headRefName` then filter `mergedAt != null` AND `headRefName` contains the slug (post-filter in jq: `.[] | select(.mergedAt != null) | select(.headRefName | contains("<slug>"))`). Note merge-queue ambiguity (MEMORY.md): a closed-not-merged PR has `mergedAt: null` — must check this field, not just state. Bare-prose body matches are rejected — only title and branch-name matches count, to avoid false positives from generic slugs (e.g., `refactor`) matching unrelated PRs.
+2. `git log main --oneline --grep="$SLUG"` — at least one commit.
+3. Read plan body; for each `path/to/file.ts`-style reference under "Files to create" or "Files to modify" sections, check file exists. Report fraction.
+
+UNCERTAIN if PR check has zero results but commit check has results (unusual — usually means slug mismatch). PASS if all three have evidence. FAIL if all three are empty.
+
+## Acceptance Criteria
+
+1. Running `/workflows:plan` writes a plan with `slug:` and `created:` frontmatter.
+2. Running `/plan:status` produces a plain-text table listing 3 open + 44 archived plans (current corpus) with checkbox progress; 100%-complete open plans annotated `-- ready to complete`.
+3. Running `/plan:complete <plan>` against a plan whose work has merged passes Gate A and Gate C, runs the Graphite archival flow, and reports the PR URL.
+4. Running `/plan:complete <plan>` twice in a row: second invocation exits with "already archived" message.
+5. `pnpm validate:plans` passes against the current `plans/complete/` corpus after migration commit.
+6. `pnpm validate:plans` fails when a new file with unchecked boxes (and no `ci-skip-checkbox-check: true`) is introduced into `plans/complete/`.
+7. `pnpm release:check` and `pnpm validate:schemas` both include `validate:plans` in their chain.
+
+## Edge Cases
+
+- **Plan with no frontmatter:** `/plan:complete` prompts for slug via AskUserQuestion. `validate-plans.js` treats absence of frontmatter as `ci-skip-checkbox-check: false` (default), so legacy archived plans without frontmatter and with stray `- [ ]` lines fail until backfilled.
+- **Slug collision:** Multiple plans with the same slug in different states. Migration script must detect and warn; humans resolve. Out of scope for the runtime command.
+- **Dirty working tree at /plan:complete:** Warn, ask, proceed if confirmed. Don't block — the user may have unrelated WIP they want to keep.
+- **`gh pr list` returns nothing but commits exist:** Verifier returns UNCERTAIN; user confirms via AskUserQuestion. (Common for old plans archived before this workflow existed.)
+- **Plan with zero `- [ ]` and zero `- [x]`:** Status renders `[ 0/0 ]`, no annotation. `/plan:complete` Gate A trivially passes.
+- **`plans/complete/` doesn't exist on first run:** `/plan:complete` runs `mkdir -p plans/complete/` before mv. Validator no-ops gracefully.
+- **Filename with traversal characters:** Step 1 regex rejects.
+
+## Stack Decomposition
+
+<!-- stack-topology: linear -->
+<!-- stack-trunk: main -->
+
+### 1. agent/feat/plan-frontmatter-parser
+- **Type:** feat
+- **Description:** Add scripts/lib/plan-frontmatter.js parser plus integration tests
+- **Scope:** scripts/lib/plan-frontmatter.js, tests/integration/plan-frontmatter.test.ts
+- **Tasks:** 1.1, 1.2, 1.3
+- **Depends on:** (none)
+
+### 2. agent/feat/workflows-plan-writes-slug
+- **Type:** feat
+- **Description:** /workflows:plan writes slug + created frontmatter on every new plan
+- **Scope:** plugins/yellow-core/commands/workflows/plan.md
+- **Tasks:** 2.1, 2.2, 2.3
+- **Depends on:** #1
+
+### 3. agent/feat/validate-plans-and-backfill
+- **Type:** feat
+- **Description:** validate-plans.js CI gate + one-shot backfill of 62 existing plan files
+- **Scope:** scripts/validate-plans.js, scripts/backfill-plan-slugs.js, package.json, plans/*.md, plans/complete/*.md, tests/integration/validate-plans.test.ts
+- **Tasks:** 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 4.3, 4.4, 4.5
+- **Depends on:** #2
+
+### 4. agent/feat/plan-status-command
+- **Type:** feat
+- **Description:** /plan:status read-only dashboard with checkbox progress + ready-to-complete annotation
+- **Scope:** plugins/yellow-core/commands/plan/status.md, plugins/yellow-core/tests/plan-commands.bats
+- **Tasks:** 5.1, 5.2, 5.3, 5.4, 7.3
+- **Depends on:** #3
+
+### 5. agent/feat/plan-complete-command
+- **Type:** feat
+- **Description:** /plan:complete two-gate archival + plan-verifier agent + docs + changeset
+- **Scope:** plugins/yellow-core/commands/plan/complete.md, plugins/yellow-core/agents/plan/plan-verifier.md, plugins/yellow-core/README.md, plugins/yellow-core/CLAUDE.md, CLAUDE.md, .changeset/*.md, docs/solutions/workflow/plan-lifecycle-management.md
+- **Tasks:** 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, 6.9, 6.10, 6.11, 7.4, 8.1, 8.2, 8.3, 8.4, 8.5
+- **Depends on:** #4
+
+## References
+
+- Brainstorm: `docs/brainstorms/2026-05-08-plan-lifecycle-management-brainstorm.md`
+- Validator pattern: `scripts/validate-marketplace.js`, `scripts/validate-plugin.js`
+- Verification agent precedent: `plugins/yellow-core/agents/research/repo-research-analyst.md`
+- Reference command: `plugins/yellow-core/commands/worktree/cleanup.md` (uses `gh pr list --head`)
+- Merge-queue gotcha: `docs/solutions/integration-issues/merge-queue-closed-pr-null-mergedat-detection.md`
+- Bash hardening: `MEMORY.md` "Bash Hook & Validation Patterns" section
+- Command anti-patterns: `docs/solutions/code-quality/claude-code-command-authoring-anti-patterns.md`


### PR DESCRIPTION
Brainstorm captures the design for /plan:status and /plan:complete commands
plus a validate-plans.js CI gate. Plan decomposes implementation into 5
stacked PRs.

Brainstorm previously bundled in PR #481; cherry-picked here for cleaner
per-feature grouping. Removal from #481 follows in a separate commit on
that branch.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/plan:status` command to view open and archived plans
  * Added `/plan:complete` command to archive plans with automated validation checks

* **Documentation**
  * Added comprehensive plan lifecycle management specification and metadata conventions

* **Chores**
  * Added CI validation for plan structure and checkbox coverage
  * Added migration helper for existing plans

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two documentation artifacts for plan lifecycle management: a historical brainstorm (preserved per protected-artifact policy) and a revised implementation plan that collapses the original 5-PR stack, 3-check Gate C agent, and frontmatter migration into a leaner 2-PR delivery (PR-scoped CI validator + two shell commands with a single `gh` Gate C call).

- **Brainstorm** (`docs/brainstorms/…`): Preserved as historical context with inline \"Superseded\" annotations; the gate-naming gap (A, C — no B) and the frontmatter-purpose distinction were flagged in earlier threads.
- **Plan** (`plans/plan-lifecycle-management.md`): Specifies `validate-plans.js` (PR-diff-scoped, `--no-renames` explicit), `/plan:status`, and `/plan:complete` with runtime slug derivation; several spec defects remain open from earlier review rounds — idempotency guard ordering (Step 0 before `CLEAN_ARG` derivation), underscore filenames that clear filename validation but fail slug validation, and the missing source-file existence guard before Gate A.

<h3>Confidence Score: 4/5</h3>

Safe to merge as a documentation-only change; no production code is modified, but the plan carries spec defects that were flagged in earlier review rounds and remain unaddressed in this diff.

The plan describes several bash steps with ordering or validation gaps — idempotency guard running before the `plans/` prefix is stripped, underscore filenames clearing filename validation but failing slug validation downstream, and no source-file existence check before Gate A — that would cause confusing failures when an implementing agent follows the spec literally.

plans/plan-lifecycle-management.md — the /plan:complete step ordering and regex parity issues flagged in prior threads remain present in this diff and are the primary risk area for an implementer following the spec.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/brainstorms/2026-05-08-plan-lifecycle-management-brainstorm.md | New historical brainstorm document preserved as context; several sections are annotated as superseded by the plan, with gate-naming gap (B skipped) and frontmatter-purpose distinction noted in previous threads. |
| plans/plan-lifecycle-management.md | New implementation plan for /plan:status, /plan:complete, and validate-plans.js; several spec-level defects already flagged in prior threads remain present in this diff (idempotency guard ordering, underscore filename regex mismatch, missing source-file existence check before Gate A). |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["/plan:complete arg"] --> B["Step 0: idempotency guard\ncheck plans/complete/arg exists"]
    B -- already archived --> Z1["exit: already archived"]
    B -- not archived --> C["Step 1: derive CLEAN_ARG\nstrip plans/ prefix"]
    C --> D["filename regex validation\n^[a-z0-9_][a-z0-9_.-]*\\.md$"]
    D -- invalid --> Z2["exit: invalid filename"]
    D -- valid --> E["Step 2: derive SLUG\nbasename + strip date prefix\nvalidate slug regex"]
    E -- invalid slug --> Z3["exit: invalid slug characters"]
    E -- valid --> F["Gate A: grep -c unchecked boxes\nplans/CLEAN_ARG"]
    F -- unchecked > 0 --> Z4["exit: N unchecked tasks remain"]
    F -- all checked --> G["Gate C: gh pr list\n--search in:title SLUG\n--state merged\n--jq headRefName word-boundary filter"]
    G -- COUNT >= 1 --> H["Step 5: clean-tree check\n(warn + AskUserQuestion)"]
    G -- COUNT == 0 --> I["AskUserQuestion: no merged PR found\nConfirm with PR# or Cancel"]
    I -- cancelled --> Z5["exit: cancelled"]
    I -- PR# confirmed --> H
    H --> J["Step 6: git checkout main and gt repo sync"]
    J --> K["Step 7: gt branch create plan/archive-SLUG\nmkdir -p plans/complete\ngit mv plans/CLEAN_ARG plans/complete/CLEAN_ARG"]
    K --> L["Step 8: gt commit create with trailer"]
    L --> M["Step 9: gt stack submit\nprint PR URL"]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `plans/plan-lifecycle-management.md`, line 392 ([link](https://github.com/kinginyellows/yellow-plugins/blob/2b4d4f55eb913d2107d28f630114843031ef89b9/plans/plan-lifecycle-management.md#L392)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Stale file count in "Files to modify" contradicts the rest of the plan**

   The "Files to modify" section says `plans/*.md and plans/complete/*.md (62 files, frontmatter prepend via migration script)`, but the corrected corpus counts used throughout the rest of the document — Current State (line 220), task 3.2, and Acceptance Criterion #2 — all agree on 44 archived + 3 open = **47** files. The `62` figure is a leftover from an earlier version of the plan before the corpus numbers were corrected, and an implementer reading the technical-details section would assume substantially more files are involved than the backfill script will actually touch.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: plans/plan-lifecycle-management.md
   Line: 392

   Comment:
   **Stale file count in "Files to modify" contradicts the rest of the plan**

   The "Files to modify" section says `plans/*.md and plans/complete/*.md (62 files, frontmatter prepend via migration script)`, but the corrected corpus counts used throughout the rest of the document — Current State (line 220), task 3.2, and Acceptance Criterion #2 — all agree on 44 archived + 3 open = **47** files. The `62` figure is a leftover from an earlier version of the plan before the corpus numbers were corrected, and an implementer reading the technical-details section would assume substantially more files are involved than the backfill script will actually touch.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Fdocs%2Fplan-lifecycle-management%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Fdocs%2Fplan-lifecycle-management%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plans%2Fplan-lifecycle-management.md%0ALine%3A%20392%0A%0AComment%3A%0A**Stale%20file%20count%20in%20%22Files%20to%20modify%22%20contradicts%20the%20rest%20of%20the%20plan**%0A%0AThe%20%22Files%20to%20modify%22%20section%20says%20%60plans%2F*.md%20and%20plans%2Fcomplete%2F*.md%20%2862%20files%2C%20frontmatter%20prepend%20via%20migration%20script%29%60%2C%20but%20the%20corrected%20corpus%20counts%20used%20throughout%20the%20rest%20of%20the%20document%20%E2%80%94%20Current%20State%20%28line%20220%29%2C%20task%203.2%2C%20and%20Acceptance%20Criterion%20%232%20%E2%80%94%20all%20agree%20on%2044%20archived%20%2B%203%20open%20%3D%20**47**%20files.%20The%20%6062%60%20figure%20is%20a%20leftover%20from%20an%20earlier%20version%20of%20the%20plan%20before%20the%20corpus%20numbers%20were%20corrected%2C%20and%20an%20implementer%20reading%20the%20technical-details%20section%20would%20assume%20substantially%20more%20files%20are%20involved%20than%20the%20backfill%20script%20will%20actually%20touch.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Fdocs%2Fplan-lifecycle-management%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Fdocs%2Fplan-lifecycle-management%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aplans%2Fplan-lifecycle-management.md%3A424-433%0A**Gate%20C%20has%20no%20%60gh%60%20failure%20path**%0A%0AIf%20%60gh%20pr%20list%60%20exits%20non-zero%20%28network%20unavailable%2C%20auth%20failure%2C%20rate-limit%29%2C%20%60%24MERGED%60%20receives%20empty%20or%20error%20text%20and%20%60jq%20'length'%60%20fails%20silently%2C%20leaving%20%60COUNT%60%20unset.%20The%20subsequent%20%60%5B%20%22%24COUNT%22%20-ge%201%20%5D%60%20then%20errors%20with%20%60unary%20operator%20expected%60%2C%20aborting%20the%20command%20with%20no%20user-actionable%20message%20rather%20than%20a%20clean%20%22Gate%20C%20unavailable%20%E2%80%94%20confirm%20override%3F%22%20prompt.%20The%20spec%20should%20specify%20a%20fallback%3A%20treat%20a%20non-zero%20%60gh%60%20exit%20as%20the%20no-evidence%20path%20and%20route%20the%20user%20to%20%60AskUserQuestion%60%20with%20a%20note%20about%20the%20%60gh%60%20failure%20reason.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
plans/plan-lifecycle-management.md:424-433
**Gate C has no `gh` failure path**

If `gh pr list` exits non-zero (network unavailable, auth failure, rate-limit), `$MERGED` receives empty or error text and `jq 'length'` fails silently, leaving `COUNT` unset. The subsequent `[ "$COUNT" -ge 1 ]` then errors with `unary operator expected`, aborting the command with no user-actionable message rather than a clean "Gate C unavailable — confirm override?" prompt. The spec should specify a fallback: treat a non-zero `gh` exit as the no-evidence path and route the user to `AskUserQuestion` with a note about the `gh` failure reason.


`````

</details>

<sub>Reviews (7): Last reviewed commit: ["docs(plans): apply review fixes from PR ..."](https://github.com/kinginyellows/yellow-plugins/commit/f2cc6ed8b3e8fd499252656ccb148198500fdefe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31411522)</sub>

<!-- /greptile_comment -->