### PR TITLE
feat(validate-plugin): RULE 12 — warn on userConfig env interpolation without shell-env fallback

### DIFF
--- a/.changeset/validate-plugin-credential-warnings.md
+++ b/.changeset/validate-plugin-credential-warnings.md
@@ -1,5 +1,5 @@
 ---
-'yellow-plugins-validator': patch
+'yellow-plugins-root': patch
 ---
 
 feat(validate-plugin): warn on credential userConfig interpolation without shell-env fallback

--- a/.changeset/validate-plugin-credential-warnings.md
+++ b/.changeset/validate-plugin-credential-warnings.md
@@ -1,0 +1,21 @@
+---
+'yellow-plugins-validator': patch
+---
+
+feat(validate-plugin): warn on credential userConfig interpolation without shell-env fallback
+
+Adds RULE 12 to `scripts/validate-plugin.js` (warning, non-blocking) that flags
+`mcpServers.<server>.env.<KEY>: "${user_config.X}"` patterns lacking a
+companion `${KEY:-}` shell-env-passthrough entry. The diagnostic recommends
+the 3-element wrapper pattern (yellow-research/yellow-morph precedent) so
+power users on multi-host fleets can resolve credentials from shell env
+without per-host userConfig prompts.
+
+Detection: iterates each mcpServers entry's env block, matches
+`${user_config.<field>}`, skips entries with the conventional `_USERCONFIG`
+suffix (which signals the plugin already uses the wrapper pattern), and
+warns when no companion fallback is found.
+
+This is a warning, not an error — existing plugins that don't follow the
+pattern continue to pass validation. New plugins authors see the
+recommendation surfaced at validation time.

--- a/docs/plugin-validation-guide.md
+++ b/docs/plugin-validation-guide.md
@@ -204,6 +204,42 @@ mv plugins/hookify-old plugins/hookify
 > plugin-local hook script paths (existence and basic structure). These checks
 > run automatically but are not documented as separate numbered rules above.
 
+### Rule 12: Credential-userConfig Env-Var Fallback (warning)
+
+For each `mcpServers.<server>.env.<KEY>: "${user_config.X}"` interpolation,
+the validator checks whether a companion `${KEY:-}` shell-env-passthrough
+entry exists in the same env block (or whether the env-key name itself ends
+with `_USERCONFIG`, indicating the wrapper pattern is already in use).
+
+When the companion entry is missing, the validator emits a warning
+recommending the 3-element fallback wrapper pattern (yellow-research /
+yellow-morph precedent). This pattern lets power users on multi-host fleets
+resolve credentials from shell env vars (`PERPLEXITY_API_KEY`,
+`SEMGREP_APP_TOKEN`, etc.) instead of running the userConfig prompt cycle
+on every host.
+
+**Why a warning, not an error**: Plugins that interpolate `${user_config.X}`
+directly aren't broken — they just don't accept a shell env fallback. The
+warning gives plugin authors a clear remediation path without breaking
+existing manifests.
+
+**Example warning**:
+
+```text
+[warn] yellow-foo: mcpServers.foo-server.env.FOO_API_KEY interpolates
+${user_config.foo_api_key} directly. Consider the 3-element wrapper pattern
+(FOO_API_KEY_USERCONFIG + FOO_API_KEY with ${FOO_API_KEY:-} fallback) so
+power users on multi-host fleets can use shell env. See
+plugins/yellow-research/bin/start-*.sh for the canonical pattern.
+```
+
+**Remediation**: Add a wrapper script under `bin/` that resolves precedence
+(userConfig wins → shell env fallback → unset empty), and rewrite the env
+block to declare both `_USERCONFIG` and shell-passthrough variants. See
+`plugins/yellow-core/skills/multi-host-fleet/SKILL.md` for the canonical
+contract and `plugins/yellow-research/bin/start-perplexity.sh` for the
+~12-line wrapper template.
+
 ---
 
 ## CI Integration

