### PR TITLE
feat(yellow-core): credential-status protocol foundation

### DIFF
--- a/.changeset/credential-status-protocol-foundation.md
+++ b/.changeset/credential-status-protocol-foundation.md
@@ -1,0 +1,21 @@
+---
+'yellow-core': minor
+---
+
+feat(yellow-core): credential-status protocol foundation
+
+Adds the credential-status JSON protocol that lets `/setup:all` classify
+plugins as READY/PARTIAL/NEEDS SETUP without probing the system keychain.
+
+- `plugins/yellow-core/lib/credential-status.sh` — reusable Bash helper
+  exposing `write_credential_status(plugin, version, fields_json)`. Source
+  from any SessionStart hook in a credential-bearing plugin.
+- `docs/plugin-credential-status-protocol.md` — schema spec, lifecycle,
+  reader/writer contracts, and known Claude Code bugs (#41156 protected-dir
+  prompt, #51398 Cowork Desktop session-scoped data dir).
+- `AGENTS.md` — new authoring rules for credential-bearing MCP servers
+  covering the 3-element fallback pattern and the status-file protocol.
+
+This is the foundation PR for the plugin-install-resilience stack. Subsequent
+PRs (yellow-semgrep, yellow-composio, yellow-research, /setup:all dashboard)
+consume this helper to emit/read status files.

--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -822,15 +822,25 @@ jobs:
       - name: Run yellow-core git-worktree bats suite (required)
         run: bats plugins/yellow-core/skills/git-worktree/tests/
 
+      - name: Run yellow-core top-level bats suite (required)
+        # Covers credential-status.sh and any future yellow-core lib helpers.
+        # Required (not advisory) because yellow-core libraries are sourced
+        # by every credential-bearing plugin in the marketplace.
+        run: bats plugins/yellow-core/tests/
+
       - name: Run other plugins' bats suites (advisory)
         continue-on-error: true
         run: |
           set -uo pipefail
           STATUS=0
-          # Both top-level and nested test dirs (yellow-core's bats suite
-          # lives under skills/git-worktree/tests/, not at the plugin root).
+          # Both top-level and nested test dirs. yellow-core's suites are
+          # run as required steps above; skip them here to avoid double
+          # execution and to keep the advisory status accurate.
           for d in plugins/*/tests plugins/*/skills/*/tests; do
             [ -d "$d" ] || continue
+            case "$d" in
+              plugins/yellow-core/tests|plugins/yellow-core/skills/git-worktree/tests) continue ;;
+            esac
             echo "::group::bats $d"
             bats "$d" || STATUS=$?
             echo "::endgroup::"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,20 @@ and `pnpm test:lint-plugins` when `scripts/lint-plugins.sh` changes.
 - For `userConfig`, mark secrets with `sensitive: true`. Do not interpolate
   untrusted user config directly into shell commands; pass it through
   environment variables or validated wrapper scripts.
+- Credential-bearing MCP servers should follow the 3-element fallback pattern
+  (yellow-research/yellow-morph precedent): `plugin.json` env block declares
+  both `${user_config.KEY}` and `${KEY:-}` shell passthrough, and a wrapper
+  script in `bin/` resolves userConfig-wins precedence before exec'ing the
+  MCP binary. `required: true` on credential fields does NOT block install —
+  per anthropics/claude-code#39827 it surfaces at MCP startup as a confusing
+  error. Prefer optional fields + wrapper-side empty-string detection.
+- Plugins with credential-bearing fields should emit a credential-status JSON
+  from a SessionStart hook so `/setup:all` can render an accurate dashboard
+  without probing the system keychain. See
+  `docs/plugin-credential-status-protocol.md` for the schema and
+  `plugins/yellow-core/lib/credential-status.sh` for the reusable helper.
+  Never write credential values to the status file — only the resolution
+  source (`userConfig` / `shell_env` / `absent`) and a presence boolean.
 
 ## Command, Agent, And Skill Authoring
 

--- a/docs/plugin-credential-status-protocol.md
+++ b/docs/plugin-credential-status-protocol.md
@@ -1,0 +1,169 @@
+# Plugin Credential Status Protocol
+
+A shared JSON file written by each credential-bearing plugin during
+SessionStart. `/setup:all` reads these files to classify plugins as
+READY / PARTIAL / NEEDS SETUP without probing the system keychain.
+
+## File Location
+
+```
+${CLAUDE_PLUGIN_DATA}/credential-status.json
+```
+
+Resolves to `~/.claude/plugins/data/<plugin-id>/credential-status.json` on
+disk (per official Claude Code [plugins reference](https://code.claude.com/docs/en/plugins-reference)).
+
+One file per plugin. Files for different plugins live in different
+directories — no cross-plugin write contention.
+
+## Schema
+
+```json
+{
+  "plugin": "yellow-composio",
+  "version": "1.3.0",
+  "session_ts": "2026-05-13T18:42:31Z",
+  "credentials": [
+    {
+      "field": "composio_mcp_url",
+      "source": "userConfig",
+      "present": true,
+      "valid": true
+    },
+    {
+      "field": "composio_api_key",
+      "source": "shell_env",
+      "present": true,
+      "valid": null
+    }
+  ]
+}
+```
+
+### Fields
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `plugin` | string | Plugin name (must match `name` in plugin.json) |
+| `version` | string | Plugin version at write time |
+| `session_ts` | string | ISO 8601 UTC timestamp when written |
+| `credentials` | array | One entry per credential-bearing field |
+| `credentials[].field` | string | Field name (must match a `userConfig` key) |
+| `credentials[].source` | enum | `"userConfig"` \| `"shell_env"` \| `"absent"` |
+| `credentials[].present` | boolean | True if the resolved value is non-empty |
+| `credentials[].valid` | bool\|null | Optional: `true` after a live probe, `false` if probe failed, `null` if unverified |
+
+### Forbidden
+
+The file MUST NOT contain credential values. Only the resolution source
+(`userConfig` / `shell_env` / `absent`) and presence boolean. Validators
+will fail any file containing a recognizable credential pattern (40+ char
+strings, `sk_*`, `sgp_*`, etc.).
+
+## Lifecycle
+
+| Event | Behavior |
+|-------|----------|
+| First SessionStart after install | File created with all `userConfig` fields enumerated |
+| Subsequent SessionStarts | Full overwrite (no append; no merge) |
+| `/plugin disable <name>` | File deleted by hook teardown (best-effort) |
+| `/plugin update <name>` | Stale until next SessionStart populates a new file |
+| Hook crash / write failure | Silently skipped — readers treat missing file as "unknown" |
+
+## Writer Contract (SessionStart hooks)
+
+Hooks emit JSON via the shared helper:
+
+```bash
+source "${CLAUDE_PLUGIN_ROOT}/../yellow-core/lib/credential-status.sh"
+# or, if cross-plugin sourcing is not available, copy the helper inline
+
+fields_json=$(cat <<'__EOF__'
+[
+  {"field": "composio_mcp_url",
+   "source": "userConfig",
+   "present": true,
+   "valid": null},
+  {"field": "composio_api_key",
+   "source": "shell_env",
+   "present": true,
+   "valid": null}
+]
+__EOF__
+)
+
+write_credential_status "yellow-composio" "1.3.0" "$fields_json"
+```
+
+The helper:
+
+1. Resolves `${CLAUDE_PLUGIN_DATA}` (falls back to
+   `~/.claude/plugins/data/<plugin>/`).
+2. Writes to `<dir>/credential-status.json.tmp` first.
+3. Atomically renames to `credential-status.json` (POSIX rename atomicity).
+4. Silently exits on any failure — never blocks SessionStart.
+5. Always finishes with `printf '{"continue": true}\n'` if invoked as a
+   standalone hook (caller is responsible if sourced into a larger hook).
+
+## Reader Contract (`/setup:all`)
+
+The dashboard reads each plugin's status file via plain Bash + jq:
+
+```bash
+STATUS_FILE="$HOME/.claude/plugins/data/${plugin}/credential-status.json"
+if [ -f "$STATUS_FILE" ] && command -v jq >/dev/null 2>&1; then
+  present_count=$(jq '[.credentials[] | select(.present == true)] | length' "$STATUS_FILE" 2>/dev/null)
+  total_count=$(jq '.credentials | length' "$STATUS_FILE" 2>/dev/null)
+else
+  # File absent → "credential status unknown"
+  present_count=""
+  total_count=""
+fi
+```
+
+Three states the reader handles:
+
+- **File present + parseable** → use the field/source/present data to
+  drive classification.
+- **File present + malformed JSON** → treat as "status unknown" and emit
+  a warning to stderr.
+- **File absent** → treat as "status unknown — restart Claude Code or run
+  `/plugin disable && /plugin enable`."
+
+The reader NEVER attempts to read the system keychain or shell env vars
+not visible to the dashboard Bash subprocess.
+
+## Known Bugs (May 2026)
+
+- [anthropics/claude-code#41156](https://github.com/anthropics/claude-code/issues/41156) —
+  writes to `${CLAUDE_PLUGIN_DATA}` may trigger a protected-directory
+  prompt even in `bypassPermissions` mode. Hooks must `2>/dev/null || true`
+  the write and never block SessionStart.
+- [anthropics/claude-code#51398](https://github.com/anthropics/claude-code/issues/51398) —
+  in Cowork Desktop, `${CLAUDE_PLUGIN_DATA}` is session-scoped, not
+  persistent. Readers treat "file absent" as expected, not as a
+  configuration error.
+
+## Why This Protocol
+
+Claude Code does not expose a programmatic API for "which userConfig
+fields are populated for this plugin?" outside the plugin's own
+subprocess (where `CLAUDE_PLUGIN_OPTION_<KEY>` env vars are injected).
+The status file is a deliberate, low-cost bridge between plugin
+subprocess context and dashboard context — every credential-bearing
+plugin emits one identical-shape file so `/setup:all` can render an
+accurate dashboard without per-plugin special-casing.
+
+Plugins that emit this file:
+
+- yellow-research (perplexity/tavily/exa keys + ceramic OAuth state)
+- yellow-morph (morph key)
+- yellow-semgrep (semgrep token)
+- yellow-composio (URL + API key)
+
+Plugins that intentionally do NOT emit this file:
+
+- yellow-devin (uses shell env only; setup:all probes `DEVIN_*` env vars
+  directly)
+- yellow-linear, yellow-chatprd, yellow-codex (OAuth flows — status is
+  ToolSearch-visibility, not credential-presence)

--- a/docs/plugin-credential-status-protocol.md
+++ b/docs/plugin-credential-status-protocol.md
@@ -56,9 +56,11 @@ directories — no cross-plugin write contention.
 ### Forbidden
 
 The file MUST NOT contain credential values. Only the resolution source
-(`userConfig` / `shell_env` / `absent`) and presence boolean. Validators
-will fail any file containing a recognizable credential pattern (40+ char
-strings, `sk_*`, `sgp_*`, etc.).
+(`userConfig` / `shell_env` / `absent`) and presence boolean. This rule
+is currently enforced via code review on the SessionStart hook contents;
+a `validate-credential-status.js` companion to `validate-plugin.js`
+checking written status files for recognizable credential patterns
+(40+ char strings, `sk_*`, `sgp_*`, etc.) is planned but not yet shipped.
 
 ## Lifecycle
 
@@ -66,7 +68,7 @@ strings, `sk_*`, `sgp_*`, etc.).
 |-------|----------|
 | First SessionStart after install | File created with all `userConfig` fields enumerated |
 | Subsequent SessionStarts | Full overwrite (no append; no merge) |
-| `/plugin disable <name>` | File deleted by hook teardown (best-effort) |
+| `/plugin disable <name>` | File becomes orphaned; Claude Code does not currently expose a plugin-disable hook event, so the file persists until the next SessionStart of an installed-and-enabled instance overwrites it. Readers treat a stale file as "status unknown" once the plugin no longer appears in `claude plugin list`. |
 | `/plugin update <name>` | Stale until next SessionStart populates a new file |
 | Hook crash / write failure | Silently skipped — readers treat missing file as "unknown" |
 
@@ -99,11 +101,22 @@ The helper:
 
 1. Resolves `${CLAUDE_PLUGIN_DATA}` (falls back to
    `~/.claude/plugins/data/<plugin>/`).
-2. Writes to `<dir>/credential-status.json.tmp` first.
+2. Writes to a per-invocation unique temp file
+   (`credential-status.json.tmp.XXXXXX` via `mktemp`) so concurrent
+   SessionStart writers cannot clobber each other's tmp path.
 3. Atomically renames to `credential-status.json` (POSIX rename atomicity).
 4. Silently exits on any failure — never blocks SessionStart.
-5. Always finishes with `printf '{"continue": true}\n'` if invoked as a
-   standalone hook (caller is responsible if sourced into a larger hook).
+
+The helper does NOT emit `{"continue": true}`. That JSON is the
+SessionStart hook's contract with Claude Code, not the writer's. Every
+hook that sources this helper is responsible for emitting the response
+itself, e.g.:
+
+```bash
+source "${CLAUDE_PLUGIN_ROOT}/../yellow-core/lib/credential-status.sh"
+write_credential_status "yellow-foo" "1.2.3" "$fields_json"
+printf '{"continue": true}\n'
+```
 
 ## Reader Contract (`/setup:all`)
 
@@ -154,7 +167,9 @@ subprocess context and dashboard context — every credential-bearing
 plugin emits one identical-shape file so `/setup:all` can render an
 accurate dashboard without per-plugin special-casing.
 
-Plugins that emit this file:
+Plugins planned to emit this file (per the
+`plans/plugin-install-resilience.md` stack — adopters land in follow-up
+PRs after this foundation merges):
 
 - yellow-research (perplexity/tavily/exa keys + ceramic OAuth state)
 - yellow-morph (morph key)

--- a/docs/plugin-credential-status-protocol.md
+++ b/docs/plugin-credential-status-protocol.md
@@ -51,7 +51,7 @@ directories — no cross-plugin write contention.
 | `credentials[].field` | string | Field name (must match a `userConfig` key) |
 | `credentials[].source` | enum | `"userConfig"` \| `"shell_env"` \| `"absent"` |
 | `credentials[].present` | boolean | True if the resolved value is non-empty |
-| `credentials[].valid` | bool\|null | Optional: `true` after a live probe, `false` if probe failed, `null` if unverified |
+| `credentials[].valid` | boolean\|null | Optional: `true` after a live probe, `false` if probe failed, `null` if unverified |
 
 ### Forbidden
 
@@ -68,7 +68,7 @@ checking written status files for recognizable credential patterns
 |-------|----------|
 | First SessionStart after install | File created with all `userConfig` fields enumerated |
 | Subsequent SessionStarts | Full overwrite (no append; no merge) |
-| `/plugin disable <name>` | File becomes orphaned; Claude Code does not currently expose a plugin-disable hook event, so the file persists until the next SessionStart of an installed-and-enabled instance overwrites it. Readers treat a stale file as "status unknown" once the plugin no longer appears in `claude plugin list`. |
+| `/plugin disable <name>` | File becomes orphaned. Claude Code does not<br/>expose a plugin-disable hook event, so the file persists<br/>until the next SessionStart of an installed-and-enabled<br/>instance overwrites it. Readers treat a stale file as<br/>"status unknown" once the plugin no longer appears in<br/>`claude plugin list`. |
 | `/plugin update <name>` | Stale until next SessionStart populates a new file |
 | Hook crash / write failure | Silently skipped — readers treat missing file as "unknown" |
 

--- a/plans/plugin-install-resilience.md
+++ b/plans/plugin-install-resilience.md
@@ -147,8 +147,10 @@ Four coordinated workstreams, each independently shippable:
 ### Trade-offs Considered
 
 - **Composio proxy shim adds a dependency.** Verified: `@composio/mcp` or a
-  ~30-line hand-rolled proxy in `bin/composio-proxy.mjs` can pipe stdio MCP to
-  Composio's HTTPS endpoint. Per-session startup cost is one Node process
+  60–120 LoC hand-rolled proxy in `bin/composio-proxy.mjs` can pipe stdio MCP
+  to Composio's HTTPS endpoint (revised upward from the original ~30 LoC
+  estimate after reference-implementation review — see Phase 3.1
+  deepen-plan note). Per-session startup cost is one Node process
   (negligible).
 - **Status files vs. live keychain probing.** Status files require SessionStart
   hook to have fired at least once. First-install state is ambiguous. Mitigation:
@@ -243,8 +245,9 @@ Four coordinated workstreams, each independently shippable:
 
 - [ ] 3.1 Spike: verify `@composio/mcp` (or equivalent) exposes a stdio MCP
        relay accepting `--url` and `--header` flags. If not, write
-       `plugins/yellow-composio/bin/composio-proxy.mjs` (~30 LoC stdio↔HTTPS
-       proxy using Node's built-in `https` and `process.stdin`/`stdout`).
+       `plugins/yellow-composio/bin/composio-proxy.mjs` (60–120 LoC stdio↔HTTPS
+       proxy using Node's built-in `https` and `process.stdin`/`stdout`; see
+       the deepen-plan research note below for the revised LoC budget).
 
 <!-- deepen-plan: external -->
 > **Research:** Spike inputs identified:
@@ -557,7 +560,8 @@ Four coordinated workstreams, each independently shippable:
 ### Dependencies
 
 - No new external runtime deps if `composio-proxy.mjs` is hand-rolled
-  (~30 LoC, Node 18+ builtin `https`, `process.stdin/stdout`).
+  (60–120 LoC per the Phase 3.1 deepen-plan research above, using Node
+  18+ builtin `https` and `process.stdin/stdout`).
 - If external relay package is chosen (Phase 3.1 spike outcome), pin via
   `npx -y @composio/mcp@<version>` and document supported range.
 
@@ -735,51 +739,96 @@ behind 1 in a Graphite stack; PRs 4–8 sequential.
 <!-- stack-trunk: main -->
 
 ### 1. agent/feat/credential-status-protocol
+
 - **Type:** feat
 - **Description:** add credential-status protocol + yellow-core lib helper
-- **Scope:** plugins/yellow-core/lib/credential-status.sh, docs/plugin-credential-status-protocol.md, AGENTS.md, plugins/yellow-core/tests/credential-status.bats, .changeset/
+- **Scope:**
+  - `plugins/yellow-core/lib/credential-status.sh`
+  - `docs/plugin-credential-status-protocol.md`
+  - `AGENTS.md`
+  - `plugins/yellow-core/tests/credential-status.bats`
+  - `.changeset/`
 - **Tasks:** 1.1, 1.2, 1.3, 1.4
 - **Depends on:** (none)
 
 ### 2. agent/fix/yellow-semgrep-env-fallback
+
 - **Type:** fix
 - **Description:** honor shell env as fallback for SEMGREP_APP_TOKEN
-- **Scope:** plugins/yellow-semgrep/.claude-plugin/plugin.json, plugins/yellow-semgrep/bin/start-semgrep.sh, plugins/yellow-semgrep/hooks/write-credential-status.sh, plugins/yellow-semgrep/CLAUDE.md, plugins/yellow-semgrep/tests/, .changeset/
+- **Scope:**
+  - `plugins/yellow-semgrep/.claude-plugin/plugin.json`
+  - `plugins/yellow-semgrep/bin/start-semgrep.sh`
+  - `plugins/yellow-semgrep/hooks/write-credential-status.sh`
+  - `plugins/yellow-semgrep/CLAUDE.md`
+  - `plugins/yellow-semgrep/tests/`
+  - `.changeset/`
 - **Tasks:** 2.1, 2.2, 2.3, 2.4, 2.5, 2.6
 - **Depends on:** #1
 
 ### 3. agent/feat/yellow-composio-stdio-fallback
+
 - **Type:** feat
 - **Description:** convert yellow-composio to type:stdio with proxy + env fallback
-- **Scope:** plugins/yellow-composio/.claude-plugin/plugin.json (transport change), plugins/yellow-composio/bin/start-composio.sh, plugins/yellow-composio/bin/composio-proxy.mjs, plugins/yellow-composio/hooks/check-mcp-url.sh (status emit), plugins/yellow-composio/CLAUDE.md, plugins/yellow-composio/README.md, plugins/yellow-composio/tests/, .changeset/
+- **Scope:**
+  - `plugins/yellow-composio/.claude-plugin/plugin.json` (transport change)
+  - `plugins/yellow-composio/bin/start-composio.sh`
+  - `plugins/yellow-composio/bin/composio-proxy.mjs`
+  - `plugins/yellow-composio/hooks/check-mcp-url.sh` (status emit)
+  - `plugins/yellow-composio/CLAUDE.md`
+  - `plugins/yellow-composio/README.md`
+  - `plugins/yellow-composio/tests/`
+  - `.changeset/`
 - **Tasks:** 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7
 - **Depends on:** #2
 
 ### 4. agent/feat/yellow-research-status-hook
+
 - **Type:** feat
 - **Description:** emit credential-status.json from SessionStart for yellow-research
-- **Scope:** plugins/yellow-research/hooks/write-credential-status.sh, plugins/yellow-research/.claude-plugin/plugin.json (hooks block), plugins/yellow-research/CLAUDE.md, .changeset/
+- **Scope:**
+  - `plugins/yellow-research/hooks/write-credential-status.sh`
+  - `plugins/yellow-research/.claude-plugin/plugin.json` (hooks block)
+  - `plugins/yellow-research/CLAUDE.md`
+  - `.changeset/`
 - **Tasks:** 4.1, 4.2, 4.3
 - **Depends on:** #3
 
 ### 5. agent/feat/setup-all-status-classification
+
 - **Type:** feat
 - **Description:** classify plugins via status files + version drift in /setup:all
-- **Scope:** plugins/yellow-core/commands/setup/all.md, plugins/yellow-browser-test/agents/testing/app-discoverer.md, .changeset/
+- **Scope:**
+  - `plugins/yellow-core/commands/setup/all.md`
+  - `plugins/yellow-browser-test/agents/testing/app-discoverer.md`
+  - `.changeset/`
 - **Tasks:** 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7
 - **Depends on:** #4
 
 ### 6. agent/feat/validate-plugin-credential-warnings
+
 - **Type:** feat
 - **Description:** warn on required+sensitive userConfig fields without wrapper indirection
-- **Scope:** scripts/validate-plugin.js (RULE 12+13), packages/infrastructure tests, fixtures, docs/plugin-validation-guide.md
+- **Scope:**
+  - `scripts/validate-plugin.js` (RULE 12+13)
+  - `packages/infrastructure` tests
+  - fixtures
+  - `docs/plugin-validation-guide.md`
 - **Tasks:** 7.1, 7.2, 7.3, 7.4
 - **Depends on:** #5
 
 ### 7. agent/docs/multi-host-fleet-skill
+
 - **Type:** docs
 - **Description:** multi-host fleet SKILL.md + migration solution doc + release notes
-- **Scope:** plugins/yellow-core/skills/multi-host-fleet/SKILL.md, docs/solutions/build-errors/userconfig-required-fires-at-startup-not-install.md, AGENTS.md, plugins/yellow-research/README.md, plugins/yellow-morph/README.md, plugins/yellow-semgrep/README.md, plugins/yellow-composio/README.md, .changeset/
+- **Scope:**
+  - `plugins/yellow-core/skills/multi-host-fleet/SKILL.md`
+  - `docs/solutions/build-errors/userconfig-required-fires-at-startup-not-install.md`
+  - `AGENTS.md`
+  - `plugins/yellow-research/README.md`
+  - `plugins/yellow-morph/README.md`
+  - `plugins/yellow-semgrep/README.md`
+  - `plugins/yellow-composio/README.md`
+  - `.changeset/`
 - **Tasks:** 6.1, 6.2, 6.3, 6.4, 8.1, 8.2, 8.3, 8.4, 8.5
 - **Depends on:** #6
 

--- a/plans/plugin-install-resilience.md
+++ b/plans/plugin-install-resilience.md
@@ -204,8 +204,13 @@ Four coordinated workstreams, each independently shippable:
 <!-- deepen-plan: codebase -->
 > **Codebase:** `plugins/yellow-core/lib/` directory does NOT exist today.
 > Only `plugins/yellow-morph/lib/` exists (`install-morphmcp.sh`). Phase 1.2
-> creates the `yellow-core/lib/` directory from scratch. Follow yellow-morph's
-> sourcing precedent: `source "${CLAUDE_PLUGIN_ROOT}/lib/credential-status.sh"`.
+> creates the `yellow-core/lib/` directory from scratch. Because the helper
+> lives in `yellow-core/lib/` (not the consuming plugin's own
+> `${CLAUDE_PLUGIN_ROOT}/lib/`), adopter plugins source it via the
+> cross-plugin path documented in `docs/plugin-credential-status-protocol.md`:
+> `source "${CLAUDE_PLUGIN_ROOT}/../yellow-core/lib/credential-status.sh"`.
+> Adopters that need yellow-core-independent install must copy the helper
+> inline (also called out in the protocol doc's writer contract).
 <!-- /deepen-plan -->
 - [ ] 1.3 Unit test the helper with bats: file absent → write succeeds;
        file present + new schema → overwrite preserves valid JSON; jq

--- a/plans/plugin-install-resilience.md
+++ b/plans/plugin-install-resilience.md
@@ -1,0 +1,852 @@
+# Feature: Plugin Install Resilience — Cache Detection, Env Fallback Parity, and Multi-Host Sync
+
+## Overview
+
+Three pain points are blocking clean plugin installs across fleets:
+
+1. **Cache/upgrade drift** — when a plugin (e.g., yellow-research) ships a new
+   userConfig schema in an upgrade, Claude Code does not re-prompt; the only
+   remediation is `/plugin disable && /plugin enable`. `/setup:all` has no
+   detection for this state.
+2. **Env-fallback parity gaps** — yellow-research and yellow-morph honor shell
+   env vars as a fallback for userConfig; yellow-composio (userConfig-only,
+   `type: http`) and yellow-semgrep (userConfig overwrites shell env with
+   empty string) do not. Power users on multi-host fleets must enter creds
+   per host.
+3. **`/setup:all` misclassification** — `yellow-browser-test` reports
+   NEEDS SETUP on every non-web-app repo; `yellow-research` classifies as
+   PARTIAL when keys are in keychain (not shell env); `yellow-composio`
+   reports NEEDS SETUP without distinguishing "no userConfig" from
+   "userConfig set but MCP failed."
+
+This plan also adds a multi-host SKILL.md documenting the env-var contract so
+fleets can wire up dotfiles, direnv, or secrets managers without trial-and-error.
+
+## Problem Statement
+
+### Current Pain Points
+
+- **yellow-research PARTIAL classification persists despite working MCPs.**
+  setup:all reads only shell env (`EXA_API_KEY`, `TAVILY_API_KEY`,
+  `PERPLEXITY_API_KEY`). If user answered the userConfig prompt (keychain),
+  shell env is unset and the dashboard reports 0/6 sources even though all
+  three MCPs are healthy.
+- **yellow-composio cascade failure.** Empty `composio_mcp_url` (user dismissed
+  prompt on a fleet host) registers an empty-URL MCP that breaks
+  `claude doctor` for all other MCPs in the same session (`SDK auth failed:
+  "/" cannot be parsed as a URL`). No env-var fallback exists; `required: true`
+  does not block install (only causes startup failure per GH #39827).
+- **yellow-semgrep regression.** `"SEMGREP_APP_TOKEN":
+  "${user_config.semgrep_app_token}"` with no `:-` fallback. Empty userConfig
+  overwrites a working shell env value with `""`, breaking the MCP for power
+  users who set the token in `.zshrc` and dismissed the userConfig prompt.
+- **yellow-browser-test noise.** Reports NEEDS SETUP on every dotfiles
+  repo, server-only project, or CLI tool. No project-type detection in the
+  dashboard.
+- **No multi-host story.** Each plugin documents (or fails to document) its
+  shell env name independently. Setting up a new host requires reading 18
+  plugin READMEs to find the env-var contract.
+
+### User Impact
+
+Reported directly by the user on multiple hosts: "Still need attention" for
+yellow-research, yellow-composio, yellow-browser-test even after API keys are
+properly exported. Disable/enable cycle required per plugin per host —
+operationally painful for users running on >2 machines (workstation, laptop,
+WSL2, CI).
+
+### Business Value
+
+Marketplace adoption depends on first-install ergonomics. Every "PARTIAL"
+banner that requires manual remediation is a churn risk. Env-var contract
+parity makes the marketplace fleet-deployable (CI, devcontainers, dotfiles).
+
+## Proposed Solution
+
+### High-Level Architecture
+
+Four coordinated workstreams, each independently shippable:
+
+1. **Env-fallback parity** — extend the 3-element wrapper pattern
+   (yellow-research/yellow-morph precedent) to yellow-composio and yellow-semgrep.
+   Composio requires architectural change: `type: http` → `type: stdio` via a
+   thin proxy shim that pipes stdio MCP JSON-RPC to the Composio HTTPS endpoint.
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Verified — no stdio↔HTTP MCP proxy precedent exists anywhere
+> in this repo. The only `${CLAUDE_PLUGIN_DATA}` usage is yellow-morph's
+> `bin/start-morph.sh` and `lib/install-morphmcp.sh`, which install a local
+> npm binary (not an HTTP proxy). Composio's stdio conversion will be a
+> novel pattern; reference implementations come from external packages
+> (see Phase 3 external notes). Also: yellow-research mcpServers block
+> spans lines 44–88 of `plugin.json` (plan originally cited 44–69).
+<!-- /deepen-plan -->
+
+<!-- deepen-plan: external -->
+> **Research:** Path B (stdio + proxy) is *more reliable* than Path A
+> (keep type:http with `${VAR}` in headers) because `${VAR}` substitution
+> in HTTP MCP `headers` fields is a confirmed Claude Code bug — see
+> [issue #51581](https://github.com/anthropics/claude-code/issues/51581)
+> (closed Apr 22 2026 as "completed" but no fix version cited) and the
+> still-open [#47789](https://github.com/anthropics/claude-code/issues/47789)
+> for `headersHelper` missing `${CLAUDE_PLUGIN_ROOT}`. Note: Composio's
+> *officially recommended* integration is `claude mcp add --transport http
+> composio https://connect.composio.dev/mcp --header "x-consumer-api-key:
+> KEY"` — Path B diverges from upstream guidance. Trade-off is acceptable
+> for env-var-fallback parity but should be documented in
+> `plugins/yellow-composio/CLAUDE.md`.
+<!-- /deepen-plan -->
+
+2. **Status-file protocol + drift detection** — define
+   `${CLAUDE_PLUGIN_DATA}/credential-status.json` schema; each credential-bearing
+   plugin emits one via a SessionStart hook. `/setup:all` reads these files
+   directly (no keychain probing).
+
+<!-- deepen-plan: external -->
+> **Research:** `${CLAUDE_PLUGIN_DATA}` is the officially documented
+> persistent plugin-state directory
+> ([plugins-reference](https://code.claude.com/docs/en/plugins-reference)).
+> Two open bugs to track: [#41156](https://github.com/anthropics/claude-code/issues/41156)
+> triggers a protected-directory prompt on writes even in
+> `bypassPermissions` mode (still open May 2026), and
+> [#51398](https://github.com/anthropics/claude-code/issues/51398) reports
+> `${CLAUDE_PLUGIN_DATA}` is session-scoped (not persistent) in Cowork
+> Desktop. Status-file hooks should fail gracefully when writes fail and
+> not block SessionStart.
+<!-- /deepen-plan -->
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** No `credential-status.json` prototype exists anywhere in
+> the repo today. The only similar pattern is yellow-composio's
+> `.claude/composio-usage.json` (project-local, not `${CLAUDE_PLUGIN_DATA}`).
+> The plan correctly chooses `${CLAUDE_PLUGIN_DATA}` (cross-project,
+> per-plugin) over project-local for credential status.
+<!-- /deepen-plan -->
+3. **`/setup:all` enhancements** — version-drift detection via
+   `claude plugin list --json --available` (cached to
+   `${CLAUDE_PLUGIN_DATA}/version-check-cache.json` with 24h TTL);
+   browser-test heuristic with proactive "create local.md?" prompt;
+   classification block updates for composio/semgrep/research using new
+   status files.
+4. **Multi-host fleet SKILL.md** — comprehensive env-var contract reference
+   for workstations + CI + ephemeral sandboxes. Tool-agnostic (direnv +
+   shell rc primary; 1Password/Vault optional alternatives).
+
+### Key Design Decisions
+
+| # | Decision | Choice | Rationale |
+|---|----------|--------|-----------|
+| D1 | Composio architecture | `type: stdio` + proxy shim (Path B) | Only path that supports the 3-element fallback. User-confirmed in planning. |
+| D2 | browser-test exclusion | Permanent omit + proactive recommendation | User-confirmed "auto-detect and exclude." Re-scan adds a recommend-include step when web signals appear. |
+| D3 | `plugin list --json --available` cache | 24h TTL at `${CLAUDE_PLUGIN_DATA}/version-check-cache.json` | Balances freshness with performance — version drift rarely changes within a day. |
+| D4 | Status-file protocol | `${CLAUDE_PLUGIN_DATA}/credential-status.json` schema below | Defined once, used by all plugins; setup:all reads via jq. |
+| D5 | Composio empty-URL wrapper | Exit non-zero, block MCP start | Prevents cascade failure to `claude doctor`. Trade graceful degradation for blast-radius containment. |
+| D6 | Validator rules | Warning, not blocking | Future-proofing for new plugins; non-blocking avoids churn for existing manifests. |
+| D7 | Env-var contract docs | New `plugins/yellow-core/skills/multi-host-fleet/SKILL.md` + table in `AGENTS.md` | Single source of truth for the contract; per-plugin READMEs reference the skill. |
+
+### Trade-offs Considered
+
+- **Composio proxy shim adds a dependency.** Verified: `@composio/mcp` or a
+  ~30-line hand-rolled proxy in `bin/composio-proxy.mjs` can pipe stdio MCP to
+  Composio's HTTPS endpoint. Per-session startup cost is one Node process
+  (negligible).
+- **Status files vs. live keychain probing.** Status files require SessionStart
+  hook to have fired at least once. First-install state is ambiguous. Mitigation:
+  setup:all treats "file absent" as "credential status unknown — restart Claude
+  Code to populate."
+- **`required: true` removal.** Composio currently uses `required: true` on
+  both fields. Per research, this fires at MCP startup not install. Removing it
+  (in favor of wrapper-side empty-string detection) makes the plugin install
+  gracefully without prompting confusion when users dismiss prompts.
+
+### Status File Schema (D4)
+
+```json
+{
+  "plugin": "yellow-composio",
+  "version": "1.3.0",
+  "session_ts": "2026-05-11T22:08:35Z",
+  "credentials": [
+    {
+      "field": "composio_mcp_url",
+      "source": "userConfig",
+      "present": true,
+      "valid": true
+    },
+    {
+      "field": "composio_api_key",
+      "source": "shell_env",
+      "present": true,
+      "valid": null
+    }
+  ]
+}
+```
+
+- `source`: one of `userConfig`, `shell_env`, `absent`
+- `present`: boolean — non-empty value resolved from either path
+- `valid`: optional — `null` if unverified, `true` after a live probe,
+  `false` if probe failed
+- File is rewritten on every SessionStart (no append; full overwrite)
+- Cleanup: file deleted on `/plugin disable`; recreated on next SessionStart
+
+## Implementation Plan
+
+### Phase 1: Status-File Protocol Foundation
+
+- [ ] 1.1 Author `docs/plugin-credential-status-protocol.md` documenting the
+       schema, invalidation rules, and reader/writer responsibilities.
+- [ ] 1.2 Add a reusable Bash helper at
+       `plugins/yellow-core/lib/credential-status.sh` exposing
+       `write_credential_status(plugin, version, fields_json)` for hooks to
+       call. Source from `${CLAUDE_PLUGIN_ROOT}/lib/credential-status.sh`.
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** `plugins/yellow-core/lib/` directory does NOT exist today.
+> Only `plugins/yellow-morph/lib/` exists (`install-morphmcp.sh`). Phase 1.2
+> creates the `yellow-core/lib/` directory from scratch. Follow yellow-morph's
+> sourcing precedent: `source "${CLAUDE_PLUGIN_ROOT}/lib/credential-status.sh"`.
+<!-- /deepen-plan -->
+- [ ] 1.3 Unit test the helper with bats: file absent → write succeeds;
+       file present + new schema → overwrite preserves valid JSON; jq
+       missing → falls back to printf-based JSON construction with
+       conservative defaults.
+- [ ] 1.4 Add reference snippet to `AGENTS.md` "Credential Status Protocol"
+       section so future plugins follow the same shape.
+
+### Phase 2: yellow-semgrep Env-Fallback Fix (lowest-risk, highest-value)
+
+- [ ] 2.1 Add `plugins/yellow-semgrep/bin/start-semgrep.sh` mirroring the
+       `start-perplexity.sh` pattern:
+       userConfig wins → shell env fallback → unset empty before exec.
+- [ ] 2.2 Update `plugins/yellow-semgrep/.claude-plugin/plugin.json`:
+       - Replace `"command": "semgrep", "args": ["mcp"]` with
+         `"command": "${CLAUDE_PLUGIN_ROOT}/bin/start-semgrep.sh"`
+       - Replace `"SEMGREP_APP_TOKEN": "${user_config.semgrep_app_token}"`
+         with `_USERCONFIG` + bare-env-passthrough pair
+- [ ] 2.3 Add SessionStart hook `hooks/write-credential-status.sh` invoking
+       the lib helper. Wire in `plugin.json.hooks.SessionStart`.
+- [ ] 2.4 Mark `chmod +x bin/start-semgrep.sh hooks/write-credential-status.sh`;
+       add to `.gitattributes` LF rule.
+- [ ] 2.5 Update `plugins/yellow-semgrep/CLAUDE.md` documenting the env-var
+       contract and that `SEMGREP_APP_TOKEN` env now takes effect as a
+       fallback when userConfig is empty.
+- [ ] 2.6 Bats test: wrapper exec env where userConfig empty + shell env
+       set → `SEMGREP_APP_TOKEN` non-empty in exec environment.
+
+### Phase 3: yellow-composio Stdio Conversion + Env Fallback
+
+- [ ] 3.1 Spike: verify `@composio/mcp` (or equivalent) exposes a stdio MCP
+       relay accepting `--url` and `--header` flags. If not, write
+       `plugins/yellow-composio/bin/composio-proxy.mjs` (~30 LoC stdio↔HTTPS
+       proxy using Node's built-in `https` and `process.stdin`/`stdout`).
+
+<!-- deepen-plan: external -->
+> **Research:** Spike inputs identified:
+> - `@composio/mcp@1.0.9` (npm, ISC license, 9.1K weekly downloads, 7
+>   Composio maintainers, last published Aug 2025) — has `setup.ts` and
+>   `start.ts` CLI subcommands. The `start` subcommand is the likely stdio
+>   relay entrypoint. Expected invocation form (per OpenClaw integration):
+>   `npx @composio/mcp@1.0.9 start --api-key $KEY` — but exact flags need
+>   empirical verification because the package's public docs only cover the
+>   `setup` subcommand.
+> - `composio-mcp` (separate npm package referenced in OpenClaw's
+>   `mcporter.json` as `{"command": "composio-mcp", "args": ["--api-key",
+>   "KEY"], "transport": "stdio"}` proxying to
+>   `https://connect.composio.dev/mcp`). Treat with moderate confidence —
+>   may be an alias for `@composio/mcp`.
+> - Generic fallback: [`mcp-proxy`](https://www.npmjs.com/package/mcp-proxy)
+>   (npm v6.4.6) or PyPI v0.11.0 (287K downloads/month) — well-maintained
+>   stdio↔Streamable HTTP/SSE bridge. Used by FastMCP.
+> - Hand-roll reference: [inference-sh/mcp-bridge](https://github.com/inference-sh/mcp-bridge)
+>   (MIT) — closest single-file reference for stdio→HTTP POST with auth
+>   header. Hand-roll budget realistic at **60–120 LoC** (not the 30 LoC
+>   originally claimed in this plan).
+> - Spike order: try `npx @composio/mcp@latest start --help` first to
+>   confirm the relay flags exist. If not, evaluate `mcp-proxy` next. Hand-roll
+>   only if both fail.
+<!-- /deepen-plan -->
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** No stdio↔HTTP proxy precedent anywhere in this repo. The
+> only `${CLAUDE_PLUGIN_DATA}` consumer is yellow-morph's wrapper that runs
+> an npm-installed binary locally — fundamentally different from the
+> network-proxy pattern needed here. yellow-composio will be establishing
+> a new pattern; document the rationale prominently in
+> `plugins/yellow-composio/CLAUDE.md` for future maintainers.
+<!-- /deepen-plan -->
+- [ ] 3.2 Convert `plugins/yellow-composio/.claude-plugin/plugin.json`
+       `mcpServers.composio-server`:
+       - `"type": "stdio"` (or omit; stdio is default for command-type)
+       - `"command": "${CLAUDE_PLUGIN_ROOT}/bin/start-composio.sh"`
+       - Add `env` block with the 4 entries from the Path B preview
+         (`COMPOSIO_MCP_URL_USERCONFIG`, `COMPOSIO_MCP_URL`,
+         `COMPOSIO_API_KEY_USERCONFIG`, `COMPOSIO_API_KEY`)
+       - Drop `"url"` and `"headers"` blocks
+       - Drop `"required": true` from both userConfig fields (per research:
+         required fires at startup not install; wrapper handles graceful
+         OFFLINE state)
+- [ ] 3.3 Author `plugins/yellow-composio/bin/start-composio.sh`:
+       - Resolve userConfig → shell env precedence for both URL and API key
+       - If URL is empty OR non-HTTPS → printf clear error to stderr and
+         `exit 1` (blocks MCP start, no cascade to `claude doctor`)
+       - exec the proxy with resolved values
+
+<!-- deepen-plan: external -->
+> **Research:** MCP stdio transport framing per the
+> [MCP transports spec](https://modelcontextprotocol.io/docs/concepts/transports):
+> "Stdio messages are delimited by newlines and must not contain embedded
+> newlines." Newline-delimited JSON, NOT Content-Length framed (LSP-style).
+> One JSON-RPC object per line. If hand-rolling the proxy, this is the
+> framing contract — `readline.createInterface({input: process.stdin})`
+> and `console.log(JSON.stringify(...))` are correct primitives. Composio's
+> `https://connect.composio.dev/mcp` endpoint is request/response HTTP
+> (no persistent SSE/WebSocket required) — confirmed across Claude Code,
+> Codex, Vercel AI SDK, and OpenClaw integration docs. Proxy can use plain
+> Node 18+ `fetch()` with `await response.json()`.
+<!-- /deepen-plan -->
+- [ ] 3.4 Update `plugins/yellow-composio/hooks/check-mcp-url.sh` to also
+       write the status file (or replace with a single SessionStart hook
+       that does both warning + status emission).
+- [ ] 3.5 Update `plugins/yellow-composio/CLAUDE.md`, README, and the
+       command surface (`/composio:setup`, `/composio:status`) to reflect
+       the new env-var contract (`COMPOSIO_MCP_URL`, `COMPOSIO_API_KEY`).
+- [ ] 3.6 Migration note in changeset: existing users with a working
+       userConfig install will be unaffected. Users on legacy install
+       paths with `type: http` cached must run
+       `/plugin disable yellow-composio && /plugin enable yellow-composio`
+       after update.
+- [ ] 3.7 Bats test: wrapper blocks startup with empty URL; wrapper resolves
+       shell env when userConfig empty; wrapper rejects non-HTTPS URL.
+
+### Phase 4: yellow-research Status File (env detection upgrade)
+
+- [ ] 4.1 Add SessionStart hook at
+       `plugins/yellow-research/hooks/write-credential-status.sh` emitting
+       status for all 3 keys (perplexity, tavily, exa) + ceramic OAuth
+       state + parallel OAuth state + ast-grep availability.
+- [ ] 4.2 No `plugin.json` changes needed (3-element fallback is already in
+       place). Just wire the hook.
+- [ ] 4.3 Verify the SessionStart hook reads `CLAUDE_PLUGIN_OPTION_*` for
+       userConfig presence detection without needing the keychain.
+
+### Phase 5: `/setup:all` Dashboard Updates
+
+- [ ] 5.1 Add a Step 1 sub-block (after env-var probes) that reads each
+       credential-bearing plugin's status file:
+       ```bash
+       for plugin in yellow-research yellow-composio yellow-semgrep yellow-morph; do
+         status_file="$HOME/.claude/plugins/data/${plugin}/credential-status.json"
+         if [ -f "$status_file" ]; then
+           # jq extract: present count, source breakdown
+         else
+           # file absent → label "credential status unknown"
+         fi
+       done
+       ```
+- [ ] 5.2 Update yellow-research classification block (lines 304-320 of
+       `commands/setup/all.md`): READY = (status file shows ≥6/6 sources
+       present) OR (legacy fallback to current shell-env-only check).
+- [ ] 5.3 Update yellow-composio classification block (lines 370-375):
+       NEEDS SETUP = status file shows URL absent OR file absent.
+       PARTIAL = URL present, API key absent.
+       READY = both present + ToolSearch confirms `mcp__plugin_yellow-composio_*` visible.
+- [ ] 5.4 Add yellow-semgrep classification using status file (currently
+       relies on shell env probe only).
+- [ ] 5.5 Add Step 1.7 (new): version-drift check via
+       `claude plugin list --json --available 2>/dev/null | jq ...`
+       cached to `~/.claude/plugins/data/yellow-core/version-check-cache.json`
+       with 24h TTL. On miss/staleness, run live. Report per-plugin:
+       CURRENT / OUTDATED (with available version) / UNKNOWN.
+
+<!-- deepen-plan: external -->
+> **Research:** `claude plugin list --json --available` schema partially
+> documented. Confirmed fields per `installed` entry: `id` (string),
+> `version` (string), `scope` (`"user"|"project"|"local"`), `enabled`
+> (boolean), `installPath` (string). The `available` array structure is
+> not directly observed in public docs but likely mirrors marketplace.json
+> fields (`name`, `description`, `version`, `repository`). Flag stability:
+> confirmed stable in current Claude Code (used by Claude Desktop VM per
+> [#31408](https://github.com/anthropics/claude-code/issues/31408)).
+> [Plugins reference](https://code.claude.com/docs/en/plugins-reference)
+> documents the flag but not the full output schema — Phase 5.5 spike
+> should run `claude plugin list --json --available > /tmp/sample.json`
+> on a host with both updated and outdated plugins and snapshot the actual
+> schema into the protocol doc.
+<!-- /deepen-plan -->
+<!-- deepen-plan: codebase -->
+> **Codebase:** Line numbers verified against `commands/setup/all.md`:
+> yellow-semgrep block lines **296–300**, yellow-research block lines
+> **302–321** (plan originally said 304–320 — start is 302, not 304),
+> yellow-browser-test block lines **359–363** (plan said 359–364; 363 is
+> the actual end), yellow-composio block lines **370–375** (exact match).
+> Step 1.5 ToolSearch probes (line 221+) currently run exactly 5: linear's
+> `list_user_organizations`, `list_teams`, parallel's `createDeepResearch`,
+> `ast-grep__find_code`, `ceramic_search`. Phase 5.5/5.6 must add probes
+> here, not at a different location.
+<!-- /deepen-plan -->
+
+- [ ] 5.6 Update yellow-browser-test classification (lines 359-364):
+       run web-app heuristic scan FIRST. If no signals AND
+       `.claude/yellow-browser-test.local.md` absent → omit from dashboard
+       entirely (no PARTIAL/NEEDS SETUP row). If signals present + file
+       absent → emit "RECOMMENDED: web app detected; run
+       `/browser-test:setup` to enable testing."
+       Heuristic signals (any one positive):
+       - `package.json` deps match
+         `(next|react|vue|svelte|astro|nuxt|remix|express|fastify|koa|hono|gatsby|vite|webpack-dev-server|@angular/core|lit|solid-js|preact|alpinejs)`
+       - `vercel.json`, `netlify.toml`, `fly.toml`, `render.yaml` present
+       - `Gemfile` contains `rails`
+       - `requirements.txt` or `pyproject.toml` matches
+         `django|flask|fastapi|starlette|sanic`
+       - `go.mod` matches `gin-gonic|echo|fiber|chi|gorilla/mux`
+       - `Cargo.toml` matches `axum|actix-web|rocket|warp`
+       - `docker-compose.yml` has any service with HTTP port mapping
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** The `app-discoverer` agent at
+> `plugins/yellow-browser-test/agents/testing/app-discoverer.md` already
+> handles some of these signals (Rails `config/routes.rb`, Django `urls.py`
+> mentioned in example at line 24). The "If no `package.json`" block at
+> **lines 63–78** is the augmentation point for `go.mod`, `Cargo.toml`,
+> `fly.toml`, `requirements.txt`, and `pyproject.toml` Python detection.
+> Update the dashboard heuristic AND this agent together to keep
+> classification and discovery in sync.
+<!-- /deepen-plan -->
+
+- [ ] 5.7 Add a Step 4 (new): consolidated remediation block. If any
+       outdated plugins, print one consolidated `/plugin update <name>`
+       command list. If any drift-detector status files show
+       newly-added userConfig fields, print one consolidated
+       `/plugin disable <name> && /plugin enable <name>` command list.
+
+### Phase 6: Multi-Host SKILL.md
+
+- [ ] 6.1 Create `plugins/yellow-core/skills/multi-host-fleet/SKILL.md` with
+       three standard headings:
+       - `## What It Does`: Document env-var contract for fleet-deployable
+         plugins.
+       - `## When to Use`: New host setup, CI deployment, devcontainer,
+         WSL2 + Windows duality, ephemeral sandbox bootstrap.
+       - `## Usage`: Three subsections:
+         - `### Dev hosts (dotfiles + shell rc + direnv)`
+         - `### CI/CD (GitHub Actions secrets, GitLab CI variables,
+           devcontainer.json)`
+         - `### Secrets managers (1Password CLI op run, Vault envconsul,
+           Doppler, generic env-file pattern)` — tool-agnostic; brief
+           per-tool example
+- [ ] 6.2 Include canonical env-var contract table for all credential-bearing
+       plugins:
+       | Plugin | Env Var | userConfig field | Type |
+       |--------|---------|------------------|------|
+       | yellow-research | `EXA_API_KEY` | `exa_api_key` | sensitive |
+       | yellow-research | `TAVILY_API_KEY` | `tavily_api_key` | sensitive |
+       | yellow-research | `PERPLEXITY_API_KEY` | `perplexity_api_key` | sensitive |
+       | yellow-research | `CERAMIC_API_KEY` | (none; OAuth + REST probe) | optional |
+       | yellow-morph | `MORPH_API_KEY` | `morph_api_key` | sensitive |
+       | yellow-semgrep | `SEMGREP_APP_TOKEN` | `semgrep_app_token` | sensitive |
+       | yellow-composio | `COMPOSIO_MCP_URL` | `composio_mcp_url` | non-sensitive |
+       | yellow-composio | `COMPOSIO_API_KEY` | `composio_api_key` | sensitive |
+       | yellow-devin | `DEVIN_SERVICE_USER_TOKEN`, `DEVIN_ORG_ID` | (none) | sensitive (env-only) |
+- [ ] 6.3 Add an `## Examples` subsection with a complete `.envrc` and
+       `.zshrc` snippet (commented, so users can selectively enable).
+- [ ] 6.4 Cross-reference: mention in
+       `plugins/yellow-core/skills/mcp-health-probe/SKILL.md` and
+       `plugins/yellow-research/CLAUDE.md`, README files.
+
+### Phase 7: Validator Additions (D6 — warnings, not blocking)
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** `scripts/validate-plugin.js` is 1122 lines with rules
+> numbered RULE 1–11 in comments. Existing mcpServers parsing at lines
+> **618–628** only does path validation; no content inspection. New rules
+> should be RULE 12+ inserted between the end of RULE 11 (line 1004) and
+> the summary block (line 1006). Entry point is `validatePlugin()` at
+> line 485. New rules iterate `manifest.mcpServers` and inspect `env`
+> values for bare `${user_config.xxx}` patterns (no `_USERCONFIG` suffix
+> alongside a `${VAR:-}` passthrough = warning).
+<!-- /deepen-plan -->
+
+- [ ] 7.1 Add a `validate-plugin.js` rule (warning only):
+       userConfig fields marked `required: true` AND `sensitive: true` SHOULD
+       have an associated wrapper script + env-passthrough block. Emit
+       `[warn] yellow-composio: composio_api_key is required+sensitive but no
+       shell env fallback found — consider 3-element fallback pattern.`
+- [ ] 7.2 Add a `validate-plugin.js` rule (warning only):
+       MCP server `command` blocks that interpolate `${user_config.X}`
+       directly (not via wrapper script) miss the empty-string-unset
+       safety. Recommend wrapper indirection.
+- [ ] 7.3 Test fixtures in `tests/unit/validate-plugin/`:
+       - `fixture-required-no-fallback.json` (expects 1 warning)
+       - `fixture-required-with-wrapper.json` (expects 0 warnings)
+       - `fixture-direct-substitution.json` (expects 1 warning)
+- [ ] 7.4 Update `docs/plugin-validation-guide.md` documenting the two new
+       warning categories.
+
+### Phase 8: Migration, Documentation, Release
+
+- [ ] 8.1 Add `docs/solutions/build-errors/userconfig-required-fires-at-startup-not-install.md`
+       documenting the GH #39827 + #39455 behavior and the wrapper-pattern
+       workaround.
+- [ ] 8.2 Update `AGENTS.md` "Critical Agent Authoring Rules" with a new
+       entry: "Credential-bearing MCPs must use the 3-element wrapper
+       pattern; see multi-host-fleet SKILL.md."
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** `AGENTS.md` is 306 lines. Two candidate insertion points:
+> "Plugin Manifest Rules" section starting at line **159** (preferred —
+> the rule is about manifest shape, not security policy) or "Security &
+> Prompt-Injection Rules" at line **216** (already lists `SEMGREP_APP_TOKEN`
+> and `MORPH_API_KEY` in the never-commit list at line 238). Use the
+> Plugin Manifest Rules location. Also: `.changeset/` currently has only
+> `config.json` (no pending changesets), and the per-plugin changeset
+> shape follows `@changesets/changelog-github` format.
+<!-- /deepen-plan -->
+- [ ] 8.3 Per-plugin changesets:
+       - yellow-semgrep: minor (env-fallback added)
+       - yellow-composio: minor (env-fallback + stdio conversion;
+         migration note in changeset)
+       - yellow-research: patch (SessionStart hook only; no behavioral
+         change)
+       - yellow-core: minor (setup:all enhancements + new SKILL.md)
+- [ ] 8.4 Update root `README.md` if env-var contract belongs on the
+       front page (skip if it's discoverable via the skill).
+- [ ] 8.5 Run `pnpm release:check` and `pnpm validate:setup-all` per Phase.
+
+## Technical Specifications
+
+### Files to Modify
+
+- `plugins/yellow-semgrep/.claude-plugin/plugin.json` — env block rewrite,
+  command→wrapper, hooks block added
+- `plugins/yellow-semgrep/CLAUDE.md` — env-var contract section
+- `plugins/yellow-composio/.claude-plugin/plugin.json` — type:http →
+  command+stdio, env block, required:true removal
+- `plugins/yellow-composio/hooks/check-mcp-url.sh` — also emit status file
+- `plugins/yellow-composio/CLAUDE.md` and `README.md` — env-var contract,
+  migration note
+- `plugins/yellow-research/hooks/` — new SessionStart hook (or extend
+  existing if any)
+- `plugins/yellow-core/commands/setup/all.md` — Step 1.5 status-file
+  readers, Step 1.7 version drift, Step 4 consolidated remediation,
+  classification block updates for browser-test/research/composio/semgrep
+- `AGENTS.md` — credential-status protocol reference, new authoring rule
+- `docs/plugin-validation-guide.md` — two new warning categories
+- `scripts/validate-plugin.js` — two new rules (warnings only)
+
+### Files to Create
+
+- `plugins/yellow-core/lib/credential-status.sh` — reusable Bash helper
+- `plugins/yellow-semgrep/bin/start-semgrep.sh` — wrapper
+- `plugins/yellow-semgrep/hooks/write-credential-status.sh` — SessionStart
+- `plugins/yellow-composio/bin/start-composio.sh` — wrapper
+- `plugins/yellow-composio/bin/composio-proxy.mjs` — stdio↔HTTPS proxy
+  (if external relay not viable)
+- `plugins/yellow-research/hooks/write-credential-status.sh` — SessionStart
+- `plugins/yellow-core/skills/multi-host-fleet/SKILL.md` — fleet doc
+- `docs/plugin-credential-status-protocol.md` — protocol spec
+- `docs/solutions/build-errors/userconfig-required-fires-at-startup-not-install.md`
+- Bats test files in `plugins/yellow-semgrep/tests/`,
+  `plugins/yellow-composio/tests/`, `plugins/yellow-core/tests/`
+
+### Dependencies
+
+- No new external runtime deps if `composio-proxy.mjs` is hand-rolled
+  (~30 LoC, Node 18+ builtin `https`, `process.stdin/stdout`).
+- If external relay package is chosen (Phase 3.1 spike outcome), pin via
+  `npx -y @composio/mcp@<version>` and document supported range.
+
+### API Changes
+
+**Composio MCP transport: HTTP → stdio.** Externally observable change
+(invisible to tool callers; same MCP tool surface). MCP client (Claude
+Code) connects via stdio to wrapper → wrapper proxies stdio JSON-RPC to
+Composio's HTTPS endpoint. No tool name changes.
+
+### Database Changes
+
+N/A.
+
+## Testing Strategy
+
+### Unit Tests
+
+- `credential-status.sh` lib: file absence, presence, malformed JSON,
+  schema field validation, jq absence fallback
+- `validate-plugin.js` new rules: fixture-based test additions
+- `start-semgrep.sh`, `start-composio.sh` wrapper precedence (bats)
+
+### Integration Tests
+
+- `tests/integration/setup-all.test.ts`: mock status files in temp
+  `${CLAUDE_PLUGIN_DATA}` directories, run setup:all classification, assert
+  output reports correct READY/PARTIAL/NEEDS SETUP
+- Composio proxy round-trip test: stdio JSON-RPC → HTTPS → response (uses
+  test fixture server)
+
+### Manual Testing Checklist
+
+- [ ] Fresh install on Linux WSL2 with no shell env, answer userConfig
+       prompts for all credential-bearing plugins → all READY
+- [ ] Fresh install with all shell env vars exported, dismiss all userConfig
+       prompts → all READY (env-fallback works end-to-end)
+- [ ] Upgrade from yellow-composio v1.2.x (`type: http`) to v1.3.0
+       (`type: stdio`) → MCP still works after `/plugin update` +
+       Claude Code restart; status file populated after first SessionStart
+- [ ] Dotfiles repo (no web app) → yellow-browser-test omitted from
+       dashboard entirely; no NEEDS SETUP banner
+- [ ] React project with no `.claude/yellow-browser-test.local.md` →
+       RECOMMENDED banner with "/browser-test:setup" suggestion
+- [ ] Stale plugin install (version drift detected) → consolidated
+       `/plugin update` list shown in Step 4
+
+## Acceptance Criteria
+
+1. yellow-semgrep + yellow-composio honor shell env as a fallback when
+   userConfig is empty. Verified by wrapper exec env test and live MCP
+   startup with `SEMGREP_APP_TOKEN`/`COMPOSIO_API_KEY` exported.
+2. yellow-composio with empty URL fails to start (wrapper exits non-zero)
+   instead of cascading to `claude doctor` failures for other MCPs.
+   Verified by `claude doctor` output before/after on a host with empty
+   composio URL.
+3. `/setup:all` correctly classifies yellow-research as READY when keys
+   are in keychain (not shell env). Verified by setup-all output diff.
+4. `/setup:all` omits yellow-browser-test from the dashboard on
+   non-web-app repos. Verified by running in dotfiles repo with no
+   web-app signals.
+5. `/setup:all` reports plugin version drift when installed < catalog
+   (with 24h cache). Verified by mocking outdated installed_plugins.json.
+6. Multi-host SKILL.md is discoverable via `find-skills` and lists every
+   credential-bearing plugin's env-var contract. Verified by
+   `pnpm validate:agents`.
+7. `pnpm release:check`, `pnpm validate:setup-all`, `pnpm test:unit`,
+   `pnpm test:integration` all pass.
+
+## Edge Cases & Error Handling
+
+- **First-install state (no status file yet):** setup:all labels affected
+  plugins "credential status unknown — restart Claude Code to populate."
+  Not an error; expected ambiguity.
+- **macOS keychain not readable from Bash:** setup:all does NOT attempt
+  `security find-generic-password`. Relies on status file (SessionStart
+  hook can read `CLAUDE_PLUGIN_OPTION_*` from its own subprocess env).
+- **Inter-session window after `/plugin update`:** New userConfig fields
+  added in an upgrade do not auto-re-prompt. setup:all Step 4 detects
+  this via status file diff (fields in plugin.json not in status file)
+  and emits "run `/plugin disable && /plugin enable`."
+- **`claude plugin list` not available (older Claude Code):** Step 1.7
+  feature-detects via `command -v claude && claude plugin list --help`;
+  silently skips version-drift check if unsupported.
+- **Composio proxy crash mid-session:** stdio MCPs reconnect automatically.
+  Wrapper exits cleanly; Claude Code restarts the process. Status file
+  remains valid (last-known SessionStart state).
+- **`${VAR}` substitution broken in HTTP MCP `headers` (Path A
+  alternative):** Confirmed Claude Code bug — see
+  [#51581](https://github.com/anthropics/claude-code/issues/51581) and
+  [#47789](https://github.com/anthropics/claude-code/issues/47789).
+  This is why Path B (wrapper + stdio) is the only reliable path for
+  env-var fallback on yellow-composio. Document this rationale in
+  `plugins/yellow-composio/CLAUDE.md` so future maintainers understand
+  why the plugin diverges from Composio's official `--transport http`
+  recommendation.
+- **`${CLAUDE_PLUGIN_DATA}` write permission prompt
+  ([#41156](https://github.com/anthropics/claude-code/issues/41156),
+  open):** SessionStart hooks writing the status file may trigger a
+  protected-directory prompt in restricted permission modes. Hook must
+  fail gracefully (write attempt → `2>/dev/null || true` → emit
+  `{"continue": true}` regardless) so SessionStart never blocks the
+  session.
+- **`${CLAUDE_PLUGIN_DATA}` not persistent in Cowork Desktop
+  ([#51398](https://github.com/anthropics/claude-code/issues/51398),
+  open):** In Cowork Desktop sessions the directory is session-scoped.
+  setup:all should treat "status file absent" as expected, not as
+  configuration-error.
+- **WSL2 CRLF on new `.sh` and `.mjs` files:** Normalize per existing
+  protocol (`sed -i 's/\r$//'`); add a Phase 8.6 task if not already
+  enforced by repo `.gitattributes`.
+
+## Performance Considerations
+
+- `claude plugin list --json --available` is a network call; cached with
+  24h TTL. Setup:all worst case adds one HTTP fetch per day per workspace.
+- Status-file reads in setup:all add ~5-10 jq calls in Step 1 — sub-100ms
+  overhead.
+- Composio proxy adds a Node startup per session (~200ms cold start).
+  Acceptable for non-hot-path MCP.
+
+## Security Considerations
+
+- Wrapper unsets empty-string env vars before exec — preserves
+  "absent vs. explicitly empty" distinction that MCP servers may rely on.
+- Composio wrapper exits non-zero on non-HTTPS URL — prevents API key
+  leakage over cleartext.
+- Status file lives under `${CLAUDE_PLUGIN_DATA}` (0700 dir on Linux);
+  contains source labels (`userConfig`/`shell_env`/`absent`) but NEVER
+  the credential value itself. Validate this in Phase 1.3 schema test.
+- Env vars are visible to MCP subprocesses (same as existing
+  yellow-research pattern); document in multi-host SKILL.md security
+  section as expected behavior.
+
+## Migration & Rollback
+
+### Deployment Steps
+
+Each phase ships as an independent PR; Phase 1 (foundation) is the only
+blocking dependency. Phases 2–4 can ship in parallel after Phase 1
+merges. Phase 5 depends on Phases 2–4 (needs status files in place).
+Phase 6 and 7 are independent. Phase 8 ships last.
+
+Recommended order: 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8. PRs 2 and 3 can stack
+behind 1 in a Graphite stack; PRs 4–8 sequential.
+
+### Rollback Procedure
+
+- yellow-semgrep: revert plugin.json + delete bin/, hooks/ additions. No
+  data migration needed.
+- yellow-composio: revert plugin.json (type:http restored) + delete
+  bin/, proxy. Existing userConfig values remain in keychain (no data
+  loss). Users keep working setups.
+- setup:all: revert all.md to prior commit. Status files become orphans
+  but harmless (Claude Code ignores files outside its schema).
+- Version cache: delete `~/.claude/plugins/data/yellow-core/version-check-cache.json`
+  to force re-fetch.
+
+### Breaking Changes
+
+- **Composio MCP transport change** (`type: http` → `type: stdio`): users
+  on legacy installs must run `/plugin disable && /plugin enable` after
+  Claude Code restart. Documented in v1.3.0 changeset.
+- **yellow-semgrep behavior change**: shell env `SEMGREP_APP_TOKEN` now
+  takes effect when userConfig is empty. Previously a no-op. Not breaking
+  per se but worth noting.
+- **`required: true` removed from yellow-composio fields**: install no
+  longer fails on dismissed prompts (it never did anyway per research,
+  but the schema-level signal is gone). Wrapper handles the empty-state
+  with a clear error message.
+
+## Stack Decomposition
+
+<!-- stack-topology: linear -->
+<!-- stack-trunk: main -->
+
+### 1. agent/feat/credential-status-protocol
+- **Type:** feat
+- **Description:** add credential-status protocol + yellow-core lib helper
+- **Scope:** plugins/yellow-core/lib/credential-status.sh, docs/plugin-credential-status-protocol.md, AGENTS.md, plugins/yellow-core/tests/credential-status.bats, .changeset/
+- **Tasks:** 1.1, 1.2, 1.3, 1.4
+- **Depends on:** (none)
+
+### 2. agent/fix/yellow-semgrep-env-fallback
+- **Type:** fix
+- **Description:** honor shell env as fallback for SEMGREP_APP_TOKEN
+- **Scope:** plugins/yellow-semgrep/.claude-plugin/plugin.json, plugins/yellow-semgrep/bin/start-semgrep.sh, plugins/yellow-semgrep/hooks/write-credential-status.sh, plugins/yellow-semgrep/CLAUDE.md, plugins/yellow-semgrep/tests/, .changeset/
+- **Tasks:** 2.1, 2.2, 2.3, 2.4, 2.5, 2.6
+- **Depends on:** #1
+
+### 3. agent/feat/yellow-composio-stdio-fallback
+- **Type:** feat
+- **Description:** convert yellow-composio to type:stdio with proxy + env fallback
+- **Scope:** plugins/yellow-composio/.claude-plugin/plugin.json (transport change), plugins/yellow-composio/bin/start-composio.sh, plugins/yellow-composio/bin/composio-proxy.mjs, plugins/yellow-composio/hooks/check-mcp-url.sh (status emit), plugins/yellow-composio/CLAUDE.md, plugins/yellow-composio/README.md, plugins/yellow-composio/tests/, .changeset/
+- **Tasks:** 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7
+- **Depends on:** #2
+
+### 4. agent/feat/yellow-research-status-hook
+- **Type:** feat
+- **Description:** emit credential-status.json from SessionStart for yellow-research
+- **Scope:** plugins/yellow-research/hooks/write-credential-status.sh, plugins/yellow-research/.claude-plugin/plugin.json (hooks block), plugins/yellow-research/CLAUDE.md, .changeset/
+- **Tasks:** 4.1, 4.2, 4.3
+- **Depends on:** #3
+
+### 5. agent/feat/setup-all-status-classification
+- **Type:** feat
+- **Description:** classify plugins via status files + version drift in /setup:all
+- **Scope:** plugins/yellow-core/commands/setup/all.md, plugins/yellow-browser-test/agents/testing/app-discoverer.md, .changeset/
+- **Tasks:** 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7
+- **Depends on:** #4
+
+### 6. agent/feat/validate-plugin-credential-warnings
+- **Type:** feat
+- **Description:** warn on required+sensitive userConfig fields without wrapper indirection
+- **Scope:** scripts/validate-plugin.js (RULE 12+13), packages/infrastructure tests, fixtures, docs/plugin-validation-guide.md
+- **Tasks:** 7.1, 7.2, 7.3, 7.4
+- **Depends on:** #5
+
+### 7. agent/docs/multi-host-fleet-skill
+- **Type:** docs
+- **Description:** multi-host fleet SKILL.md + migration solution doc + release notes
+- **Scope:** plugins/yellow-core/skills/multi-host-fleet/SKILL.md, docs/solutions/build-errors/userconfig-required-fires-at-startup-not-install.md, AGENTS.md, plugins/yellow-research/README.md, plugins/yellow-morph/README.md, plugins/yellow-semgrep/README.md, plugins/yellow-composio/README.md, .changeset/
+- **Tasks:** 6.1, 6.2, 6.3, 6.4, 8.1, 8.2, 8.3, 8.4, 8.5
+- **Depends on:** #6
+
+## Stack Progress
+<!-- Updated by workflows:work. Do not edit manually. -->
+- [x] 1. agent/feat/credential-status-protocol (completed 2026-05-13, PR #510)
+- [ ] 2. agent/fix/yellow-semgrep-env-fallback
+- [ ] 3. agent/feat/yellow-composio-stdio-fallback
+- [ ] 4. agent/feat/yellow-research-status-hook
+- [ ] 5. agent/feat/setup-all-status-classification
+- [ ] 6. agent/feat/validate-plugin-credential-warnings
+- [ ] 7. agent/docs/multi-host-fleet-skill
+
+## References
+
+- Research findings: `docs/research/claude-code-plugins-versioning-auto-upda.md`
+- Solution docs:
+  - `docs/solutions/build-errors/userconfig-type-title-remote-validator-drift.md`
+  - `docs/solutions/build-errors/userconfig-pattern-field-schema-extension.md`
+  - `docs/solutions/integration-issues/heredoc-delimiter-collision.md`
+- Brainstorms:
+  - `docs/brainstorms/2026-03-01-yellow-research-setup-mcp-health-checks-brainstorm.md`
+  - `docs/brainstorms/2026-05-06-ceramic-setup-all-coverage-audit-brainstorm.md`
+  - `docs/brainstorms/2026-03-04-setup-all-command-brainstorm.md`
+- Existing patterns to follow:
+  - `plugins/yellow-research/.claude-plugin/plugin.json` (3-element fallback)
+  - `plugins/yellow-research/bin/start-perplexity.sh` (wrapper precedence)
+  - `plugins/yellow-morph/.claude-plugin/plugin.json` + `bin/start-morph.sh`
+  - `plugins/yellow-core/skills/mcp-health-probe/SKILL.md` (OFFLINE/DEGRADED/HEALTHY)
+  - `plugins/yellow-core/skills/mcp-integration-patterns/SKILL.md`
+- Anthropic docs:
+  - https://code.claude.com/docs/en/plugins-reference (userConfig, env substitution, `${CLAUDE_PLUGIN_OPTION_*}`, `claude plugin list --json --available`)
+  - https://www.schemastore.org/claude-code-plugin-manifest.json (allowed userConfig fields)
+- Tracked GitHub issues (open as of 2026-05-11):
+  - anthropics/claude-code#39827 (userConfig prompt not shown on install)
+  - anthropics/claude-code#39455 (userConfig values not prompted on enable)
+  - anthropics/claude-code#31462 (plugin update detection workflow)
+  - anthropics/claude-code#15642 (CLAUDE_PLUGIN_ROOT stale after update)
+  - anthropics/claude-code#17361 (autoUpdate doesn't update what Claude reads)
+  - anthropics/claude-code#26744 (third-party marketplace auto-update bug, this repo's docs)
+
+<!-- deepen-plan: external -->
+> **Research:** Additional GitHub issues + external sources surfaced
+> during enrichment:
+> - [anthropics/claude-code#51581](https://github.com/anthropics/claude-code/issues/51581) —
+>   `${VAR}` not substituted in HTTP MCP `headers` (closed Apr 2026 as
+>   "completed"; specific fix version not cited)
+> - [anthropics/claude-code#47789](https://github.com/anthropics/claude-code/issues/47789) —
+>   `headersHelper` does not expand `${CLAUDE_PLUGIN_ROOT}` (open May 2026)
+> - [anthropics/claude-code#41156](https://github.com/anthropics/claude-code/issues/41156) —
+>   `${CLAUDE_PLUGIN_DATA}` protected-directory prompt in bypassPermissions
+>   (open)
+> - [anthropics/claude-code#51398](https://github.com/anthropics/claude-code/issues/51398) —
+>   `${CLAUDE_PLUGIN_DATA}` session-scoped in Cowork Desktop (open)
+>
+> External packages identified for Phase 3 spike:
+> - [`@composio/mcp@1.0.9`](https://www.npmjs.com/package/@composio/mcp)
+>   (npm, ISC, 9.1K weekly downloads, `start` and `setup` subcommands)
+> - [`composio-mcp`](https://composio.dev/content/how-to-use-composio-mcp-with-openclaw) —
+>   alternate package name documented in OpenClaw integration
+> - [`mcp-proxy`](https://www.npmjs.com/package/mcp-proxy) (npm v6.4.6) /
+>   [`mcp-proxy`](https://pypi.org/project/mcp-proxy/) (PyPI v0.11.0,
+>   287K downloads/month) — generic stdio↔HTTP bridge
+> - [`inference-sh/mcp-bridge`](https://github.com/inference-sh/mcp-bridge) —
+>   MIT, reference impl for stdio→HTTP POST + Bearer header
+>
+> MCP transport spec authoritative reference:
+> [modelcontextprotocol.io/docs/concepts/transports](https://modelcontextprotocol.io/docs/concepts/transports) —
+> stdio = newline-delimited JSON, one JSON-RPC object per line.
+>
+> Composio recommended Claude Code integration (diverged from in this plan
+> for env-var-fallback parity):
+> [docs.composio.dev/docs/composio-connect](https://docs.composio.dev/docs/composio-connect) —
+> `claude mcp add --scope user --transport http composio https://connect.composio.dev/mcp --header "x-consumer-api-key: KEY"`.
+<!-- /deepen-plan -->

--- a/plugins/yellow-core/lib/credential-status.sh
+++ b/plugins/yellow-core/lib/credential-status.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# yellow-core: credential-status helper.
+#
+# Source from a SessionStart hook to emit a credential-status.json file
+# describing which credential fields are populated for this plugin.
+#
+# Usage:
+#   source "${CLAUDE_PLUGIN_ROOT}/../yellow-core/lib/credential-status.sh"
+#   fields_json='[{"field":"foo_api_key","source":"userConfig","present":true,"valid":null}]'
+#   write_credential_status "yellow-foo" "1.2.3" "$fields_json"
+#
+# Contract:
+#   - Writes atomically (tmp + rename).
+#   - Never aborts on failure — readers handle "file absent" gracefully.
+#   - Never echoes credential values; only resolution sources.
+#
+# Note: -e omitted intentionally — hook must output {"continue": true} on
+# all paths. The caller is responsible for the final JSON emission.
+set -uo pipefail
+
+# Resolve the data directory for the given plugin.
+# Honors $CLAUDE_PLUGIN_DATA (canonical, per Claude Code docs) and falls
+# back to the documented disk path when unset (e.g., when sourced from a
+# bats test).
+_credstatus_resolve_dir() {
+  local plugin="${1:-}"
+  if [ -z "$plugin" ]; then
+    return 1
+  fi
+  if [ -n "${CLAUDE_PLUGIN_DATA:-}" ]; then
+    printf '%s' "$CLAUDE_PLUGIN_DATA"
+  else
+    printf '%s/.claude/plugins/data/%s' "${HOME:-/tmp}" "$plugin"
+  fi
+}
+
+# Compose the JSON document. Prefers jq when available so we get correct
+# escaping for free; falls back to printf for environments without jq.
+# The shell env passthrough cannot produce arbitrary user input here — the
+# only string inputs are the plugin name (from manifest) and version
+# (semver) — so printf-only fallback is safe.
+_credstatus_compose() {
+  local plugin="$1"
+  local version="$2"
+  local fields_json="$3"
+  local session_ts
+  session_ts=$(date -u +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || printf '1970-01-01T00:00:00Z')
+
+  if command -v jq >/dev/null 2>&1; then
+    jq -nc \
+      --arg plugin "$plugin" \
+      --arg version "$version" \
+      --arg session_ts "$session_ts" \
+      --argjson credentials "$fields_json" \
+      '{plugin: $plugin, version: $version, session_ts: $session_ts, credentials: $credentials}' \
+      2>/dev/null && return 0
+  fi
+
+  # Fallback: assume fields_json is already valid JSON (caller responsibility).
+  # Plugin and version are constrained by validate-plugin.js to safe chars.
+  printf '{"plugin":"%s","version":"%s","session_ts":"%s","credentials":%s}' \
+    "$plugin" "$version" "$session_ts" "$fields_json"
+}
+
+# Public API: write credential status for a plugin.
+# Args:
+#   $1: plugin name (e.g., "yellow-composio")
+#   $2: plugin version (e.g., "1.3.0")
+#   $3: credentials JSON array as a string
+# Returns 0 on success, 0 on any failure (intentional — never block SessionStart).
+write_credential_status() {
+  local plugin="${1:-}"
+  local version="${2:-}"
+  local fields_json="${3:-[]}"
+
+  if [ -z "$plugin" ] || [ -z "$version" ]; then
+    printf '[credential-status] Warning: plugin name and version are required\n' >&2
+    return 0
+  fi
+
+  local data_dir
+  data_dir=$(_credstatus_resolve_dir "$plugin") || {
+    printf '[credential-status] Warning: could not resolve data directory for %s\n' "$plugin" >&2
+    return 0
+  }
+
+  mkdir -p "$data_dir" 2>/dev/null || {
+    # GH issue #41156: writes may trigger a protected-directory prompt.
+    # Silently skip rather than blocking SessionStart.
+    printf '[credential-status] Warning: could not create %s (skipping status write)\n' "$data_dir" >&2
+    return 0
+  }
+
+  local doc
+  doc=$(_credstatus_compose "$plugin" "$version" "$fields_json") || {
+    printf '[credential-status] Warning: could not compose status document\n' >&2
+    return 0
+  }
+
+  local target="$data_dir/credential-status.json"
+  local tmp="${target}.tmp"
+
+  printf '%s\n' "$doc" >"$tmp" 2>/dev/null || {
+    printf '[credential-status] Warning: could not write %s\n' "$tmp" >&2
+    rm -f "$tmp" 2>/dev/null
+    return 0
+  }
+
+  mv -f "$tmp" "$target" 2>/dev/null || {
+    printf '[credential-status] Warning: could not rename %s -> %s\n' "$tmp" "$target" >&2
+    rm -f "$tmp" 2>/dev/null
+    return 0
+  }
+
+  return 0
+}
+
+# Compose a single credential field entry. Helper for hook authors who
+# want to build fields_json incrementally rather than emitting a single
+# heredoc.
+# Args:
+#   $1: field name
+#   $2: source ("userConfig" | "shell_env" | "absent")
+#   $3: present (true | false)
+#   $4: valid ("true" | "false" | "null"; default "null")
+credential_status_field() {
+  local field="${1:-}"
+  local source="${2:-absent}"
+  local present="${3:-false}"
+  local valid="${4:-null}"
+
+  if command -v jq >/dev/null 2>&1; then
+    jq -nc \
+      --arg field "$field" \
+      --arg source "$source" \
+      --argjson present "$present" \
+      --argjson valid "$valid" \
+      '{field: $field, source: $source, present: $present, valid: $valid}' \
+      2>/dev/null && return 0
+  fi
+
+  printf '{"field":"%s","source":"%s","present":%s,"valid":%s}' \
+    "$field" "$source" "$present" "$valid"
+}

--- a/plugins/yellow-core/lib/credential-status.sh
+++ b/plugins/yellow-core/lib/credential-status.sh
@@ -14,9 +14,24 @@
 #   - Never aborts on failure — readers handle "file absent" gracefully.
 #   - Never echoes credential values; only resolution sources.
 #
-# Note: -e omitted intentionally — hook must output {"continue": true} on
-# all paths. The caller is responsible for the final JSON emission.
-set -uo pipefail
+# Note: this file is intended to be sourced. It MUST NOT alter the caller's
+# shell options (no top-level `set -e`, `set -u`, `set -o pipefail`) — doing
+# so can break a SessionStart hook's required `{"continue": true}` emission
+# if the caller relied on default behavior. Functions below use ${var:-}
+# defaulting and explicit failure branches instead of relying on `set`.
+
+# Escape a value for safe embedding inside a JSON string literal. Handles
+# backslash, double-quote, and the two control characters most likely to
+# appear in plugin/version strings (newline, tab). Sufficient for the
+# printf fallback path; jq does its own escaping when available.
+_credstatus_json_escape() {
+  local s="${1:-}"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\t'/\\t}"
+  printf '%s' "$s"
+}
 
 # Resolve the data directory for the given plugin.
 # Honors $CLAUDE_PLUGIN_DATA (canonical, per Claude Code docs) and falls
@@ -34,11 +49,13 @@ _credstatus_resolve_dir() {
   fi
 }
 
-# Compose the JSON document. Prefers jq when available so we get correct
-# escaping for free; falls back to printf for environments without jq.
-# The shell env passthrough cannot produce arbitrary user input here — the
-# only string inputs are the plugin name (from manifest) and version
-# (semver) — so printf-only fallback is safe.
+# Compose the JSON document. Prefers jq when available — both for correct
+# escaping AND for fields_json validation. When jq is installed, a parse
+# failure (e.g., malformed fields_json) returns non-zero and the caller
+# skips the write rather than emitting invalid JSON via the printf path.
+# The printf fallback is reserved for environments where jq is not
+# installed; it escapes plugin/version but trusts that fields_json is
+# already valid JSON (caller responsibility, documented in the protocol).
 _credstatus_compose() {
   local plugin="$1"
   local version="$2"
@@ -47,19 +64,26 @@ _credstatus_compose() {
   session_ts=$(date -u +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || printf '1970-01-01T00:00:00Z')
 
   if command -v jq >/dev/null 2>&1; then
+    # When jq is available, treat parse/build failure as a hard error so
+    # we never overwrite a previously valid status file with garbage.
     jq -nc \
       --arg plugin "$plugin" \
       --arg version "$version" \
       --arg session_ts "$session_ts" \
       --argjson credentials "$fields_json" \
       '{plugin: $plugin, version: $version, session_ts: $session_ts, credentials: $credentials}' \
-      2>/dev/null && return 0
+      2>/dev/null
+    return $?
   fi
 
-  # Fallback: assume fields_json is already valid JSON (caller responsibility).
-  # Plugin and version are constrained by validate-plugin.js to safe chars.
+  # jq not installed → printf fallback. Escape plugin/version so unusual
+  # input (quotes, backslashes) cannot break the JSON shape. fields_json
+  # is assumed valid (caller responsibility per the protocol contract).
+  local plugin_esc version_esc
+  plugin_esc=$(_credstatus_json_escape "$plugin")
+  version_esc=$(_credstatus_json_escape "$version")
   printf '{"plugin":"%s","version":"%s","session_ts":"%s","credentials":%s}' \
-    "$plugin" "$version" "$session_ts" "$fields_json"
+    "$plugin_esc" "$version_esc" "$session_ts" "$fields_json"
 }
 
 # Public API: write credential status for a plugin.
@@ -98,7 +122,12 @@ write_credential_status() {
   }
 
   local target="$data_dir/credential-status.json"
-  local tmp="${target}.tmp"
+  # Per-invocation unique temp filename so concurrent SessionStart writers
+  # for the same plugin (e.g., two Claude Code sessions racing) cannot
+  # clobber each other's tmp file mid-write. Falls back to a PID-suffixed
+  # path if mktemp is unavailable (extremely rare).
+  local tmp
+  tmp=$(mktemp "${target}.tmp.XXXXXX" 2>/dev/null) || tmp="${target}.tmp.$$"
 
   printf '%s\n' "$doc" >"$tmp" 2>/dev/null || {
     printf '[credential-status] Warning: could not write %s\n' "$tmp" >&2
@@ -130,15 +159,22 @@ credential_status_field() {
   local valid="${4:-null}"
 
   if command -v jq >/dev/null 2>&1; then
+    # Mirrors _credstatus_compose: jq parse failure (e.g., non-boolean
+    # present/valid) returns non-zero so callers don't accidentally embed
+    # invalid JSON into the composed document.
     jq -nc \
       --arg field "$field" \
       --arg source "$source" \
       --argjson present "$present" \
       --argjson valid "$valid" \
       '{field: $field, source: $source, present: $present, valid: $valid}' \
-      2>/dev/null && return 0
+      2>/dev/null
+    return $?
   fi
 
+  local field_esc source_esc
+  field_esc=$(_credstatus_json_escape "$field")
+  source_esc=$(_credstatus_json_escape "$source")
   printf '{"field":"%s","source":"%s","present":%s,"valid":%s}' \
-    "$field" "$source" "$present" "$valid"
+    "$field_esc" "$source_esc" "$present" "$valid"
 }

--- a/plugins/yellow-core/package.json
+++ b/plugins/yellow-core/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "Dev toolkit with review agents, research agents, and workflow commands for TypeScript, Python, Rust, and Go",
   "scripts": {
-    "test": "bats skills/git-worktree/tests/"
+    "test": "bats skills/git-worktree/tests/ tests/"
   }
 }

--- a/plugins/yellow-core/tests/credential-status.bats
+++ b/plugins/yellow-core/tests/credential-status.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+# Tests for lib/credential-status.sh
+
+setup() {
+  . "$BATS_TEST_DIRNAME/../lib/credential-status.sh"
+  CLAUDE_PLUGIN_DATA="$(mktemp -d)"
+  export CLAUDE_PLUGIN_DATA
+}
+
+teardown() {
+  if [ -n "${CLAUDE_PLUGIN_DATA:-}" ] && [ -d "$CLAUDE_PLUGIN_DATA" ]; then
+    rm -rf "$CLAUDE_PLUGIN_DATA"
+  fi
+}
+
+# --- write_credential_status: happy path ---
+
+@test "writes a valid JSON file when given valid inputs" {
+  fields='[{"field":"foo_key","source":"userConfig","present":true,"valid":null}]'
+  write_credential_status "yellow-foo" "1.0.0" "$fields"
+  [ -f "$CLAUDE_PLUGIN_DATA/credential-status.json" ]
+  if command -v jq >/dev/null 2>&1; then
+    name=$(jq -r '.plugin' "$CLAUDE_PLUGIN_DATA/credential-status.json")
+    [ "$name" = "yellow-foo" ]
+    version=$(jq -r '.version' "$CLAUDE_PLUGIN_DATA/credential-status.json")
+    [ "$version" = "1.0.0" ]
+    cred_count=$(jq '.credentials | length' "$CLAUDE_PLUGIN_DATA/credential-status.json")
+    [ "$cred_count" = "1" ]
+  fi
+}
+
+@test "overwrites an existing file (no append)" {
+  fields1='[{"field":"foo","source":"userConfig","present":true,"valid":null}]'
+  fields2='[{"field":"bar","source":"shell_env","present":false,"valid":null}]'
+  write_credential_status "yellow-foo" "1.0.0" "$fields1"
+  write_credential_status "yellow-foo" "1.1.0" "$fields2"
+  if command -v jq >/dev/null 2>&1; then
+    version=$(jq -r '.version' "$CLAUDE_PLUGIN_DATA/credential-status.json")
+    [ "$version" = "1.1.0" ]
+    field=$(jq -r '.credentials[0].field' "$CLAUDE_PLUGIN_DATA/credential-status.json")
+    [ "$field" = "bar" ]
+  fi
+}
+
+@test "produces a session_ts in ISO 8601 UTC format" {
+  fields='[]'
+  write_credential_status "yellow-foo" "1.0.0" "$fields"
+  if command -v jq >/dev/null 2>&1; then
+    ts=$(jq -r '.session_ts' "$CLAUDE_PLUGIN_DATA/credential-status.json")
+    # Expect e.g. 2026-05-13T18:42:31Z
+    [[ "$ts" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+  fi
+}
+
+# --- write_credential_status: error paths (must not block SessionStart) ---
+
+@test "returns 0 when plugin name is empty" {
+  run write_credential_status "" "1.0.0" '[]'
+  [ "$status" -eq 0 ]
+}
+
+@test "returns 0 when version is empty" {
+  run write_credential_status "yellow-foo" "" '[]'
+  [ "$status" -eq 0 ]
+}
+
+@test "returns 0 when CLAUDE_PLUGIN_DATA is unwritable" {
+  unwritable=$(mktemp -d)
+  chmod 0500 "$unwritable"
+  CLAUDE_PLUGIN_DATA="$unwritable/cannot-create" \
+    run write_credential_status "yellow-foo" "1.0.0" '[]'
+  [ "$status" -eq 0 ]
+  chmod 0700 "$unwritable"
+  rm -rf "$unwritable"
+}
+
+@test "atomic write: no leftover .tmp file on success" {
+  fields='[]'
+  write_credential_status "yellow-foo" "1.0.0" "$fields"
+  [ ! -f "$CLAUDE_PLUGIN_DATA/credential-status.json.tmp" ]
+}
+
+# --- credential_status_field helper ---
+
+@test "credential_status_field composes a valid field object" {
+  result=$(credential_status_field "foo_key" "userConfig" "true" "null")
+  if command -v jq >/dev/null 2>&1; then
+    field=$(printf '%s' "$result" | jq -r '.field')
+    [ "$field" = "foo_key" ]
+    source=$(printf '%s' "$result" | jq -r '.source')
+    [ "$source" = "userConfig" ]
+    present=$(printf '%s' "$result" | jq -r '.present')
+    [ "$present" = "true" ]
+  fi
+}
+
+@test "credential_status_field uses defaults for missing args" {
+  result=$(credential_status_field "foo_key")
+  if command -v jq >/dev/null 2>&1; then
+    source=$(printf '%s' "$result" | jq -r '.source')
+    [ "$source" = "absent" ]
+    present=$(printf '%s' "$result" | jq -r '.present')
+    [ "$present" = "false" ]
+  fi
+}
+
+# --- Falls back to HOME path when CLAUDE_PLUGIN_DATA is unset ---
+
+@test "falls back to ~/.claude/plugins/data/<plugin>/ when CLAUDE_PLUGIN_DATA is unset" {
+  fake_home=$(mktemp -d)
+  unset CLAUDE_PLUGIN_DATA
+  HOME="$fake_home" write_credential_status "yellow-bar" "2.0.0" '[]'
+  [ -f "$fake_home/.claude/plugins/data/yellow-bar/credential-status.json" ]
+  rm -rf "$fake_home"
+}

--- a/plugins/yellow-core/tests/credential-status.bats
+++ b/plugins/yellow-core/tests/credential-status.bats
@@ -77,7 +77,43 @@ teardown() {
 @test "atomic write: no leftover .tmp file on success" {
   fields='[]'
   write_credential_status "yellow-foo" "1.0.0" "$fields"
-  [ ! -f "$CLAUDE_PLUGIN_DATA/credential-status.json.tmp" ]
+  # Unique per-invocation tmp filenames (mktemp template
+  # credential-status.json.tmp.XXXXXX) — assert none survived the rename.
+  shopt -s nullglob
+  leftovers=( "$CLAUDE_PLUGIN_DATA"/credential-status.json.tmp* )
+  shopt -u nullglob
+  [ "${#leftovers[@]}" -eq 0 ]
+}
+
+@test "malformed fields_json does not overwrite a previously valid file (when jq is present)" {
+  if ! command -v jq >/dev/null 2>&1; then
+    skip "jq not installed; printf fallback path skipped"
+  fi
+  write_credential_status "yellow-foo" "1.0.0" '[{"field":"k","source":"userConfig","present":true,"valid":null}]'
+  [ -f "$CLAUDE_PLUGIN_DATA/credential-status.json" ]
+  prev_version=$(jq -r '.version' "$CLAUDE_PLUGIN_DATA/credential-status.json")
+  [ "$prev_version" = "1.0.0" ]
+
+  # Second call with invalid JSON in fields_json — jq rejects, helper
+  # returns 0 (non-blocking) but does NOT overwrite the file.
+  run write_credential_status "yellow-foo" "9.9.9" 'not-json-at-all'
+  [ "$status" -eq 0 ]
+  after_version=$(jq -r '.version' "$CLAUDE_PLUGIN_DATA/credential-status.json")
+  [ "$after_version" = "1.0.0" ]
+}
+
+@test "does not pollute the caller's shell options" {
+  # The lib MUST NOT enable nounset / pipefail at file scope, otherwise
+  # SessionStart hooks that omit `set -u` would abort on unset vars and
+  # fail to emit their required {"continue": true} response. Run in a
+  # fresh subshell so bats's own option state doesn't mask drift.
+  result=$(bash -c '
+    before=$(set +o | tr -d "\n")
+    . "$1"
+    after=$(set +o | tr -d "\n")
+    [ "$before" = "$after" ] && echo OK || echo "DRIFT: $before -> $after"
+  ' _ "$BATS_TEST_DIRNAME/../lib/credential-status.sh")
+  [ "$result" = "OK" ]
 }
 
 # --- credential_status_field helper ---


### PR DESCRIPTION
Adds the credential-status JSON protocol that lets /setup:all classify plugins
as READY/PARTIAL/NEEDS SETUP without probing the system keychain. This is the
foundation PR for the plugin-install-resilience stack.

- plugins/yellow-core/lib/credential-status.sh: reusable Bash helper
  exposing write_credential_status(plugin, version, fields_json) with atomic
  tmp+rename writes, jq fallback to printf-based JSON, and graceful failure
  on unwritable CLAUDE_PLUGIN_DATA (issue #41156).
- docs/plugin-credential-status-protocol.md: schema spec, lifecycle,
  reader/writer contracts, known Claude Code bugs.
- plugins/yellow-core/tests/credential-status.bats: 10 bats tests covering
  happy path, atomic writes, fallback to HOME, error paths.
- AGENTS.md: new authoring rules for credential-bearing MCP servers (3-element
  fallback pattern, required:true semantics, status-file protocol).
- plans/plugin-install-resilience.md: full plan + stack decomposition.

Subsequent PRs in this stack (yellow-semgrep, yellow-composio, yellow-research,
/setup:all dashboard, validator, multi-host SKILL) consume this helper.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added credential-status protocol to classify plugins as READY, PARTIAL, or NEEDS SETUP during setup without keychain probing.

* **Documentation**
  * Credential-status protocol specification and developer guidelines for managing plugin credentials.
  * Plugin installation resilience improvement roadmap.

* **Tests**
  * Comprehensive credential-status functionality test coverage.

* **Chores**
  * Updated CI/CD workflows for test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KingInYellows/yellow-plugins/pull/510)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->