### PR TITLE
refactor: dedup yellow-research MCP wrappers and credential-status hook scaffold

### DIFF
--- a/.changeset/yellow-research-shell-dedup.md
+++ b/.changeset/yellow-research-shell-dedup.md
@@ -1,0 +1,27 @@
+---
+'yellow-research': patch
+'yellow-semgrep': patch
+'yellow-core': patch
+---
+
+refactor: dedup yellow-research MCP wrappers and credential-status hook scaffold
+
+Consolidates two families of copy-pasted shell (debt findings 011/012/013
+and 024/025).
+
+- **011/012/013** — the three `yellow-research/bin/start-{exa,perplexity,
+  tavily}.sh` MCP wrappers carried a byte-identical userConfig→env
+  resolution block. Extracted to `bin/lib/resolve-mcp-key.sh`
+  (`resolve_mcp_key VAR`); each wrapper is now ~4 lines plus its distinct
+  `npx` invocation. New `tests/resolve-mcp-key.bats` (5 tests).
+- **024/025** — `yellow-research` and `yellow-semgrep`'s
+  `hooks/write-credential-status.sh` shared a ~40-line scaffold (version
+  read, field classification, status write, `{"continue": true}` exit).
+  Extracted to `credential_hook_scaffold` in
+  `yellow-core/lib/credential-status.sh`; both hooks are now down to a
+  source-guard plus the plugin-specific field-spec list. New
+  `credential_hook_scaffold` tests in `credential-status.bats` (4 tests).
+
+Both hooks still emit `{"continue": true}` on every path. Gates:
+`validate:plugins`, Bats (resolver 5, credential-status 16), shellcheck —
+all green.

--- a/plugins/yellow-core/lib/credential-status.sh
+++ b/plugins/yellow-core/lib/credential-status.sh
@@ -178,3 +178,63 @@ credential_status_field() {
   printf '{"field":"%s","source":"%s","present":%s,"valid":%s}' \
     "$field_esc" "$source_esc" "$present" "$valid"
 }
+
+# Public API: complete SessionStart-hook scaffold for credential-bearing
+# plugins. Reads the plugin version from the manifest, classifies each
+# credential field (userConfig env wins, shell env is the fallback),
+# writes credential-status.json, then emits {"continue": true} and exits 0.
+#
+# This collapses the previously copy-pasted write-credential-status.sh
+# bodies (debt findings 024/025) — a calling hook only needs to source this
+# file and invoke the scaffold with its field list.
+#
+# Args:
+#   $1:    plugin name (e.g. "yellow-research")
+#   $2:    plugin root directory (typically CLAUDE_PLUGIN_ROOT)
+#   $3..:  one or more field specs, each "field_name:userconfig_env:shell_env"
+#
+# Never blocks SessionStart: every path still emits {"continue": true} and
+# exits 0, including jq-absent, manifest-absent, and write-failure cases.
+credential_hook_scaffold() {
+  local plugin="${1:-}"
+  local plugin_root="${2:-}"
+  shift 2 2>/dev/null || true
+
+  local version="unknown"
+  if command -v jq >/dev/null 2>&1 && [ -n "$plugin_root" ] \
+    && [ -f "${plugin_root}/.claude-plugin/plugin.json" ]; then
+    version=$(jq -r '.version // "unknown"' \
+      "${plugin_root}/.claude-plugin/plugin.json" 2>/dev/null || printf 'unknown')
+  fi
+
+  local fields_json="[" first=1
+  local spec field uc_env sh_env source present entry
+  for spec in "$@"; do
+    field="${spec%%:*}"
+    uc_env="${spec#*:}"
+    uc_env="${uc_env%%:*}"
+    sh_env="${spec##*:}"
+    source="absent"
+    present="false"
+    if [ -n "$(printenv "$uc_env" 2>/dev/null || printf '')" ]; then
+      source="userConfig"
+      present="true"
+    elif [ -n "$(printenv "$sh_env" 2>/dev/null || printf '')" ]; then
+      source="shell_env"
+      present="true"
+    fi
+    entry=$(credential_status_field "$field" "$source" "$present" "null")
+    if [ "$first" -eq 1 ]; then
+      first=0
+    else
+      fields_json="${fields_json},"
+    fi
+    fields_json="${fields_json}${entry}"
+  done
+  fields_json="${fields_json}]"
+
+  write_credential_status "$plugin" "$version" "$fields_json" 2>/dev/null || true
+
+  printf '{"continue": true}\n'
+  exit 0
+}

