### PR TITLE
feat(yellow-research): emit credential-status.json from SessionStart

### DIFF
--- a/.changeset/yellow-research-status-hook.md
+++ b/.changeset/yellow-research-status-hook.md
@@ -6,8 +6,9 @@ feat(yellow-research): emit credential-status.json from SessionStart
 
 Adds `hooks/write-credential-status.sh` (wired via plugin.json SessionStart)
 that emits `${CLAUDE_PLUGIN_DATA}/credential-status.json` describing which
-of the four API key fields (perplexity, tavily, exa, ceramic) are resolved
-from `userConfig` vs shell env vs absent.
+of the three `userConfig` API key fields (perplexity, tavily, exa) are
+resolved from `userConfig` vs shell env vs absent. Ceramic and parallel
+are OAuth-managed (no `userConfig` field) and are intentionally omitted.
 
 This lets `/setup:all` (in a subsequent PR) classify yellow-research as
 READY when keys are in the keychain (which it couldn't see before — it only

--- a/.changeset/yellow-research-status-hook.md
+++ b/.changeset/yellow-research-status-hook.md
@@ -1,0 +1,15 @@
+---
+'yellow-research': patch
+---
+
+feat(yellow-research): emit credential-status.json from SessionStart
+
+Adds `hooks/write-credential-status.sh` (wired via plugin.json SessionStart)
+that emits `${CLAUDE_PLUGIN_DATA}/credential-status.json` describing which
+of the four API key fields (perplexity, tavily, exa, ceramic) are resolved
+from `userConfig` vs shell env vs absent.
+
+This lets `/setup:all` (in a subsequent PR) classify yellow-research as
+READY when keys are in the keychain (which it couldn't see before — it only
+probed shell env vars). No behavioral change to MCP servers; the 3-element
+fallback wrapper from v3.1.0 already worked correctly at runtime.

--- a/docs/plugin-credential-status-protocol.md
+++ b/docs/plugin-credential-status-protocol.md
@@ -171,7 +171,9 @@ Plugins planned to emit this file (per the
 `plans/plugin-install-resilience.md` stack — adopters land in follow-up
 PRs after this foundation merges):
 
-- yellow-research (perplexity/tavily/exa keys + ceramic OAuth state)
+- yellow-research (perplexity/tavily/exa userConfig keys; ceramic/parallel
+  are OAuth-managed and have no userConfig field, so they are intentionally
+  omitted from the credentials array)
 - yellow-morph (morph key)
 - yellow-semgrep (semgrep token)
 - yellow-composio (URL + API key)

--- a/plans/plugin-install-resilience.md
+++ b/plans/plugin-install-resilience.md
@@ -836,8 +836,8 @@ behind 1 in a Graphite stack; PRs 4–8 sequential.
 <!-- Updated by workflows:work. Do not edit manually. -->
 - [x] 1. agent/feat/credential-status-protocol (completed 2026-05-13, PR #510)
 - [x] 2. agent/fix/yellow-semgrep-env-fallback (completed 2026-05-13, PR #511)
-- [x] 3. agent/feat/yellow-composio-stdio-fallback (completed 2026-05-13)
-- [ ] 4. agent/feat/yellow-research-status-hook
+- [x] 3. agent/feat/yellow-composio-stdio-fallback (completed 2026-05-13, PR #512)
+- [x] 4. agent/feat/yellow-research-status-hook (completed 2026-05-13)
 - [ ] 5. agent/feat/setup-all-status-classification
 - [ ] 6. agent/feat/validate-plugin-credential-warnings
 - [ ] 7. agent/docs/multi-host-fleet-skill

--- a/plugins/yellow-research/.claude-plugin/plugin.json
+++ b/plugins/yellow-research/.claude-plugin/plugin.json
@@ -85,5 +85,19 @@
         "ast-grep-server"
       ]
     }
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/write-credential-status.sh",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
   }
 }

--- a/plugins/yellow-research/hooks/write-credential-status.sh
+++ b/plugins/yellow-research/hooks/write-credential-status.sh
@@ -43,22 +43,20 @@ classify() {
   printf '%s|%s' "$source" "$present"
 }
 
-# Perplexity, Tavily, EXA — all use the 3-element fallback wrapper.
+# Only userConfig-declared keys (perplexity, tavily, exa) — the protocol
+# requires credentials[].field to match a userConfig key. Ceramic and parallel
+# are OAuth-managed by Claude Code with no userConfig field, so they are
+# intentionally omitted; including them would inflate the readiness denominator
+# and force /setup:all to classify the plugin as PARTIAL even when all three
+# real keys are configured.
 read -r PERP_SRC PERP_PRES <<< "$(classify CLAUDE_PLUGIN_OPTION_PERPLEXITY_API_KEY PERPLEXITY_API_KEY | tr '|' ' ')"
 read -r TAV_SRC TAV_PRES   <<< "$(classify CLAUDE_PLUGIN_OPTION_TAVILY_API_KEY TAVILY_API_KEY | tr '|' ' ')"
 read -r EXA_SRC EXA_PRES   <<< "$(classify CLAUDE_PLUGIN_OPTION_EXA_API_KEY EXA_API_KEY | tr '|' ' ')"
 
