### PR TITLE
docs(yellow-core): multi-host-fleet skill + userConfig required-vs-startup solution doc

### DIFF
--- a/.changeset/multi-host-fleet-skill.md
+++ b/.changeset/multi-host-fleet-skill.md
@@ -1,0 +1,26 @@
+---
+'yellow-core': minor
+---
+
+docs(yellow-core): multi-host-fleet skill + userConfig required-vs-startup solution doc
+
+Adds the user-facing reference for replicating yellow-plugins credentials
+across a fleet (workstations, CI, devcontainers, ephemeral sandboxes)
+without per-host userConfig prompt cycles.
+
+- `plugins/yellow-core/skills/multi-host-fleet/SKILL.md` — canonical
+  env-var contract table for every credential-bearing plugin
+  (yellow-research, yellow-morph, yellow-semgrep, yellow-composio,
+  yellow-devin), with patterns for dotfiles/direnv, GitHub Actions /
+  GitLab CI / devcontainers, and tool-agnostic secrets managers
+  (1Password CLI, Vault envconsul, Doppler). User-invokable skill:
+  `/multi-host-fleet`.
+- `docs/solutions/build-errors/userconfig-required-fires-at-startup-not-install.md`
+  — solution doc explaining why `required: true` on userConfig fields
+  does NOT block install (it surfaces at MCP startup, per Claude Code
+  bug #39827) and the wrapper-script pattern that should be used
+  instead.
+
+This closes the "no multi-host story" gap reported by users running
+plugins on multiple hosts. The 3-element fallback wrapper pattern
+introduced in the foundation PR is now discoverable end-to-end.

--- a/docs/solutions/build-errors/userconfig-required-fires-at-startup-not-install.md
+++ b/docs/solutions/build-errors/userconfig-required-fires-at-startup-not-install.md
@@ -1,7 +1,14 @@
 ---
-title: userConfig `required: true` fires at MCP startup, not install
-captured-at: 2026-05-13
-tags: [userConfig, MCP, plugin-install, claude-code-bugs]
+title: 'userConfig `required: true` fires at MCP startup, not install'
+category: build-errors
+track: bug
+problem: 'userConfig `required: true` does not block plugin install — error surfaces at MCP startup via variable substitution, leaving users with no actionable feedback'
+date: 2026-05-13
+tags:
+  - userConfig
+  - MCP
+  - plugin-install
+  - claude-code-bugs
 ---
 
 # `required: true` on userConfig fields does NOT block plugin install

--- a/docs/solutions/build-errors/userconfig-required-fires-at-startup-not-install.md
+++ b/docs/solutions/build-errors/userconfig-required-fires-at-startup-not-install.md
@@ -1,0 +1,104 @@
+---
+title: userConfig `required: true` fires at MCP startup, not install
+captured-at: 2026-05-13
+tags: [userConfig, MCP, plugin-install, claude-code-bugs]
+---
+
+# `required: true` on userConfig fields does NOT block plugin install
+
+## TL;DR
+
+Setting `userConfig.<field>.required: true` in `plugin.json` does NOT block
+plugin install when the user dismisses the prompt. The value only surfaces
+as an error at MCP-server startup time (variable substitution), producing
+a confusing "Missing required user configuration value" message that
+suggests pre-validation should have caught it.
+
+Reference: [anthropics/claude-code#39827](https://github.com/anthropics/claude-code/issues/39827)
+(open as of 2026-05-13).
+
+## Symptoms
+
+- Plugin installs and shows as "enabled" in `claude plugin list --json`.
+- The bundled MCP server fails to start.
+- `claude doctor` reports: `Missing required user configuration value:
+  <field>. This should have been validated before variable substitution.`
+- Tools provided by the bundled MCP are invisible to the current session.
+- On platforms where the initial enable-prompt doesn't fire at all
+  (see [#39455](https://github.com/anthropics/claude-code/issues/39455)),
+  users see this with NO way to know what to enter.
+
+## Why It Happens
+
+Per the [Claude Code plugin reference](https://code.claude.com/docs/en/plugins-reference)
+schema, `required: true` is documented as "validation fails when the field
+is empty." In practice the validation does not run at install time — it
+runs at MCP startup, when Claude Code substitutes `${user_config.<field>}`
+into the `env`, `args`, `url`, or `headers` blocks. If the value is empty,
+the substitution engine refuses, the MCP fails to start, and the user is
+left with no actionable error.
+
+## How to Avoid It
+
+**Do not use `required: true` for credential fields on graceful-degradation
+plugins.** Instead:
+
+1. Mark the field as optional (omit `required`).
+2. Use the 3-element fallback wrapper pattern
+   (yellow-research/yellow-morph precedent) — see
+   `plugins/yellow-core/skills/multi-host-fleet/SKILL.md`:
+   ```json
+   {
+     "env": {
+       "FOO_API_KEY_USERCONFIG": "${user_config.foo_api_key}",
+       "FOO_API_KEY": "${FOO_API_KEY:-}"
+     }
+   }
+   ```
+   And a wrapper script in `bin/start-foo.sh`:
+   ```bash
+   if [ -n "${FOO_API_KEY_USERCONFIG:-}" ]; then
+     export FOO_API_KEY="$FOO_API_KEY_USERCONFIG"
+   fi
+   unset FOO_API_KEY_USERCONFIG
+   [ -z "${FOO_API_KEY:-}" ] && unset FOO_API_KEY
+   exec foo-mcp-server "$@"
+   ```
+3. If you need to BLOCK MCP startup when both userConfig and shell env are
+   empty (the yellow-composio case, to prevent `claude doctor` cascade
+   failure), do that in the wrapper script with an explicit non-zero exit:
+   ```bash
+   [ -z "${FOO_API_KEY:-}" ] && {
+     printf '[start-foo] Error: FOO_API_KEY is not set. The bundled MCP will not start; other MCPs are unaffected.\n' >&2
+     exit 1
+   }
+   ```
+   This is the actual safeguard — `required: true` cannot perform it.
+
+## Detection in the Marketplace
+
+The `validate-plugin.js` script (RULE 12, added in v1.16.0) emits a warning
+on any `${user_config.X}` interpolation in `mcpServers.<server>.env` that
+lacks a companion `${X:-}` shell-env-passthrough entry. Plugins that follow
+the wrapper pattern pass cleanly; plugins that interpolate userConfig
+directly trigger the warning at validation time.
+
+## Related Bugs
+
+- [#39827](https://github.com/anthropics/claude-code/issues/39827) —
+  `required: true` validates at substitution time
+- [#39455](https://github.com/anthropics/claude-code/issues/39455) —
+  userConfig values not prompted on enable (some platforms)
+- [#51581](https://github.com/anthropics/claude-code/issues/51581) —
+  `${VAR}` substitution in HTTP MCP `headers` field doesn't work (closed
+  as "completed" Apr 2026, fix version unknown)
+- [#41156](https://github.com/anthropics/claude-code/issues/41156) —
+  `${CLAUDE_PLUGIN_DATA}` write triggers protected-directory prompt in
+  bypassPermissions mode
+
+## Affected Plugins (as of 2026-05-13)
+
+| Plugin | Was Affected? | Resolved In |
+|--------|---------------|-------------|
+| yellow-composio | yes (v1.2.x had `required: true`) | v1.3.0 (stdio wrapper + required removed) |
+| All others | no (never used `required: true` for sensitive credentials) | n/a |

--- a/plans/plugin-install-resilience.md
+++ b/plans/plugin-install-resilience.md
@@ -839,8 +839,8 @@ behind 1 in a Graphite stack; PRs 4–8 sequential.
 - [x] 3. agent/feat/yellow-composio-stdio-fallback (completed 2026-05-13, PR #512)
 - [x] 4. agent/feat/yellow-research-status-hook (completed 2026-05-13, PR #513)
 - [x] 5. agent/feat/setup-all-status-classification (completed 2026-05-13, PR #514)
-- [x] 6. agent/feat/validate-plugin-credential-warnings (completed 2026-05-13)
-- [ ] 7. agent/docs/multi-host-fleet-skill
+- [x] 6. agent/feat/validate-plugin-credential-warnings (completed 2026-05-13, PR #515)
+- [x] 7. agent/docs/multi-host-fleet-skill (completed 2026-05-13)
 
 ## References
 

--- a/plugins/yellow-core/skills/multi-host-fleet/SKILL.md
+++ b/plugins/yellow-core/skills/multi-host-fleet/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: multi-host-fleet
+description: Multi-host plugin credential and config reference for yellow-plugins. Use when setting up a new workstation, configuring CI/devcontainer, replicating credentials across a fleet, or wiring a secrets manager. Documents the canonical shell env var names for every credential-bearing plugin.
+user-invokable: true
+---
+
+# Multi-Host Fleet Reference
+
+## What It Does
+
+Documents the canonical shell environment variable for every
+credential-bearing plugin in this marketplace, with patterns for replicating
+credentials across multiple hosts (workstations, CI runners, ephemeral
+sandboxes, devcontainers) without re-running `/plugin disable && /plugin
+enable` per host.
+
+The yellow-plugins marketplace adopts a uniform 3-element credential
+resolution pattern for every credential-bearing plugin:
+
+1. `userConfig` value (stored in OS keychain) — **preferred** for single-host
+   installs
+2. Shell env var (canonical name, see table below) — **fallback** for fleet
+   and CI usage
+3. Unset → MCP server either fails to start (composio) or starts in
+   degraded mode (research, semgrep)
+
+Setting the canonical shell env var on a new host bypasses the userConfig
+prompt entirely. Wrapper scripts in each plugin honor the precedence.
+
+## When to Use
+
+- Setting up a new workstation, laptop, WSL2 instance, or VM
+- Configuring a CI job (GitHub Actions, GitLab CI, CircleCI) that runs
+  Claude Code
+- Building a devcontainer image with pre-injected credentials
+- Wiring a secrets manager (direnv, 1Password CLI, HashiCorp Vault,
+  Doppler, AWS Secrets Manager) so credentials flow into Claude Code
+- Diagnosing why a plugin reports PARTIAL or NEEDS SETUP on one host but
+  READY on another
+
+## Usage
+
+### Canonical Env-Var Contract
+
+| Plugin | Shell Env Var | userConfig Field | Sensitive | Notes |
+|--------|---------------|------------------|-----------|-------|
+| yellow-research | `PERPLEXITY_API_KEY` | `perplexity_api_key` | yes | |
+| yellow-research | `TAVILY_API_KEY` | `tavily_api_key` | yes | |
+| yellow-research | `EXA_API_KEY` | `exa_api_key` | yes | |
+| yellow-research | `CERAMIC_API_KEY` | (none) | yes | REST live-probe only; MCP uses OAuth |
+| yellow-morph | `MORPH_API_KEY` | `morph_api_key` | yes | |
+| yellow-semgrep | `SEMGREP_APP_TOKEN` | `semgrep_app_token` | yes | `sgp_` prefix |
+| yellow-composio | `COMPOSIO_MCP_URL` | `composio_mcp_url` | no | Must start with `https://` |
+| yellow-composio | `COMPOSIO_API_KEY` | `composio_api_key` | yes | |
+| yellow-devin | `DEVIN_SERVICE_USER_TOKEN` | (none) | yes | env-only; no userConfig |
+| yellow-devin | `DEVIN_ORG_ID` | (none) | no | env-only; no userConfig |
+
+The userConfig path uses the system keychain when available (macOS,
+Windows) or `~/.claude/.credentials.json` (0600 perms) on minimal Linux.
+The shell env path is what makes multi-host fleets practical.
+
+### Dev hosts (dotfiles + shell rc + direnv)
+
+For a typical developer workstation, store secrets in shell rc files or
+direnv:
+
+```bash
+# In ~/.zshrc or ~/.bashrc (NOT version-controlled in plaintext)
+export PERPLEXITY_API_KEY="$(cat ~/.secrets/perplexity)"
+export TAVILY_API_KEY="$(cat ~/.secrets/tavily)"
+export EXA_API_KEY="$(cat ~/.secrets/exa)"
+export MORPH_API_KEY="$(cat ~/.secrets/morph)"
+export SEMGREP_APP_TOKEN="$(cat ~/.secrets/semgrep)"
+export COMPOSIO_MCP_URL="https://mcp.composio.dev/your-customer-id"
+export COMPOSIO_API_KEY="$(cat ~/.secrets/composio)"
+export DEVIN_SERVICE_USER_TOKEN="$(cat ~/.secrets/devin-token)"
+export DEVIN_ORG_ID="your-org-id"
+```
+
+Or with [direnv](https://direnv.net) (per-project `.envrc`, not committed):
+
+```bash
+# .envrc (gitignored)
+export PERPLEXITY_API_KEY="$(cat ~/.secrets/perplexity)"
+# ... etc
+```
+
+`~/.secrets/` files at 0600 perms are the simplest portable secret store.
+For shared workstations or higher-sensitivity environments, use the
+secrets-manager patterns below.
+
+### CI/CD (GitHub Actions, GitLab CI, devcontainer)
+
+**GitHub Actions:**
+
+```yaml
+- name: Run /workflows:work
+  env:
+    PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+    EXA_API_KEY: ${{ secrets.EXA_API_KEY }}
+    SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+    COMPOSIO_MCP_URL: ${{ vars.COMPOSIO_MCP_URL }}
+    COMPOSIO_API_KEY: ${{ secrets.COMPOSIO_API_KEY }}
+  run: claude code --headless ...
+```
+
+Add each canonical env var name to **Repository Settings → Secrets and
+variables → Actions**. The `composio_mcp_url` can live in `vars` (not
+secrets) since it's non-sensitive; everything else goes in `secrets`.
+
+**GitLab CI:**
+
+Define each canonical env var as a Project CI/CD variable (mask sensitive
+ones). They auto-propagate to job environments.
+
+**devcontainer.json:**
+
+```json
+{
+  "containerEnv": {
+    "PERPLEXITY_API_KEY": "${localEnv:PERPLEXITY_API_KEY}",
+    "EXA_API_KEY": "${localEnv:EXA_API_KEY}",
+    "SEMGREP_APP_TOKEN": "${localEnv:SEMGREP_APP_TOKEN}"
+  }
+}
+```
+
+Pulls from the host's env (which must be set per the dev hosts section
+above). For ephemeral cloud devcontainers (Codespaces, Coder), inject via
+the platform's secret-management UI.
+
+### Secrets managers (tool-agnostic)
+
+**direnv (recommended for local dev — simplest):**
+
+```bash
+# .envrc (per-project, gitignored)
+dotenv ~/.secrets/yellow-plugins.env
+
+# ~/.secrets/yellow-plugins.env (0600 perms, gitignored)
+PERPLEXITY_API_KEY=pk_...
+EXA_API_KEY=...
+```
+
+direnv loads env vars when you `cd` into the project. Use `direnv allow`
+to authorize the `.envrc`.
+
+**1Password CLI (`op run`):**
+
+```bash
+# .envrc.template (committed)
+export PERPLEXITY_API_KEY="op://Personal/Perplexity API/credential"
+export EXA_API_KEY="op://Personal/EXA API/credential"
+
+# Then launch Claude Code via:
+op run --env-file=.envrc.template -- claude code
+```
+
+**HashiCorp Vault (envconsul):**
+
+```bash
+envconsul -consul-addr=vault.internal -prefix=secret/yellow-plugins claude code
+```
+
+**Doppler:**
+
+```bash
+doppler run --project yellow-plugins -- claude code
+```
+
+**Generic env-file pattern (any tool):**
+
+The contract is: by the time `claude code` starts, the canonical env vars
+must be in the process environment. Any tool that achieves this works.
+The wrapper scripts inside each plugin will pick them up.
+
+## Examples
+
+### Complete `.zshrc` snippet (uncomment what you use)
+
+```bash
+# === yellow-plugins env-var contract ===
+# Source of truth: plugins/yellow-core/skills/multi-host-fleet/SKILL.md
+
+# yellow-research
+# export PERPLEXITY_API_KEY="$(cat ~/.secrets/perplexity 2>/dev/null)"
+# export TAVILY_API_KEY="$(cat ~/.secrets/tavily 2>/dev/null)"
+# export EXA_API_KEY="$(cat ~/.secrets/exa 2>/dev/null)"
+# export CERAMIC_API_KEY="$(cat ~/.secrets/ceramic 2>/dev/null)"  # REST probe only
+
+# yellow-morph
+# export MORPH_API_KEY="$(cat ~/.secrets/morph 2>/dev/null)"
+
+# yellow-semgrep
+# export SEMGREP_APP_TOKEN="$(cat ~/.secrets/semgrep 2>/dev/null)"
+
+# yellow-composio
+# export COMPOSIO_MCP_URL="https://mcp.composio.dev/your-customer-id"
+# export COMPOSIO_API_KEY="$(cat ~/.secrets/composio 2>/dev/null)"
+
+# yellow-devin
+# export DEVIN_SERVICE_USER_TOKEN="$(cat ~/.secrets/devin 2>/dev/null)"
+# export DEVIN_ORG_ID="your-org-id"
+```
+
+### Verifying credentials resolve correctly
+
+After setting env vars, run `/setup:all` to verify each plugin reports
+READY. Look at the "Credential Status Files" section — each
+credential-bearing plugin should show `source: shell_env` (not `absent`)
+for fields you set via env.
+
+If a plugin shows the OLD source (e.g., `source: userConfig` from a
+previous keychain entry) but you want the shell env value to win,
+remember: **userConfig wins over shell env**. To prefer shell env, run
+`/plugin disable <name>` then `/plugin enable <name>` and dismiss the
+userConfig prompt (or unset the keychain entry).
+
+## Security
+
+- Never commit `.env`, `.envrc`, or `~/.secrets/*` files. Use
+  `.gitignore` patterns: `.envrc`, `.env*`, `*.secret`.
+- Keep `~/.secrets/` at 0700 directory perms and 0600 file perms.
+- For sensitive plugins (semgrep, perplexity, exa, tavily, morph,
+  composio_api_key), prefer keychain (userConfig) over shell env when
+  running on a single host. Shell env is the only practical option for
+  fleets.
+- `COMPOSIO_MCP_URL` is non-sensitive (URL pattern, no secret) and can
+  safely live in committed `.envrc.template` or GitHub Actions `vars`.
+- The wrapper script in yellow-composio (`bin/start-composio.sh`) rejects
+  non-HTTPS URLs to prevent cleartext key transmission.
+- Env vars are visible to MCP subprocesses spawned by Claude Code. Don't
+  store keys with broader scope than needed.

--- a/plugins/yellow-core/skills/multi-host-fleet/SKILL.md
+++ b/plugins/yellow-core/skills/multi-host-fleet/SKILL.md
@@ -14,8 +14,9 @@ credentials across multiple hosts (workstations, CI runners, ephemeral
 sandboxes, devcontainers) without re-running `/plugin disable && /plugin
 enable` per host.
 
-The yellow-plugins marketplace adopts a uniform 3-element credential
-resolution pattern for every credential-bearing plugin:
+The yellow-plugins marketplace adopts a 3-element credential resolution
+pattern for credential-bearing plugins that bundle a stdio MCP server
+(yellow-research, yellow-morph, yellow-semgrep, yellow-composio):
 
 1. `userConfig` value (stored in OS keychain) — **preferred** for single-host
    installs
@@ -24,8 +25,15 @@ resolution pattern for every credential-bearing plugin:
 3. Unset → MCP server either fails to start (composio) or starts in
    degraded mode (research, semgrep)
 
-Setting the canonical shell env var on a new host bypasses the userConfig
-prompt entirely. Wrapper scripts in each plugin honor the precedence.
+Plugins with HTTP-only MCPs (yellow-devin) accept the same userConfig OR
+shell env var sources, but commands read shell env directly rather than
+flowing through a wrapper.
+
+Setting the canonical shell env var on a new host lets the plugin operate
+without ever populating the userConfig keychain entry. The enable-time
+userConfig prompt still fires on platforms where prompting works
+(see [#39455](https://github.com/anthropics/claude-code/issues/39455));
+dismissing or skipping it is safe when the shell env var is set.
 
 ## When to Use
 
@@ -52,8 +60,8 @@ prompt entirely. Wrapper scripts in each plugin honor the precedence.
 | yellow-semgrep | `SEMGREP_APP_TOKEN` | `semgrep_app_token` | yes | `sgp_` prefix |
 | yellow-composio | `COMPOSIO_MCP_URL` | `composio_mcp_url` | no | Must start with `https://` |
 | yellow-composio | `COMPOSIO_API_KEY` | `composio_api_key` | yes | |
-| yellow-devin | `DEVIN_SERVICE_USER_TOKEN` | (none) | yes | env-only; no userConfig |
-| yellow-devin | `DEVIN_ORG_ID` | (none) | no | env-only; no userConfig |
+| yellow-devin | `DEVIN_SERVICE_USER_TOKEN` | `devin_service_user_token` | yes | HTTP MCP; commands read shell env directly |
+| yellow-devin | `DEVIN_ORG_ID` | `devin_org_id` | no | HTTP MCP; commands read shell env directly |
 
 The userConfig path uses the system keychain when available (macOS,
 Windows) or `~/.claude/.credentials.json` (0600 perms) on minimal Linux.
@@ -66,14 +74,14 @@ direnv:
 
 ```bash
 # In ~/.zshrc or ~/.bashrc (NOT version-controlled in plaintext)
-export PERPLEXITY_API_KEY="$(cat ~/.secrets/perplexity)"
-export TAVILY_API_KEY="$(cat ~/.secrets/tavily)"
-export EXA_API_KEY="$(cat ~/.secrets/exa)"
-export MORPH_API_KEY="$(cat ~/.secrets/morph)"
-export SEMGREP_APP_TOKEN="$(cat ~/.secrets/semgrep)"
+export PERPLEXITY_API_KEY="$(cat ~/.secrets/perplexity 2>/dev/null)"
+export TAVILY_API_KEY="$(cat ~/.secrets/tavily 2>/dev/null)"
+export EXA_API_KEY="$(cat ~/.secrets/exa 2>/dev/null)"
+export MORPH_API_KEY="$(cat ~/.secrets/morph 2>/dev/null)"
+export SEMGREP_APP_TOKEN="$(cat ~/.secrets/semgrep 2>/dev/null)"
 export COMPOSIO_MCP_URL="https://mcp.composio.dev/your-customer-id"
-export COMPOSIO_API_KEY="$(cat ~/.secrets/composio)"
-export DEVIN_SERVICE_USER_TOKEN="$(cat ~/.secrets/devin-token)"
+export COMPOSIO_API_KEY="$(cat ~/.secrets/composio 2>/dev/null)"
+export DEVIN_SERVICE_USER_TOKEN="$(cat ~/.secrets/devin-token 2>/dev/null)"
 export DEVIN_ORG_ID="your-org-id"
 ```
 
@@ -81,7 +89,7 @@ Or with [direnv](https://direnv.net) (per-project `.envrc`, not committed):
 
 ```bash
 # .envrc (gitignored)
-export PERPLEXITY_API_KEY="$(cat ~/.secrets/perplexity)"
+export PERPLEXITY_API_KEY="$(cat ~/.secrets/perplexity 2>/dev/null)"
 # ... etc
 ```
 
@@ -101,7 +109,7 @@ secrets-manager patterns below.
     SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     COMPOSIO_MCP_URL: ${{ vars.COMPOSIO_MCP_URL }}
     COMPOSIO_API_KEY: ${{ secrets.COMPOSIO_API_KEY }}
-  run: claude code --headless ...
+  run: claude -p "/workflows:work ..." 
 ```
 
 Add each canonical env var name to **Repository Settings → Secrets and
@@ -153,24 +161,24 @@ export PERPLEXITY_API_KEY="op://Personal/Perplexity API/credential"
 export EXA_API_KEY="op://Personal/EXA API/credential"
 
 # Then launch Claude Code via:
-op run --env-file=.envrc.template -- claude code
+op run --env-file=.envrc.template -- claude
 ```
 
 **HashiCorp Vault (envconsul):**
 
 ```bash
-envconsul -consul-addr=vault.internal -prefix=secret/yellow-plugins claude code
+envconsul -vault-addr=https://vault.internal -secret=secret/yellow-plugins claude
 ```
 
 **Doppler:**
 
 ```bash
-doppler run --project yellow-plugins -- claude code
+doppler run --project yellow-plugins -- claude
 ```
 
 **Generic env-file pattern (any tool):**
 
-The contract is: by the time `claude code` starts, the canonical env vars
+The contract is: by the time `claude` starts, the canonical env vars
 must be in the process environment. Any tool that achieves this works.
 The wrapper scripts inside each plugin will pick them up.
 
@@ -219,7 +227,9 @@ userConfig prompt (or unset the keychain entry).
 ## Security
 
 - Never commit `.env`, `.envrc`, or `~/.secrets/*` files. Use
-  `.gitignore` patterns: `.envrc`, `.env*`, `*.secret`.
+  `.gitignore` patterns: `.env`, `.envrc`, `*.secret`, `!.envrc.template`.
+  Do not use a bare `.env*` glob — it also matches `.envrc.template`, which
+  this guide recommends committing.
 - Keep `~/.secrets/` at 0700 directory perms and 0600 file perms.
 - For sensitive plugins (semgrep, perplexity, exa, tavily, morph,
   composio_api_key), prefer keychain (userConfig) over shell env when


### PR DESCRIPTION
Adds the user-facing reference for replicating yellow-plugins credentials across
a fleet (workstations, CI, devcontainers, ephemeral sandboxes) without per-host
userConfig prompt cycles.

- plugins/yellow-core/skills/multi-host-fleet/SKILL.md: canonical env-var
  contract table for all credential-bearing plugins, with patterns for
  dotfiles/direnv, GitHub Actions/GitLab CI/devcontainers, and tool-agnostic
  secrets managers (1Password CLI, Vault envconsul, Doppler).
- docs/solutions/build-errors/userconfig-required-fires-at-startup-not-install.md:
  documents the required:true behavior (#39827) and the wrapper-script pattern.

Closes the 'no multi-host story' gap reported by users running plugins on
multiple hosts.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->