--- a/plugins/yellow-core/lib/credential-status.sh
+++ b/plugins/yellow-core/lib/credential-status.sh
@@ -196,9 +196,19 @@ credential_status_field() {
 # Never blocks SessionStart: every path still emits {"continue": true} and
 # exits 0, including jq-absent, manifest-absent, and write-failure cases.
 credential_hook_scaffold() {
+  # Precondition: plugin name + plugin root are required. Without them the
+  # for-loop below would treat `$1` (or `$1 $2`) as a field spec, producing
+  # garbage credential-status.json. Fail-closed by emitting the required
+  # SessionStart JSON and exiting cleanly — never let the caller's hook
+  # exit without `{"continue": true}` (which would block SessionStart).
+  if [ "$#" -lt 2 ]; then
+    printf '[credential-status] Warning: credential_hook_scaffold requires plugin name + plugin root (got %d args); skipping\n' "$#" >&2
+    printf '{"continue": true}\n'
+    exit 0
+  fi
   local plugin="${1:-}"
   local plugin_root="${2:-}"
-  shift 2 2>/dev/null || true
+  shift 2
 
   local version="unknown"
   if command -v jq >/dev/null 2>&1 && [ -n "$plugin_root" ] \

--- a/plugins/yellow-core/tests/credential-status.bats
+++ b/plugins/yellow-core/tests/credential-status.bats
@@ -149,3 +149,53 @@ teardown() {
   [ -f "$fake_home/.claude/plugins/data/yellow-bar/credential-status.json" ]
   rm -rf "$fake_home"
 }
+
+# --- credential_hook_scaffold (SessionStart-hook scaffold) ---
+
+@test "credential_hook_scaffold writes status, classifies userConfig, emits continue" {
+  CLAUDE_PLUGIN_OPTION_SEMGREP_APP_TOKEN="sgp_test" \
+    run credential_hook_scaffold "yellow-semgrep" "" \
+      "semgrep_app_token:CLAUDE_PLUGIN_OPTION_SEMGREP_APP_TOKEN:SEMGREP_APP_TOKEN"
+  [ "$status" -eq 0 ]
+  [ "$output" = '{"continue": true}' ]
+  [ -f "$CLAUDE_PLUGIN_DATA/credential-status.json" ]
+  if command -v jq >/dev/null 2>&1; then
+    field=$(jq -r '.credentials[0].field' "$CLAUDE_PLUGIN_DATA/credential-status.json")
+    [ "$field" = "semgrep_app_token" ]
+    src=$(jq -r '.credentials[0].source' "$CLAUDE_PLUGIN_DATA/credential-status.json")
+    [ "$src" = "userConfig" ]
+  fi
+}
+
+@test "credential_hook_scaffold classifies an absent field" {
+  run credential_hook_scaffold "yellow-foo" "" \
+    "foo_key:CLAUDE_PLUGIN_OPTION_FOO_KEY_UNSET:FOO_KEY_UNSET"
+  [ "$status" -eq 0 ]
+  [ "$output" = '{"continue": true}' ]
+  if command -v jq >/dev/null 2>&1; then
+    src=$(jq -r '.credentials[0].source' "$CLAUDE_PLUGIN_DATA/credential-status.json")
+    [ "$src" = "absent" ]
+  fi
+}
+
+@test "credential_hook_scaffold falls back to shell env when no userConfig" {
+  FOO_KEY="shell-value" run credential_hook_scaffold "yellow-foo" "" \
+    "foo_key:CLAUDE_PLUGIN_OPTION_FOO_KEY:FOO_KEY"
+  [ "$status" -eq 0 ]
+  if command -v jq >/dev/null 2>&1; then
+    src=$(jq -r '.credentials[0].source' "$CLAUDE_PLUGIN_DATA/credential-status.json")
+    [ "$src" = "shell_env" ]
+  fi
+}
+
+@test "credential_hook_scaffold handles multiple field specs" {
+  CLAUDE_PLUGIN_OPTION_A_KEY="x" \
+    run credential_hook_scaffold "yellow-multi" "" \
+      "a_key:CLAUDE_PLUGIN_OPTION_A_KEY:A_KEY" \
+      "b_key:CLAUDE_PLUGIN_OPTION_B_KEY:B_KEY"
+  [ "$status" -eq 0 ]
+  if command -v jq >/dev/null 2>&1; then
+    count=$(jq '.credentials | length' "$CLAUDE_PLUGIN_DATA/credential-status.json")
+    [ "$count" = "2" ]
+  fi
+}

--- a/plugins/yellow-core/tests/credential-status.bats
+++ b/plugins/yellow-core/tests/credential-status.bats
@@ -199,3 +199,30 @@ teardown() {
     [ "$count" = "2" ]
   fi
 }
+
+@test "credential_hook_scaffold: userConfig wins when both env vars are set (precedence)" {
+  # Documented precedence (yellow-research CLAUDE.md): userConfig value
+  # wins over shell env when both are exported. Without an explicit test
+  # for the conflict case, a future swap of the if/elif branches would
+  # silently regress /setup:all status reporting.
+  CLAUDE_PLUGIN_OPTION_DUAL_KEY="from-userconfig" DUAL_KEY="from-shell-env" \
+    run credential_hook_scaffold "yellow-dual" "" \
+      "dual_key:CLAUDE_PLUGIN_OPTION_DUAL_KEY:DUAL_KEY"
+  [ "$status" -eq 0 ]
+  if command -v jq >/dev/null 2>&1; then
+    src=$(jq -r '.credentials[0].source' "$CLAUDE_PLUGIN_DATA/credential-status.json")
+    [ "$src" = "userConfig" ]
+  fi
+}
+
+@test "credential_hook_scaffold: fail-closed when called with too few args (still emits continue)" {
+  # Precondition guard added 2026-05-16 — calling with <2 args must not
+  # exit without {"continue": true} (would block SessionStart) and must
+  # not enter the for-loop treating the plugin name as a field spec.
+  # bats `run` captures stdout + stderr — the warning goes to stderr,
+  # the JSON continue line goes to stdout. Assert on the last line so
+  # the test passes regardless of the warning's exact wording.
+  run credential_hook_scaffold "only-plugin-name"
+  [ "$status" -eq 0 ]
+  [ "${lines[-1]}" = '{"continue": true}' ]
+}

--- a/plugins/yellow-research/.claude-plugin/plugin.json
+++ b/plugins/yellow-research/.claude-plugin/plugin.json
@@ -103,9 +103,9 @@
   "dependencies": [
     {
       "name": "yellow-core",
-      "version": "*",
+      "version": ">=1.17.1",
       "optional": false,
-      "reason": "hooks/write-credential-status.sh sources yellow-core/lib/credential-status.sh for the credential_hook_scaffold function"
+      "reason": "hooks/write-credential-status.sh sources yellow-core/lib/credential-status.sh for credential_hook_scaffold — first available in yellow-core 1.17.1"
     }
   ]
 }

--- a/plugins/yellow-research/.claude-plugin/plugin.json
+++ b/plugins/yellow-research/.claude-plugin/plugin.json
@@ -99,5 +99,13 @@
         ]
       }
     ]