-# Ceramic, Parallel — OAuth-managed by Claude Code, no API key. We report
-# them as "absent" (no env key to check) but include them so /setup:all
-# knows yellow-research declares them.
-# CERAMIC_API_KEY is a separate env var for the REST live-probe only.
-read -r CER_SRC CER_PRES   <<< "$(classify CLAUDE_PLUGIN_OPTION_CERAMIC_API_KEY CERAMIC_API_KEY | tr '|' ' ')"
-
 PERP=$(credential_status_field "perplexity_api_key" "$PERP_SRC" "$PERP_PRES" "null")
 TAV=$(credential_status_field "tavily_api_key" "$TAV_SRC" "$TAV_PRES" "null")
 EXA=$(credential_status_field "exa_api_key" "$EXA_SRC" "$EXA_PRES" "null")
-CER=$(credential_status_field "ceramic_api_key" "$CER_SRC" "$CER_PRES" "null")
 
-write_credential_status "yellow-research" "$VERSION" "[$PERP,$TAV,$EXA,$CER]"
+write_credential_status "yellow-research" "$VERSION" "[$PERP,$TAV,$EXA]"
 
 json_exit

--- a/plugins/yellow-research/hooks/write-credential-status.sh
+++ b/plugins/yellow-research/hooks/write-credential-status.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# yellow-research SessionStart hook: emit credential-status.json so /setup:all
+# can render an accurate dashboard without probing the keychain.
+#
+# Note: -e omitted intentionally — SessionStart hooks must output
+# {"continue": true} on all paths.
+set -uo pipefail
+
+json_exit() {
+  printf '{"continue": true}\n'
+  exit 0
+}
+
+HELPER="${CLAUDE_PLUGIN_ROOT:-}/../yellow-core/lib/credential-status.sh"
+
+if [ ! -f "$HELPER" ]; then
+  json_exit
+fi
+
+# shellcheck source=/dev/null
+. "$HELPER" 2>/dev/null || json_exit
+
+VERSION="unknown"
+if command -v jq >/dev/null 2>&1 && [ -f "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" ]; then
+  VERSION=$(jq -r '.version // "unknown"' "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" 2>/dev/null || printf 'unknown')
+fi
+
+# Classify each credential field: userConfig wins, shell env is fallback.
+classify() {
+  local userconfig_var="$1"
+  local shell_var="$2"
+  local source="absent" present="false"
+  local uc_val sh_val
+  # shellcheck disable=SC2086
+  uc_val=$(printenv "$userconfig_var" 2>/dev/null || printf '')
+  # shellcheck disable=SC2086
+  sh_val=$(printenv "$shell_var" 2>/dev/null || printf '')
+  if [ -n "$uc_val" ]; then
+    source="userConfig"; present="true"
+  elif [ -n "$sh_val" ]; then
+    source="shell_env"; present="true"
+  fi
+  printf '%s|%s' "$source" "$present"
+}
+
+# Perplexity, Tavily, EXA — all use the 3-element fallback wrapper.
+read -r PERP_SRC PERP_PRES <<< "$(classify CLAUDE_PLUGIN_OPTION_PERPLEXITY_API_KEY PERPLEXITY_API_KEY | tr '|' ' ')"
+read -r TAV_SRC TAV_PRES   <<< "$(classify CLAUDE_PLUGIN_OPTION_TAVILY_API_KEY TAVILY_API_KEY | tr '|' ' ')"
+read -r EXA_SRC EXA_PRES   <<< "$(classify CLAUDE_PLUGIN_OPTION_EXA_API_KEY EXA_API_KEY | tr '|' ' ')"
+
+# Ceramic, Parallel — OAuth-managed by Claude Code, no API key. We report
+# them as "absent" (no env key to check) but include them so /setup:all
+# knows yellow-research declares them.
+# CERAMIC_API_KEY is a separate env var for the REST live-probe only.
+read -r CER_SRC CER_PRES   <<< "$(classify CLAUDE_PLUGIN_OPTION_CERAMIC_API_KEY CERAMIC_API_KEY | tr '|' ' ')"
+
+PERP=$(credential_status_field "perplexity_api_key" "$PERP_SRC" "$PERP_PRES" "null")
+TAV=$(credential_status_field "tavily_api_key" "$TAV_SRC" "$TAV_PRES" "null")
+EXA=$(credential_status_field "exa_api_key" "$EXA_SRC" "$EXA_PRES" "null")
+CER=$(credential_status_field "ceramic_api_key" "$CER_SRC" "$CER_PRES" "null")
+
+write_credential_status "yellow-research" "$VERSION" "[$PERP,$TAV,$EXA,$CER]"
+
+json_exit


### PR DESCRIPTION
Adds hooks/write-credential-status.sh wired via plugin.json SessionStart that
emits credential-status.json describing which of the four API key fields
(perplexity, tavily, exa, ceramic) are resolved from userConfig vs shell env
vs absent.

Closes the dashboard detection gap: /setup:all previously only probed shell
env vars (EXA_API_KEY etc), classifying yellow-research as PARTIAL when keys
were in the keychain even though MCPs were healthy.

No behavioral change to MCP servers; the 3-element fallback wrapper from
v3.1.0 already worked correctly at runtime. The status file is consumed by
the /setup:all dashboard updates in a subsequent PR in this stack.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->
