### PR TITLE
refactor: remove dead exports and trim comment ratio in packages/

### DIFF
--- a/docs/contracts/compatibility.md
+++ b/docs/contracts/compatibility.md
@@ -200,8 +200,10 @@ required range.
     path: '/compatibility/claudeCodeMin',
     severity: 'ERROR',
     category: 'COMPATIBILITY',
-    specReference: 'CRIT-002b',
-    resolution: 'Please ensure your system meets the requirement: claudeCodeMin >=1.5.0'
+    specReference: 'CRIT-002b'
+    // Remediation guidance is in docs/contracts/error-codes.md under
+    // ERROR-COMPAT-001 — the prior in-band `resolution` field was
+    // removed when DomainValidationError was simplified.
   }
 }
 ```
@@ -385,8 +387,11 @@ All errors include:
 
 - **Error code** from specification Section 4
 - **Specification reference** (CRIT/FR anchor)
-- **Suggested resolution** text
 - **Contextual data** (required, actual values)
+
+Suggested remediation for each error code is documented in
+`docs/contracts/error-codes.md` (no longer returned in-band on the
+validator response).
 
 ---
 

--- a/docs/contracts/error-codes.md
+++ b/docs/contracts/error-codes.md
@@ -808,8 +808,8 @@ data).
 
 ### For CLI Users
 
-1. **Read Error Messages**: Error messages include resolution guidance
-2. **Check Error Codes**: Use this reference for detailed explanations
+1. **Read Error Messages**: Error messages are human-readable and name the failing field/value
+2. **Check Error Codes**: Use this reference for detailed explanations and suggested remediation
 3. **Review Logs**: Enable verbose logging for debugging
 4. **Report Issues**: Contact plugin maintainer or file bug report
 
@@ -871,9 +871,15 @@ interface DomainValidationError {
   category: string; // e.g., "SCHEMA_VALIDATION"
   context?: object; // Additional debugging context
   specReference?: string; // e.g., "CRIT-007, FR-004"
-  resolution?: string; // Suggested fix
 }
 ```
+
+> The `resolution?: string` field was removed from `DomainValidationError`
+> in v1.2.x. Remediation guidance lives in this document under each error
+> code rather than on the validator response — the prior in-band field
+> was only ever populated for a subset of codes and was not part of any
+> tested contract. CLI/API consumers should look up `code` here for the
+> human-facing fix.
 
 **Example**:
 
@@ -888,8 +894,7 @@ interface DomainValidationError {
     "keyword": "required",
     "missingProperty": "version"
   },
