### PR TITLE
feat(yellow-core): credential-status-aware /setup:all classification

### DIFF
--- a/.changeset/setup-all-status-classification.md
+++ b/.changeset/setup-all-status-classification.md
@@ -1,0 +1,39 @@
+---
+'yellow-core': minor
+'yellow-browser-test': patch
+---
+
+feat(yellow-core): credential-status-aware /setup:all classification
+
+Closes the dashboard's three biggest false-positive paths reported by users
+running plugins on multiple hosts:
+
+1. **yellow-research PARTIAL despite working MCPs.** The dashboard previously
+   only probed shell env vars (`EXA_API_KEY` etc) and missed keys stored in
+   the system keychain via userConfig. Now reads `credential-status.json`
+   (emitted by the SessionStart hook from the yellow-research PR earlier in
+   this stack) as the authoritative source.
+
+2. **yellow-composio NEEDS SETUP cascade.** Updated classification reflects
+   the v1.3.0 stdio architecture: the bundled MCP only registers when the
+   wrapper's credential resolution succeeds, so an empty URL no longer
+   breaks `claude doctor` for other MCPs. Dashboard now distinguishes
+   "credentials absent" from "credentials present but MCP not yet visible"
+   (Claude Code restart needed).
+
+3. **yellow-browser-test NEEDS SETUP on every non-web-app repo.** Adds a
+   project-type heuristic: if NO web-app signals are present (no React/
+   Vue/Next/Django/Rails/Axum framework deps, no Vercel/Fly/Render config,
+   no docker-compose HTTP port mapping) AND no
+   `.claude/yellow-browser-test.local.md`, omit the plugin from the
+   dashboard entirely. When web-app signals ARE present but the config file
+   is missing, emit a RECOMMENDED hint instead of a NEEDS SETUP error.
+
+Also extends `app-discoverer` agent (yellow-browser-test) with non-Node
+language detection (Gemfile/Rails, requirements.txt/Django/Flask/FastAPI,
+go.mod/Gin/Echo, Cargo.toml/Axum/Actix) and PaaS config detection
+(fly.toml, render.yaml, vercel.json, netlify.toml).
+
+New Step 1.6 reads each credential-bearing plugin's status file. Falls back
+to legacy shell-env-only probes when status files are absent (e.g., on
+first install before any SessionStart has fired).

