### PR TITLE
feat(yellow-composio)!: stdio MCP transport with shell env fallback

### DIFF
--- a/.changeset/yellow-composio-stdio-fallback.md
+++ b/.changeset/yellow-composio-stdio-fallback.md
@@ -1,5 +1,5 @@
 ---
-'yellow-composio': minor
+'yellow-composio': major
 ---
 
 feat(yellow-composio): stdio MCP transport with shell env fallback

--- a/.changeset/yellow-composio-stdio-fallback.md
+++ b/.changeset/yellow-composio-stdio-fallback.md
@@ -1,0 +1,44 @@
+---
+'yellow-composio': minor
+---
+
+feat(yellow-composio): stdio MCP transport with shell env fallback
+
+Converts the bundled Composio MCP server from `type: http` to a `command`-type
+stdio MCP that proxies to Composio's HTTPS endpoint. This unblocks two pain
+points:
+
+1. **Multi-host fleet support.** Power users can now set `COMPOSIO_MCP_URL`
+   and `COMPOSIO_API_KEY` in shell rc / direnv / a secrets manager. The
+   wrapper (`bin/start-composio.sh`) resolves userConfig OR shell env with
+   userConfig-preferred precedence — mirroring the canonical pattern from
+   yellow-research and yellow-morph.
+2. **Cascade failure protection.** Previously, an empty `composio_mcp_url`
+   registered the bundled MCP with `url: ""` and broke `claude doctor` for
+   every other MCP in the session. The wrapper now exits non-zero on empty
+   or non-HTTPS URLs, so the bundled MCP simply doesn't register — all
+   other MCPs are unaffected.
+
+Architecture:
+- `bin/start-composio.sh` — credential resolver, HTTPS-only enforcement
+- `bin/composio-proxy.mjs` — minimal Node.js stdio↔HTTPS proxy
+  (newline-delimited JSON-RPC per MCP spec; request/response only —
+  Composio does not need persistent SSE)
+- `plugin.json` — `mcpServers.composio-server` is now command-based with
+  env block declaring both `_USERCONFIG` and shell-env-passthrough variants
+- `hooks/check-mcp-url.sh` — extended to also emit `credential-status.json`
+  per the protocol from the yellow-core foundation PR
+- `userConfig.composio_mcp_url`/`composio_api_key` — `required: true`
+  removed (per research: it does not block install, only surfaces as
+  confusing MCP-startup errors)
+
+Breaking change: legacy installs from v1.2.x must `/plugin disable
+yellow-composio && /plugin enable yellow-composio` after Claude Code restart
+to re-trigger the userConfig prompt. Existing keychain-stored values are
+preserved.
+
+Trade-off: this diverges from Composio's officially recommended
+`claude mcp add --transport http` integration. Documented in CLAUDE.md.
+The trade-off is necessary because Claude Code bug #51581 makes `${VAR}`
+substitution in HTTP MCP `headers` non-functional, preventing shell env
+fallback for the API key on the http transport.