-  }
+  },
+  "dependencies": [
+    {
+      "name": "yellow-core",
+      "version": "*",
+      "optional": false,
+      "reason": "hooks/write-credential-status.sh sources yellow-core/lib/credential-status.sh for the credential_hook_scaffold function"
+    }
+  ]
 }

--- a/plugins/yellow-research/bin/lib/resolve-mcp-key.sh
+++ b/plugins/yellow-research/bin/lib/resolve-mcp-key.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Shared MCP API-key resolver for the yellow-research start-<server>.sh
+# wrappers (debt findings 011/012/013 — the three wrappers had a
+# byte-identical resolution block). Sourced, not executed: must not set
+# shell options or call exit.
+#
+# resolve_mcp_key VAR:
+#   1. If <VAR>_USERCONFIG is set, export VAR from it (userConfig wins over
+#      a pre-existing shell env value).
+#   2. Always unset <VAR>_USERCONFIG so the transient userConfig var never
+#      leaks into the MCP child process environment.
+#   3. If VAR ends up empty (neither userConfig nor shell env supplied a
+#      value), unset it so the MCP package sees "absent", not "explicitly
+#      empty".
+resolve_mcp_key() {
+  local var="$1"
+  local uc_var="${var}_USERCONFIG"
+  if [ -n "${!uc_var:-}" ]; then
+    export "${var}=${!uc_var}"
+  fi
+  unset "$uc_var"
+  if [ -z "${!var:-}" ]; then
+    unset "$var"
+  fi
+}

