### PR TITLE
chore(yellow-council): replace stale diff-match-patch annotation with rapidfuzz

### DIFF
--- a/plans/yellow-council-v2-four-cli.md
+++ b/plans/yellow-council-v2-four-cli.md
@@ -506,7 +506,7 @@ Add a `verify_finding()` bash function that:
 - Document in CLAUDE.md as an optional dependency
 
 <!-- deepen-plan: external -->
-> **Research (Q3, threshold scale — HISTORICAL / SUPERSEDED by the rapidfuzz lock):** This annotation documents `diff-match-patch`'s `Match_Threshold` semantics (a tolerance/looseness scale where `0.0 = exact match required`, `1.0 = accept any match`, so "≥85% match" inverts to `dmp.Match_Threshold = 0.15`, NOT `0.85`). It is retained only as background for why `rapidfuzz`'s intuitive 0–100 scale was preferred. **Plan-locked: Tier 2 uses `rapidfuzz` (`fuzz.ratio(a, b) >= 85`, no inverted threshold).** Do NOT use `diff-match-patch`'s `Match_Threshold` API in implementation — see the locked decision in Task 5.1 body and the "Locked decisions" section.
+> **Research (Q3, threshold scale):** `rapidfuzz` uses an intuitive 0–100 percentage scale where `fuzz.ratio(a, b) >= 85` means "≥85% similar" — no inversion required. This is the plan-locked Tier 2 threshold. **Plan-locked: Tier 2 uses `rapidfuzz` (`fuzz.ratio(a, b) >= 85`, intuitive 0–100 scale).** See the locked decision in Task 5.1 body and the "Locked decisions" section.
 <!-- /deepen-plan -->
 
 <!-- deepen-plan: external -->


### PR DESCRIPTION
Resolves PR #462 codex P2 review thread (PRRT_kwDOQ3SUys6Axjru, marked resolved on the now-merged PR). The Task 5.1 deepen-plan annotation referenced 'dmp.Match_Threshold = 0.15' even though the plan-locked decision in the same task standardizes on rapidfuzz's intuitive 0-100 scale. Per the plan preamble, deepen-plan annotations supersede body text on conflict, so the stale annotation could mislead PR-E implementers into using the wrong fuzzy-match library/threshold.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal planning documentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KingInYellows/yellow-plugins/pull/502)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->