--- a/plans/plugin-install-resilience.md
+++ b/plans/plugin-install-resilience.md
@@ -835,8 +835,8 @@ behind 1 in a Graphite stack; PRs 4–8 sequential.
 ## Stack Progress
 <!-- Updated by workflows:work. Do not edit manually. -->
 - [x] 1. agent/feat/credential-status-protocol (completed 2026-05-13, PR #510)
-- [ ] 2. agent/fix/yellow-semgrep-env-fallback
-- [ ] 3. agent/feat/yellow-composio-stdio-fallback
+- [x] 2. agent/fix/yellow-semgrep-env-fallback (completed 2026-05-13, PR #511)
+- [x] 3. agent/feat/yellow-composio-stdio-fallback (completed 2026-05-13)
 - [ ] 4. agent/feat/yellow-research-status-hook
 - [ ] 5. agent/feat/setup-all-status-classification
 - [ ] 6. agent/feat/validate-plugin-credential-warnings

--- a/plugins/yellow-composio/.claude-plugin/plugin.json
+++ b/plugins/yellow-composio/.claude-plugin/plugin.json
@@ -21,24 +21,24 @@
     "composio_mcp_url": {
       "type": "string",
       "title": "Composio MCP URL",
-      "description": "Per-customer Composio MCP endpoint. Generate via the Composio dashboard or `npx @composio/mcp@latest setup YOUR_CUSTOMER_ID YOUR_APP_ID`. Looks like https://mcp.composio.dev/<id>. MUST start with `https://` — Claude Code sends the API key as the `X-API-Key` header to whatever URL you provide, so a non-HTTPS URL leaks the credential in cleartext. Only `https://mcp.composio.dev/*` URLs are expected; do not paste arbitrary URLs (`http://`, `file://`, internal hosts, metadata endpoints). Format is not enforced at the schema level; a SessionStart hook surfaces a runtime warning if the URL is non-HTTPS. Required to prevent the bundled MCP server from registering with an empty URL — `claude doctor` reports that failure mode as `SDK auth failed: \"/\" cannot be parsed as a URL`, and it blocks every other MCP from passing its auth check. If you do not have a Composio URL yet, disable yellow-composio via /plugin until you do.",
-      "sensitive": false,
-      "required": true
+      "description": "Per-customer Composio MCP endpoint. Generate via the Composio dashboard or `npx @composio/mcp@latest setup YOUR_CUSTOMER_ID YOUR_APP_ID`. Looks like https://mcp.composio.dev/<id> or https://connect.composio.dev/mcp. MUST start with `https://` — the start-composio.sh wrapper rejects non-HTTPS URLs to prevent cleartext key leak. Alternatively set the `COMPOSIO_MCP_URL` shell env var for multi-host fleets (the wrapper honors it as a fallback when this userConfig is empty). If you have neither yet, disable yellow-composio via /plugin until you do — the wrapper exits non-zero on empty values, which keeps `claude doctor` from cascade-failing other MCPs.",
+      "sensitive": false
     },
     "composio_api_key": {
       "type": "string",
       "title": "Composio API key",
-      "description": "Composio API key from https://app.composio.dev/settings. Sent as the X-API-Key header on every MCP request. Stored in the system keychain. Format is not validated at schema level — invalid keys produce a 401 at runtime from Composio. Required for the same reason as the MCP URL: a blank value attaches an empty `X-API-Key` header and the bundled server fails authentication on every request.",
-      "sensitive": true,
-      "required": true
+      "description": "Composio API key from https://app.composio.dev/settings. Sent as the X-API-Key header on every MCP request. Stored in the system keychain. Alternatively set `COMPOSIO_API_KEY` in shell env — the start-composio.sh wrapper honors it as a fallback when this userConfig is empty. Invalid keys produce a 401 at runtime from Composio.",
+      "sensitive": true
     }
   },
   "mcpServers": {
     "composio-server": {
-      "type": "http",
-      "url": "${user_config.composio_mcp_url}",
-      "headers": {
-        "X-API-Key": "${user_config.composio_api_key}"
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/start-composio.sh",
+      "env": {
+        "COMPOSIO_MCP_URL_USERCONFIG": "${user_config.composio_mcp_url}",
+        "COMPOSIO_MCP_URL": "${COMPOSIO_MCP_URL:-}",
+        "COMPOSIO_API_KEY_USERCONFIG": "${user_config.composio_api_key}",
+        "COMPOSIO_API_KEY": "${COMPOSIO_API_KEY:-}"
       }
     }
   },

--- a/plugins/yellow-composio/CLAUDE.md
+++ b/plugins/yellow-composio/CLAUDE.md
@@ -4,25 +4,33 @@ Optional Composio accelerator for batch workflows with local usage tracking.
 
 ## How It Works
 
-This plugin bundles a `type: http` Composio MCP server, declared in
-`plugin.json` and configured via two `userConfig` prompts on enable: the
-per-customer MCP URL and the Composio API key. Both are `required: true`
-— on a fresh enable, Claude Code refuses to enable the plugin if either
-is left blank, because the bundled MCP would otherwise register with an
-empty URL and break `claude doctor` for every other MCP server
-(`SDK auth failed: "/" cannot be parsed as a URL`). The API key is
-stored in the system keychain (`sensitive: true`); the MCP URL is
-stored as plain (non-sensitive) `userConfig`. Bundled tools appear
-under the `mcp__plugin_yellow-composio_composio-server__*` prefix.
+This plugin bundles a Composio MCP server via a small `command`-type stdio
+wrapper (`bin/start-composio.sh` + `bin/composio-proxy.mjs`) that resolves
+credentials and proxies stdio MCP JSON-RPC to Composio's HTTPS endpoint.
 
-`required: true` gates *new* enables only — it does not retroactively
-remediate plugins that were already enabled before v1.2.4 with empty
-or absent values, so a legacy install can still hold a blank
-`composio_mcp_url` until the user disables and re-enables. The
-SessionStart hook (`hooks/check-mcp-url.sh`) accepts the empty-URL
-case and exits silently because, in that legacy state, the bundled
-MCP simply fails to start and there is no API key on the wire to
-warn about.
+**Why stdio + proxy instead of `type: http`?** Claude Code's `${VAR}`
+substitution in HTTP MCP `headers` fields is a confirmed bug
+([anthropics/claude-code#51581](https://github.com/anthropics/claude-code/issues/51581)).
+The wrapper sidesteps this — it runs in a normal shell subprocess where
+both `userConfig` and shell env are visible. Composio's official
+recommendation is `claude mcp add --transport http`, but that path
+cannot honor `COMPOSIO_MCP_URL` / `COMPOSIO_API_KEY` shell env vars,
+which blocks dotfile-managed multi-host fleets.
+
+**Credential resolution precedence** (in `bin/start-composio.sh`):
+1. `userConfig.composio_mcp_url` / `composio_api_key` (keychain — preferred)
+2. Shell env `COMPOSIO_MCP_URL` / `COMPOSIO_API_KEY` (fleet fallback)
+3. Unset → wrapper exits **non-zero**, preventing the bundled MCP from
+   registering with an empty URL (which would cascade-fail `claude doctor`
+   for all other MCPs in the session).
+
+`required: true` was removed from the userConfig fields. Per
+[#39827](https://github.com/anthropics/claude-code/issues/39827) it does
+NOT block install — it merely produces a confusing MCP-startup error. The
+wrapper's hard exit on empty values is the actual safeguard. The
+SessionStart hook (`hooks/check-mcp-url.sh`) also writes a
+`credential-status.json` consumed by `/setup:all` for dashboard
+classification.
 
 The plugin still detects externally-configured Composio MCPs as a
 migration aid (`mcp__claude_ai_composio__*` for the Claude.ai native

--- a/plugins/yellow-composio/README.md
+++ b/plugins/yellow-composio/README.md
@@ -2,6 +2,34 @@
 
 Optional Composio accelerator for batch workflows with local usage tracking.
 
+## Upgrading from v1.2.x to v1.3.0
+
+v1.3.0 converts the bundled Composio MCP from `type: http` to a `command`-type
+stdio wrapper. This is a transport-level change; tool names and behavior are
+identical. Existing keychain-stored credentials are preserved.
+
+**After Claude Code picks up the new plugin manifest, run:**
+
+```text
+/plugin disable yellow-composio
+/plugin enable yellow-composio
+```
+
+The disable/enable cycle re-registers the MCP server with its new
+`command`-type configuration. If you skip this step, the previous `type: http`
+registration may linger until your next session restart.
+
+**New: shell env fallback for multi-host fleets.** v1.3.0 honors
+`COMPOSIO_MCP_URL` and `COMPOSIO_API_KEY` shell env vars when the userConfig
+fields are empty. Set them in your shell rc / direnv / secrets manager and
+the wrapper picks them up automatically — no per-host userConfig prompts
+needed. See `/multi-host-fleet` (in yellow-core) for the full fleet pattern.
+
+**Empty URL no longer cascades.** Previously, a blank `composio_mcp_url`
+broke `claude doctor` for all other MCPs (`SDK auth failed: "/" cannot be
+parsed as a URL`). The v1.3.0 wrapper now exits non-zero on empty values,
+so only Composio fails to start — other MCPs are unaffected.
+
 ## Installation
 
 ```bash

--- a/plugins/yellow-composio/bin/composio-proxy.mjs
+++ b/plugins/yellow-composio/bin/composio-proxy.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// yellow-composio: minimal stdio<->HTTPS MCP proxy.
+//
+// MCP stdio transport per spec: newline-delimited JSON, one JSON-RPC object
+// per line. https://modelcontextprotocol.io/docs/concepts/transports
+//
+// This proxy reads JSON-RPC messages from stdin, POSTs each one to the
+// Composio MCP HTTPS endpoint with the X-API-Key header, and writes the
+// response back to stdout. No persistent SSE/WebSocket — Composio's
+// endpoint is request/response per the docs.
+//
+// Required env: COMPOSIO_MCP_URL, COMPOSIO_API_KEY. The wrapper script
+// start-composio.sh resolves these from userConfig OR shell env.
+
+import { createInterface } from 'node:readline';
+
+const URL = process.env.COMPOSIO_MCP_URL;
+const API_KEY = process.env.COMPOSIO_API_KEY;
+
+if (!URL) {
+  process.stderr.write('[composio-proxy] Fatal: COMPOSIO_MCP_URL is not set\n');
+  process.exit(1);
+}
+if (!API_KEY) {
+  process.stderr.write('[composio-proxy] Fatal: COMPOSIO_API_KEY is not set\n');
+  process.exit(1);
+}
+if (!URL.startsWith('https://')) {
+  process.stderr.write(`[composio-proxy] Fatal: COMPOSIO_MCP_URL must be https:// (got ${URL.slice(0, 8)}...)\n`);
+  process.exit(1);
+}
+
+const rl = createInterface({
+  input: process.stdin,
+  crlfDelay: Infinity,
+});
+
+async function forward(jsonRpcMessage) {
+  let parsed;
+  try {
+    parsed = JSON.parse(jsonRpcMessage);
+  } catch (err) {
+    process.stderr.write(`[composio-proxy] Skipping unparseable line: ${err.message}\n`);
+    return;
+  }
+
+  try {
+    const response = await fetch(URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+        'X-API-Key': API_KEY,
+      },
+      body: JSON.stringify(parsed),
+    });
+
+    if (!response.ok) {
+      const errBody = await response.text().catch(() => '');
+      process.stderr.write(`[composio-proxy] HTTP ${response.status} ${response.statusText}: ${errBody.slice(0, 200)}\n`);
+      // Only emit a JSON-RPC error response if the inbound was a request (has id).
+      if (parsed.id !== undefined) {
+        const errResponse = {
+          jsonrpc: '2.0',
+          id: parsed.id,
+          error: {
+            code: -32603,
+            message: `Composio HTTP ${response.status}: ${response.statusText}`,
+          },
+        };
+        process.stdout.write(JSON.stringify(errResponse) + '\n');
+      }
+      return;
+    }
+
+    const responseBody = await response.text();
+    if (responseBody.trim().length === 0) {
+      // Notification (no response expected) — drop silently.
+      return;
+    }
+
+    // Composio returns one JSON object per request — emit as one stdio line.
+    process.stdout.write(responseBody.trim() + '\n');
+  } catch (err) {
+    process.stderr.write(`[composio-proxy] Network error: ${err.message}\n`);
+    if (parsed.id !== undefined) {
+      const errResponse = {
+        jsonrpc: '2.0',
+        id: parsed.id,
+        error: {
+          code: -32603,
+          message: `Composio network error: ${err.message}`,
+        },
+      };
+      process.stdout.write(JSON.stringify(errResponse) + '\n');
+    }
+  }
+}
+
+rl.on('line', (line) => {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return;
+  // Fire-and-forget per line; Composio's request/response means each line
+  // is independent so we don't need ordered serialization.
+  forward(trimmed).catch((err) => {
+    process.stderr.write(`[composio-proxy] Unhandled forward error: ${err.message}\n`);
+  });
+});
+
+rl.on('close', () => {
+  process.exit(0);
+});
+
+process.on('SIGTERM', () => process.exit(0));
+process.on('SIGINT', () => process.exit(0));

--- a/plugins/yellow-composio/bin/composio-proxy.mjs
+++ b/plugins/yellow-composio/bin/composio-proxy.mjs
@@ -111,5 +111,5 @@ rl.on('close', () => {
   process.exit(0);
 });
 
-process.on('SIGTERM', () => process.exit(0));
-process.on('SIGINT', () => process.exit(0));
+process.on('SIGTERM', () => rl.close());
+process.on('SIGINT', () => rl.close());

--- a/plugins/yellow-composio/bin/composio-proxy.mjs
+++ b/plugins/yellow-composio/bin/composio-proxy.mjs
@@ -30,6 +30,14 @@ if (!URL.startsWith('https://')) {
   process.exit(1);
 }
 
+// Streamable HTTP MCP session state. Both are server-opt-in: if the upstream
+// never issues a session id or never echoes a protocolVersion, these stay null
+// and the headers are simply omitted (matches Composio's documented behavior).
+// Captured here so spec-compliant upstreams that DO enforce these don't fail
+// after initialize.
+let sessionId = null;
+let protocolVersion = null;
+
 const rl = createInterface({
   input: process.stdin,
   crlfDelay: Infinity,
@@ -44,16 +52,23 @@ async function forward(jsonRpcMessage) {
     return;
   }
 
+  const headers = {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+    'X-API-Key': API_KEY,
+  };
+  if (sessionId) headers['Mcp-Session-Id'] = sessionId;
+  if (protocolVersion) headers['MCP-Protocol-Version'] = protocolVersion;
+
   try {
     const response = await fetch(URL, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json',
-        'X-API-Key': API_KEY,
-      },
+      headers,
       body: JSON.stringify(parsed),
     });
+
+    const respSessionId = response.headers.get('mcp-session-id');
+    if (respSessionId) sessionId = respSessionId;
 
     if (!response.ok) {
       const errBody = await response.text().catch(() => '');
@@ -77,6 +92,20 @@ async function forward(jsonRpcMessage) {
     if (responseBody.trim().length === 0) {
       // Notification (no response expected) — drop silently.
       return;
+    }
+
+    // Capture negotiated protocolVersion from the initialize result so we can
+    // echo it on every subsequent request per Streamable HTTP MCP. Parse for
+    // inspection only — the original body is still forwarded verbatim.
+    if (parsed.method === 'initialize') {
+      try {
+        const r = JSON.parse(responseBody);
+        if (r && r.result && typeof r.result.protocolVersion === 'string') {
+          protocolVersion = r.result.protocolVersion;
+        }
+      } catch {
+        // Non-JSON or unexpected shape — leave protocolVersion null.
+      }
     }
 
     // Composio returns one JSON object per request — emit as one stdio line.

--- a/plugins/yellow-composio/bin/start-composio.sh
+++ b/plugins/yellow-composio/bin/start-composio.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# yellow-composio MCP wrapper.
+# Resolves COMPOSIO_MCP_URL and COMPOSIO_API_KEY from userConfig (preferred)
+# or shell env fallback, then execs the stdio<->HTTPS proxy.
+#
+# Why a wrapper instead of type:http?
+# - Claude Code bug #51581: ${VAR} substitution in HTTP MCP `headers` field
+#   does not work (sends literal string). Wrapper avoids the substitution
+#   engine entirely.
+# - Without a wrapper, multi-host fleets cannot use shell env for the URL
+#   or key — every host would need a userConfig prompt cycle.
+set -euo pipefail
+
+# Resolve COMPOSIO_MCP_URL: userConfig wins, shell env is fallback.
+if [ -n "${COMPOSIO_MCP_URL_USERCONFIG:-}" ]; then
+  export COMPOSIO_MCP_URL="$COMPOSIO_MCP_URL_USERCONFIG"
+fi
+unset COMPOSIO_MCP_URL_USERCONFIG
+[ -z "${COMPOSIO_MCP_URL:-}" ] && unset COMPOSIO_MCP_URL
+
+# Resolve COMPOSIO_API_KEY: userConfig wins, shell env is fallback.
+if [ -n "${COMPOSIO_API_KEY_USERCONFIG:-}" ]; then
+  export COMPOSIO_API_KEY="$COMPOSIO_API_KEY_USERCONFIG"
+fi
+unset COMPOSIO_API_KEY_USERCONFIG
+[ -z "${COMPOSIO_API_KEY:-}" ] && unset COMPOSIO_API_KEY
+
+# Fail fast if either value is missing. Exiting non-zero here prevents the
+# bundled MCP server from registering with an empty URL, which would
+# cascade-fail `claude doctor` for ALL other MCPs in the session.
+if [ -z "${COMPOSIO_MCP_URL:-}" ]; then
+  printf '[start-composio] Error: COMPOSIO_MCP_URL is not set.\n' >&2
+  printf '[start-composio]   Set via userConfig (composio_mcp_url) or shell env.\n' >&2
+  printf '[start-composio]   The Composio MCP server will not start; other MCPs are unaffected.\n' >&2
+  exit 1
+fi
+if [ -z "${COMPOSIO_API_KEY:-}" ]; then
+  printf '[start-composio] Error: COMPOSIO_API_KEY is not set.\n' >&2
+  printf '[start-composio]   Set via userConfig (composio_api_key) or shell env.\n' >&2
+  exit 1
+fi
+case "$COMPOSIO_MCP_URL" in
+  https://*) ;;
+  *)
+    printf '[start-composio] Error: COMPOSIO_MCP_URL must be https:// (got %s)\n' "${COMPOSIO_MCP_URL:0:8}..." >&2
+    printf '[start-composio]   API keys sent over non-HTTPS would leak in cleartext.\n' >&2
+    exit 1
+    ;;
+esac
+
+exec node "${CLAUDE_PLUGIN_ROOT}/bin/composio-proxy.mjs"

--- a/plugins/yellow-composio/hooks/check-mcp-url.sh
+++ b/plugins/yellow-composio/hooks/check-mcp-url.sh
@@ -33,14 +33,18 @@ API_KEY_OPT="${CLAUDE_PLUGIN_OPTION_COMPOSIO_API_KEY:-}"
 
 # Emit credential-status.json (best-effort; never blocks SessionStart).
 emit_status() {
-  local helper="${CLAUDE_PLUGIN_ROOT}/../yellow-core/lib/credential-status.sh"
+  # Guard CLAUDE_PLUGIN_ROOT against `set -u` unbound exit when the hook runs
+  # outside a Claude Code session (e.g. manual invocation or stale environment).
+  # Fallback mirrors the cached plugin location used by yellow-semgrep.
+  local plugin_root="${CLAUDE_PLUGIN_ROOT:-${HOME}/.claude/plugins/cache/yellow-plugins/yellow-composio}"
+  local helper="${plugin_root}/../yellow-core/lib/credential-status.sh"
   [ -f "$helper" ] || return 0
   # shellcheck source=/dev/null
   . "$helper" 2>/dev/null || return 0
 
   local version="unknown"
-  if command -v jq >/dev/null 2>&1 && [ -f "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" ]; then
-    version=$(jq -r '.version // "unknown"' "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" 2>/dev/null || printf 'unknown')
+  if command -v jq >/dev/null 2>&1 && [ -f "${plugin_root}/.claude-plugin/plugin.json" ]; then
+    version=$(jq -r '.version // "unknown"' "${plugin_root}/.claude-plugin/plugin.json" 2>/dev/null || printf 'unknown')
   fi
 
   # URL: userConfig wins, shell env fallback.

--- a/plugins/yellow-composio/hooks/check-mcp-url.sh
+++ b/plugins/yellow-composio/hooks/check-mcp-url.sh
@@ -29,13 +29,54 @@ json_exit() {
 }
 
 URL="${CLAUDE_PLUGIN_OPTION_COMPOSIO_MCP_URL:-}"
+API_KEY_OPT="${CLAUDE_PLUGIN_OPTION_COMPOSIO_API_KEY:-}"
 
-# Empty URL = user dismissed the prompt; bundled MCP will fail to start, no leak risk.
-if [ -z "$URL" ]; then
+# Emit credential-status.json (best-effort; never blocks SessionStart).
+emit_status() {
+  local helper="${CLAUDE_PLUGIN_ROOT}/../yellow-core/lib/credential-status.sh"
+  [ -f "$helper" ] || return 0
+  # shellcheck source=/dev/null
+  . "$helper" 2>/dev/null || return 0
+
+  local version="unknown"
+  if command -v jq >/dev/null 2>&1 && [ -f "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" ]; then
+    version=$(jq -r '.version // "unknown"' "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" 2>/dev/null || printf 'unknown')
+  fi
+
+  # URL: userConfig wins, shell env fallback.
+  local url_source="absent" url_present="false"
+  if [ -n "$URL" ]; then
+    url_source="userConfig"; url_present="true"
+  elif [ -n "${COMPOSIO_MCP_URL:-}" ]; then
+    url_source="shell_env"; url_present="true"
+  fi
+
+  # API key: userConfig wins, shell env fallback.
+  local key_source="absent" key_present="false"
+  if [ -n "$API_KEY_OPT" ]; then
+    key_source="userConfig"; key_present="true"
+  elif [ -n "${COMPOSIO_API_KEY:-}" ]; then
+    key_source="shell_env"; key_present="true"
+  fi
+
+  local url_field key_field
+  url_field=$(credential_status_field "composio_mcp_url" "$url_source" "$url_present" "null")
+  key_field=$(credential_status_field "composio_api_key" "$key_source" "$key_present" "null")
+  write_credential_status "yellow-composio" "$version" "[$url_field,$key_field]" 2>/dev/null || true
+}
+
+emit_status
+
+# Empty URL = no source provided; wrapper will exit non-zero and the bundled MCP
+# will not start. Nothing to warn about — no API key is on the wire.
+if [ -z "$URL" ] && [ -z "${COMPOSIO_MCP_URL:-}" ]; then
   json_exit ""
 fi
 
-case "$URL" in
+# Use the resolved value (userConfig preferred, then shell env) for HTTPS check.
+EFFECTIVE_URL="${URL:-${COMPOSIO_MCP_URL:-}}"
+
+case "$EFFECTIVE_URL" in
   https://*)
     json_exit ""
     ;;

--- a/plugins/yellow-composio/tests/start-composio.bats
+++ b/plugins/yellow-composio/tests/start-composio.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+# Tests for bin/start-composio.sh — verifies fail-fast on missing/invalid creds.
+
+WRAPPER="$BATS_TEST_DIRNAME/../bin/start-composio.sh"
+
+# Replace `exec node ...` with `exec env` so we can capture the resolved env
+# without actually starting the proxy or needing node available.
+prep_wrapper() {
+  local tmp_wrapper="$BATS_TMPDIR/start-composio-test.sh"
+  sed 's|exec node ".*composio-proxy.mjs"|exec env|' "$WRAPPER" >"$tmp_wrapper"
+  chmod +x "$tmp_wrapper"
+  printf '%s' "$tmp_wrapper"
+}
+
+@test "userConfig URL wins over shell env URL" {
+  test_wrapper=$(prep_wrapper)
+  output=$(CLAUDE_PLUGIN_ROOT="/tmp/test" \
+    COMPOSIO_MCP_URL_USERCONFIG="https://userconfig.example/mcp" \
+    COMPOSIO_MCP_URL="https://shellenv.example/mcp" \
+    COMPOSIO_API_KEY_USERCONFIG="key_uc" \
+    COMPOSIO_API_KEY="key_se" \
+    "$test_wrapper" 2>&1 | grep '^COMPOSIO_MCP_URL=')
+  [ "$output" = "COMPOSIO_MCP_URL=https://userconfig.example/mcp" ]
+}
+
+@test "shell env URL is used when userConfig URL is empty" {
+  test_wrapper=$(prep_wrapper)
+  output=$(CLAUDE_PLUGIN_ROOT="/tmp/test" \
+    COMPOSIO_MCP_URL_USERCONFIG="" \
+    COMPOSIO_MCP_URL="https://shellenv.example/mcp" \
+    COMPOSIO_API_KEY_USERCONFIG="" \
+    COMPOSIO_API_KEY="key_se" \
+    "$test_wrapper" 2>&1 | grep '^COMPOSIO_MCP_URL=')
+  [ "$output" = "COMPOSIO_MCP_URL=https://shellenv.example/mcp" ]
+}
+
+@test "exits non-zero when URL is empty (no cascade)" {
+  test_wrapper=$(prep_wrapper)
+  run env -i CLAUDE_PLUGIN_ROOT="/tmp/test" "$test_wrapper"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "COMPOSIO_MCP_URL is not set" ]]
+}
+
+@test "exits non-zero when API key is empty" {
+  test_wrapper=$(prep_wrapper)
+  run env -i CLAUDE_PLUGIN_ROOT="/tmp/test" \
+    COMPOSIO_MCP_URL="https://shellenv.example/mcp" \
+    "$test_wrapper"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "COMPOSIO_API_KEY is not set" ]]
+}
+
+@test "rejects non-HTTPS URL (prevents cleartext key leak)" {
+  test_wrapper=$(prep_wrapper)
+  run env -i CLAUDE_PLUGIN_ROOT="/tmp/test" \
+    COMPOSIO_MCP_URL="http://insecure.example/mcp" \
+    COMPOSIO_API_KEY="key_se" \
+    "$test_wrapper"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "must be https://" ]]
+}
+
+@test "regression guard: empty userConfig does not break shell env path" {
+  # This is the multi-host fleet use case the wrapper enables.
+  test_wrapper=$(prep_wrapper)
+  output=$(CLAUDE_PLUGIN_ROOT="/tmp/test" \
+    COMPOSIO_MCP_URL_USERCONFIG="" \
+    COMPOSIO_API_KEY_USERCONFIG="" \
+    COMPOSIO_MCP_URL="https://fleet.example/mcp" \
+    COMPOSIO_API_KEY="fleet_key" \
+    "$test_wrapper" 2>&1 | grep '^COMPOSIO_MCP_URL=')
+  [ "$output" = "COMPOSIO_MCP_URL=https://fleet.example/mcp" ]
+}