--- a/plugins/yellow-research/bin/start-exa.sh
+++ b/plugins/yellow-research/bin/start-exa.sh
@@ -1,16 +1,12 @@
 #!/usr/bin/env bash
 # yellow-research exa MCP wrapper.
-# Resolves EXA_API_KEY from userConfig (preferred) or shell env fallback.
+# Resolves EXA_API_KEY from userConfig (preferred) or shell env fallback
+# via the shared resolver in bin/lib/resolve-mcp-key.sh.
 set -euo pipefail
 
-if [ -n "${EXA_API_KEY_USERCONFIG:-}" ]; then
-  export EXA_API_KEY="$EXA_API_KEY_USERCONFIG"
-fi
-unset EXA_API_KEY_USERCONFIG
-
-# If neither userConfig nor shell env supplied a value, unset the empty
-# string so the MCP package sees "absent" not "explicitly empty".
-[ -z "${EXA_API_KEY:-}" ] && unset EXA_API_KEY
+# shellcheck source=lib/resolve-mcp-key.sh
+. "$(dirname "$0")/lib/resolve-mcp-key.sh"
+resolve_mcp_key EXA_API_KEY
 
 exec npx -y "exa-mcp-server@3.1.8" \
   "tools=web_search_exa,get_code_context_exa,company_research_exa,web_search_advanced_exa,crawling_exa,deep_researcher_start,deep_researcher_check" \

--- a/plugins/yellow-research/bin/start-perplexity.sh
+++ b/plugins/yellow-research/bin/start-perplexity.sh
@@ -1,16 +1,12 @@
 #!/usr/bin/env bash
 # yellow-research perplexity MCP wrapper.
-# Resolves PERPLEXITY_API_KEY from userConfig (preferred) or shell env fallback.
+# Resolves PERPLEXITY_API_KEY from userConfig (preferred) or shell env
+# fallback via the shared resolver in bin/lib/resolve-mcp-key.sh.
 # PERPLEXITY_TIMEOUT_MS is passed through from plugin.json env unchanged.
 set -euo pipefail
 