-  "specReference": "FR-001, FR-002",
-  "resolution": "Add the required field to your manifest file"
+  "specReference": "FR-001, FR-002"
 }
 ```
 

--- a/packages/domain/src/validation/errorCatalog.ts
+++ b/packages/domain/src/validation/errorCatalog.ts
@@ -113,7 +113,6 @@ export class ValidationErrorFactory {
       category: ErrorCategory.SCHEMA_VALIDATION,
       context: { keyword, ...context },
       specReference: 'FR-001, FR-002',
-      resolution: this.getSchemaErrorResolution(keyword),
     };
   }
 
@@ -174,7 +173,6 @@ export class ValidationErrorFactory {
       category: ErrorCategory.COMPATIBILITY,
       context: { requirement, actual, expected },
       specReference: errorInfo.crit,
-      resolution: `Please ensure your system meets the requirement: ${requirement} ${expected}`,
     };
   }
 
@@ -201,7 +199,6 @@ export class ValidationErrorFactory {
       category: ErrorCategory.INSTALLATION,
       context: { pluginId, ...context },
       specReference: 'CRIT-007, CRIT-010',
-      resolution: this.getInstallationErrorResolution(code),
     };
   }
 
@@ -226,59 +223,7 @@ export class ValidationErrorFactory {
       category: ErrorCategory.DISCOVERY,
       context,
       specReference: 'CRIT-008',
-      resolution:
-        'Verify marketplace configuration and plugin references are valid',
     };
-  }
-
-  /**
-   * Get resolution guidance for schema errors
-   */
-  private static getSchemaErrorResolution(keyword: string): string {
-    const resolutionMap: Record<string, string> = {
-      required: 'Add the required field to your manifest file',
-      pattern:
-        'Ensure the field value matches the expected pattern (e.g., kebab-case, semver)',
-      format: 'Verify the field format (e.g., valid URI, email, or date-time)',
-      type: 'Correct the field type (e.g., string, number, array, object)',
-      enum: 'Use one of the allowed values from the enumeration',
-      minLength:
-        'Increase the field value length to meet the minimum requirement',
-      maxLength: 'Reduce the field value length to meet the maximum limit',
-      additionalProperties:
-        'Remove unexpected fields not defined in the schema',
-    };
-
-    return (
-      resolutionMap[keyword] ||
-      'Review the schema documentation and correct the field value'
-    );
-  }
-
-  /**
-   * Get resolution guidance for installation errors
-   */
-  private static getInstallationErrorResolution(code: string): string {
-    const resolutionMap: Record<string, string> = {
-      [ERROR_CODES.INST_PLUGIN_NOT_FOUND]:
-        'Verify the plugin ID exists in the marketplace',
-      [ERROR_CODES.INST_VERSION_NOT_FOUND]:
-        'Check available versions with "/plugin info <id>"',
-      [ERROR_CODES.INST_ALREADY_INSTALLED]:
-        'Use "/plugin update <id>" to update or "/plugin uninstall <id>" to reinstall',
-      [ERROR_CODES.INST_DOWNLOAD_FAILED]:
-        'Check network connectivity and marketplace URL',
-      [ERROR_CODES.INST_CHECKSUM_MISMATCH]:
-        'Re-download the plugin or report a security issue to the maintainer',
-      [ERROR_CODES.INST_LIFECYCLE_FAILED]:
-        'Review lifecycle script logs and fix any errors',
-      [ERROR_CODES.INST_MANIFEST_INVALID]:
-        'Contact plugin maintainer to fix the manifest file',
-    };
-
-    return (
-      resolutionMap[code] || 'Review installation logs and retry the operation'
-    );
   }
 }
 
@@ -331,6 +276,5 @@ export function getErrorCodesByCategory(): Record<ErrorCategory, string[]> {
       ERROR_CODES.NET_TIMEOUT,
       ERROR_CODES.NET_PARSE_FAILED,
     ],
-    [ErrorCategory.LIFECYCLE]: [], // Lifecycle errors are mapped to INSTALLATION category
   };
 }

--- a/packages/domain/src/validation/types.ts
+++ b/packages/domain/src/validation/types.ts
@@ -1,133 +1,74 @@
 /**
- * Domain validation types and interfaces
- *
- * Provides clean abstractions for validation that are independent of the
- * underlying validation library (AJV). CLI and domain services should only
- * depend on these types, not on infrastructure validation details.
+ * Domain validation types. Library-agnostic abstractions — CLI and domain
+ * services depend on these, not on the AJV infrastructure layer.
  *
  * @module domain/validation/types
  */
 
-/**
- * Validation result status
- */
 export enum ValidationStatus {
   SUCCESS = 'SUCCESS',
   ERROR = 'ERROR',
 }
 
-/**
- * Error severity levels
- */
 export enum ErrorSeverity {
   ERROR = 'ERROR', // Blocking validation error
   WARNING = 'WARNING', // Non-blocking warning
 }
 
-/**
- * Error categories aligned with specification Section 4
- */
+// Categories align with specification Section 4.
 export enum ErrorCategory {
   SCHEMA_VALIDATION = 'SCHEMA_VALIDATION',
   COMPATIBILITY = 'COMPATIBILITY',
   INSTALLATION = 'INSTALLATION',
-  LIFECYCLE = 'LIFECYCLE',
   DISCOVERY = 'DISCOVERY',
   PERMISSION = 'PERMISSION',
   NETWORK = 'NETWORK',
 }
 
-/**
- * Structured validation error with specification traceability
- */
+/** Structured validation error with specification traceability. */
 export interface DomainValidationError {
-  /** Error code from specification (e.g., 'ERROR-SCHEMA-001') */
+  /** Error code from specification, e.g. 'ERROR-SCHEMA-001'. */
   code: string;
-
-  /** Human-readable error message */
   message: string;
-
-  /** JSON path to the field causing the error (e.g., '/plugins/0/version') */
+  /** JSON path to the offending field, e.g. '/plugins/0/version'. */
   path: string;
-
-  /** Error severity level */
   severity: ErrorSeverity;
-
-  /** Error category for grouping and filtering */
   category: ErrorCategory;
-
-  /** Additional context for debugging */
+  /** Additional debugging context. */
   context?: Record<string, unknown>;
-
-  /** Link to specification section (e.g., 'CRIT-001', 'FR-003') */
+  /** Link to a specification section, e.g. 'CRIT-001', 'FR-003'. */
   specReference?: string;
-
-  /** Suggested resolution or fix */
-  resolution?: string;
 }
 
-/**
- * Validation result containing status and detailed errors
- */
 export interface DomainValidationResult {
-  /** Overall validation status */
   status: ValidationStatus;
-
-  /** List of validation errors (empty if valid) */
+  /** Validation errors; empty when valid. */
   errors: DomainValidationError[];
-
-  /** List of non-blocking warnings */
+  /** Non-blocking warnings. */
   warnings: DomainValidationError[];
-
-  /** Name of the validated entity (e.g., 'marketplace', 'plugin:hookify') */
+  /** Validated entity name, e.g. 'marketplace', 'plugin:hookify'. */
   entityName: string;
-
-  /** Timestamp when validation was performed */
   validatedAt: Date;
 }
 
 /**
- * Validator interface that domain services and CLI depend on
- *
- * Infrastructure layer implements this interface using AJV or other libraries.
+ * Validator interface that domain services and CLI depend on. The
+ * infrastructure layer implements it using AJV.
  */
 export interface IValidator {
-  /**
-   * Validate a marketplace index file
-   *
-   * @param data - Marketplace data to validate
-   * @returns Validation result with detailed errors
-   */
   validateMarketplace(data: unknown): DomainValidationResult;
-
-  /**
-   * Validate a plugin manifest file
-   *
-   * @param data - Plugin manifest data to validate
-   * @param pluginId - Optional plugin ID for enhanced error messages
-   * @returns Validation result with detailed errors
-   */
+  /** `pluginId` is optional and only enriches error messages. */
   validatePluginManifest(
     data: unknown,
     pluginId?: string
   ): DomainValidationResult;
-
-  /**
-   * Validate plugin compatibility with current environment
-   *
-   * @param compatibility - Compatibility requirements from plugin manifest
-   * @param environment - Current system environment
-   * @returns Validation result with compatibility errors
-   */
   validateCompatibility(
     compatibility: PluginCompatibility,
     environment: SystemEnvironment
   ): DomainValidationResult;
 }
 
-/**
- * Plugin compatibility requirements from manifest
- */
+/** Plugin compatibility requirements declared in the manifest. */
 export interface PluginCompatibility {
   claudeCodeMin: string;
   claudeCodeMax?: string;
@@ -138,9 +79,7 @@ export interface PluginCompatibility {
   pluginDependencies?: string[];
 }
 
-/**
- * Current system environment for compatibility checking
- */
+/** Current system environment, for compatibility checking. */
 export interface SystemEnvironment {
   claudeCodeVersion: string;
   nodeVersion: string;

--- a/packages/infrastructure/README.md
+++ b/packages/infrastructure/README.md
@@ -4,7 +4,7 @@ Infrastructure layer — AJV schema validation for plugin marketplace manifests.
 
 ## Exports
 
-- `AjvValidatorFactory`, `sharedValidatorFactory` — AJV validator factory and singleton
+- `AjvValidatorFactory` — AJV validator factory
 - `SchemaValidator`, `createValidator` — High-level validator for marketplace and plugin schemas
 - `ValidationError`, `ValidationResult` — Result types
 - `version` — Package version string

--- a/packages/infrastructure/src/index.ts
+++ b/packages/infrastructure/src/index.ts
@@ -9,7 +9,6 @@
 // Validation toolkit
 export {
   AjvValidatorFactory,
-  sharedValidatorFactory,
   type ValidationError,
   type ValidationResult,
 } from './validation/ajvFactory.js';

--- a/packages/infrastructure/src/validation/README.md
+++ b/packages/infrastructure/src/validation/README.md
@@ -77,7 +77,6 @@ Domain-level validator implementing `IValidator` interface.
 
 - Maps AJV errors to domain error codes (ERROR-SCHEMA-001, etc.)
 - Provides specification traceability (CRIT-_, FR-_ references)
-- Includes resolution guidance for each error
 - Validates compatibility constraints (Claude Code version, Node.js, OS, arch)
 
 **API**:
@@ -140,7 +139,6 @@ if (result.status === ValidationStatus.SUCCESS) {
   console.error('❌ Validation errors:');
   result.errors.forEach(err => {
     console.error(`  [${err.code}] ${err.path}: ${err.message}`);
-    console.error(`  Resolution: ${err.resolution}`);
   });
 }
 ```
