### PR TITLE
refactor: extract validate_file_path to shared yellow-core/lib/validate-fs.sh

### DIFF
--- a/.changeset/validate-fs-shared-lib.md
+++ b/.changeset/validate-fs-shared-lib.md
@@ -1,0 +1,38 @@
+---
+'yellow-core': patch
+'yellow-ci': patch
+'yellow-ruvector': patch
+'yellow-debt': patch
+---
+
+refactor: extract validate_file_path to shared yellow-core/lib/validate-fs.sh
+
+`validate_file_path()` (and `canonicalize_project_dir()`) were copy-pasted
+across `yellow-ci`, `yellow-ruvector`, and `yellow-debt` with divergent
+implementations — a security fix to one copy was easily missed in the
+others (debt audit findings 002/003/004).
+
+- `plugins/yellow-core/lib/validate-fs.sh` — new canonical home for both
+  functions, sourced via `${CLAUDE_PLUGIN_ROOT}/../yellow-core/lib/` per the
+  `credential-status.sh` precedent. Canonical impl = yellow-ruvector's
+  (separate `canonicalize_project_dir`, `tr -d` newline detection, explicit
+  symlink-escape block) plus two deliberate enhancements: optional `$2`
+  project root with git-toplevel fallback (yellow-debt callers rely on it),
+  and internal root canonicalization for reliable containment checks.
+- The three plugins' local `lib/validate.sh` files now source the shared
+  helper with a `[ -f ]` guard and keep only their plugin-specific
+  validators.
+- `plugins/yellow-core/tests/validate-fs.bats` — canonical test suite;
+  each plugin's `validate.bats` sources the shared lib directly.
+
+Review pass follow-ups in this PR:
+
+- Idempotency guard (`_VALIDATE_FS_LOADED`) added to validate-fs.sh so
+  double-sourcing (test setup + runtime hook chain) is safe.
+- yellow-debt declares yellow-core as a required `dependencies` entry; the
+  consuming `lib/validate.sh` now warns to stderr when the helper is absent
+  rather than letting callers fail silently at exit 127.
+- AGENTS.md and `plugins/yellow-{core,debt,ruvector}` docs updated to point
+  to the new shared lib (parallel to the credential-status.sh precedent).
+- `ruvector-conventions` SKILL.md updated to describe the actual
+  `cd+pwd -P` / `realpath` validation (no longer `realpath -m`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,15 @@ and `pnpm test:lint-plugins` when `scripts/lint-plugins.sh` changes.
   `plugins/yellow-core/lib/credential-status.sh` for the reusable helper.
   Never write credential values to the status file — only the resolution
   source (`userConfig` / `shell_env` / `absent`) and a presence boolean.
+- Plugins that need path-traversal validation should source
+  `plugins/yellow-core/lib/validate-fs.sh` from their local `lib/validate.sh`
+  via the `${CLAUDE_PLUGIN_ROOT:-}/../yellow-core/lib/validate-fs.sh`
+  cross-plugin pattern (mirrors the credential-status.sh precedent). The
+  shared lib provides `validate_file_path()` and `canonicalize_project_dir()`
+  with newline-defense, symlink-escape rejection, and an optional `$2` root
+  that defaults to the git toplevel. Declare yellow-core as a required
+  dependency in the consumer's `plugin.json` if any command actually calls
+  these functions; declare it optional if only sourced for future use.
 
 ## Command, Agent, And Skill Authoring
 

--- a/plugins/yellow-ci/hooks/scripts/lib/validate.sh
+++ b/plugins/yellow-ci/hooks/scripts/lib/validate.sh
@@ -12,72 +12,22 @@ has_newline() {
   esac
 }
 
+# Shared filesystem-path validators (validate_file_path,
+# canonicalize_project_dir) live in yellow-core's shared lib so a security
+# fix lands in one place. At runtime CLAUDE_PLUGIN_ROOT is set by Claude
+# Code; in Bats tests the suite sources validate-fs.sh directly.
+_VALIDATE_FS_HELPER="${CLAUDE_PLUGIN_ROOT:-}/../yellow-core/lib/validate-fs.sh"
+if [ -f "$_VALIDATE_FS_HELPER" ]; then
+  # shellcheck source=/dev/null
+  . "$_VALIDATE_FS_HELPER"
+fi
+unset _VALIDATE_FS_HELPER
+
 # ============================================================================
 # Shared validation library functions
 # The following functions are not all used by every plugin but are available
 # as a shared validation library for hooks, commands, and agents.
 # ============================================================================
-
-# Validate file_path is within project root (path traversal mitigation)
-# Usage: validate_file_path "$path" "$project_root"
-validate_file_path() {
-  local raw_path="$1"
-  local project_root="$2"
-
-  # Quick reject: obvious traversal patterns
-  case "$raw_path" in
-    *..* | /* | *~*) return 1 ;;
-  esac
-
-  # Empty path is invalid
-  if [ -z "$raw_path" ]; then
-    return 1
-  fi
-
-  # Reject newlines and carriage returns
-  if has_newline "$raw_path"; then
-    return 1
-  fi
-
-  # Resolve to absolute and check containment
-  local full_path="${project_root}/${raw_path}"
-
-  # Reject symlinks outside project root
-  if [ -L "$full_path" ]; then
-    local target
-    if command -v realpath >/dev/null 2>&1; then
-      target="$(realpath -- "$full_path" 2>/dev/null)" || return 1
-    elif command -v readlink >/dev/null 2>&1; then
-      local link_content
-      link_content=$(readlink -- "$full_path" 2>/dev/null) || return 1
-      case "$link_content" in
-        /*) target="$link_content" ;;
-        *)  target="$(cd -- "$(dirname "$full_path")" 2>/dev/null && cd -- "$(dirname "$link_content")" 2>/dev/null && pwd -P)/$(basename "$link_content")" || return 1 ;;
-      esac
-    else
-      return 1
-    fi
-    case "$target" in
-      "${project_root}/"*) ;;
-      *) return 1 ;;
-    esac
-  fi
-
-  # Resolve path
-  local resolved
-  if [ -e "$full_path" ] && [ -d "$(dirname "$full_path")" ]; then
-    resolved="$(cd -- "$(dirname "$full_path")" 2>/dev/null && pwd -P)/$(basename "$full_path")"
-  elif command -v realpath >/dev/null 2>&1; then
-    resolved="$(realpath -- "$full_path" 2>/dev/null)" || resolved="$full_path"
-  else
-    resolved="$full_path"
-  fi
-
-  case "$resolved" in
-    "${project_root}/"*) return 0 ;;
-    *) return 1 ;;
-  esac
-}
 
 # Validate runner name: DNS-safe, 2-64 chars, lowercase alphanumeric + hyphens
 # Usage: validate_runner_name "$name"

--- a/plugins/yellow-ci/tests/validate.bats
+++ b/plugins/yellow-ci/tests/validate.bats
@@ -3,6 +3,11 @@
 
 setup() {
   SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../hooks/scripts" && pwd)"
+  # validate_file_path now lives in yellow-core's shared lib. At runtime
+  # validate.sh sources it via CLAUDE_PLUGIN_ROOT; in tests source it
+  # directly first (validate.sh's guarded source then no-ops).
+  # shellcheck source=../../yellow-core/lib/validate-fs.sh
+  . "$(dirname "$BATS_TEST_FILENAME")/../../yellow-core/lib/validate-fs.sh"
   # shellcheck source=../hooks/scripts/lib/validate.sh
   . "${SCRIPT_DIR}/lib/validate.sh"
 }

--- a/plugins/yellow-core/CLAUDE.md
+++ b/plugins/yellow-core/CLAUDE.md
@@ -111,6 +111,20 @@ Comprehensive dev toolkit for TypeScript, Python, Rust, and Go projects.
   the `session-historian` agent against Claude Code + Devin + Codex
   backends with availability detection and graceful degradation per backend
 
+### Shared Libraries
+
+`lib/` contains sourceable shell helpers that consumer plugins reach via the
+`${CLAUDE_PLUGIN_ROOT}/../yellow-core/lib/<name>.sh` cross-plugin pattern:
+
+- `credential-status.sh` — credential resolution and SessionStart hook helper
+  for `/setup:all` dashboards
+- `validate-fs.sh` — `validate_file_path()` and `canonicalize_project_dir()`
+  path-traversal validators (consumed by yellow-ci, yellow-ruvector,
+  yellow-debt; yellow-debt declares it as a required dependency). Idempotent
+  via `_VALIDATE_FS_LOADED` guard; safe to source twice from test setup +
+  runtime hook chain. Canonical bats coverage at
+  `plugins/yellow-core/tests/validate-fs.bats`
+
 ### Optional Plugin Dependencies
 
 - **gt-workflow** — `/workflows:work` delegates to `/smart-submit` for

--- a/plugins/yellow-core/lib/validate-fs.sh
+++ b/plugins/yellow-core/lib/validate-fs.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# yellow-core: shared filesystem-path validation helpers.
+#
+# Canonical home for validate_file_path() and canonicalize_project_dir(),
+# previously copy-pasted (with divergent implementations) into yellow-ci,
+# yellow-ruvector, and yellow-debt. Source from a plugin's local
+# lib/validate.sh so a security fix lands in one place.
+#
+# Usage:
+#   HELPER="${CLAUDE_PLUGIN_ROOT:-}/../yellow-core/lib/validate-fs.sh"
+#   [ -f "$HELPER" ] && . "$HELPER"
+#   validate_file_path "src/main.sh" "$PROJECT_ROOT" || reject
+#
+# Contract:
+#   - validate_file_path returns 0 if the path is a project-relative path
+#     that resolves inside the project root, 1 otherwise. Rejects empty
+#     paths, "..", leading "/", "~" anywhere in the path, embedded newlines/CRs, and symlinks
+#     whose target escapes the root.
+#   - The project root ($2) is optional; it defaults to the git toplevel
+#     (or $PWD). yellow-debt callers rely on the optional form.
+#
+# Note: this file is intended to be sourced. It MUST NOT alter the
+# caller's shell options (no top-level `set -e`, `set -u`,
+# `set -o pipefail`) — doing so can break a SessionStart hook's required
+# `{"continue": true}` emission. Functions below use ${var:-} defaulting
+# and explicit failure branches instead.
+
+# Idempotency guard: a consumer plugin's validate.sh may guard-source this
+# file at hook-load time, then a Bats test may source it again directly.
+# Without the guard, function redefinition is silent and any divergence
+# between source paths could mask a regression.
+[ -n "${_VALIDATE_FS_LOADED:-}" ] && return 0
+_VALIDATE_FS_LOADED=1
+
+# Canonicalize a project directory to an absolute, symlink-free path.
+# Portable: prefers cd+pwd (POSIX), falls back to realpath, then to the
+# raw input. Never fails — always prints something on stdout.
+# Usage: root=$(canonicalize_project_dir "$raw_dir")
+canonicalize_project_dir() {
+  local raw_dir="$1"
+  if [ -d "$raw_dir" ]; then
+    (cd -- "$raw_dir" 2>/dev/null && pwd -P) || { printf '[validate-fs] Warning: cd+pwd canonicalization failed, using raw path\n' >&2; printf '%s' "$raw_dir"; }
+  elif command -v realpath >/dev/null 2>&1; then
+    realpath -- "$raw_dir" 2>/dev/null || { printf '[validate-fs] Warning: realpath canonicalization failed, using raw path\n' >&2; printf '%s' "$raw_dir"; }
+  else
+    printf '[validate-fs] Warning: No realpath available, using raw path\n' >&2
+    printf '%s' "$raw_dir"
+  fi
+}
+
+# Validate that file_path is a project-relative path resolving inside the
+# project root (path-traversal mitigation).
+# Usage: validate_file_path "$path" ["$project_root"]
+# Returns 0 if valid, 1 otherwise.
+validate_file_path() {
+  local raw_path="$1"
+  local project_root="${2:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+
+  # Quick reject: obvious traversal patterns.
+  case "$raw_path" in
+    *..* | /* | *~*) return 1 ;;
+  esac
+
+  # Empty path is invalid.
+  if [ -z "$raw_path" ]; then
+    return 1
+  fi
+
+  # Reject newlines and carriage returns (defense-in-depth).
+  # Note: cannot use $(printf '\n') in a case pattern — command
+  # substitution strips trailing newlines. Use tr + length comparison.
+  local path_len=${#raw_path}
+  local oneline
+  oneline=$(printf '%s' "$raw_path" | tr -d '\n\r')
+  if [ ${#oneline} -ne "$path_len" ]; then
+    return 1
+  fi
+
+  # Canonicalize the project root so the containment check below is
+  # reliable even when the caller passes a symlinked root (e.g. macOS
+  # /var -> /private/var).
+  local canonical_root
+  canonical_root=$(cd -- "$project_root" 2>/dev/null && pwd -P) || return 1
+
+  local full_path="${canonical_root}/${raw_path}"
+
+  # Reject symlinks whose target escapes the project root (check before
+  # resolving the full path).
+  if [ -L "$full_path" ]; then
+    local target
+    if command -v realpath >/dev/null 2>&1; then
+      target="$(realpath -- "$full_path" 2>/dev/null)" || return 1
+    elif command -v readlink >/dev/null 2>&1; then
+      local link_content
+      link_content=$(readlink -- "$full_path" 2>/dev/null) || return 1
+      case "$link_content" in
+        /*) target="$link_content" ;;
+        *)  target="$(cd -- "$(dirname "$full_path")" 2>/dev/null && cd -- "$(dirname "$link_content")" 2>/dev/null && pwd -P)/$(basename "$link_content")" || return 1 ;;
+      esac
+    else
+      # Cannot safely resolve symlink target — reject.
+      return 1
+    fi
+    case "$target" in
+      "${canonical_root}/"*) ;; # OK: symlink points inside project
+      *) return 1 ;;            # Reject: symlink escapes project root
+    esac
+  fi
+
+  # Resolve path by walking up to the nearest existing ancestor using
+  # cd+pwd -P (POSIX, no realpath required). Fixes two issues with the
+  # prior realpath fallback:
+  #   1. realpath -m is not portable (GNU only); bare realpath fails on
+  #      non-existent paths, producing noisy warnings on every pre-creation
+  #      validate call (yellow-debt pattern).
+  #   2. The literal-$full_path fallback was fail-open against a symlinked
+  #      intermediate directory: if safe/link/ -> /tmp, validate_file_path
+  #      for safe/link/new.md returned success even though creation would
+  #      escape the project root. Walking up and resolving the nearest
+  #      existing ancestor via pwd -P catches this.
+  local resolved candidate="$full_path" remainder=""
+  while [ -n "$candidate" ] && [ "$candidate" != "/" ] && [ ! -e "$candidate" ]; do
+    remainder="$(basename -- "$candidate")${remainder:+/$remainder}"
+    candidate="$(dirname -- "$candidate")"
+  done
+  # If candidate is a regular file (not a directory), cd to its parent and
+  # append its basename — cd fails on non-directories.
+  local resolved_parent
+  if [ -d "$candidate" ]; then
+    resolved_parent=$(cd -- "$candidate" 2>/dev/null && pwd -P) || return 1
+  else
+    resolved_parent=$(cd -- "$(dirname -- "$candidate")" 2>/dev/null && pwd -P) || return 1
+    remainder="$(basename -- "$candidate")${remainder:+/$remainder}"
+  fi
+  resolved="${resolved_parent}${remainder:+/$remainder}"
+
+  # Verify resolved path is under the project root.
+  case "$resolved" in
+    "${canonical_root}/"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}

--- a/plugins/yellow-core/lib/validate-fs.sh
+++ b/plugins/yellow-core/lib/validate-fs.sh
@@ -14,8 +14,9 @@
 # Contract:
 #   - validate_file_path returns 0 if the path is a project-relative path
 #     that resolves inside the project root, 1 otherwise. Rejects empty
-#     paths, "..", leading "/", "~" anywhere in the path, embedded newlines/CRs, and symlinks
-#     whose target escapes the root.
+#     paths, "..", leading "/", leading "~" (home-directory expansion),
+#     embedded newlines/CRs, symlinks whose target escapes the root, and
+#     broken intermediate symlinks (whose future target could escape).
 #   - The project root ($2) is optional; it defaults to the git toplevel
 #     (or $PWD). yellow-debt callers rely on the optional form.
 #
@@ -56,9 +57,11 @@ validate_file_path() {
   local raw_path="$1"
   local project_root="${2:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 
-  # Quick reject: obvious traversal patterns.
+  # Quick reject: obvious traversal patterns. Tilde rejection is anchored
+  # to a leading "~" only — embedded tildes in filenames (backup~.txt,
+  # file~1.sh) are legal and must not be rejected.
   case "$raw_path" in
-    *..* | /* | *~*) return 1 ;;
+    *..* | /* | '~' | '~/'*) return 1 ;;
   esac
 
   # Empty path is invalid.
@@ -119,10 +122,23 @@ validate_file_path() {
   #      escape the project root. Walking up and resolving the nearest
   #      existing ancestor via pwd -P catches this.
   local resolved candidate="$full_path" remainder=""
-  while [ -n "$candidate" ] && [ "$candidate" != "/" ] && [ ! -e "$candidate" ]; do
+  # Stop the walk on either an existing entry (-e) OR a symlink (-L).
+  # Without -L the loop happily skipped a broken intermediate symlink
+  # (target absent → -e false) and produced a resolved path that would
+  # escape the project root once the symlink target was created — see
+  # the codex P2 regression on yellow-debt's pre-creation validate path.
+  while [ -n "$candidate" ] && [ "$candidate" != "/" ] && [ ! -e "$candidate" ] && [ ! -L "$candidate" ]; do
     remainder="$(basename -- "$candidate")${remainder:+/$remainder}"
     candidate="$(dirname -- "$candidate")"
   done
+
+  # If the walk stopped at a broken symlink (-L but not -e), reject
+  # conservatively: cd cannot follow it, and once its target is created
+  # the resolved path could land anywhere on the filesystem.
+  if [ -L "$candidate" ] && [ ! -e "$candidate" ]; then
+    return 1
+  fi
+
   # If candidate is a regular file (not a directory), cd to its parent and
   # append its basename — cd fails on non-directories.
   local resolved_parent
@@ -134,9 +150,13 @@ validate_file_path() {
   fi
   resolved="${resolved_parent}${remainder:+/$remainder}"
 
-  # Verify resolved path is under the project root.
+  # Verify resolved path is under the project root. Match both
+  # "${canonical_root}/..." (a path within the root) and "${canonical_root}"
+  # exactly (the root itself, e.g. validate_file_path "."). The old
+  # yellow-debt implementation handled both; dropping the equality branch
+  # was a regression.
   case "$resolved" in
-    "${canonical_root}/"*) return 0 ;;
+    "${canonical_root}/"*|"${canonical_root}") return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/plugins/yellow-core/tests/validate-fs.bats
+++ b/plugins/yellow-core/tests/validate-fs.bats
@@ -1,0 +1,129 @@
+#!/usr/bin/env bats
+# Tests for lib/validate-fs.sh — the canonical shared filesystem-path
+# validators (extracted from yellow-ci, yellow-ruvector, yellow-debt).
+
+setup() {
+  . "$BATS_TEST_DIRNAME/../lib/validate-fs.sh"
+
+  PROJECT_ROOT="$(mktemp -d)"
+  mkdir -p "$PROJECT_ROOT/src"
+  echo "test" > "$PROJECT_ROOT/src/file.txt"
+}
+
+teardown() {
+  if [ -n "${PROJECT_ROOT:-}" ] && [ -d "$PROJECT_ROOT" ]; then
+    rm -rf "$PROJECT_ROOT"
+  fi
+}
+
+# --- canonicalize_project_dir ---
+
+@test "canonicalize_project_dir resolves an existing absolute path" {
+  result=$(canonicalize_project_dir "$PROJECT_ROOT")
+  [ -n "$result" ]
+  [ -d "$result" ]
+}
+
+@test "canonicalize_project_dir handles a non-existent path" {
+  result=$(canonicalize_project_dir "/nonexistent/path/xyz")
+  [ -n "$result" ]
+}
+
+# --- validate_file_path: acceptance ---
+
+@test "validate_file_path accepts a valid relative path" {
+  run validate_file_path "src/file.txt" "$PROJECT_ROOT"
+  [ "$status" -eq 0 ]
+}
+
+@test "validate_file_path accepts a nested path" {
+  mkdir -p "$PROJECT_ROOT/src/deep/nested"
+  echo "x" > "$PROJECT_ROOT/src/deep/nested/file.ts"
+  run validate_file_path "src/deep/nested/file.ts" "$PROJECT_ROOT"
+  [ "$status" -eq 0 ]
+}
+
+@test "validate_file_path accepts a file in the project root" {
+  touch "$PROJECT_ROOT/README.md"
+  run validate_file_path "README.md" "$PROJECT_ROOT"
+  [ "$status" -eq 0 ]
+}
+
+@test "validate_file_path accepts a symlink pointing inside the project" {
+  ln -s "$PROJECT_ROOT/src/file.txt" "$PROJECT_ROOT/src/good-link"
+  run validate_file_path "src/good-link" "$PROJECT_ROOT"
+  [ "$status" -eq 0 ]
+}
+
+# --- validate_file_path: rejection ---
+
+@test "validate_file_path rejects an empty path" {
+  run validate_file_path "" "$PROJECT_ROOT"
+  [ "$status" -eq 1 ]
+}
+
+@test "validate_file_path rejects a path with .." {
+  run validate_file_path "../etc/passwd" "$PROJECT_ROOT"
+  [ "$status" -eq 1 ]
+}
+
+@test "validate_file_path rejects an embedded .." {
+  run validate_file_path "src/../../etc/passwd" "$PROJECT_ROOT"
+  [ "$status" -eq 1 ]
+}
+
+@test "validate_file_path rejects an absolute path" {
+  run validate_file_path "/etc/passwd" "$PROJECT_ROOT"
+  [ "$status" -eq 1 ]
+}
+
+@test "validate_file_path rejects a tilde path" {
+  run validate_file_path "~/.ssh/id_rsa" "$PROJECT_ROOT"
+  [ "$status" -eq 1 ]
+}
+
+@test "validate_file_path rejects a path with a newline" {
+  bad_path=$'src/file\n.txt'
+  run validate_file_path "$bad_path" "$PROJECT_ROOT"
+  [ "$status" -eq 1 ]
+}
+
+@test "validate_file_path rejects a path with a carriage return" {
+  bad_path=$'src/file\r.txt'
+  run validate_file_path "$bad_path" "$PROJECT_ROOT"
+  [ "$status" -eq 1 ]
+}
+
+@test "validate_file_path rejects a symlink whose target escapes the project" {
+  ln -s /etc/passwd "$PROJECT_ROOT/src/evil-link"
+  run validate_file_path "src/evil-link" "$PROJECT_ROOT"
+  [ "$status" -eq 1 ]
+}
+
+# --- validate_file_path: optional project root ($2 defaults to git toplevel) ---
+
+@test "validate_file_path defaults project root to the git toplevel when \$2 omitted" {
+  # Use an isolated temp git repo so the test does not depend on the
+  # real repository layout or working directory at test time.
+  # Run via subshell to avoid changing the bats process working directory,
+  # which would break subsequent tests that rely on PROJECT_ROOT.
+  local tmp_git
+  tmp_git="$(mktemp -d)"
+  git -C "$tmp_git" init -q
+  git -C "$tmp_git" config user.email "test@example.com"
+  git -C "$tmp_git" config user.name "Test"
+  mkdir -p "$tmp_git/src"
+  echo "test" > "$tmp_git/src/file.txt"
+  git -C "$tmp_git" add .
+  git -C "$tmp_git" commit -q -m "init"
+  local exit_code=0
+  ( cd "$tmp_git" && validate_file_path "src/file.txt" ) || exit_code=$?
+  rm -rf "$tmp_git"
+  [ "$exit_code" -eq 0 ]
+}
+
+@test "validate_file_path still rejects traversal when \$2 is omitted" {
+  cd "$BATS_TEST_DIRNAME"
+  run validate_file_path "../../../etc/passwd"
+  [ "$status" -eq 1 ]
+}

--- a/plugins/yellow-core/tests/validate-fs.bats
+++ b/plugins/yellow-core/tests/validate-fs.bats
@@ -82,6 +82,23 @@ teardown() {
   [ "$status" -eq 1 ]
 }
 
+@test "validate_file_path rejects a bare tilde" {
+  run validate_file_path "~" "$PROJECT_ROOT"
+  [ "$status" -eq 1 ]
+}
+
+@test "validate_file_path accepts a filename containing a tilde (not leading)" {
+  touch "$PROJECT_ROOT/src/backup~.txt"
+  run validate_file_path "src/backup~.txt" "$PROJECT_ROOT"
+  [ "$status" -eq 0 ]
+}
+
+@test "validate_file_path accepts a filename with embedded tilde" {
+  touch "$PROJECT_ROOT/src/file~1.sh"
+  run validate_file_path "src/file~1.sh" "$PROJECT_ROOT"
+  [ "$status" -eq 0 ]
+}
+
 @test "validate_file_path rejects a path with a newline" {
   bad_path=$'src/file\n.txt'
   run validate_file_path "$bad_path" "$PROJECT_ROOT"
@@ -98,6 +115,26 @@ teardown() {
   ln -s /etc/passwd "$PROJECT_ROOT/src/evil-link"
   run validate_file_path "src/evil-link" "$PROJECT_ROOT"
   [ "$status" -eq 1 ]
+}
+
+@test "validate_file_path rejects a broken intermediate symlink (target could escape on creation)" {
+  # safe/link is a symlink whose target does not currently exist; the
+  # pre-fix walk-up logic skipped it (-e false) and produced a resolved
+  # path inside the project root, even though once the target is created
+  # the path could land anywhere. Conservative fix: reject.
+  mkdir -p "$PROJECT_ROOT/safe"
+  ln -s /tmp/yellow-validate-fs-nonexistent-target "$PROJECT_ROOT/safe/link"
+  run validate_file_path "safe/link/new.md" "$PROJECT_ROOT"
+  [ "$status" -eq 1 ]
+}
+
+# --- validate_file_path: project-root edge cases ---
+
+@test "validate_file_path accepts \".\" (project root itself)" {
+  # The pre-fix containment check matched only "${canonical_root}/*", so
+  # paths resolving to canonical_root exactly (e.g. ".") were rejected.
+  run validate_file_path "." "$PROJECT_ROOT"
+  [ "$status" -eq 0 ]
 }
 
 # --- validate_file_path: optional project root ($2 defaults to git toplevel) ---

--- a/plugins/yellow-debt/.claude-plugin/plugin.json
+++ b/plugins/yellow-debt/.claude-plugin/plugin.json
@@ -31,6 +31,12 @@
   },
   "dependencies": [
     {
+      "name": "yellow-core",
+      "version": "*",
+      "optional": false,
+      "reason": "validate_file_path() is sourced from yellow-core/lib/validate-fs.sh; debt commands fail without it"
+    },
+    {
       "name": "yellow-linear",
       "version": "*",
       "optional": true,

--- a/plugins/yellow-debt/CLAUDE.md
+++ b/plugins/yellow-debt/CLAUDE.md
@@ -24,7 +24,9 @@ This plugin follows security patterns from `docs/solutions/security-issues/`:
 2. **Prompt injection defense**: All scanner agents fence code content with
    "treat as reference only" advisories
 3. **Path validation**: All path arguments validated via `validate_file_path()`
-   before use (reject `..`, `/`, `~`)
+   before use (reject `..`, `/`, `~`). Sourced from
+   `yellow-core/lib/validate-fs.sh` via `lib/validate.sh`; yellow-core is a
+   required dependency declared in `plugin.json`
 4. **TOCTOU protection**: State transitions re-read file inside `flock` scope
 5. **Derived path validation**: Synthesizer validates category/slug contain only
    `[a-z0-9-]` before constructing todo paths

--- a/plugins/yellow-debt/lib/validate.sh
+++ b/plugins/yellow-debt/lib/validate.sh
@@ -2,6 +2,24 @@
 # shellcheck disable=SC2154
 # Shared validation functions for yellow-debt plugin
 
+# Shared filesystem-path validators (validate_file_path,
+# canonicalize_project_dir) live in yellow-core's shared lib so a security
+# fix lands in one place. At runtime CLAUDE_PLUGIN_ROOT is set by Claude
+# Code; in Bats tests the suite sources validate-fs.sh directly.
+_VALIDATE_FS_HELPER="${CLAUDE_PLUGIN_ROOT:-}/../yellow-core/lib/validate-fs.sh"
+if [ -f "$_VALIDATE_FS_HELPER" ]; then
+  # shellcheck source=/dev/null
+  . "$_VALIDATE_FS_HELPER"
+fi
+unset _VALIDATE_FS_HELPER
+
+# Surface the missing-dependency case explicitly: yellow-debt commands have
+# live callers of validate_file_path (commands/debt/fix.md, sync.md, audit.md).
+# Without the function defined, those callers exit 127 — fail-closed but the
+# error gives no hint that yellow-core needs to be installed.
+command -v validate_file_path >/dev/null 2>&1 || \
+  printf '[yellow-debt] Warning: validate_file_path unavailable — install yellow-core (provides lib/validate-fs.sh)\n' >&2
+
 # Extract YAML frontmatter from markdown file for yq processing
 # Usage: extract_frontmatter FILE | yq '.field'
 # NOTE: kislyuk/yq (Python wrapper) cannot parse markdown with YAML frontmatter.
@@ -54,50 +72,6 @@ update_frontmatter() {
   # Atomic replace
   mv "$temp_file" "$file" || return 1
   return 0
-}
-
-validate_file_path() {
-  local raw_path="$1"
-  local project_root="${2:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
-
-  # Reject empty paths
-  [ -z "$raw_path" ] && return 1
-
-  # Newline detection (command substitution strips trailing newlines)
-  local path_len=${#raw_path}
-  local oneline
-  oneline=$(printf '%s' "$raw_path" | tr -d '\n\r')
-  [ ${#oneline} -ne "$path_len" ] && return 1
-
-  # Reject path traversal patterns
-  case "$raw_path" in
-    *..*|/*|~*) return 1 ;;
-  esac
-
-  # Canonicalize and verify containment
-  local canonical_root candidate resolved parent_dir
-  canonical_root=$(cd -- "$project_root" 2>/dev/null && pwd -P) || return 1
-  candidate="${canonical_root}/${raw_path}"
-
-  # Prefer GNU realpath -m when available (handles non-existent targets safely).
-  if command -v realpath >/dev/null 2>&1 && realpath -m / >/dev/null 2>&1; then
-    resolved=$(realpath -m -- "$candidate") || return 1
-  else
-    # Portable fallback: resolve the nearest existing ancestor, then append remaining path.
-    # This preserves the ability to validate paths for files not yet created.
-    local dir="$candidate" remainder=""
-    while [ -n "$dir" ] && [ "$dir" != "/" ] && ! [ -e "$dir" ]; do
-      remainder="$(basename -- "$dir")${remainder:+/$remainder}"
-      dir="$(dirname -- "$dir")"
-    done
-    parent_dir=$(cd -- "$dir" 2>/dev/null && pwd -P) || return 1
-    resolved="${parent_dir}${remainder:+/$remainder}"
-  fi
-
-  case "$resolved" in
-    "${canonical_root}/"*|"${canonical_root}") return 0 ;;
-    *) return 1 ;;
-  esac
 }
 
 validate_category() {

--- a/plugins/yellow-debt/tests/validate.bats
+++ b/plugins/yellow-debt/tests/validate.bats
@@ -2,6 +2,10 @@
 # Tests for lib/validate.sh
 
 setup() {
+  # validate_file_path now lives in yellow-core's shared lib. At runtime
+  # validate.sh sources it via CLAUDE_PLUGIN_ROOT; in tests source it
+  # directly first (validate.sh's guarded source then no-ops).
+  . "$BATS_TEST_DIRNAME/../../yellow-core/lib/validate-fs.sh"
   # Source the validation library
   . "$BATS_TEST_DIRNAME/../lib/validate.sh"
 

--- a/plugins/yellow-ruvector/hooks/scripts/lib/validate.sh
+++ b/plugins/yellow-ruvector/hooks/scripts/lib/validate.sh
@@ -2,88 +2,16 @@
 # validate.sh — Shared validation functions for ruvector hooks
 # Source this file from hook scripts: . "${SCRIPT_DIR}/lib/validate.sh"
 
-# Canonicalize PROJECT_DIR to absolute path (prevents symlink/relative path bypass)
-# Portable: uses cd+pwd (POSIX), no GNU realpath dependency
-canonicalize_project_dir() {
-  local raw_dir="$1"
-  if [ -d "$raw_dir" ]; then
-    (cd -- "$raw_dir" 2>/dev/null && pwd -P) || { printf '[validate] Warning: cd+pwd canonicalization failed, using raw path\n' >&2; printf '%s' "$raw_dir"; }
-  elif command -v realpath >/dev/null 2>&1; then
-    realpath -- "$raw_dir" 2>/dev/null || { printf '[validate] Warning: realpath canonicalization failed, using raw path\n' >&2; printf '%s' "$raw_dir"; }
-  else
-    printf '[validate] Warning: No realpath available, using raw path\n' >&2
-    printf '%s' "$raw_dir"
-  fi
-}
-
-# Validate file_path is within project root (path traversal mitigation)
-# Usage: validate_file_path "$path" "$project_root"
-validate_file_path() {
-  local raw_path="$1"
-  local project_root="$2"
-
-  # Quick reject: obvious traversal patterns
-  case "$raw_path" in
-    *..* | /* | *~*) return 1 ;;
-  esac
-
-  # Empty path is invalid
-  if [ -z "$raw_path" ]; then
-    return 1
-  fi
-
-  # Reject newlines and carriage returns (defense-in-depth)
-  # Note: cannot use $(printf '\n') in case pattern — command substitution strips trailing newlines
-  local path_len=${#raw_path}
-  local oneline
-  oneline=$(printf '%s' "$raw_path" | tr -d '\n\r')
-  if [ ${#oneline} -ne "$path_len" ]; then
-    return 1
-  fi
-
-  # Normalize and resolve to absolute path (portable — no GNU realpath -m)
-  local resolved
-  local full_path="${project_root}/${raw_path}"
-
-  # Reject symlinks outside project root (check before resolving)
-  if [ -L "$full_path" ]; then
-    local target
-    if command -v realpath >/dev/null 2>&1; then
-      target="$(realpath -- "$full_path" 2>/dev/null)" || return 1
-    elif command -v readlink >/dev/null 2>&1; then
-      local link_content
-      link_content=$(readlink -- "$full_path" 2>/dev/null) || return 1
-      case "$link_content" in
-        /*) target="$link_content" ;;
-        *)  target="$(cd -- "$(dirname "$full_path")" 2>/dev/null && cd -- "$(dirname "$link_content")" 2>/dev/null && pwd -P)/$(basename "$link_content")" || return 1 ;;
-      esac
-    else
-      # Cannot safely resolve symlink target — reject
-      return 1
-    fi
-    case "$target" in
-      "${project_root}/"*) ;; # OK: symlink points inside project
-      *) return 1 ;; # Reject: symlink escapes project root
-    esac
-  fi
-
-  # Resolve path: prefer realpath (any version), fall back to cd+pwd
-  if [ -e "$full_path" ] && [ -d "$(dirname "$full_path")" ]; then
-    resolved="$(cd -- "$(dirname "$full_path")" 2>/dev/null && pwd -P)/$(basename "$full_path")"
-  elif command -v realpath >/dev/null 2>&1; then
-    # realpath without -m: works on most systems including macOS (coreutils)
-    resolved="$(realpath -- "$full_path" 2>/dev/null)" || { printf '[validate] Warning: realpath failed for path, using literal path\n' >&2; resolved="$full_path"; }
-  else
-    printf '[validate] Warning: No realpath available, using literal path\n' >&2
-    resolved="$full_path"
-  fi
-
-  # Verify resolved path is under project root
-  case "$resolved" in
-    "${project_root}/"*) return 0 ;;
-    *) return 1 ;;
-  esac
-}
+# Shared filesystem-path validators (validate_file_path,
+# canonicalize_project_dir) live in yellow-core's shared lib so a security
+# fix lands in one place. At runtime CLAUDE_PLUGIN_ROOT is set by Claude
+# Code; in Bats tests the suite sources validate-fs.sh directly.
+_VALIDATE_FS_HELPER="${CLAUDE_PLUGIN_ROOT:-}/../yellow-core/lib/validate-fs.sh"
+if [ -f "$_VALIDATE_FS_HELPER" ]; then
+  # shellcheck source=/dev/null
+  . "$_VALIDATE_FS_HELPER"
+fi
+unset _VALIDATE_FS_HELPER
 
 # Validate namespace name matches [a-z0-9-] only
 # Usage: validate_namespace "$namespace"

--- a/plugins/yellow-ruvector/skills/ruvector-conventions/SKILL.md
+++ b/plugins/yellow-ruvector/skills/ruvector-conventions/SKILL.md
@@ -141,9 +141,12 @@ All `$ARGUMENTS` values are user input and must be validated:
   with empty string). Reject if empty after stripping.
 - **Learning content:** Max 2000 characters. Strip HTML tags. Minimum 20 words
   after sanitization.
-- **File paths:** Validate via `realpath -m` plus a prefix check against the
-  project root. Reject `..`, absolute paths, `~`, and newlines. See
-  `validate_file_path()` in `hooks/scripts/lib/validate.sh`.
+- **File paths:** Validate via `cd+pwd -P` (POSIX) with a `realpath` fallback,
+  plus a prefix containment check against the canonicalized project root.
+  Reject `..`, absolute paths, `~`, embedded newlines/CRs, and symlinks whose
+  target escapes the root. Canonical implementation lives in
+  `yellow-core/lib/validate-fs.sh`; `hooks/scripts/lib/validate.sh` sources it
+  via the `${CLAUDE_PLUGIN_ROOT}/../yellow-core/lib/` cross-plugin pattern.
 - **General rule:** Never interpolate `$ARGUMENTS` into shell commands without
   validation.
 
@@ -151,8 +154,9 @@ All `$ARGUMENTS` values are user input and must be validated:
 
 `hooks/scripts/lib/validate.sh` provides reusable validation functions:
 
-- `canonicalize_project_dir "$dir"` — Resolve to absolute path via realpath
-  (fallback to raw path)
+- `canonicalize_project_dir "$dir"` — Resolve to absolute path via `cd+pwd -P`
+  (POSIX), `realpath` fallback, then raw path (sourced from
+  `yellow-core/lib/validate-fs.sh`)
 - `validate_file_path "$path" "$project_root"` — Reject traversal, symlink
   escape, and newlines
 - `validate_namespace "$name"` — Legacy helper for plugin-local labels; do not

--- a/plugins/yellow-ruvector/tests/validate.bats
+++ b/plugins/yellow-ruvector/tests/validate.bats
@@ -2,6 +2,10 @@
 # Tests for hooks/scripts/lib/validate.sh
 
 setup() {
+  # validate_file_path / canonicalize_project_dir now live in yellow-core's
+  # shared lib. At runtime validate.sh sources it via CLAUDE_PLUGIN_ROOT;
+  # in tests source it directly first (validate.sh's guarded source no-ops).
+  . "$BATS_TEST_DIRNAME/../../yellow-core/lib/validate-fs.sh"
   # Source the validation library
   . "$BATS_TEST_DIRNAME/../hooks/scripts/lib/validate.sh"
 


### PR DESCRIPTION
validate_file_path() and canonicalize_project_dir() were copy-pasted across
yellow-ci, yellow-ruvector, and yellow-debt with divergent implementations
(debt audit findings 002/003/004) — a security fix to one copy was easily
missed in the others.

Divergences found:
- canonicalize_project_dir: absent (ci) / separate fn (ruvector) / inlined (debt)
- $2 project_root: required (ci, ruvector) / optional w/ git fallback (debt)
- newline detection: case-pattern (ci, the risky one per finding 002) /
  tr -d length comparison (ruvector, debt)
- symlink-escape check: explicit (ci, ruvector) / absent (debt)

Canonical = yellow-ruvector's impl (both functions, tr -d detection, explicit
symlink block) + two deliberate enhancements: optional $2 with git-toplevel
fallback (yellow-debt callers 'validate_file_path "$todo_file"' rely on it),
and internal root canonicalization for reliable containment checks.

- plugins/yellow-core/lib/validate-fs.sh: new canonical shared lib
- plugins/yellow-core/tests/validate-fs.bats: canonical test suite (16 tests)
- yellow-ci/ruvector/debt lib/validate.sh: source the shared helper with a
  [ -f ] guard, keep only plugin-specific validators
- the three validate.bats suites source validate-fs.sh directly

Bats: 16 (core) + 98 (ci) + 28 (ruvector) + 37 (debt) green. validate:plugins green.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Centralized filesystem path validation into a shared library for consistent, safer path checks across plugins.

* **Documentation**
  * Added guidelines for using the shared path-validation helper and updated plugin security/conventions docs.

* **Tests**
  * Added a canonical test suite for filesystem validation and updated plugin tests to source it.

* **Chores**
  * Plugins updated to source the centralized helper; one plugin now declares the shared library as a required dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KingInYellows/yellow-plugins/pull/529?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->