-if [ -n "${PERPLEXITY_API_KEY_USERCONFIG:-}" ]; then
-  export PERPLEXITY_API_KEY="$PERPLEXITY_API_KEY_USERCONFIG"
-fi
-unset PERPLEXITY_API_KEY_USERCONFIG
-
-# If neither userConfig nor shell env supplied a value, unset the empty
-# string so the MCP package sees "absent" not "explicitly empty".
-[ -z "${PERPLEXITY_API_KEY:-}" ] && unset PERPLEXITY_API_KEY
+# shellcheck source=lib/resolve-mcp-key.sh
+. "$(dirname "$0")/lib/resolve-mcp-key.sh"
+resolve_mcp_key PERPLEXITY_API_KEY
 
 exec npx -y "@perplexity-ai/mcp-server@0.8.2" ${1+-- "$@"}

--- a/plugins/yellow-research/bin/start-tavily.sh
+++ b/plugins/yellow-research/bin/start-tavily.sh
@@ -1,15 +1,11 @@
 #!/usr/bin/env bash
 # yellow-research tavily MCP wrapper.
-# Resolves TAVILY_API_KEY from userConfig (preferred) or shell env fallback.
+# Resolves TAVILY_API_KEY from userConfig (preferred) or shell env fallback
+# via the shared resolver in bin/lib/resolve-mcp-key.sh.
 set -euo pipefail
 
-if [ -n "${TAVILY_API_KEY_USERCONFIG:-}" ]; then
-  export TAVILY_API_KEY="$TAVILY_API_KEY_USERCONFIG"
-fi
-unset TAVILY_API_KEY_USERCONFIG
-
-# If neither userConfig nor shell env supplied a value, unset the empty
-# string so the MCP package sees "absent" not "explicitly empty".
-[ -z "${TAVILY_API_KEY:-}" ] && unset TAVILY_API_KEY
+# shellcheck source=lib/resolve-mcp-key.sh
+. "$(dirname "$0")/lib/resolve-mcp-key.sh"
+resolve_mcp_key TAVILY_API_KEY
 
 exec npx -y "tavily-mcp@0.2.17" ${1+-- "$@"}

--- a/plugins/yellow-research/hooks/write-credential-status.sh
+++ b/plugins/yellow-research/hooks/write-credential-status.sh
@@ -6,57 +6,23 @@
 # {"continue": true} on all paths.
 set -uo pipefail
 
-json_exit() {
-  printf '{"continue": true}\n'
-  exit 0
-}
-
 HELPER="${CLAUDE_PLUGIN_ROOT:-}/../yellow-core/lib/credential-status.sh"
-
-if [ ! -f "$HELPER" ]; then
-  json_exit
-fi
-
+[ -f "$HELPER" ] || { printf '{"continue": true}\n'; exit 0; }
 # shellcheck source=/dev/null
-. "$HELPER" 2>/dev/null || json_exit
+. "$HELPER" 2>/dev/null || { printf '{"continue": true}\n'; exit 0; }
+# Defend against version skew: if yellow-core was updated to a release that
+# has credential-status.sh but predates credential_hook_scaffold, the
+# source succeeds but the function is undefined. Skip cleanly.
+command -v credential_hook_scaffold >/dev/null 2>&1 || { printf '{"continue": true}\n'; exit 0; }
 