### PR DESCRIPTION
Converts the bundled Composio MCP from type:http to command-based stdio with a
hand-rolled minimal proxy. This unblocks multi-host fleet support (shell env
fallback for COMPOSIO_MCP_URL/COMPOSIO_API_KEY) and prevents the cascade
failure where an empty URL broke claude doctor for all other MCPs.

- bin/start-composio.sh: credential resolver (userConfig wins → shell env →
  exit non-zero on empty), HTTPS-only enforcement to prevent cleartext leak.
- bin/composio-proxy.mjs: ~110 LoC stdio<->HTTPS proxy. Reads
  newline-delimited JSON-RPC from stdin, POSTs each to the configured URL
  with X-API-Key header, writes responses to stdout. No SSE needed.
- plugin.json: mcpServers.composio-server is command-based, env block has
  USERCONFIG + shell-passthrough pair, required:true removed.
- hooks/check-mcp-url.sh: extended to emit credential-status.json per the
  protocol from PR #510.
- tests/start-composio.bats: 6 wrapper tests including fail-fast on empty
  URL/key and HTTPS enforcement.
- CLAUDE.md: documents the architectural divergence from Composio's
  recommended http transport and the rationale (#51581).

BREAKING: legacy installs from v1.2.x must /plugin disable && /plugin enable
after Claude Code restart. Existing keychain-stored values are preserved.

Refs anthropics/claude-code#51581 (${VAR} in headers bug),
anthropics/claude-code#39827 (required:true at startup not install).

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->