--- a/plans/plugin-install-resilience.md
+++ b/plans/plugin-install-resilience.md
@@ -838,8 +838,8 @@ behind 1 in a Graphite stack; PRs 4–8 sequential.
 - [x] 2. agent/fix/yellow-semgrep-env-fallback (completed 2026-05-13, PR #511)
 - [x] 3. agent/feat/yellow-composio-stdio-fallback (completed 2026-05-13, PR #512)
 - [x] 4. agent/feat/yellow-research-status-hook (completed 2026-05-13, PR #513)
-- [x] 5. agent/feat/setup-all-status-classification (completed 2026-05-13)
-- [ ] 6. agent/feat/validate-plugin-credential-warnings
+- [x] 5. agent/feat/setup-all-status-classification (completed 2026-05-13, PR #514)
+- [x] 6. agent/feat/validate-plugin-credential-warnings (completed 2026-05-13)
 - [ ] 7. agent/docs/multi-host-fleet-skill
 
 ## References

--- a/scripts/validate-plugin.js
+++ b/scripts/validate-plugin.js
@@ -1003,6 +1003,48 @@ function validatePlugin(pluginDir) {
     }
   }
 
+  // RULE 12: credential-bearing MCP servers should use the 3-element fallback
+  // pattern. If a mcpServers entry's env block contains `${user_config.X}`
+  // directly (without a `${X:-}` shell-env-passthrough companion), the plugin
+  // overwrites any pre-existing shell env value with an empty string when the
+  // user dismisses the userConfig prompt. Warn so plugin authors adopt the
+  // wrapper pattern (yellow-research/yellow-morph precedent).
+  if (manifest.mcpServers && typeof manifest.mcpServers === 'object') {
+    for (const [serverName, server] of Object.entries(manifest.mcpServers)) {
+      if (!server || typeof server !== 'object') continue;
+      const env = server.env;
+      if (!env || typeof env !== 'object') continue;
+
+      for (const [envKey, envValue] of Object.entries(env)) {
+        if (typeof envValue !== 'string') continue;
+        // Match `${user_config.<field>}` interpolations.
+        const userConfigMatch = envValue.match(
+          /\$\{user_config\.([a-zA-Z_][a-zA-Z0-9_]*)\}/
+        );
+        if (!userConfigMatch) continue;
+
+        // Skip if the env key has the conventional `_USERCONFIG` suffix —
+        // this indicates the plugin IS using the wrapper pattern (the bare
+        // env var name will hold the resolved value).
+        if (envKey.endsWith('_USERCONFIG')) continue;
+
+        // Look for a companion `${ENV_VAR:-}` passthrough entry to confirm the
+        // wrapper pattern is in place.
+        const companionShellEnv = env[envKey];
+        const hasFallbackPattern =
+          envKey + '_USERCONFIG' in env ||
+          (typeof companionShellEnv === 'string' &&
+            companionShellEnv.includes(':-'));
+
+        if (!hasFallbackPattern) {
+          logWarning(
+            `${manifest.name}: mcpServers.${serverName}.env.${envKey} interpolates ${userConfigMatch[0]} directly. Consider the 3-element wrapper pattern (${envKey}_USERCONFIG + ${envKey} with \${${envKey}:-} fallback) so power users on multi-host fleets can use shell env. See plugins/yellow-research/bin/start-*.sh for the canonical pattern.`
+          );
+        }
+      }
+    }
+  }
+
   // Summary
   if (errors.length === 0) {
     logSuccess(`Plugin "${manifest.name}" is valid`);

--- a/scripts/validate-plugin.js
+++ b/scripts/validate-plugin.js
@@ -1028,13 +1028,17 @@ function validatePlugin(pluginDir) {
         // env var name will hold the resolved value).
         if (envKey.endsWith('_USERCONFIG')) continue;
 
-        // Look for a companion `${ENV_VAR:-}` passthrough entry to confirm the
-        // wrapper pattern is in place.
-        const companionShellEnv = env[envKey];
-        const hasFallbackPattern =
-          envKey + '_USERCONFIG' in env ||
-          (typeof companionShellEnv === 'string' &&
-            companionShellEnv.includes(':-'));
+        // The canonical wrapper pattern moves `${user_config.X}` to a
+        // `<KEY>_USERCONFIG` sibling and sets the bare `<KEY>` to
+        // `${<KEY>:-}`. The bare key matching `${user_config.X}` here means
+        // that move did not happen. The only valid non-broken shape is an
+        // inline fallback that self-references this env var, e.g.
+        // `${user_config.X:-${<envKey>:-}}`. Anything else (including a
+        // `<KEY>_USERCONFIG` sibling that exists but coexists with a broken
+        // bare KEY, or an unrelated `:-` default elsewhere) is the broken
+        // case the rule is meant to catch.
+        const selfFallback = '${' + envKey + ':-';
+        const hasFallbackPattern = envValue.includes(selfFallback);
 
         if (!hasFallbackPattern) {
           logWarning(

--- a/scripts/validate-plugin.js
+++ b/scripts/validate-plugin.js
@@ -1017,9 +1017,14 @@ function validatePlugin(pluginDir) {
 
       for (const [envKey, envValue] of Object.entries(env)) {
         if (typeof envValue !== 'string') continue;
-        // Match `${user_config.<field>}` interpolations.
+        // Match `${user_config.<field>` interpolations. The lookahead allows
+        // either a plain close (`${user_config.X}`) or a default clause
+        // (`${user_config.X:-...}`) — both shapes still write the user_config
+        // value to the env var when set, and both can clobber shell env when
+        // unset (the bare and empty-default forms write empty; only an
+        // inline self-passthrough default rescues shell env).
         const userConfigMatch = envValue.match(
-          /\$\{user_config\.([a-zA-Z_][a-zA-Z0-9_]*)\}/
+          /\$\{user_config\.([a-zA-Z_][a-zA-Z0-9_]*)(?=[}:])/
         );
         if (!userConfigMatch) continue;
 
@@ -1042,7 +1047,7 @@ function validatePlugin(pluginDir) {
 
         if (!hasFallbackPattern) {
           logWarning(
-            `${manifest.name}: mcpServers.${serverName}.env.${envKey} interpolates ${userConfigMatch[0]} directly. Consider the 3-element wrapper pattern (${envKey}_USERCONFIG + ${envKey} with \${${envKey}:-} fallback) so power users on multi-host fleets can use shell env. See plugins/yellow-research/bin/start-*.sh for the canonical pattern.`
+            `${manifest.name}: mcpServers.${serverName}.env.${envKey} interpolates \${user_config.${userConfigMatch[1]}} directly without a \${${envKey}:-} self-passthrough. Consider the 3-element wrapper pattern (${envKey}_USERCONFIG + ${envKey} with \${${envKey}:-} fallback) so power users on multi-host fleets can use shell env. See plugins/yellow-research/bin/start-*.sh for the canonical pattern.`
           );
         }
       }


### PR DESCRIPTION
Adds a non-blocking warning that fires when a mcpServers entry's env block has
${user_config.X} interpolated directly without a companion shell-env-passthrough
entry (${KEY:-}). Recommends the 3-element wrapper pattern from yellow-research/
yellow-morph. Validates correctly across all current marketplace plugins (zero
warnings — they all already follow the pattern after PRs #511-#513).

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->