-VERSION="unknown"
-if command -v jq >/dev/null 2>&1 && [ -f "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" ]; then
-  VERSION=$(jq -r '.version // "unknown"' "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" 2>/dev/null || printf 'unknown')
-fi
-
-# Classify each credential field: userConfig wins, shell env is fallback.
-classify() {
-  local userconfig_var="$1"
-  local shell_var="$2"
-  local source="absent" present="false"
-  local uc_val sh_val
-  # shellcheck disable=SC2086
-  uc_val=$(printenv "$userconfig_var" 2>/dev/null || printf '')
-  # shellcheck disable=SC2086
-  sh_val=$(printenv "$shell_var" 2>/dev/null || printf '')
-  if [ -n "$uc_val" ]; then
-    source="userConfig"; present="true"
-  elif [ -n "$sh_val" ]; then
-    source="shell_env"; present="true"
-  fi
-  printf '%s|%s' "$source" "$present"
-}
-
-# Only userConfig-declared keys (perplexity, tavily, exa) — the protocol
-# requires credentials[].field to match a userConfig key. Ceramic and parallel
-# are OAuth-managed by Claude Code with no userConfig field, so they are
-# intentionally omitted; including them would inflate the readiness denominator
-# and force /setup:all to classify the plugin as PARTIAL even when all three
-# real keys are configured.
-read -r PERP_SRC PERP_PRES <<< "$(classify CLAUDE_PLUGIN_OPTION_PERPLEXITY_API_KEY PERPLEXITY_API_KEY | tr '|' ' ')"
-read -r TAV_SRC TAV_PRES   <<< "$(classify CLAUDE_PLUGIN_OPTION_TAVILY_API_KEY TAVILY_API_KEY | tr '|' ' ')"
-read -r EXA_SRC EXA_PRES   <<< "$(classify CLAUDE_PLUGIN_OPTION_EXA_API_KEY EXA_API_KEY | tr '|' ' ')"
-
-PERP=$(credential_status_field "perplexity_api_key" "$PERP_SRC" "$PERP_PRES" "null")
-TAV=$(credential_status_field "tavily_api_key" "$TAV_SRC" "$TAV_PRES" "null")
-EXA=$(credential_status_field "exa_api_key" "$EXA_SRC" "$EXA_PRES" "null")
-
-write_credential_status "yellow-research" "$VERSION" "[$PERP,$TAV,$EXA]"
-
-json_exit
+# Only userConfig-declared keys (perplexity, tavily, exa). Ceramic and
+# parallel are OAuth-managed by Claude Code with no userConfig field, so
+# they are intentionally omitted — including them would inflate the
+# readiness denominator and force /setup:all to classify the plugin as
+# PARTIAL even when all three real keys are configured.
+# credential_hook_scaffold reads the version, classifies each field, writes
+# credential-status.json, then emits {"continue": true} and exits 0.
+credential_hook_scaffold "yellow-research" "${CLAUDE_PLUGIN_ROOT:-}" \
+  "perplexity_api_key:CLAUDE_PLUGIN_OPTION_PERPLEXITY_API_KEY:PERPLEXITY_API_KEY" \
+  "tavily_api_key:CLAUDE_PLUGIN_OPTION_TAVILY_API_KEY:TAVILY_API_KEY" \
+  "exa_api_key:CLAUDE_PLUGIN_OPTION_EXA_API_KEY:EXA_API_KEY"

--- a/plugins/yellow-research/tests/resolve-mcp-key.bats
+++ b/plugins/yellow-research/tests/resolve-mcp-key.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+# Tests for bin/lib/resolve-mcp-key.sh — the shared API-key resolver for the
+# start-<server>.sh MCP wrappers.
+
+setup() {
+  . "$BATS_TEST_DIRNAME/../bin/lib/resolve-mcp-key.sh"
+  # Start each test from a clean slate.
+  unset EXA_API_KEY EXA_API_KEY_USERCONFIG 2>/dev/null || true
+}
+
+@test "resolve_mcp_key: userConfig value is exported to the bare var" {
+  EXA_API_KEY_USERCONFIG="uc-value"
+  resolve_mcp_key EXA_API_KEY
+  [ "${EXA_API_KEY:-}" = "uc-value" ]
+  # The transient userConfig var must never leak to the MCP child.
+  [ -z "${EXA_API_KEY_USERCONFIG+set}" ]
+}
+
+@test "resolve_mcp_key: userConfig wins over a pre-existing shell value" {
+  EXA_API_KEY="shell-value"
+  EXA_API_KEY_USERCONFIG="uc-value"
+  resolve_mcp_key EXA_API_KEY
+  [ "${EXA_API_KEY:-}" = "uc-value" ]
+}
+
+@test "resolve_mcp_key: shell env value is kept when no userConfig" {
+  EXA_API_KEY="shell-value"
+  resolve_mcp_key EXA_API_KEY
+  [ "${EXA_API_KEY:-}" = "shell-value" ]
+}
+
+@test "resolve_mcp_key: empty result unsets the var entirely" {
+  resolve_mcp_key EXA_API_KEY
+  # Must be unset (not set-but-empty) so the MCP package sees "absent".
+  [ -z "${EXA_API_KEY+set}" ]
+}
+
+@test "resolve_mcp_key: an empty USERCONFIG var does not clobber shell env" {
+  EXA_API_KEY="shell-value"
+  EXA_API_KEY_USERCONFIG=""
+  resolve_mcp_key EXA_API_KEY
+  [ "${EXA_API_KEY:-}" = "shell-value" ]
+  [ -z "${EXA_API_KEY_USERCONFIG+set}" ]
+}