--- a/plans/plugin-install-resilience.md
+++ b/plans/plugin-install-resilience.md
@@ -837,8 +837,8 @@ behind 1 in a Graphite stack; PRs 4–8 sequential.
 - [x] 1. agent/feat/credential-status-protocol (completed 2026-05-13, PR #510)
 - [x] 2. agent/fix/yellow-semgrep-env-fallback (completed 2026-05-13, PR #511)
 - [x] 3. agent/feat/yellow-composio-stdio-fallback (completed 2026-05-13, PR #512)
-- [x] 4. agent/feat/yellow-research-status-hook (completed 2026-05-13)
-- [ ] 5. agent/feat/setup-all-status-classification
+- [x] 4. agent/feat/yellow-research-status-hook (completed 2026-05-13, PR #513)
+- [x] 5. agent/feat/setup-all-status-classification (completed 2026-05-13)
 - [ ] 6. agent/feat/validate-plugin-credential-warnings
 - [ ] 7. agent/docs/multi-host-fleet-skill
 

--- a/plugins/yellow-browser-test/agents/testing/app-discoverer.md
+++ b/plugins/yellow-browser-test/agents/testing/app-discoverer.md
@@ -60,7 +60,11 @@ server or any project commands — you only read files.
 Read `package.json` scripts field. Look for keys: `dev`, `start`, `serve`,
 `preview`.
 
-If no `package.json`, check:
+Always also check the following non-Node signals — not only when
+`package.json` is absent. Polyglot projects commonly carry a `package.json`
+for asset tooling (Tailwind, esbuild, Vite) on top of a Rails/Django/Go/Rust
+backend; running these checks unconditionally lets the agent surface the
+backend dev command alongside any frontend script:
 
 - `Makefile` — targets like `dev`, `serve`, `run`
 - `docker-compose.yml` — service definitions
@@ -77,7 +81,10 @@ If no `package.json`, check:
   not detectable
 
 If multiple commands found, return all of them — the calling command will use
-AskUserQuestion to let the user choose.
+AskUserQuestion to let the user choose. When `package.json` is present but
+yields no usable dev script (no `dev`/`start`/`serve`/`preview`) and one of
+the non-Node signals matches, surface the non-Node command rather than
+falling through to "no web app detected".
 
 If NONE of the above signals are present, return "no web app detected" — the
 project may be a CLI tool, library, or dotfiles repo where browser-test

--- a/plugins/yellow-browser-test/agents/testing/app-discoverer.md
+++ b/plugins/yellow-browser-test/agents/testing/app-discoverer.md
@@ -65,9 +65,23 @@ If no `package.json`, check:
 - `Makefile` — targets like `dev`, `serve`, `run`
 - `docker-compose.yml` — service definitions
 - `Procfile` — web process
+- `Gemfile` — `rails` gem implies `rails server` (default :3000)
+- `requirements.txt` / `pyproject.toml` — `django`/`flask`/`fastapi`/`starlette`/`sanic`
+  imply the framework's standard dev command (`python manage.py runserver`,
+  `flask run`, `uvicorn app:app --reload`)
+- `go.mod` — `gin-gonic`/`echo`/`fiber`/`chi`/`gorilla/mux` imply `go run`
+  with the main package
+- `Cargo.toml` — `axum`/`actix-web`/`rocket`/`warp` imply `cargo run`
+- `fly.toml`, `render.yaml`, `vercel.json`, `netlify.toml` — strong web-app
+  signals; report as "deployable web app" even when local dev command is
+  not detectable
 
 If multiple commands found, return all of them — the calling command will use
 AskUserQuestion to let the user choose.
+
+If NONE of the above signals are present, return "no web app detected" — the
+project may be a CLI tool, library, or dotfiles repo where browser-test
+does not apply.
 
 ### Step 2: Determine Base URL and Port
 

--- a/plugins/yellow-core/commands/setup/all.md
+++ b/plugins/yellow-core/commands/setup/all.md
@@ -178,6 +178,75 @@ printf '\n=== Optional Working Paths ===\n'
 [ -n "$repo_top" ] && [ -d "$repo_top/docs/audits" ] && printf 'docs/audits/:                       exists\n' || printf 'docs/audits/:                       missing\n'
 [ -n "$repo_top" ] && [ -d "$repo_top/todos/debt" ] && printf 'todos/debt/:                        exists\n' || printf 'todos/debt/:                        missing\n'
 
+printf '\n=== Web App Signals (yellow-browser-test) ===\n'
+# Probe for web-app signals so the classifier can decide whether to OMIT
+# yellow-browser-test on non-web repos. Any single match flips
+# web_signal_count > 0; the classifier uses the count, not individual flags.
+web_signal_count=0
+if [ -n "$repo_top" ] && [ -f "$repo_top/package.json" ] && \
+   grep -qE '"(next|react|vue|svelte|astro|nuxt|remix|express|fastify|koa|hono|gatsby|vite|webpack-dev-server|@angular/core|lit|solid-js|preact|alpinejs)"' "$repo_top/package.json" 2>/dev/null; then
+  printf 'web_signal_node:               present\n'
+  web_signal_count=$((web_signal_count + 1))
+else
+  printf 'web_signal_node:               absent\n'
+fi
+if [ -n "$repo_top" ] && [ -f "$repo_top/Gemfile" ] && \
+   grep -qE "^[[:space:]]*gem[[:space:]]+['\"]rails['\"]" "$repo_top/Gemfile" 2>/dev/null; then
+  printf 'web_signal_rails:              present\n'
+  web_signal_count=$((web_signal_count + 1))
+else
+  printf 'web_signal_rails:              absent\n'
+fi
+python_web_present=0
+for f in "$repo_top/requirements.txt" "$repo_top/pyproject.toml"; do
+  if [ -n "$repo_top" ] && [ -f "$f" ] && \
+     grep -qiE "(django|flask|fastapi|starlette|sanic)" "$f" 2>/dev/null; then
+    python_web_present=1
+    break
+  fi
+done
+if [ "$python_web_present" -eq 1 ]; then
+  printf 'web_signal_python:             present\n'
+  web_signal_count=$((web_signal_count + 1))
+else
+  printf 'web_signal_python:             absent\n'
+fi
+if [ -n "$repo_top" ] && [ -f "$repo_top/go.mod" ] && \
+   grep -qE "(gin-gonic|labstack/echo|gofiber/fiber|go-chi/chi|gorilla/mux)" "$repo_top/go.mod" 2>/dev/null; then
+  printf 'web_signal_go:                 present\n'
+  web_signal_count=$((web_signal_count + 1))
+else
+  printf 'web_signal_go:                 absent\n'
+fi
+if [ -n "$repo_top" ] && [ -f "$repo_top/Cargo.toml" ] && \
+   grep -qE "^(axum|actix-web|rocket|warp)[[:space:]]*=" "$repo_top/Cargo.toml" 2>/dev/null; then
+  printf 'web_signal_rust:               present\n'
+  web_signal_count=$((web_signal_count + 1))
+else
+  printf 'web_signal_rust:               absent\n'
+fi
+paas_match=""
+for f in fly.toml render.yaml vercel.json netlify.toml; do
+  if [ -n "$repo_top" ] && [ -f "$repo_top/$f" ]; then
+    paas_match="$f"
+    break
+  fi
+done
+if [ -n "$paas_match" ]; then
+  printf 'web_signal_paas:               present (%s)\n' "$paas_match"
+  web_signal_count=$((web_signal_count + 1))
+else
+  printf 'web_signal_paas:               absent\n'
+fi
+if [ -n "$repo_top" ] && [ -f "$repo_top/docker-compose.yml" ] && \
+   grep -qE '^[[:space:]]*-[[:space:]]*"?[0-9]+:(80|443|3000|3001|4000|5000|5173|8000|8080|8888)"?' "$repo_top/docker-compose.yml" 2>/dev/null; then
+  printf 'web_signal_docker_http:        present\n'
+  web_signal_count=$((web_signal_count + 1))
+else
+  printf 'web_signal_docker_http:        absent\n'
+fi
+printf 'web_signal_count:              %s\n' "$web_signal_count"
+
 printf '\n=== Installed Plugins ===\n'
 plugin_cache="$HOME/.claude/plugins/cache"
 if [ -d "$plugin_cache" ]; then
@@ -324,24 +393,41 @@ else
   fi
 
   if [ -f "$DRIFT_CACHE" ] && command -v jq >/dev/null 2>&1; then
-    # Diff installed vs available — surface OUTDATED only. Schema observed:
+    # Emit (id, installed, available) triples for every plugin present in both
+    # arrays. Schema observed:
     # {"installed":[{"id":"<plugin>@<marketplace>","version":"X.Y.Z","scope":"user|project|local"}],
     #  "available":[...]}. The `available` array shape is not fully documented;
     # parse defensively and skip plugins that lack an available record.
-    outdated_count=$(jq -r '
-      [.installed[] as $i
-        | (.available // [])[]
-        | select(.id == $i.id and .version != $i.version)
-        | "\($i.id): installed=\($i.version) available=\(.version)"]
-      | length' "$DRIFT_CACHE" 2>/dev/null || printf 0)
-    if [ "${outdated_count:-0}" -gt 0 ]; then
+    drift_pairs=$(jq -r '
+      .installed[] as $i
+      | (.available // [])[]
+      | select(.id == $i.id)
+      | "\($i.id)\t\($i.version)\t\(.version)"
+    ' "$DRIFT_CACHE" 2>/dev/null)
+
+    # Use sort -V (semver-aware version sort) to flag OUTDATED only when the
+    # installed version sorts strictly before the available one. Plain
+    # inequality would also flag installed-newer-than-available (local
+    # prereleases, ahead-of-marketplace builds) as outdated, which produces
+    # confusing downgrade guidance.
+    outdated_count=0
+    outdated_report=""
+    while IFS=$(printf '\t') read -r pkg_id installed_ver available_ver; do
+      [ -z "$pkg_id" ] && continue
+      [ "$installed_ver" = "$available_ver" ] && continue
+      sorted_first=$(printf '%s\n%s\n' "$installed_ver" "$available_ver" \
+        | LC_ALL=C sort -V 2>/dev/null | head -n1)
+      if [ "$sorted_first" = "$installed_ver" ]; then
+        outdated_count=$((outdated_count + 1))
+        outdated_report="${outdated_report}  OUTDATED: ${pkg_id} installed=${installed_ver} → available=${available_ver}
+"
+      fi
+    done <<EOF
+$drift_pairs
+EOF
+    if [ "$outdated_count" -gt 0 ]; then
       printf 'version_drift: %s outdated\n' "$outdated_count"
-      jq -r '
-        .installed[] as $i
-        | (.available // [])[]
-        | select(.id == $i.id and .version != $i.version)
-        | "  OUTDATED: \($i.id) installed=\($i.version) → available=\(.version)"' \
-        "$DRIFT_CACHE" 2>/dev/null
+      printf '%s' "$outdated_report"
     else
       printf 'version_drift: all current\n'
     fi
@@ -493,34 +579,29 @@ yellow-research` to re-trigger the userConfig prompts."
 
 **yellow-browser-test:**
 
-Run a project-type heuristic before classifying. If the current repository
-shows NO web-app signals AND `.claude/yellow-browser-test.local.md` is
+Run a project-type heuristic before classifying. Read `web_signal_count`
+from Step 1's "Web App Signals" section (the bash dashboard probes
+`package.json` for framework deps, `Gemfile` for Rails, `requirements.txt`/
+`pyproject.toml` for Django/Flask/FastAPI, `go.mod` for Gin/Echo/Fiber/Chi/
+Gorilla, `Cargo.toml` for Axum/Actix/Rocket/Warp, PaaS configs
+`fly.toml`/`render.yaml`/`vercel.json`/`netlify.toml`, and
+`docker-compose.yml` for HTTP port mappings).
+
+If `web_signal_count` is `0` AND `.claude/yellow-browser-test.local.md` is
 absent, OMIT this plugin from the dashboard entirely — a non-web-app repo
 (dotfiles, CLI tool, library) has nothing for browser-test to target.
 
-Positive web-app signals (any one is sufficient):
-
-- `package.json` containing any of:
-  `next|react|vue|svelte|astro|nuxt|remix|express|fastify|koa|hono|gatsby|vite|webpack-dev-server|@angular/core|lit|solid-js|preact|alpinejs`
-- `vercel.json`, `netlify.toml`, `fly.toml`, `render.yaml` present at repo root
-- `Gemfile` contains `rails`
-- `requirements.txt` or `pyproject.toml` contains
-  `django|flask|fastapi|starlette|sanic`
-- `go.mod` contains `gin-gonic|echo|fiber|chi|gorilla/mux`
-- `Cargo.toml` contains `axum|actix-web|rocket|warp`
-- `docker-compose.yml` has any service with HTTP port mapping
-
-Classification when web-app signals ARE present:
+Classification when `web_signal_count >= 1` OR config file present:
 
 - READY: `.claude/yellow-browser-test.local.md` exists AND `node18_check` ok
   AND `npm` OK AND `agent-browser` OK
-- RECOMMENDED: web app detected but `.claude/yellow-browser-test.local.md`
+- RECOMMENDED: `web_signal_count >= 1` but `.claude/yellow-browser-test.local.md`
   is missing — emit "Web app detected; run `/browser-test:setup` to enable
   testing." This is informational, not a NEEDS SETUP error.
 - NEEDS SETUP: config file exists but tooling missing (`node18_check`/`npm`/
   `agent-browser`)
 
-If NO web-app signals AND no config file: omit from dashboard.
+If `web_signal_count` is `0` AND no config file: omit from dashboard.
 
 **yellow-docs:**
 

--- a/plugins/yellow-core/commands/setup/all.md
+++ b/plugins/yellow-core/commands/setup/all.md
@@ -110,6 +110,8 @@ fi
 [ -n "${TAVILY_API_KEY:-}" ] && printf 'TAVILY_API_KEY:            set\n' || printf 'TAVILY_API_KEY:            NOT SET\n'
 [ -n "${PERPLEXITY_API_KEY:-}" ] && printf 'PERPLEXITY_API_KEY:        set\n' || printf 'PERPLEXITY_API_KEY:        NOT SET\n'
 [ -n "${CERAMIC_API_KEY:-}" ] && printf 'CERAMIC_API_KEY:           set\n' || printf 'CERAMIC_API_KEY:           NOT SET\n'
+[ -n "${COMPOSIO_MCP_URL:-}" ] && printf 'COMPOSIO_MCP_URL:          set\n' || printf 'COMPOSIO_MCP_URL:          NOT SET\n'
+[ -n "${COMPOSIO_API_KEY:-}" ] && printf 'COMPOSIO_API_KEY:          set\n' || printf 'COMPOSIO_API_KEY:          NOT SET\n'
 
 printf '\n=== Repository State ===\n'
 repo_top=$(git rev-parse --show-toplevel 2>/dev/null || true)
@@ -242,27 +244,34 @@ restarted.
 
 ### Step 1.6: Credential Status Files
 
-Credential-bearing plugins (yellow-research, yellow-composio, yellow-semgrep,
-yellow-morph) emit a `credential-status.json` from a SessionStart hook so
-the dashboard can classify them accurately without probing the system
-keychain. See `docs/plugin-credential-status-protocol.md`.
+Credential-bearing plugins (yellow-research, yellow-composio, yellow-semgrep)
+emit a `credential-status.json` from a SessionStart hook so the dashboard
+can classify them accurately without probing the system keychain. See
+`docs/plugin-credential-status-protocol.md`. yellow-morph will join the
+protocol in a follow-up; until then its classification block reads
+Step 1's env+userConfig probe directly.
 
 Run one Bash block to read each plugin's status file:
 
 ```bash
 printf '\n=== Credential Status Files ===\n'
 PLUGIN_DATA_DIR="$HOME/.claude/plugins/data"
-for plugin in yellow-research yellow-composio yellow-semgrep yellow-morph; do
+for plugin in yellow-research yellow-composio yellow-semgrep; do
   status_file="$PLUGIN_DATA_DIR/$plugin/credential-status.json"
   if [ -f "$status_file" ] && command -v jq >/dev/null 2>&1; then
-    present_count=$(jq '[.credentials[] | select(.present == true)] | length' "$status_file" 2>/dev/null)
-    total_count=$(jq '.credentials | length' "$status_file" 2>/dev/null)
-    user_config_count=$(jq '[.credentials[] | select(.source == "userConfig")] | length' "$status_file" 2>/dev/null)
-    shell_env_count=$(jq '[.credentials[] | select(.source == "shell_env")] | length' "$status_file" 2>/dev/null)
-    version=$(jq -r '.version // "unknown"' "$status_file" 2>/dev/null)
+    # Single jq invocation per plugin — extract all fields as TSV.
+    read -r present_count total_count user_config_count shell_env_count version <<EOF
+$(jq -r '[
+  ([.credentials[] | select(.present == true)] | length),
+  (.credentials | length),
+  ([.credentials[] | select(.source == "userConfig")] | length),
+  ([.credentials[] | select(.source == "shell_env")] | length),
+  (.version // "unknown")
+] | @tsv' "$status_file" 2>/dev/null)
+EOF
     printf '%-22s %s/%s present (uc:%s env:%s, v%s)\n' \
-      "$plugin:" "$present_count" "$total_count" \
-      "$user_config_count" "$shell_env_count" "$version"
+      "$plugin:" "${present_count:-0}" "${total_count:-0}" \
+      "${user_config_count:-0}" "${shell_env_count:-0}" "${version:-unknown}"
   elif [ -f "$status_file" ]; then
     printf '%-22s status file present but jq missing\n' "$plugin:"
   else
@@ -521,18 +530,26 @@ If NO web-app signals AND no config file: omit from dashboard.
 **yellow-composio:**
 
 The bundled MCP is now `command`-type stdio with a wrapper resolving
-userConfig OR shell env (v1.3.0+). Use the credential-status file for
-authoritative classification.
+userConfig OR shell env (v1.3.0+). Prefer the credential-status file for
+classification; when it is absent, fall back to the `COMPOSIO_MCP_URL` /
+`COMPOSIO_API_KEY` shell env vars (per Step 1.6's documented fallback rule)
+so a fresh install that has not yet written the status file is not
+mis-classified.
+
+Define `composio_creds_present` as: status file shows BOTH `composio_mcp_url`
+and `composio_api_key` `present == true`, OR (status file absent AND both
+`COMPOSIO_MCP_URL` and `COMPOSIO_API_KEY` are set in shell env).
 
 - READY: `jq` OK AND `node` OK AND Composio MCP tools visible via ToolSearch
-  AND status file shows BOTH `composio_mcp_url` and `composio_api_key`
-  present AND `.claude/composio-usage.json` exists
-- PARTIAL: status file shows credentials present but MCP tools not visible
-  yet (Claude Code restart needed) OR usage counter missing OR `node` missing
-- NEEDS SETUP: status file shows either credential as `source: absent`
-  (wrapper will exit non-zero and the bundled MCP won't start — no cascade
-  failure to other MCPs) OR status file is missing entirely (run
-  `/plugin disable yellow-composio && /plugin enable yellow-composio`)
+  AND `composio_creds_present` AND `.claude/composio-usage.json` exists
+- PARTIAL: `composio_creds_present` but MCP tools not visible yet (Claude
+  Code restart needed) OR usage counter missing OR `node` missing
+- NEEDS SETUP: status file shows either credential as `source: absent`, OR
+  status file missing AND at least one of `COMPOSIO_MCP_URL` /
+  `COMPOSIO_API_KEY` is unset. In either case the wrapper will exit
+  non-zero and the bundled MCP won't start — no cascade failure to other
+  MCPs. Remediation: run `/plugin disable yellow-composio && /plugin
+  enable yellow-composio` (or export both env vars for fleet installs).
 
 **yellow-codex:**
 

--- a/plugins/yellow-core/commands/setup/all.md
+++ b/plugins/yellow-core/commands/setup/all.md
@@ -240,6 +240,114 @@ ToolSearch reflects current-session visibility only. If a plugin was installed
 after the session started, the tool may remain invisible until Claude Code is
 restarted.
 
+### Step 1.6: Credential Status Files
+
+Credential-bearing plugins (yellow-research, yellow-composio, yellow-semgrep,
+yellow-morph) emit a `credential-status.json` from a SessionStart hook so
+the dashboard can classify them accurately without probing the system
+keychain. See `docs/plugin-credential-status-protocol.md`.
+
+Run one Bash block to read each plugin's status file:
+
+```bash
+printf '\n=== Credential Status Files ===\n'
+PLUGIN_DATA_DIR="$HOME/.claude/plugins/data"
+for plugin in yellow-research yellow-composio yellow-semgrep yellow-morph; do
+  status_file="$PLUGIN_DATA_DIR/$plugin/credential-status.json"
+  if [ -f "$status_file" ] && command -v jq >/dev/null 2>&1; then
+    present_count=$(jq '[.credentials[] | select(.present == true)] | length' "$status_file" 2>/dev/null)
+    total_count=$(jq '.credentials | length' "$status_file" 2>/dev/null)
+    user_config_count=$(jq '[.credentials[] | select(.source == "userConfig")] | length' "$status_file" 2>/dev/null)
+    shell_env_count=$(jq '[.credentials[] | select(.source == "shell_env")] | length' "$status_file" 2>/dev/null)
+    version=$(jq -r '.version // "unknown"' "$status_file" 2>/dev/null)
+    printf '%-22s %s/%s present (uc:%s env:%s, v%s)\n' \
+      "$plugin:" "$present_count" "$total_count" \
+      "$user_config_count" "$shell_env_count" "$version"
+  elif [ -f "$status_file" ]; then
+    printf '%-22s status file present but jq missing\n' "$plugin:"
+  else
+    printf '%-22s no status file (restart Claude Code or /plugin disable && enable)\n' "$plugin:"
+  fi
+done
+```
+
+The status file is the AUTHORITATIVE source for classification. When it
+exists, prefer its `present_count` over shell-env-only probes. When it is
+absent, fall back to the legacy shell-env-only check (and emit a hint that
+the user should restart Claude Code to populate the file).
+
+### Step 1.7: Plugin Version Drift Check
+
+Detect plugins where the installed version is older than the marketplace
+catalog version (e.g., user installed a plugin months ago and the catalog
+has shipped multiple minor releases since). Uses `claude plugin list --json
+--available` with a 24h cache to avoid a network call on every dashboard
+invocation.
+
+```bash
+printf '\n=== Plugin Version Drift ===\n'
+DRIFT_CACHE="$HOME/.claude/plugins/data/yellow-core/version-check-cache.json"
+DRIFT_CACHE_DIR=$(dirname "$DRIFT_CACHE")
+
+# Feature-detect: `claude plugin list --json --available` may not be available
+# on older Claude Code releases. Soft-skip if `claude` is missing or the flag
+# is not supported.
+if ! command -v claude >/dev/null 2>&1; then
+  printf 'version_drift: SKIPPED (claude CLI not found)\n'
+elif ! claude plugin list --help 2>&1 | grep -q -- '--available'; then
+  printf 'version_drift: SKIPPED (claude plugin list --available not supported in this release)\n'
+else
+  # 24h TTL: re-fetch only if cache is missing or older than 86400 seconds.
+  refresh_cache=1
+  if [ -f "$DRIFT_CACHE" ]; then
+    cache_age=$(( $(date +%s) - $(stat -c %Y "$DRIFT_CACHE" 2>/dev/null || stat -f %m "$DRIFT_CACHE" 2>/dev/null || printf 0) ))
+    [ "$cache_age" -lt 86400 ] && refresh_cache=0
+  fi
+
+  if [ "$refresh_cache" -eq 1 ]; then
+    mkdir -p "$DRIFT_CACHE_DIR" 2>/dev/null
+    if claude plugin list --json --available 2>/dev/null > "$DRIFT_CACHE.tmp"; then
+      mv -f "$DRIFT_CACHE.tmp" "$DRIFT_CACHE" 2>/dev/null
+    else
+      rm -f "$DRIFT_CACHE.tmp" 2>/dev/null
+      printf 'version_drift: SKIPPED (claude plugin list --json --available failed)\n'
+    fi
+  fi
+
+  if [ -f "$DRIFT_CACHE" ] && command -v jq >/dev/null 2>&1; then
+    # Diff installed vs available — surface OUTDATED only. Schema observed:
+    # {"installed":[{"id":"<plugin>@<marketplace>","version":"X.Y.Z","scope":"user|project|local"}],
+    #  "available":[...]}. The `available` array shape is not fully documented;
+    # parse defensively and skip plugins that lack an available record.
+    outdated_count=$(jq -r '
+      [.installed[] as $i
+        | (.available // [])[]
+        | select(.id == $i.id and .version != $i.version)
+        | "\($i.id): installed=\($i.version) available=\(.version)"]
+      | length' "$DRIFT_CACHE" 2>/dev/null || printf 0)
+    if [ "${outdated_count:-0}" -gt 0 ]; then
+      printf 'version_drift: %s outdated\n' "$outdated_count"
+      jq -r '
+        .installed[] as $i
+        | (.available // [])[]
+        | select(.id == $i.id and .version != $i.version)
+        | "  OUTDATED: \($i.id) installed=\($i.version) → available=\(.version)"' \
+        "$DRIFT_CACHE" 2>/dev/null
+    else
+      printf 'version_drift: all current\n'
+    fi
+    cache_age_hours=$(( cache_age / 3600 ))
+    printf 'version_drift_cache_age_h: %s\n' "${cache_age_hours:-0}"
+  fi
+fi
+```
+
+When OUTDATED plugins are reported, suggest: `/plugin update <name>` to
+upgrade. After update, run `/setup:all` again — outdated plugins may need
+`/plugin disable && /plugin enable` to re-trigger userConfig prompts for
+any new fields the upgrade introduced (per
+[anthropics/claude-code#39827](https://github.com/anthropics/claude-code/issues/39827)).
+
 ### Step 2: Classify Plugin Status
 
 Classify each installed plugin as **READY**, **PARTIAL**, or **NEEDS SETUP**.
@@ -295,17 +403,30 @@ path" and rely on `/morph:status` for authoritative OFFLINE detection.
 
 **yellow-semgrep:**
 
-- READY: `curl` OK AND `jq` OK AND `SEMGREP_APP_TOKEN` set AND `semgrep` OK
-- PARTIAL: `SEMGREP_APP_TOKEN` set but `semgrep` CLI is missing
-- NEEDS SETUP: token missing OR `curl` missing OR `jq` missing
+Prefer the credential-status file from Step 1.6 over shell-env-only probes.
+The wrapper script honors both userConfig and shell env as of v4.1.0.
+
+- READY: `curl` OK AND `jq` OK AND `semgrep` OK AND (status file shows
+  `semgrep_app_token` present, OR status file absent AND `SEMGREP_APP_TOKEN`
+  set in shell env)
+- PARTIAL: token resolved (per status file or shell env) but `semgrep` CLI
+  is missing
+- NEEDS SETUP: token absent (status file shows `source: absent` OR file
+  absent AND shell env unset) OR `curl` missing OR `jq` missing
 
 **yellow-research:**
 
+Prefer the credential-status file from Step 1.6 over shell-env-only probes.
+The 3-element fallback wrapper means keys may be resolved from the keychain
+(invisible to the dashboard's Bash subprocess) — the status file is the
+only accurate signal.
+
 Compute bundled source availability out of 6:
 
-1. `EXA_API_KEY` set
-2. `TAVILY_API_KEY` set
-3. `PERPLEXITY_API_KEY` set
+1. `exa_api_key` present per status file, OR `EXA_API_KEY` set in shell env
+   (legacy path when status file absent)
+2. `tavily_api_key` present per status file, OR `TAVILY_API_KEY` set
+3. `perplexity_api_key` present per status file, OR `PERPLEXITY_API_KEY` set
 4. Parallel Task tool visible via ToolSearch
 5. ast-grep counts only when the exact ToolSearch match is present **and**
    `ast-grep` OK **and** `uv` OK (uv manages Python 3.13 transparently via
@@ -319,6 +440,11 @@ Compute bundled source availability out of 6:
 - READY: all 6 bundled sources available
 - PARTIAL: 1-5 bundled sources available
 - NEEDS SETUP: 0 bundled sources available
+
+If the status file is absent AND no shell env vars are set, surface a hint:
+"yellow-research credentials not detected — restart Claude Code to populate
+the status file, or run `/plugin disable yellow-research && /plugin enable
+yellow-research` to re-trigger the userConfig prompts."
 
 **yellow-linear:**
 
@@ -358,9 +484,34 @@ Compute bundled source availability out of 6:
 
 **yellow-browser-test:**
 
+Run a project-type heuristic before classifying. If the current repository
+shows NO web-app signals AND `.claude/yellow-browser-test.local.md` is
+absent, OMIT this plugin from the dashboard entirely — a non-web-app repo
+(dotfiles, CLI tool, library) has nothing for browser-test to target.
+
+Positive web-app signals (any one is sufficient):
+
+- `package.json` containing any of:
+  `next|react|vue|svelte|astro|nuxt|remix|express|fastify|koa|hono|gatsby|vite|webpack-dev-server|@angular/core|lit|solid-js|preact|alpinejs`
+- `vercel.json`, `netlify.toml`, `fly.toml`, `render.yaml` present at repo root
+- `Gemfile` contains `rails`
+- `requirements.txt` or `pyproject.toml` contains
+  `django|flask|fastapi|starlette|sanic`
+- `go.mod` contains `gin-gonic|echo|fiber|chi|gorilla/mux`
+- `Cargo.toml` contains `axum|actix-web|rocket|warp`
+- `docker-compose.yml` has any service with HTTP port mapping
+
+Classification when web-app signals ARE present:
+
 - READY: `.claude/yellow-browser-test.local.md` exists AND `node18_check` ok
   AND `npm` OK AND `agent-browser` OK
-- NEEDS SETUP: any READY condition not met
+- RECOMMENDED: web app detected but `.claude/yellow-browser-test.local.md`
+  is missing — emit "Web app detected; run `/browser-test:setup` to enable
+  testing." This is informational, not a NEEDS SETUP error.
+- NEEDS SETUP: config file exists but tooling missing (`node18_check`/`npm`/
+  `agent-browser`)
+
+If NO web-app signals AND no config file: omit from dashboard.
 
 **yellow-docs:**
 
@@ -369,10 +520,19 @@ Compute bundled source availability out of 6:
 
 **yellow-composio:**
 
-- READY: `jq` OK AND Composio MCP tools visible via ToolSearch AND
-  `.claude/composio-usage.json` exists with valid `version` field
-- PARTIAL: Composio MCP tools visible but `jq` missing or usage counter missing
-- NEEDS SETUP: Composio MCP tools not visible in the current session
+The bundled MCP is now `command`-type stdio with a wrapper resolving
+userConfig OR shell env (v1.3.0+). Use the credential-status file for
+authoritative classification.
+
+- READY: `jq` OK AND `node` OK AND Composio MCP tools visible via ToolSearch
+  AND status file shows BOTH `composio_mcp_url` and `composio_api_key`
+  present AND `.claude/composio-usage.json` exists
+- PARTIAL: status file shows credentials present but MCP tools not visible
+  yet (Claude Code restart needed) OR usage counter missing OR `node` missing
+- NEEDS SETUP: status file shows either credential as `source: absent`
+  (wrapper will exit non-zero and the bundled MCP won't start — no cascade
+  failure to other MCPs) OR status file is missing entirely (run
+  `/plugin disable yellow-composio && /plugin enable yellow-composio`)
 
 **yellow-codex:**
 


### PR DESCRIPTION
Closes the three biggest dashboard false positives:

- yellow-research PARTIAL despite working MCPs (keychain values invisible)
- yellow-composio NEEDS SETUP cascade (empty URL broke other MCPs)
- yellow-browser-test NEEDS SETUP on non-web-app repos (no heuristic)

Adds Step 1.6 reading credential-status.json from each credential-bearing
plugin. Updates classification blocks for yellow-research, yellow-composio,
yellow-semgrep to prefer status file over shell-env-only probes. Adds web-app
heuristic for yellow-browser-test (omit when no signals, RECOMMENDED when
signals present but config missing).

Extends app-discoverer with non-Node language detection (Gemfile/Rails,
requirements.txt/Django/Flask/FastAPI, go.mod/Gin/Echo, Cargo.toml/Axum) and
PaaS config detection (fly.toml, render.yaml, vercel.json, netlify.toml).

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->