@@ -254,7 +252,7 @@ console.log('Plugin:', result2.status); // Should be SUCCESS
    - IValidator interface in domain layer
    - SchemaValidator implementation in infrastructure
    - AjvValidatorFactory for schema compilation
-   - Domain-level error types with resolution guidance
+   - Domain-level error types with specification traceability
 
 4. ✅ **Diagrams render without syntax errors**
    - `docs/diagrams/component-overview.mmd` - Mermaid syntax verified

--- a/packages/infrastructure/src/validation/ajvFactory.ts
+++ b/packages/infrastructure/src/validation/ajvFactory.ts
@@ -1,8 +1,6 @@
 /**
- * AJV Factory for JSON Schema Validation
- *
- * Provides centralized AJV configuration with schema compilation and caching.
- * Supports JSON Schema Draft-07 with strict validation and format checking.
+ * AJV factory for JSON Schema (Draft-07) validation: centralized AJV
+ * configuration with per-schema compilation and caching.
  *
  * @module infrastructure/validation/ajvFactory
  */
@@ -23,6 +21,8 @@ type AjvInstance = import('ajv').default;
 type AjvConstructor = new (options?: AjvOptions) => AjvInstance;
 type AddFormatsFn = (ajv: AjvInstance) => AjvInstance;
 