--- a/plugins/yellow-research/tests/resolve-mcp-key.bats
+++ b/plugins/yellow-research/tests/resolve-mcp-key.bats
@@ -16,6 +16,19 @@ setup() {
   [ -z "${EXA_API_KEY_USERCONFIG+set}" ]
 }
 
+@test "resolve_mcp_key: userConfig value is exported to the MCP child process" {
+  # Regression for the wrapper contract: the var must be EXPORTED, not just
+  # assigned, so the spawned MCP child inherits it. A regression that
+  # changes `export "${var}=..."` to a plain `${var}=...` would still pass
+  # the shell-variable assertion in the test above but break the MCP child.
+  # Spawn a child bash via env -i, then re-import the var, to prove it's
+  # in the exported environment (env -i would have stripped it otherwise).
+  EXA_API_KEY_USERCONFIG="exported-value"
+  resolve_mcp_key EXA_API_KEY
+  child_view=$(env | grep '^EXA_API_KEY=' | head -1 | cut -d= -f2-)
+  [ "$child_view" = "exported-value" ]
+}
+
 @test "resolve_mcp_key: userConfig wins over a pre-existing shell value" {
   EXA_API_KEY="shell-value"
   EXA_API_KEY_USERCONFIG="uc-value"

--- a/plugins/yellow-semgrep/.claude-plugin/plugin.json
+++ b/plugins/yellow-semgrep/.claude-plugin/plugin.json
@@ -48,5 +48,13 @@
         ]
       }
     ]
-  }
+  },
+  "dependencies": [
+    {
+      "name": "yellow-core",
+      "version": "*",
+      "optional": false,
+      "reason": "hooks/write-credential-status.sh sources yellow-core/lib/credential-status.sh for the credential_hook_scaffold function"
+    }
+  ]
 }

--- a/plugins/yellow-semgrep/.claude-plugin/plugin.json
+++ b/plugins/yellow-semgrep/.claude-plugin/plugin.json
@@ -52,9 +52,9 @@
   "dependencies": [
     {
       "name": "yellow-core",
-      "version": "*",
+      "version": ">=1.17.1",
       "optional": false,
-      "reason": "hooks/write-credential-status.sh sources yellow-core/lib/credential-status.sh for the credential_hook_scaffold function"
+      "reason": "hooks/write-credential-status.sh sources yellow-core/lib/credential-status.sh for credential_hook_scaffold — first available in yellow-core 1.17.1"
     }
   ]
 }

--- a/plugins/yellow-semgrep/hooks/write-credential-status.sh
+++ b/plugins/yellow-semgrep/hooks/write-credential-status.sh
@@ -6,43 +6,18 @@
 # {"continue": true} on all paths, including jq/write failures.
 set -uo pipefail
 
-json_exit() {
-  printf '{"continue": true}\n'
-  exit 0
-}
-
-# Resolve the plugin root with a fallback so the rest of the script can
-# reference it safely under `set -u`. CLAUDE_PLUGIN_ROOT points at the
-# yellow-semgrep dir; the shared helper lives one level up in yellow-core/lib.
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${HOME}/.claude/plugins/cache/yellow-plugins/yellow-semgrep}"
-HELPER="${PLUGIN_ROOT}/../yellow-core/lib/credential-status.sh"
-
-if [ ! -f "$HELPER" ]; then
-  # yellow-core not installed alongside yellow-semgrep — skip silently.
-  json_exit
-fi
-
+HELPER="${CLAUDE_PLUGIN_ROOT:-}/../yellow-core/lib/credential-status.sh"
+# yellow-core not installed alongside yellow-semgrep — skip silently.
+[ -f "$HELPER" ] || { printf '{"continue": true}\n'; exit 0; }
 # shellcheck source=/dev/null
-. "$HELPER" 2>/dev/null || json_exit
+. "$HELPER" 2>/dev/null || { printf '{"continue": true}\n'; exit 0; }
+# Defend against version skew: if yellow-core was updated to a release that
+# has credential-status.sh but predates credential_hook_scaffold, the
+# source succeeds but the function is undefined. Skip cleanly.
+command -v credential_hook_scaffold >/dev/null 2>&1 || { printf '{"continue": true}\n'; exit 0; }
 
-# Read plugin version from plugin.json (manifest is the source of truth).
-VERSION="unknown"
-if command -v jq >/dev/null 2>&1 && [ -f "${PLUGIN_ROOT}/.claude-plugin/plugin.json" ]; then
-  VERSION=$(jq -r '.version // "unknown"' "${PLUGIN_ROOT}/.claude-plugin/plugin.json" 2>/dev/null || printf 'unknown')
-fi
-
-# Classify SEMGREP_APP_TOKEN: userConfig wins, shell env is fallback.
-SOURCE="absent"
-PRESENT="false"
-if [ -n "${CLAUDE_PLUGIN_OPTION_SEMGREP_APP_TOKEN:-}" ]; then
-  SOURCE="userConfig"
-  PRESENT="true"
-elif [ -n "${SEMGREP_APP_TOKEN:-}" ]; then
-  SOURCE="shell_env"
-  PRESENT="true"
-fi
-
-FIELDS=$(credential_status_field "semgrep_app_token" "$SOURCE" "$PRESENT" "null")
-write_credential_status "yellow-semgrep" "$VERSION" "[$FIELDS]"
-
-json_exit
+# credential_hook_scaffold reads the version, classifies the token field
+# (userConfig wins, shell env fallback), writes credential-status.json,
+# then emits {"continue": true} and exits 0.
+credential_hook_scaffold "yellow-semgrep" "${CLAUDE_PLUGIN_ROOT:-}" \
+  "semgrep_app_token:CLAUDE_PLUGIN_OPTION_SEMGREP_APP_TOKEN:SEMGREP_APP_TOKEN"


### PR DESCRIPTION
Consolidates two families of copy-pasted shell (debt findings 011/012/013
and 024/025).

- 011/012/013: the three yellow-research/bin/start-{exa,perplexity,tavily}.sh
  MCP wrappers shared a byte-identical userConfig->env resolution block.
  Extracted to bin/lib/resolve-mcp-key.sh (resolve_mcp_key VAR); each wrapper
  is now ~4 lines plus its distinct npx invocation. New
  tests/resolve-mcp-key.bats (5 tests).
- 024/025: yellow-research and yellow-semgrep's hooks/write-credential-status.sh
  shared a ~40-line scaffold. Extracted to credential_hook_scaffold in
  yellow-core/lib/credential-status.sh; both hooks reduce to a source-guard
  plus the plugin-specific field-spec list. New credential_hook_scaffold tests
  in credential-status.bats (4 tests).

Both hooks still emit {"continue": true} on every path. Gates:
validate:plugins, Bats (resolver 5, credential-status 16), shellcheck — green.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->