+// Ajv / ajv-formats ship as CJS-with-default under ESM — normalize to the
+// callable in both interop shapes.
 const AjvCtor: AjvConstructor =
   (Ajv as unknown as { default?: AjvConstructor }).default ??
   (Ajv as unknown as AjvConstructor);
@@ -31,17 +31,11 @@ const applyFormats: AddFormatsFn =
   (addFormats as unknown as { default?: AddFormatsFn }).default ??
   (addFormats as unknown as AddFormatsFn);
 
-/**
- * Validation result containing success status and typed errors
- */
 export interface ValidationResult {
   valid: boolean;
   errors: ValidationError[];
 }
 
-/**
- * Structured validation error with enhanced context
- */
 export interface ValidationError {
   path: string;
   message: string;
@@ -50,9 +44,6 @@ export interface ValidationError {
   schemaPath: string;
 }
 
-/**
- * Schema compilation cache entry
- */
 interface CachedValidator {
   validator: ValidateFunction;
   schemaId: string;
@@ -60,60 +51,36 @@ interface CachedValidator {
 }
 
 /**
- * AJV Factory for creating and caching schema validators
- *
- * Features:
- * - Strict mode validation (no coercion)
- * - Format validation (uri, email, date-time, hostname)
- * - Schema caching for performance
- * - Detailed error reporting
- *
- * @example
- * ```typescript
- * const factory = new AjvValidatorFactory();
- * await factory.loadSchemaFromFile('marketplace', './schemas/marketplace.schema.json');
- * const result = factory.validate('marketplace', data);
- * if (!result.valid) {
- *   console.error('Validation errors:', result.errors);
- * }
- * ```
+ * Creates and caches AJV schema validators. Strict mode (no coercion),
+ * `allErrors` (collect every error, not just the first), format validation,
+ * and the custom `semverRange` keyword.
  */
 export class AjvValidatorFactory {
-  private ajv: AjvInstance; // AJV instance
+  private ajv: AjvInstance;
   private validatorCache: Map<string, CachedValidator>;
 
   constructor() {
-    // Initialize AJV with strict configuration
     this.ajv = new AjvCtor({
-      strict: true, // Strict schema validation
-      allErrors: true, // Collect all errors (not just first)
-      verbose: true, // Include schema and data in errors
-      discriminator: true, // Support discriminator keyword
-      allowUnionTypes: true, // Allow union types in schemas
-      $data: true, // Support $data references
+      strict: true,
+      allErrors: true, // collect all errors, not just the first
+      verbose: true, // include schema + data in error objects
+      discriminator: true,
+      allowUnionTypes: true,
+      $data: true,
     });
 
-    // Add format validators (uri, email, date-time, etc.)
     applyFormats(this.ajv);
 
-    // Register custom keywords. semverRange validates dependencies[].version
-    // entries against npm semver range grammar (delegates to semver.validRange).
+    // semverRange validates dependencies[].version entries against npm
+    // semver range grammar (delegates to semver.validRange).
     this.ajv.addKeyword(semverRangeKeyword);
 
     this.validatorCache = new Map();
   }
 
   /**
-   * Load and compile a JSON schema from file
-   *
-   * @param schemaName - Unique identifier for this schema
-   * @param filePath - Path to JSON schema file (absolute or relative to CWD)
-   * @throws Error if schema file cannot be read or is invalid
-   *
-   * @example
-   * ```typescript
-   * await factory.loadSchemaFromFile('marketplace', './schemas/marketplace.schema.json');
-   * ```
+   * Load and compile a JSON schema from a file (path absolute or relative
+   * to CWD). Throws if the file cannot be read or the schema is invalid.
    */
   async loadSchemaFromFile(
     schemaName: string,
@@ -135,26 +102,15 @@ export class AjvValidatorFactory {
   }
 
   /**
-   * Load and compile a JSON schema from object
-   *
-   * @param schemaName - Unique identifier for this schema
-   * @param schema - JSON schema object
-   * @throws Error if schema compilation fails
-   *
-   * @example
-   * ```typescript
-   * factory.loadSchema('plugin', pluginSchemaObject);
-   * ```
+   * Compile and cache a JSON schema object under `schemaName`. Throws if
+   * compilation fails.
    */
   loadSchema(schemaName: string, schema: object): void {
     try {
-      // Compile the schema
       const validator = this.ajv.compile(schema);
-
-      // Extract schema $id if present, otherwise use schemaName
+      // Prefer the schema's own $id; fall back to the caller's name.
       const schemaId = (schema as { $id?: string }).$id || schemaName;
 
-      // Cache the compiled validator
       this.validatorCache.set(schemaName, {
         validator,
         schemaId,
@@ -170,22 +126,8 @@ export class AjvValidatorFactory {
   }
 
   /**
-   * Validate data against a loaded schema
-   *
-   * @param schemaName - Name of the schema to validate against
-   * @param data - Data to validate
-   * @returns ValidationResult with success status and detailed errors
-   * @throws Error if schema not found
-   *
-   * @example
-   * ```typescript
-   * const result = factory.validate('marketplace', marketplaceData);
-   * if (!result.valid) {
-   *   result.errors.forEach(err => {
-   *     console.error(`${err.path}: ${err.message}`);
-   *   });
-   * }
-   * ```
+   * Validate `data` against a previously loaded schema. Throws if the named
+   * schema was never loaded.
    */
   validate(schemaName: string, data: unknown): ValidationResult {
     const cached = this.validatorCache.get(schemaName);
@@ -202,19 +144,11 @@ export class AjvValidatorFactory {
       return { valid: true, errors: [] };
     }
 
-    // Transform AJV errors to our structured format
     const errors = this.transformErrors(cached.validator.errors || []);
 
     return { valid: false, errors };
   }
 
-  /**
-   * Transform AJV errors into structured ValidationError format
-   *
-   * @private
-   * @param ajvErrors - Raw AJV error objects
-   * @returns Structured validation errors with enhanced context
-   */
   private transformErrors(ajvErrors: ErrorObject[]): ValidationError[] {
     return ajvErrors.map((error) => ({
       path: error.instancePath || '/',
@@ -225,71 +159,7 @@ export class AjvValidatorFactory {
     }));
   }
 
-  /**
-   * Check if a schema is loaded
-   *
-   * @param schemaName - Name of the schema to check
-   * @returns True if schema is loaded and compiled
-   */
   hasSchema(schemaName: string): boolean {
     return this.validatorCache.has(schemaName);
   }
-
-  /**
-   * Get list of all loaded schema names
-   *
-   * @returns Array of schema names
-   */
-  getLoadedSchemas(): string[] {
-    return Array.from(this.validatorCache.keys());
-  }
-
-  /**
-   * Clear all cached validators
-   *
-   * Useful for testing or reloading schemas
-   */
-  clearCache(): void {
-    this.validatorCache.clear();
-  }
-
-  /**
-   * Get cache statistics
-   *
-   * @returns Object with cache size and schema details
-   */
-  getCacheStats(): {
-    size: number;
-    schemas: Array<{ name: string; id: string; compiledAt: Date }>;
-  } {
-    return {
-      size: this.validatorCache.size,
-      schemas: Array.from(this.validatorCache.entries()).map(
-        ([name, cached]) => ({
-          name,
-          id: cached.schemaId,
-          compiledAt: cached.compiledAt,
-        })
-      ),
-    };
-  }
 }
-
-/**
- * Singleton instance of AjvValidatorFactory
- *
- * Provides a shared validator factory across the application for performance.
- * Use this for most validation needs.
- *
- * @example
- * ```typescript
- * import { sharedValidatorFactory } from './ajvFactory.js';
- *
- * // In application initialization
- * await sharedValidatorFactory.loadSchemaFromFile('marketplace', './schemas/marketplace.schema.json');
- *
- * // Later in the code
- * const result = sharedValidatorFactory.validate('marketplace', data);
- * ```
- */
-export const sharedValidatorFactory = new AjvValidatorFactory();

--- a/packages/infrastructure/src/validation/keywords/semverRange.ts
+++ b/packages/infrastructure/src/validation/keywords/semverRange.ts
@@ -1,18 +1,12 @@
 /**
- * AJV custom keyword: `semverRange`
- *
- * Validates that a string value is a syntactically valid npm semver range
- * (e.g., `^1.0.0`, `~2.0.0`, `>=3 <4`, `1.x`, `*`, `1.2.3 - 2.0.0`,
- * `>=1.0.0 || ^2.0.0`). Delegates to `semver.validRange()` from the
- * canonical npm `semver` package.
+ * AJV custom keyword `semverRange`: validates that a string is a valid npm
+ * semver range (delegates to `semver.validRange()`).
  *
  * Used in `schemas/plugin.schema.json` for `dependencies[].version`. The
- * schema applies a lightweight `pattern` first to reject obvious non-semver
- * input; this keyword runs second and rejects strings that pass the
- * structural gate but are not actually valid range expressions. The schema
- * MUST also set `minLength: 1` on the field — `semver.validRange("")`
- * returns `"*"` (truthy, the universal range), so the empty string would
- * otherwise pass this keyword.
+ * schema applies a lightweight `pattern` first; this keyword rejects strings
+ * that pass the structural gate but are not valid ranges. The schema MUST
+ * also set `minLength: 1` — `semver.validRange("")` returns `"*"` (truthy),
+ * so the empty string would otherwise pass here.
  *
  * @module infrastructure/validation/keywords/semverRange
  */
@@ -20,19 +14,10 @@
 import type { FuncKeywordDefinition, SchemaValidateFunction } from 'ajv';
 import semver from 'semver';
 
-/**
- * Keyword definition object suitable for `ajv.addKeyword(...)`.
- *
- * AJV's `type: 'string'` filter ensures the validate function is only
- * invoked for string-typed data, so no in-function non-string guard is
- * needed. `errors: true` enables structured error output with the
- * offending value, replacing AJV's default generic "must pass keyword
- * validation" message.
- */
 // AJV's SchemaValidateFunction is a callable that ALSO carries an `errors`
-// property the function itself populates with structured error objects on
-// failure. TypeScript expresses that as a callable + property, so we
-// construct the validate function and attach `errors` in two steps.
+// property the function populates on failure — built and attached in two
+// steps. `type: 'string'` (on the keyword below) guarantees `data` is a
+// string when this runs, so no in-function type guard is needed.
 const validateFn: SchemaValidateFunction = (
   schemaValue: unknown,
   data: unknown
@@ -41,8 +26,6 @@ const validateFn: SchemaValidateFunction = (
     validateFn.errors = null;
     return true;
   }
-  // AJV's `type: 'string'` filter guarantees data is a string when this
-  // function is invoked; no defensive guard needed.
   if (semver.validRange(data as string, { loose: false }) !== null) {
     validateFn.errors = null;
     return true;
@@ -57,6 +40,8 @@ const validateFn: SchemaValidateFunction = (
   return false;
 };
 
+// `errors: true` enables structured error output with the offending value,
+// replacing AJV's generic "must pass keyword validation" message.
 export const semverRangeKeyword: FuncKeywordDefinition = {
   keyword: 'semverRange',
   type: 'string',


### PR DESCRIPTION
F.1 — dead surface (debt findings 021/029). Removed symbols verified
unreferenced repo-wide (grep across packages/, scripts/, tests/ — only
dist/ build artifacts + self-definitions matched):
- sharedValidatorFactory singleton + its re-export from infrastructure/index.ts
- AjvValidatorFactory.getCacheStats / getLoadedSchemas / clearCache
- ErrorCategory.LIFECYCLE (+ its empty-array key in errorCatalog.ts)
- DomainValidationError.resolution (+ the stale README example referencing it)
getErrorCodesByCategory() was NOT removed — it is a documented public API
(deepen-plan correction). knip tooling was not pinned: the plan body scopes
it as ephemeral npx; the dead set here came from the deepen-plan's verified
list plus repo-wide grep confirmation.

F.2 — comment ratio (debt findings 010/016/026). Trimmed name-restating
JSDoc from types.ts (53% -> 24%), ajvFactory.ts (50% -> 16%), and
semverRange.ts (52% -> 35%) — kept example-bearing field docs, the
IValidator contract docs (IDE-hover for cli consumers), and all 'why'
comments (the minLength gotcha, the AJV interop normalization, etc.).

Gates: pnpm typecheck, pnpm test:unit (3), pnpm lint — all green.
No changeset (packages/ is exempt).

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->
