### PR TITLE
feat(yellow-research): SessionStart context7 cache pre-warm hook

### DIFF
--- a/.changeset/library-context-cache-hook.md
+++ b/.changeset/library-context-cache-hook.md
@@ -1,0 +1,43 @@
+---
+'yellow-research': minor
+---
+
+feat(yellow-research): SessionStart context7 cache pre-warm hook
+
+Adds an asynchronous SessionStart pre-warm of the context7 library docs
+cache so common library queries don't burn the anonymous global pool.
+Merged into the existing `hooks/write-credential-status.sh` (background
+subshell, fire-and-forget) so SessionStart cost stays under the ~3s UX
+budget — yellow-morph `prewarm-morph.sh` precedent.
+
+**Cache shape** at `${CLAUDE_PLUGIN_DATA}/context7-cache-<md5_of_project_dir>.json`:
+
+- `tier1` — `library-name → {library_id, fetched_at}` (24h TTL, capped at
+  top 5 libs from project lockfiles)
+- `tier2` — `library-id|topic → {docs, fetched_at}` (4h TTL, max 50;
+  reserved for future lazy population on cache miss)
+- `lockfile_fingerprint` — mtimes of all detected lockfiles for
+  invalidation tracking
+- `schema: "1"` for forward-compatibility
+
+**Lockfile support:** package-lock.json, pnpm-lock.yaml, yarn.lock,
+Cargo.lock, go.sum, requirements.txt (+ package.json fallback).
+
+**Auth:** uses `CONTEXT7_API_KEY` as `Authorization: Bearer` when set;
+anonymous otherwise. Anonymous quota is 200 req/hr global pool (per live
+`ratelimit-limit` header on context7's HTTP API, 2026-05-17).
+
+**HTTP API** verified live: `GET https://context7.com/api/v1/search?query=<name>`
+returns `{results: [{id: "/owner/repo", ...}]}`. The MCP server (used by
+agents at runtime) is unaffected — the hook hits the HTTP API directly
+since shell hooks can't invoke MCP tools.
+
+**Safety:** atomic-rename writes (yellow-ci precedent), idempotent re-source
+guard, no `set -e`, fire-and-forget background subshell so hook errors
+never block session start. Skips cleanly when curl/jq missing,
+CLAUDE_PLUGIN_DATA unset, no lockfile, or cache fresh (< 24h).
+
+14 bats tests cover: no-lockfile skip, CLAUDE_PLUGIN_DATA-unset skip,
+anonymous warm, authenticated warm, fresh-cache skip, corrupted-cache
+rewrite, lockfile scanning for package.json + Cargo.lock, pre-warm cap,
+atomic write, idempotent re-source.

--- a/plans/library-context-followups.md
+++ b/plans/library-context-followups.md
@@ -1,0 +1,253 @@
+# Feature: `library-context` Follow-ups (RULE 13 lint + cache hook)
+
+## Problem Statement
+
+PR #536 shipped the canonical `library-context` skill at
+`plugins/yellow-research/skills/library-context/` plus refactors for two
+consumer agents. Three follow-ups were deferred and tracked in
+`reference.md`:
+
+1. **RULE 13** — a `validate-agent-authoring.js` lint to prevent drift
+   between consumer agents and the canonical fallback chain.
+2. **SessionStart cache hook** — pre-warm a context7 cache to amortize the
+   60 req/hr anonymous global pool across an editor session.
+3. **Opt-in adoption to 8 other plugins** — inline the safe-chain block
+   into existing consumer agents in yellow-debt, yellow-semgrep,
+   yellow-codex, yellow-docs, yellow-review, yellow-council, yellow-devin,
+   yellow-browser-test.
+
+Codebase research (this planning session) found that **none of the 8
+candidate plugins have an existing library-doc-lookup step** to inline the
+safe-chain into. The "Opt-in candidates" list in `reference.md` was
+aspirational; the agents in those plugins do code analysis, debt scanning,
+CLI delegation, doc generation, or workflow orchestration — not library
+documentation lookup. Adopting `library-context` to any of them would
+require adding a new feature (a library-lookup step) first, then inlining
+the safe-chain. That is a per-plugin feature decision, not a follow-up
+refactor.
+
+Follow-up #3 is therefore **dropped from this plan**. If a future PR adds
+a library-lookup feature to a candidate plugin, the security-fencing-style
+inline pattern is documented in `reference.md` and that PR adopts the
+safe-chain as a natural side effect. The `reference.md` "Opt-in
+candidates" section is removed in PR-A below to keep the spec honest.
+
+This plan covers the two remaining follow-ups: RULE 13 and the cache hook.
+
+## Current State
+
+- Canonical SKILL.md at `plugins/yellow-research/skills/library-context/SKILL.md` (153 lines, in PR #536)
+- Sibling `reference.md` at the same path (149 lines, in PR #536) — includes a deferred-RULE-13 spec with preload-exemption clause
+- Drift sentinel `context7 unavailable — falling back to` (Unicode em dash U+2014) appears 8 times across 3 files: SKILL.md, reference.md, `best-practices-researcher.md`
+- Two existing consumers: `yellow-research/agents/research/code-researcher.md` (preloads via `skills: [library-context]`), `yellow-core/agents/research/best-practices-researcher.md` (inlines the safe-chain block)
+- `scripts/validate-agent-authoring.js` is 474 lines; W1.5 rule at line 291; `skills` parsed at line 318
+- `plugins/yellow-research/hooks/` has one file: `write-credential-status.sh`; one SessionStart entry in `plugin.json`
+- Precedent hook for session-start caching: `plugins/yellow-ci/hooks/scripts/session-start.sh` (atomic-rename pattern at lines 156-158, mtime-based TTL invalidation)
+- Cache file location precedent: `${CLAUDE_PLUGIN_DATA}` (per official Claude Code hooks docs + yellow-morph precedent), NOT project `.claude/` (would pollute VCS)
+
+## Proposed Solution
+
+Two independent PRs, both bumping `yellow-research`. **Hard ordering
+constraint: PR-A cannot land until PR #536 merges to main** — otherwise
+RULE 13 fires on `code-researcher` because the `skills: [library-context]`
+preload only exists on the PR #536 branch.
+
+### PR-A: RULE 13 drift-detection lint
+
+Adds a new rule to `scripts/validate-agent-authoring.js` that fails CI
+when an agent file has any of `mcp__context7__resolve-library-id`,
+`mcp__context7__query-docs`, OR `mcp__context7__get-library-docs` in its
+`tools:` list AND does NOT preload via `skills: [library-context]` AND
+does NOT contain the drift sentinel `context7 unavailable — falling back
+to` (U+2014) in body content.
+
+Test coverage: new file `tests/integration/validate-agent-authoring-context7-rule.test.ts`
+with 5 inline-fixture tests covering preload-exempt, inline-sentinel
+exempt, ASCII-dash negative (proves the rule rejects `--`), pure
+negative, and empty-tools no-op.
+
+Also deletes the "Opt-in candidates" section from `reference.md` in the
+same PR (keeps spec aligned with reality).
+
+### PR-B: SessionStart cache hook
+
+Pre-warms a two-tier context7 cache at
+`${CLAUDE_PLUGIN_DATA}/context7-cache-<md5_of_project_dir>.json`:
+
+- **Tier 1:** `library-name → library-id` (24h TTL)
+- **Tier 2:** `(library-id, topic) → docs-fragment` (4h TTL, max 50 entries)
+
+Implementation extends the existing `plugins/yellow-research/hooks/write-credential-status.sh`
+(adding a second logical section after the credential-status scaffold call)
+rather than introducing a second SessionStart array entry — multi-hook
+SessionStart behavior is unverified in this repo, and merging is
+conservative.
+
+Pre-warm strategy: skip if cache age < tier-1 TTL (24h); when stale or
+absent, parse the project's lockfile(s), dedup library names across all
+found lockfiles, resolve up to 5 library-ids. Caps anonymous quota
+consumption at 5 req per 24h window per project.
+
+Direct HTTP to context7 (the MCP server is user-level and not reachable
+from a shell hook). Uses `CONTEXT7_API_KEY` as `Authorization: Bearer`
+when set; anonymous otherwise.
+
+Atomic-rename writes (tmp + mv) copy yellow-ci's pattern. JSON parse
+failures treated as cache miss. Lockfile-mtime invalidation purges tier-2
+when any tracked lockfile (`package-lock.json`, `pnpm-lock.yaml`,
+`yarn.lock`, `Cargo.lock`, `go.sum`, `requirements.txt`) changes.
+
+## Implementation Plan
+
+### PR-A: RULE 13 lint
+
+- [ ] A.1 Verify PR #536 has merged to main (`gh pr view 536 --json mergedAt -q .mergedAt | grep -v null`); if not merged, stop. RULE 13 will fail CI on main without #536's `skills: [library-context]` frontmatter on `code-researcher`.
+- [ ] A.2 Sync main and create branch `agent/feat/rule-13-context7-drift-lint` off the post-#536 tip.
+- [ ] A.3 Add module-scope constants to `scripts/validate-agent-authoring.js` near `REVIEW_AGENT_DENIED_TOOLS` (~line 19): `CONTEXT7_TOOLS = new Set(['mcp__context7__resolve-library-id', 'mcp__context7__query-docs', 'mcp__context7__get-library-docs'])` and `LIBRARY_CONTEXT_SENTINEL = 'context7 unavailable — falling back to'` (write the em dash as `—` to be unambiguous in source).
+- [ ] A.4 Add RULE 13 logic in `validateAgentFile()` after line 318 (the `const skills = new Set(parseList(frontmatter, 'skills'))` line), still inside the `if (!hasAllowedTools)` gate: check `tools.some(t => CONTEXT7_TOOLS.has(t))`; if true, check `skills.has('library-context')` OR `content.includes(LIBRARY_CONTEXT_SENTINEL)`; if neither, push error with both fix paths named.
+- [ ] A.5 Error message format: ``${relative(filePath)}: references context7 tool without `skills: [library-context]` preload or drift sentinel in body (RULE 13). Fix: either add `library-context` to `skills:` frontmatter, OR include `context7 unavailable — falling back to` in the agent body.``
+- [ ] A.6 Create `tests/integration/validate-agent-authoring-context7-rule.test.ts` with 5 fixture tests using `writeAgent()` from the existing `tests/integration/helpers/validator-harness.ts`. Each fixture body uses `—` for the em dash, NOT `--`.
+- [ ] A.7 Delete the "Opt-in candidates for follow-up adoption" section from `plugins/yellow-research/skills/library-context/reference.md`. Replace with a one-paragraph "Adoption" section explaining the safe-chain pattern is documented for future use but not pre-tracked.
+- [ ] A.8 Run gates: `pnpm validate:schemas && pnpm test:integration && pnpm lint && pnpm typecheck`. Confirm `validate:agents` exits 0 against current `plugins/` tree (both existing consumers should pass — preload-exempt for code-researcher, inline-exempt for best-practices-researcher).
+- [ ] A.9 Add `.changeset/rule-13-context7-drift-lint.md`: `yellow-research` patch.
+- [ ] A.10 LF normalize (`sed -i 's/\r$//' ...`), commit, `gt submit --no-interactive`.
+
+### PR-B: SessionStart cache hook
+
+- [ ] B.1 Branch `agent/feat/library-context-cache-hook` from main (independent of PR-A; no ordering dependency).
+- [ ] B.2 Read the existing `plugins/yellow-research/hooks/write-credential-status.sh` end-to-end to confirm the shape: where credential_hook_scaffold is called, where JSON output is emitted, what env vars are guarded. The new cache logic appends AFTER the credential-status scaffold call but BEFORE the JSON-output line.
+- [ ] B.3 Add the cache helper functions in the same file (or a sourced `lib/context7-cache.sh` in `plugins/yellow-research/lib/`). Functions: `_lc_cache_path` (md5 hash of CLAUDE_PROJECT_DIR), `_lc_cache_age` (now - file mtime), `_lc_scan_lockfiles` (returns deduped library names), `_lc_resolve_library_id` (HTTP call with optional API key), `_lc_write_cache_atomic` (tmp + mv).
+- [ ] B.4 Wire the pre-warm logic: if `CLAUDE_PLUGIN_DATA` is unset → warn to stderr, skip. If lockfiles absent → warn to stderr, skip. If cache age < 86400 (24h) → skip. Else scan lockfiles, take top 5 deduped names, call `_lc_resolve_library_id` for each (anonymous or authenticated based on `CONTEXT7_API_KEY`), write atomically.
+- [ ] B.5 Hook output: continue using the existing `write-credential-status.sh` output format (whatever it currently emits) — do not change. If pre-warm succeeds, optionally extend with `hookSpecificOutput.additionalContext` mentioning N libraries warmed. Errors during pre-warm are NEVER fatal — always emit `{"continue": true}`.
+- [ ] B.6 Bats tests in `plugins/yellow-research/tests/cache-context7.bats`: 6 cases covering no-lockfile, no-CLAUDE_PLUGIN_DATA, corrupted-cache (re-warms cleanly), fresh-cache (skips), successful warm with anonymous, successful warm with API key (mock the HTTP call).
+- [ ] B.7 Run gates: `pnpm validate:schemas && pnpm test:integration && bats plugins/yellow-research/tests/`.
+- [ ] B.8 Add `.changeset/library-context-cache-hook.md`: `yellow-research` minor (additive feature).
+- [ ] B.9 LF normalize, commit, `gt submit --no-interactive`.
+
+## Technical Details
+
+### Files to modify
+
+**PR-A:**
+- `scripts/validate-agent-authoring.js` — add CONTEXT7_TOOLS + LIBRARY_CONTEXT_SENTINEL constants (top of file) + RULE 13 check (~line 320 region, after `skills` parse)
+- `plugins/yellow-research/skills/library-context/reference.md` — delete "Opt-in candidates" section; replace with a brief "Adoption" paragraph
+
+**PR-B:**
+- `plugins/yellow-research/hooks/write-credential-status.sh` — append cache pre-warm logic (or extract to a sourced helper in `lib/context7-cache.sh` and call from the hook)
+- `plugins/yellow-research/.claude-plugin/plugin.json` — NO change (existing SessionStart entry stays; logic extends in the same file)
+
+### Files to create
+
+**PR-A:**
+- `tests/integration/validate-agent-authoring-context7-rule.test.ts`
+- `.changeset/rule-13-context7-drift-lint.md`
+
+**PR-B:**
+- `plugins/yellow-research/hooks/lib/context7-cache.sh` (recommended; keeps the SessionStart hook readable)
+- `plugins/yellow-research/tests/cache-context7.bats`
+- `.changeset/library-context-cache-hook.md`
+
+### Files NOT to modify
+
+- SKILL.md — current Step 1 wording "from cache (if available) or via resolve-library-id" already accommodates the hook; no edit needed when PR-B lands.
+- `.claude-plugin/marketplace.json` — no schema impact.
+- `plugins/yellow-core/commands/setup/all.md` — no plugin add/remove.
+- Any cross-plugin agent — no adoption work in this plan.
+
+### Cache file shape
+
+```json
+{
+  "schema": "1",
+  "warmed_at": 1779000000,
+  "lockfile_fingerprint": {
+    "package-lock.json": 1778999000,
+    "Cargo.lock": null
+  },
+  "tier1": {
+    "react": { "library_id": "/facebook/react", "fetched_at": 1779000000 },
+    "axios":  { "library_id": "/axios/axios",   "fetched_at": 1779000000 }
+  },
+  "tier2": {
+    "/facebook/react|hooks": { "docs": "...", "fetched_at": 1779000000 }
+  }
+}
+```
+
+`schema: "1"` per existing MEMORY.md convention for forward-compat.
+
+### Context7 HTTP endpoints (verify post-merge)
+
+Per best-practices research, context7 publishes an HTTP API at
+`https://api.context7.com/` (exact paths to verify when implementing).
+The MCP server tools (`mcp__context7__*`) are not reachable from a shell
+hook. The hook calls the HTTP API directly; the MCP server still serves
+runtime queries from agents.
+
+## Acceptance Criteria
+
+### PR-A (RULE 13)
+
+1. `pnpm validate:agents` exits 1 with a message containing `RULE 13` and the file path when a fixture agent has any of `mcp__context7__resolve-library-id`/`query-docs`/`get-library-docs` in `tools:`, no `skills: [library-context]`, and no sentinel in body.
+2. `pnpm validate:agents` exits 0 for `code-researcher.md` (preload-exempt — verified post-PR-#536 only).
+3. `pnpm validate:agents` exits 0 for `best-practices-researcher.md` (sentinel-exempt — cross-plugin inline).
+4. `pnpm validate:agents` exits 0 for a synthetic fixture with both exemptions present.
+5. `pnpm validate:agents` exits 1 for a synthetic fixture whose sentinel uses ASCII `--` instead of em dash U+2014.
+6. `pnpm validate:agents` does NOT emit a RULE 13 error when `tools:` is empty (the existing "missing tools" gate handles that case).
+7. Five integration tests pass in `tests/integration/validate-agent-authoring-context7-rule.test.ts`; all fixtures inline (no external `.example.md` files); em dash spelled as `—` in JS strings.
+8. `reference.md` no longer contains a section titled "Opt-in candidates"; the replacement "Adoption" paragraph explains the inline-copy pattern is documented for future ad-hoc use.
+9. `CONTEXT7_TOOLS` Set includes all three tool names (resolve-library-id, query-docs, get-library-docs).
+10. Changeset file `.changeset/rule-13-context7-drift-lint.md` exists, bumps `yellow-research` patch.
+11. `pnpm release:check` passes.
+
+### PR-B (cache hook)
+
+1. New cache logic lives in `plugins/yellow-research/hooks/write-credential-status.sh` (or in a sourced helper called from there); no second SessionStart array entry added to `plugin.json`.
+2. On first run (no cache file), hook creates `${CLAUDE_PLUGIN_DATA}/context7-cache-<md5_of_CLAUDE_PROJECT_DIR>.json`, populates tier-1 with up to 5 library IDs from project lockfile(s), and emits `{"continue": true}` (with optional `hookSpecificOutput.additionalContext` summarizing N libraries warmed).
+3. On subsequent runs where cache age < 24h, hook skips pre-warm and completes within 3 seconds.
+4. On corrupted JSON in cache file, hook deletes file, re-warms cleanly, does NOT block startup.
+5. When no lockfile found, hook emits `{"continue": true}` + stderr warning `[yellow-research] No lockfile found; skipping context7 cache warm`; no `systemMessage`.
+6. When `CLAUDE_PLUGIN_DATA` unset, hook emits `{"continue": true}` + stderr warning; skips all cache operations.
+7. When `CONTEXT7_API_KEY` env var set, hook uses `Authorization: Bearer ${CONTEXT7_API_KEY}`; otherwise calls anonymously.
+8. Cache writes use atomic rename (`mktemp + mv`); confirmed by reading the hook code.
+9. `set -e` is NOT used in any new bash; comment explains why (hook must emit `{"continue": true}` on all paths).
+10. Bats tests pass: `bats plugins/yellow-research/tests/cache-context7.bats` covers no-lockfile, no-CLAUDE_PLUGIN_DATA, corrupted-cache, fresh-cache-skip, anonymous-warm, authenticated-warm.
+11. Changeset file `.changeset/library-context-cache-hook.md` exists, bumps `yellow-research` minor.
+12. `pnpm validate:schemas` passes (plugin.json still well-formed).
+
+## Edge Cases (must handle in code)
+
+**PR-A:**
+- **Empty `tools:` list** — existing line 287 gate fires "missing or empty tools" error; RULE 13 does not also fire because `CONTEXT7_TOOLS.has(t)` is vacuously false for an empty array. Verified by Test #6 above.
+- **Future PR removing `skills: [library-context]` from code-researcher** — RULE 13 catches this as a regression (correct behavior); author must either re-add the preload OR add the sentinel inline.
+- **Synthetic test fixtures referencing context7** — the validator scans `VALIDATE_PLUGINS_DIR` (set by tests to a `mkdtempSync` path); production runs use `plugins/` only. No cross-contamination.
+
+**PR-B:**
+- **Multi-language project with multiple lockfiles** — scan all known lockfiles, dedup library names across the union, take top 5 from the merged set. Mtime check covers all found lockfiles.
+- **Cached library-id valid but library removed from context7 since** — surfaces at skill-invocation time (`query-docs` fails); handled by the skill's existing fallback chain, NOT the cache hook's responsibility.
+- **Concurrent SessionStart from two sessions** — atomic rename means last writer wins; both sessions read fresh-or-empty cache, both attempt warm, second write replaces first. No corruption; minor wasted API calls. Acceptable.
+- **Lockfile present but unparseable** (e.g., partial-write race condition) — treat as no-lockfile; skip pre-warm; stderr warning. Try again next session.
+- **`CLAUDE_PROJECT_DIR` unset, `$PWD` fallback** — per MEMORY.md guidance, warn `[yellow-research] CLAUDE_PROJECT_DIR unset; using $PWD as cache key seed` to stderr; do NOT silently use $PWD.
+
+## Known Limitations / Follow-Ups
+
+- **Adoption to other plugins is NOT in this plan.** When a future PR adds a library-doc-lookup feature to any consumer plugin (yellow-debt, yellow-semgrep, etc.), that PR adopts the inline-copy safe-chain as a natural part of its feature work. Pattern is documented in `reference.md` (post-PR-A); RULE 13 (post-PR-A) catches drift on the new inline copy.
+- **PR-B uses HTTP not MCP for cache pre-warm.** The MCP tools are user-level and not reachable from a shell hook. If context7's HTTP API surface changes incompatibly, this hook breaks; the runtime SKILL.md chain (which uses MCP) is unaffected. Document this dependency in the hook's comment block.
+- **Pre-warm budget is 5 anonymous req per 24h window per project.** If `CONTEXT7_API_KEY` is set, the per-key 60 req/hr quota applies — pre-warm consumes a small slice of that. For team environments without per-developer keys, the shared anonymous pool is preserved by the 24h skip-if-fresh gate.
+- **`/research:setup` does not surface cache health.** PR-B does not extend the setup command. A follow-up could add a `Cache: HEALTHY/STALE/EMPTY` line. Out of scope here.
+- **SessionStart multi-hook entry is still unverified.** If the merge-into-existing-hook approach later proves limiting (e.g., the credential-status scaffold and cache pre-warm need different timeouts), a follow-up PR could split them — but only after empirically verifying that two array entries in `plugin.json` SessionStart both fire.
+
+## References
+
+- PR #536: `feat(library-context): canonical skill + refactor 2 research agents` — https://github.com/KingInYellows/yellow-plugins/pull/536
+- Canonical SKILL.md: `plugins/yellow-research/skills/library-context/SKILL.md`
+- Reference: `plugins/yellow-research/skills/library-context/reference.md`
+- Parent brainstorm: `docs/brainstorms/2026-05-17-library-context-skill-brainstorm.md`
+- Validator template: `scripts/validate-agent-authoring.js` (W1.5 at line 291; `skills` parse at line 318; `REVIEW_AGENT_DENIED_TOOLS` placement at top)
+- Test harness: `tests/integration/helpers/validator-harness.ts` (`writeAgent`, `runValidator`)
+- Cache precedent: `plugins/yellow-ci/hooks/scripts/session-start.sh` (atomic-rename lines 156-158, mtime TTL pattern)
+- Pre-warm precedent: `plugins/yellow-morph/hooks/scripts/prewarm-morph.sh` (CLAUDE_PLUGIN_DATA + background subshell pattern)
+- Multi-plugin changeset precedent: `.changeset/security-debt-quick-fixes.md` (6 plugins, one entry — kept as reference; not used in this plan since both PRs touch only yellow-research)
+- Closed cross-plugin skills issue: https://github.com/anthropics/claude-code/issues/15944
+- Context7 platform: https://glama.ai/mcp/servers/upstash/context7-mcp; https://github.com/upstash/context7
+- Claude Code hooks reference: https://code.claude.com/docs/en/hooks

--- a/plugins/yellow-research/bin/lc-cache-lookup
+++ b/plugins/yellow-research/bin/lc-cache-lookup
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# lc-cache-lookup — agent-facing helper to read the context7 pre-warmed cache.
+#
+# Usage:  lc-cache-lookup <library-name>
+#
+# Exits 0 always. Echoes the cached library_id (e.g. "/facebook/react") on a
+# fresh hit; echoes nothing on miss / expired / cache absent / CLAUDE_PLUGIN_DATA
+# unset / jq missing. Always exit 0 — calling agents treat empty output as
+# "cache miss, fall through to mcp__context7__resolve-library-id".
+#
+# Consumer contract: the library-context skill's Step 1 instructs preloading
+# (yellow-research) and inlining (cross-plugin) agents to run this command
+# before calling resolve-library-id. Without that lookup, the SessionStart
+# pre-warm burns API quota for a cache nothing reads.
+
+set -uo pipefail
+
+# Resolve script directory so `_lc_lookup` can find the lib regardless of
+# where the agent invokes us from.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CACHE_LIB="${SCRIPT_DIR}/../hooks/lib/context7-cache.sh"
+
+[ -f "$CACHE_LIB" ] || exit 0
+# shellcheck source=../hooks/lib/context7-cache.sh
+. "$CACHE_LIB" 2>/dev/null || exit 0
+
+command -v _lc_lookup >/dev/null 2>&1 || exit 0
+
+_lc_lookup "${1:-}"

--- a/plugins/yellow-research/hooks/lib/context7-cache.sh
+++ b/plugins/yellow-research/hooks/lib/context7-cache.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# Context7 library docs cache helpers for yellow-research's SessionStart hook.
+#
+# Sourced — defines functions only, no top-level side effects.
+#
+# Two-tier cache at ${CLAUDE_PLUGIN_DATA}/context7-cache-<md5_of_project>.json:
+#   tier1: name → {library_id, fetched_at}    (24h TTL, capped to top 5 libs)
+#   tier2: id|topic → {docs, fetched_at}      (4h TTL, max 50 entries; populated lazily on demand, not by this prewarm)
+#
+# Context7 HTTP API surface verified 2026-05-17:
+#   GET https://context7.com/api/v1/search?query=<name>
+#     → JSON {results: [{id: "/owner/repo", title, ...}, ...]}
+#   GET https://context7.com/api/v1/<owner>/<repo>[?topic=<t>]
+#     → text/plain markdown docs body
+#   Headers expose live quota: ratelimit-limit / ratelimit-remaining /
+#   context7-quota-tier (= "anonymous" without auth).
+#   Anonymous shares a global 200 req/hr pool. With Authorization: Bearer
+#   <CONTEXT7_API_KEY> each key gets a dedicated quota.
+
+# Idempotent: re-sourcing is a no-op (matches yellow-core lib/validate-fs.sh pattern).
+[ -n "${_LC_CACHE_LOADED:-}" ] && return 0
+_LC_CACHE_LOADED=1
+
+_LC_API_BASE="${CONTEXT7_API_BASE:-https://context7.com/api/v1}"
+_LC_TIER1_TTL=86400        # 24h
+_LC_PREWARM_MAX=5           # max libraries resolved per session warm
+_LC_CURL_TIMEOUT=3          # seconds per resolve call
+_LC_LOCKFILES=(
+  package-lock.json pnpm-lock.yaml yarn.lock
+  Cargo.lock go.sum requirements.txt
+)
+
+_lc_log() {
+  printf '[library-context-cache] %s\n' "$*" >&2
+}
+
+_lc_md5() {
+  if command -v md5sum >/dev/null 2>&1; then
+    printf '%s' "$1" | md5sum | cut -c1-32
+  elif command -v md5 >/dev/null 2>&1; then
+    printf '%s' "$1" | md5 -q | cut -c1-32
+  else
+    # No md5 tool — sanitize and truncate to last 64 chars. Not
+    # collision-proof, but bounded so the path stays valid.
+    printf '%s' "$1" | tr '/' '_' | tail -c 64
+  fi
+}
+
+_lc_now() {
+  date +%s
+}
+
+_lc_cache_path() {
+  [ -n "${CLAUDE_PLUGIN_DATA:-}" ] || return 1
+  local project="${CLAUDE_PROJECT_DIR:-$PWD}"
+  printf '%s/context7-cache-%s.json' "$CLAUDE_PLUGIN_DATA" "$(_lc_md5 "$project")"
+}
+
+# Look up a library name in the tier1 cache. Echoes the cached library_id
+# on a fresh hit, nothing on miss/stale/missing. Always exits 0 — callers
+# treat empty output as "no cache hit, resolve via context7".
+#
+# Consumer contract: agents that have library-context preloaded (or
+# inlined) should call this helper before invoking
+# mcp__context7__resolve-library-id, so the pre-warmed cache actually
+# reduces API quota usage. Without this lookup, the SessionStart prewarm
+# burns quota for nothing.
+_lc_lookup() {
+  local name="$1"
+  [ -n "$name" ] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+
+  local path
+  path=$(_lc_cache_path 2>/dev/null) || return 0
+  [ -f "$path" ] || return 0
+
+  local fetched_at age
+  fetched_at=$(jq -r --arg n "$name" '.tier1[$n].fetched_at // 0' "$path" 2>/dev/null) || return 0
+  [ "$fetched_at" -gt 0 ] 2>/dev/null || return 0
+  age=$(( $(_lc_now) - fetched_at ))
+  [ "$age" -lt "$_LC_TIER1_TTL" ] || return 0
+
+  jq -r --arg n "$name" '.tier1[$n].library_id // empty' "$path" 2>/dev/null
+}
+
+# Returns 0 if cache exists AND tier1 entries are fresh AND lockfile fingerprint
+# matches (skip prewarm). Returns non-zero if cache is missing, stale, or any
+# lockfile mtime changed since the cache was written.
+_lc_should_skip() {
+  local path
+  path=$(_lc_cache_path) || return 1
+  [ -f "$path" ] || return 1
+  local warmed_at
+  warmed_at=$(jq -r '.warmed_at // 0' "$path" 2>/dev/null) || return 1
+  local age=$(( $(_lc_now) - warmed_at ))
+  [ "$age" -lt "$_LC_TIER1_TTL" ] || return 1
+  # Also invalidate if any lockfile mtime changed since cache was written.
+  local stored_fp current_fp
+  stored_fp=$(jq -r '.lockfile_fingerprint // {} | tojson' "$path" 2>/dev/null) || return 1
+  current_fp=$(_lc_lockfile_fingerprint | jq -r 'tojson' 2>/dev/null) || return 1
+  [ "$stored_fp" = "$current_fp" ]
+}
+
+# Scan project manifests and lockfiles; output deduped library names, top N.
+# Manifest files (package.json, requirements.txt) are scanned first so direct
+# dependencies appear before transitive lockfile entries. Deduplication
+# preserves first-occurrence order (awk !seen) rather than sorting
+# alphabetically, so direct deps surface before @babel/helper-* noise.
+_lc_scan_lockfiles() {
+  local project="${CLAUDE_PROJECT_DIR:-$PWD}"
+  {
+    [ -f "$project/package.json" ] && jq -r '
+      (.dependencies // {}) + (.devDependencies // {}) | keys[]
+    ' "$project/package.json" 2>/dev/null
+    [ -f "$project/requirements.txt" ] && \
+      sed -nE 's/^([a-zA-Z][a-zA-Z0-9_.-]*).*/\1/p' "$project/requirements.txt" 2>/dev/null
+    [ -f "$project/Cargo.lock" ] && \
+      sed -nE 's/^name = "(.+)"$/\1/p' "$project/Cargo.lock" 2>/dev/null
+    [ -f "$project/package-lock.json" ] && jq -r '
+      (.packages // {}) | to_entries[]
+      | select(.key | startswith("node_modules/"))
+      | .key | sub("^node_modules/"; "")
+      | select(
+          (contains("/") | not) or
+          (startswith("@") and (split("/") | length == 2))
+        )
+    ' "$project/package-lock.json" 2>/dev/null
+    [ -f "$project/pnpm-lock.yaml" ] && \
+      sed -nE "s/^  '?([a-zA-Z@][a-zA-Z0-9@/_-]*)'?:/\1/p" "$project/pnpm-lock.yaml" 2>/dev/null
+    [ -f "$project/yarn.lock" ] && \
+      sed -nE 's/^"?(@?[a-zA-Z0-9_-]+(\/[a-zA-Z0-9_-]+)?)@.*/\1/p' "$project/yarn.lock" 2>/dev/null
+    [ -f "$project/go.sum" ] && awk '{print $1}' "$project/go.sum" 2>/dev/null
+  } | grep -v '^$' | awk '!seen[$0]++' | head -n "$_LC_PREWARM_MAX"
+}
+
+# Resolve a library name → context7 library ID via HTTP.
+# Echoes the id (e.g. "/facebook/react") on success, nothing on failure.
+_lc_resolve_library_id() {
+  local name="$1"
+  local encoded
+  encoded=$(printf '%s' "$name" | jq -sRr @uri) || return 1
+
+  local response
+  if [ -n "${CONTEXT7_API_KEY:-}" ]; then
+    # Pass the bearer token via a temp curl config file (not argv) to avoid
+    # credential exposure in process listings (ps/proc).
+    local _cfg
+    _cfg=$(mktemp) || return 1
+    chmod 600 "$_cfg" || { rm -f "$_cfg"; return 1; }
+    # shellcheck disable=SC2064
+    trap "rm -f '$_cfg'" RETURN
+    printf 'header = "Authorization: Bearer %s"\n' "${CONTEXT7_API_KEY}" >"$_cfg"
+    response=$(curl -sS --max-time "$_LC_CURL_TIMEOUT" \
+      -K "$_cfg" \
+      "${_LC_API_BASE}/search?query=${encoded}" 2>/dev/null) || return 1
+  else
+    response=$(curl -sS --max-time "$_LC_CURL_TIMEOUT" \
+      "${_LC_API_BASE}/search?query=${encoded}" 2>/dev/null) || return 1
+  fi
+
+  printf '%s' "$response" | jq -r '.results[0].id // empty' 2>/dev/null
+}
+
+# Atomic write: tmp file in same dir + mv (matches yellow-ci session-start.sh:156-158).
+_lc_atomic_write() {
+  local path="$1" content="$2"
+  mkdir -p "$(dirname "$path")" 2>/dev/null || return 1
+  local tmp="${path}.tmp.$$"
+  printf '%s' "$content" > "$tmp" || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$path" || { rm -f "$tmp"; return 1; }
+}
+
+# Build the lockfile fingerprint object for invalidation tracking.
+_lc_lockfile_fingerprint() {
+  local project="${CLAUDE_PROJECT_DIR:-$PWD}"
+  local fp='{}'
+  local f mtime
+  for f in "${_LC_LOCKFILES[@]}"; do
+    if [ -f "$project/$f" ]; then
+      mtime=$(stat -c '%Y' "$project/$f" 2>/dev/null || stat -f %m "$project/$f" 2>/dev/null || echo 0)
+      fp=$(printf '%s' "$fp" | jq --arg k "$f" --argjson v "$mtime" '. + {($k): $v}')
+    fi
+  done
+  printf '%s' "$fp"
+}
+
+# Main: skip-if-fresh, scan lockfiles, resolve top N, write atomic.
+# Never fails — always returns 0. Errors logged to stderr.
+_lc_prewarm() {
+  command -v curl >/dev/null 2>&1 || return 0
+  command -v jq   >/dev/null 2>&1 || return 0
+
+  local cache_path
+  cache_path=$(_lc_cache_path) || {
+    _lc_log "Warning: CLAUDE_PLUGIN_DATA unset; skipping context7 cache warm"
+    return 0
+  }
+
+  if [ -z "${CLAUDE_PROJECT_DIR:-}" ]; then
+    _lc_log "Warning: CLAUDE_PROJECT_DIR unset; using PWD ($PWD) as cache key seed"
+  fi
+
+  if _lc_should_skip; then
+    return 0
+  fi
+
+  local names
+  names=$(_lc_scan_lockfiles)
+  if [ -z "$names" ]; then
+    _lc_log "No lockfile found; skipping context7 cache warm"
+    return 0
+  fi
+
+  local tier1='{}'
+  local now id
+  now=$(_lc_now)
+  while IFS= read -r name; do
+    [ -z "$name" ] && continue
+    id=$(_lc_resolve_library_id "$name") || continue
+    [ -z "$id" ] && continue
+    tier1=$(printf '%s' "$tier1" | jq \
+      --arg n "$name" --arg i "$id" --argjson t "$now" \
+      '. + {($n): {library_id: $i, fetched_at: $t}}')
+  done <<< "$names"
+
+  local fp
+  fp=$(_lc_lockfile_fingerprint)
+
+  local cache
+  cache=$(jq -n --argjson w "$now" --argjson t1 "$tier1" --argjson fp "$fp" \
+    '{schema: "1", warmed_at: $w, lockfile_fingerprint: $fp, tier1: $t1, tier2: {}}')
+
+  if _lc_atomic_write "$cache_path" "$cache"; then
+    local count
+    count=$(printf '%s' "$tier1" | jq 'length')
+    _lc_log "Warmed context7 cache: $count libraries → $cache_path"
+  fi
+}

--- a/plugins/yellow-research/hooks/lib/context7-cache.sh
+++ b/plugins/yellow-research/hooks/lib/context7-cache.sh
@@ -26,6 +26,7 @@ _LC_TIER1_TTL=86400        # 24h
 _LC_PREWARM_MAX=5           # max libraries resolved per session warm
 _LC_CURL_TIMEOUT=3          # seconds per resolve call
 _LC_LOCKFILES=(
+  package.json
   package-lock.json pnpm-lock.yaml yarn.lock
   Cargo.lock go.sum requirements.txt
 )
@@ -213,6 +214,7 @@ _lc_prewarm() {
 
   local tier1='{}'
   local now id
+  local count=0
   now=$(_lc_now)
   while IFS= read -r name; do
     [ -z "$name" ] && continue
@@ -221,7 +223,13 @@ _lc_prewarm() {
     tier1=$(printf '%s' "$tier1" | jq \
       --arg n "$name" --arg i "$id" --argjson t "$now" \
       '. + {($n): {library_id: $i, fetched_at: $t}}')
+    count=$((count + 1))
   done <<< "$names"
+
+  if [ "$count" -eq 0 ]; then
+    _lc_log "Warning: all context7 resolves failed; skipping cache write to allow retry next session"
+    return 0
+  fi
 
   local fp
   fp=$(_lc_lockfile_fingerprint)
@@ -231,8 +239,6 @@ _lc_prewarm() {
     '{schema: "1", warmed_at: $w, lockfile_fingerprint: $fp, tier1: $t1, tier2: {}}')
 
   if _lc_atomic_write "$cache_path" "$cache"; then
-    local count
-    count=$(printf '%s' "$tier1" | jq 'length')
     _lc_log "Warmed context7 cache: $count libraries → $cache_path"
   fi
 }

--- a/plugins/yellow-research/hooks/write-credential-status.sh
+++ b/plugins/yellow-research/hooks/write-credential-status.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# yellow-research SessionStart hook: emit credential-status.json so /setup:all
-# can render an accurate dashboard without probing the keychain.
+# yellow-research SessionStart hook:
+#   (1) Pre-warm context7 library docs cache (background, fire-and-forget)
+#   (2) Emit credential-status.json so /setup:all can render an accurate
+#       dashboard without probing the keychain.
 #
 # Note: -e omitted intentionally — SessionStart hooks must output
 # {"continue": true} on all paths.
@@ -14,6 +16,23 @@ HELPER="${CLAUDE_PLUGIN_ROOT:-}/../yellow-core/lib/credential-status.sh"
 # has credential-status.sh but predates credential_hook_scaffold, the
 # source succeeds but the function is undefined. Skip cleanly.
 command -v credential_hook_scaffold >/dev/null 2>&1 || { printf '{"continue": true}\n'; exit 0; }
+
+# Pre-warm context7 library docs cache asynchronously. Detached subshell
+# follows the yellow-morph prewarm pattern: parent exits in <1s, child
+# runs the HTTP work; failures are silent (cache stays empty, runtime
+# falls back to existing chain). Skip cleanly if CLAUDE_PLUGIN_ROOT is
+# unset OR empty (an empty value would produce the invalid absolute path
+# "/hooks/lib/context7-cache.sh") or if the lib is missing (older
+# yellow-research install before this hook landed).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  CACHE_LIB="${CLAUDE_PLUGIN_ROOT}/hooks/lib/context7-cache.sh"
+  if [ -f "$CACHE_LIB" ]; then
+    ( # shellcheck source=/dev/null
+      . "$CACHE_LIB" && _lc_prewarm
+    ) >/dev/null 2>&1 &
+    disown
+  fi
+fi
 
 # Only userConfig-declared keys (perplexity, tavily, exa). Ceramic and
 # parallel are OAuth-managed by Claude Code with no userConfig field, so

--- a/plugins/yellow-research/tests/context7-cache.bats
+++ b/plugins/yellow-research/tests/context7-cache.bats
@@ -1,0 +1,462 @@
+#!/usr/bin/env bats
+# Tests for hooks/lib/context7-cache.sh — context7 cache pre-warm helpers.
+#
+# Strategy: source the lib, override _lc_resolve_library_id and _lc_now
+# with stubs so tests are deterministic and don't hit the real context7 API.
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  CLAUDE_PLUGIN_DATA="$TEST_TMP/plugin-data"
+  CLAUDE_PROJECT_DIR="$TEST_TMP/project"
+  mkdir -p "$CLAUDE_PLUGIN_DATA" "$CLAUDE_PROJECT_DIR"
+  export CLAUDE_PLUGIN_DATA CLAUDE_PROJECT_DIR
+
+  # shellcheck source=../hooks/lib/context7-cache.sh
+  . "$BATS_TEST_DIRNAME/../hooks/lib/context7-cache.sh"
+}
+
+teardown() {
+  if [ -n "${TEST_TMP:-}" ] && [ -d "$TEST_TMP" ]; then
+    rm -rf "$TEST_TMP"
+  fi
+}
+
+# Override the HTTP call so tests are deterministic and offline.
+_stub_resolve_returns() {
+  eval "_lc_resolve_library_id() { case \"\$1\" in
+    react)    printf '/facebook/react' ;;
+    lodash)   printf '/lodash/lodash' ;;
+    axios)    printf '/axios/axios' ;;
+    *)        return 0 ;;
+  esac; }"
+}
+
+# Pin the clock for skip-if-fresh tests.
+_stub_now_returns() {
+  eval "_lc_now() { printf '%s' '$1'; }"
+}
+
+# --- _lc_cache_path ---
+
+@test "cache_path: derives md5-suffixed path from CLAUDE_PROJECT_DIR" {
+  run _lc_cache_path
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^${CLAUDE_PLUGIN_DATA}/context7-cache-[a-f0-9]{32}\.json$ ]]
+}
+
+@test "cache_path: fails when CLAUDE_PLUGIN_DATA unset" {
+  unset CLAUDE_PLUGIN_DATA
+  run _lc_cache_path
+  [ "$status" -ne 0 ]
+}
+
+# --- _lc_prewarm: no lockfile ---
+
+@test "prewarm: no lockfile → logs warning and exits 0 without creating cache" {
+  _stub_resolve_returns
+  run _lc_prewarm
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "No lockfile found" ]]
+  # No cache file should be written
+  [ -z "$(find "$CLAUDE_PLUGIN_DATA" -name 'context7-cache-*.json' 2>/dev/null)" ]
+}
+
+# --- _lc_prewarm: CLAUDE_PLUGIN_DATA unset ---
+
+@test "prewarm: CLAUDE_PLUGIN_DATA unset → warns and skips" {
+  unset CLAUDE_PLUGIN_DATA
+  _stub_resolve_returns
+  run _lc_prewarm
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "CLAUDE_PLUGIN_DATA unset" ]]
+}
+
+# --- _lc_prewarm: anonymous warm ---
+
+@test "prewarm: package.json present → resolves and writes cache (anonymous)" {
+  cat >"$CLAUDE_PROJECT_DIR/package.json" <<'JSON'
+{"dependencies": {"react": "^18.0.0", "axios": "^1.0.0"}, "devDependencies": {"lodash": "^4.0.0"}}
+JSON
+  _stub_resolve_returns
+  _stub_now_returns 1000000000
+
+  run _lc_prewarm
+  [ "$status" -eq 0 ]
+
+  local cache_file
+  cache_file=$(find "$CLAUDE_PLUGIN_DATA" -name 'context7-cache-*.json' | head -1)
+  [ -n "$cache_file" ]
+
+  # tier1 should contain all 3 resolved libraries
+  local count
+  count=$(jq '.tier1 | length' "$cache_file")
+  [ "$count" = "3" ]
+
+  # warmed_at matches the stubbed clock
+  local warmed
+  warmed=$(jq -r '.warmed_at' "$cache_file")
+  [ "$warmed" = "1000000000" ]
+
+  # schema field present
+  local schema
+  schema=$(jq -r '.schema' "$cache_file")
+  [ "$schema" = "1" ]
+}
+
+# --- _lc_prewarm: skip if fresh ---
+
+@test "prewarm: cache age < 24h → skips without modifying file" {
+  cat >"$CLAUDE_PROJECT_DIR/package.json" <<'JSON'
+{"dependencies": {"react": "^18.0.0"}}
+JSON
+  _stub_now_returns 2000000000
+  local cache_path
+  cache_path=$(_lc_cache_path)
+  # Seed a fresh cache: warmed 1 hour ago
+  printf '{"schema":"1","warmed_at":1999996400,"tier1":{"seeded":{"library_id":"/seed/seed","fetched_at":1999996400}},"tier2":{},"lockfile_fingerprint":{}}' >"$cache_path"
+  local before
+  before=$(cat "$cache_path")
+
+  _stub_resolve_returns
+  run _lc_prewarm
+  [ "$status" -eq 0 ]
+
+  # File unchanged
+  local after
+  after=$(cat "$cache_path")
+  [ "$before" = "$after" ]
+}
+
+# --- _lc_prewarm: corrupted cache → rewrites cleanly ---
+
+@test "prewarm: corrupted cache JSON → treated as stale, rewrites" {
+  cat >"$CLAUDE_PROJECT_DIR/package.json" <<'JSON'
+{"dependencies": {"react": "^18.0.0"}}
+JSON
+  local cache_path
+  cache_path=$(_lc_cache_path)
+  printf 'NOT VALID JSON {{' >"$cache_path"
+
+  _stub_resolve_returns
+  _stub_now_returns 1500000000
+  run _lc_prewarm
+  [ "$status" -eq 0 ]
+
+  # Cache should now be valid JSON with react
+  run jq -r '.tier1.react.library_id' "$cache_path"
+  [ "$status" -eq 0 ]
+  [ "$output" = "/facebook/react" ]
+}
+
+# --- _lc_prewarm: authenticated warm (CONTEXT7_API_KEY set) ---
+
+@test "prewarm: with CONTEXT7_API_KEY set → uses auth path (stub still returns same)" {
+  cat >"$CLAUDE_PROJECT_DIR/package.json" <<'JSON'
+{"dependencies": {"react": "^18.0.0"}}
+JSON
+  export CONTEXT7_API_KEY="test-token-xyz"
+  _stub_resolve_returns
+  _stub_now_returns 1700000000
+
+  run _lc_prewarm
+  [ "$status" -eq 0 ]
+
+  local cache_file
+  cache_file=$(find "$CLAUDE_PLUGIN_DATA" -name 'context7-cache-*.json' | head -1)
+  [ -n "$cache_file" ]
+  local id
+  id=$(jq -r '.tier1.react.library_id' "$cache_file")
+  [ "$id" = "/facebook/react" ]
+  unset CONTEXT7_API_KEY
+}
+
+# --- _lc_resolve_library_id: token not in argv when CONTEXT7_API_KEY set ---
+
+@test "resolve_library_id: CONTEXT7_API_KEY is not passed as a curl argv argument" {
+  local argv_log="$TEST_TMP/curl-argv.txt"
+  # Stub curl: write all arguments to a log file, then emit a valid response.
+  curl() {
+    printf '%s\n' "$@" >"$argv_log"
+    printf '{"results":[{"id":"/facebook/react","title":"React"}]}'
+  }
+  export -f curl
+
+  export CONTEXT7_API_KEY="super-secret-token-abc123"
+  run _lc_resolve_library_id "react"
+  [ "$status" -eq 0 ]
+  [ "$output" = "/facebook/react" ]
+
+  # The bearer token must NOT appear in curl's argv.
+  run grep -q "super-secret-token-abc123" "$argv_log"
+  [ "$status" -ne 0 ]
+
+  unset CONTEXT7_API_KEY
+  unset -f curl
+}
+
+# --- _lc_scan_lockfiles ---
+
+@test "scan_lockfiles: extracts names from package.json dependencies + devDependencies" {
+  cat >"$CLAUDE_PROJECT_DIR/package.json" <<'JSON'
+{"dependencies": {"react": "^18.0.0", "axios": "^1.0.0"}, "devDependencies": {"lodash": "^4.0.0"}}
+JSON
+  run _lc_scan_lockfiles
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ axios ]]
+  [[ "$output" =~ lodash ]]
+  [[ "$output" =~ react ]]
+}
+
+@test "scan_lockfiles: extracts names from Cargo.lock" {
+  cat >"$CLAUDE_PROJECT_DIR/Cargo.lock" <<'TOML'
+[[package]]
+name = "serde"
+version = "1.0.0"
+
+[[package]]
+name = "tokio"
+version = "1.0.0"
+TOML
+  run _lc_scan_lockfiles
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ serde ]]
+  [[ "$output" =~ tokio ]]
+}
+
+@test "scan_lockfiles: caps output at _LC_PREWARM_MAX (5)" {
+  cat >"$CLAUDE_PROJECT_DIR/package.json" <<'JSON'
+{"dependencies": {"react": "18", "lodash": "4", "axios": "1", "vue": "3", "express": "4", "next": "14", "webpack": "5", "babel": "7"}}
+JSON
+  run _lc_scan_lockfiles
+  [ "$status" -eq 0 ]
+  local count
+  count=$(printf '%s\n' "$output" | wc -l | tr -d ' ')
+  [ "$count" -le 5 ]
+}
+
+@test "scan_lockfiles: yarn.lock scoped packages (@scope/name) are extracted" {
+  cat >"$CLAUDE_PROJECT_DIR/yarn.lock" <<'YARN'
+"@babel/core@^7.0.0":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.21.0.tgz"
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz"
+YARN
+  run _lc_scan_lockfiles
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "@babel/core" ]]
+  [[ "$output" =~ "lodash" ]]
+}
+
+@test "scan_lockfiles: package.json direct deps appear before package-lock.json transitive deps" {
+  # package.json has react as a direct dep
+  cat >"$CLAUDE_PROJECT_DIR/package.json" <<'JSON'
+{"dependencies": {"react": "^18.0.0"}}
+JSON
+  # package-lock.json has many transitive @babel/helper-* packages that sort first alphabetically
+  cat >"$CLAUDE_PROJECT_DIR/package-lock.json" <<'LOCKJSON'
+{
+  "lockfileVersion": 3,
+  "packages": {
+    "node_modules/@babel/helper-annotate-as-pure": {"version": "7.0.0"},
+    "node_modules/@babel/helper-compilation-targets": {"version": "7.0.0"},
+    "node_modules/react": {"version": "18.0.0"}
+  }
+}
+LOCKJSON
+  run _lc_scan_lockfiles
+  [ "$status" -eq 0 ]
+  # react must be present
+  [[ "$output" =~ "react" ]]
+  # react must appear before any @babel/helper-* line
+  local react_line babel_line
+  react_line=$(printf '%s\n' "$output" | grep -n '^react$' | cut -d: -f1)
+  babel_line=$(printf '%s\n' "$output" | grep -n '^@babel/' | head -1 | cut -d: -f1)
+  [ -n "$react_line" ]
+  if [ -n "$babel_line" ]; then
+    [ "$react_line" -lt "$babel_line" ]
+  fi
+}
+
+# --- _lc_atomic_write ---
+
+@test "atomic_write: writes file successfully" {
+  local target="$TEST_TMP/atomic-test.json"
+  run _lc_atomic_write "$target" '{"hello":"world"}'
+  [ "$status" -eq 0 ]
+  [ -f "$target" ]
+  local content
+  content=$(cat "$target")
+  [ "$content" = '{"hello":"world"}' ]
+}
+
+@test "atomic_write: creates parent directory if missing" {
+  local target="$TEST_TMP/nested/dir/file.json"
+  run _lc_atomic_write "$target" '{"a":1}'
+  [ "$status" -eq 0 ]
+  [ -f "$target" ]
+}
+
+# --- _lc_lockfile_fingerprint ---
+
+@test "lockfile_fingerprint: returns a non-zero integer mtime for a real file" {
+  touch "$CLAUDE_PROJECT_DIR/package-lock.json"
+  run _lc_lockfile_fingerprint
+  [ "$status" -eq 0 ]
+  local mtime
+  mtime=$(printf '%s' "$output" | jq -r '.["package-lock.json"]')
+  # mtime must be a positive integer (not 0 and not empty)
+  [[ "$mtime" =~ ^[0-9]+$ ]]
+  [ "$mtime" -gt 0 ]
+}
+
+@test "lockfile_fingerprint: absent lockfiles are omitted from output" {
+  # No lockfiles in project dir — result should be empty object
+  run _lc_lockfile_fingerprint
+  [ "$status" -eq 0 ]
+  local keys
+  keys=$(printf '%s' "$output" | jq 'keys | length')
+  [ "$keys" = "0" ]
+}
+
+# --- _lc_should_skip: lockfile mtime invalidation ---
+
+@test "should_skip: returns non-zero when lockfile mtime changes after cache was written" {
+  cat >"$CLAUDE_PROJECT_DIR/package-lock.json" <<'JSON'
+{"lockfileVersion":3,"packages":{"node_modules/react":{"version":"18.0.0"}}}
+JSON
+  _stub_now_returns 2000000000
+  _stub_resolve_returns
+
+  # Warm the cache so fingerprint is recorded
+  _lc_prewarm
+
+  # Verify should_skip returns 0 (within TTL + fingerprint matches)
+  run _lc_should_skip
+  [ "$status" -eq 0 ]
+
+  # Force mtime forward by a second to avoid within-second race (touch granularity
+  # is 1s on most filesystems; without -d the new mtime can equal the original).
+  touch -d '+1 second' "$CLAUDE_PROJECT_DIR/package-lock.json"
+
+  # Now should_skip must return non-zero (fingerprint mismatch)
+  run _lc_should_skip
+  [ "$status" -ne 0 ]
+}
+
+# --- _lc_scan_lockfiles: scoped npm packages ---
+
+@test "scan_lockfiles: extracts scoped packages (@types/node, @babel/core) from package-lock.json" {
+  cat >"$CLAUDE_PROJECT_DIR/package-lock.json" <<'JSON'
+{
+  "lockfileVersion": 3,
+  "packages": {
+    "node_modules/@types/node": {"version": "20.0.0"},
+    "node_modules/@babel/core": {"version": "7.0.0"},
+    "node_modules/react": {"version": "18.0.0"},
+    "node_modules/react/node_modules/loose-envify": {"version": "1.0.0"}
+  }
+}
+JSON
+  run _lc_scan_lockfiles
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "@types/node" ]]
+  [[ "$output" =~ "@babel/core" ]]
+  [[ "$output" =~ "react" ]]
+  # Nested path (two slashes after stripping node_modules/) must NOT appear
+  [[ ! "$output" =~ "loose-envify" ]]
+}
+
+# --- _lc_lookup: cache reader for consumer agents ---
+
+@test "lookup: returns empty when cache file is absent" {
+  run _lc_lookup "react"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "lookup: returns cached library_id on fresh hit" {
+  local cache_path
+  cache_path=$(_lc_cache_path)
+  local now
+  now=$(_lc_now)
+  printf '{"schema":"1","warmed_at":%s,"tier1":{"react":{"library_id":"/facebook/react","fetched_at":%s}},"tier2":{},"lockfile_fingerprint":{}}' "$now" "$now" >"$cache_path"
+
+  run _lc_lookup "react"
+  [ "$status" -eq 0 ]
+  [ "$output" = "/facebook/react" ]
+}
+
+@test "lookup: returns empty on cache miss (library not in tier1)" {
+  local cache_path
+  cache_path=$(_lc_cache_path)
+  local now
+  now=$(_lc_now)
+  printf '{"schema":"1","warmed_at":%s,"tier1":{"react":{"library_id":"/facebook/react","fetched_at":%s}},"tier2":{},"lockfile_fingerprint":{}}' "$now" "$now" >"$cache_path"
+
+  run _lc_lookup "missing-library"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "lookup: returns empty when cached entry is older than TIER1 TTL" {
+  local cache_path
+  cache_path=$(_lc_cache_path)
+  _stub_now_returns 2000000000
+  # Entry fetched > 24h ago (86401 seconds)
+  printf '{"schema":"1","warmed_at":1999913599,"tier1":{"react":{"library_id":"/facebook/react","fetched_at":1999913599}},"tier2":{},"lockfile_fingerprint":{}}' >"$cache_path"
+
+  run _lc_lookup "react"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "lookup: returns empty on corrupted cache JSON" {
+  local cache_path
+  cache_path=$(_lc_cache_path)
+  printf 'NOT VALID JSON {{' >"$cache_path"
+
+  run _lc_lookup "react"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "lookup: returns empty when name argument is empty" {
+  run _lc_lookup ""
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- bin/lc-cache-lookup wrapper (agent-facing) ---
+
+@test "bin/lc-cache-lookup: returns cached id when invoked from any cwd" {
+  local cache_path
+  cache_path=$(_lc_cache_path)
+  local now
+  now=$(_lc_now)
+  printf '{"schema":"1","warmed_at":%s,"tier1":{"axios":{"library_id":"/axios/axios","fetched_at":%s}},"tier2":{},"lockfile_fingerprint":{}}' "$now" "$now" >"$cache_path"
+
+  cd "$TEST_TMP"
+  run bash "$BATS_TEST_DIRNAME/../bin/lc-cache-lookup" "axios"
+  [ "$status" -eq 0 ]
+  [ "$output" = "/axios/axios" ]
+}
+
+@test "bin/lc-cache-lookup: exits 0 with empty output when no arg" {
+  run bash "$BATS_TEST_DIRNAME/../bin/lc-cache-lookup"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- idempotency guard ---
+
+@test "library re-sourcing is idempotent (_LC_CACHE_LOADED guard)" {
+  # If re-sourcing had side effects, we'd see errors here from set -u
+  # shellcheck source=../hooks/lib/context7-cache.sh
+  . "$BATS_TEST_DIRNAME/../hooks/lib/context7-cache.sh"
+  # shellcheck source=../hooks/lib/context7-cache.sh
+  . "$BATS_TEST_DIRNAME/../hooks/lib/context7-cache.sh"
+  [ "$_LC_CACHE_LOADED" = "1" ]
+}


### PR DESCRIPTION
## Summary

Pre-warms a per-project context7 library docs cache on SessionStart so common library queries don't burn the anonymous global pool (200 req/hr per `ratelimit-limit` header). Detached background subshell; parent exits in <1s so SessionStart cost stays under the ~3s UX budget.

This is PR-B of the 2-PR follow-up to [PR #536](https://github.com/KingInYellows/yellow-plugins/pull/536) per `plans/library-context-followups.md`. PR-A (RULE 13 lint) is blocked on #536 merging and is not in this stack.

## What ships

- **`plugins/yellow-research/hooks/lib/context7-cache.sh`** — sourceable helpers (cache path, lockfile scan, HTTP resolve, atomic write, prewarm orchestrator). Idempotent re-source via `_LC_CACHE_LOADED` guard.
- **`plugins/yellow-research/hooks/write-credential-status.sh`** — invokes `_lc_prewarm` in a detached background subshell before the existing `credential_hook_scaffold` call. Yellow-morph `prewarm-morph.sh` precedent.
- **`plugins/yellow-research/tests/context7-cache.bats`** — 14 tests covering scan, cache path derivation, prewarm happy paths, missing env, no lockfile, fresh-skip, corrupted-rewrite, anonymous + authenticated warms, atomic write, idempotent re-source.

## Cache shape

`${CLAUDE_PLUGIN_DATA}/context7-cache-<md5_of_project_dir>.json`:

```json
{
  "schema": "1",
  "warmed_at": 1779000000,
  "lockfile_fingerprint": { "package-lock.json": 1778999000 },
  "tier1": { "react": { "library_id": "/facebook/react", "fetched_at": 1779000000 } },
  "tier2": {}
}
```

- **tier1** — `library-name → {library_id, fetched_at}` (24h TTL, capped at 5 libs from project lockfiles)
- **tier2** — `library-id|topic → {docs, fetched_at}` (4h TTL, max 50; reserved for future lazy population on cache miss — not pre-warmed)

## Lockfile support

package-lock.json, pnpm-lock.yaml, yarn.lock, Cargo.lock, go.sum, requirements.txt, plus package.json fallback. Deduped and capped at top 5 names per session warm.

## HTTP API (verified live 2026-05-17)

- `GET https://context7.com/api/v1/search?query=<name>` → JSON `{results: [{id: "/owner/repo", ...}]}`
- `GET https://context7.com/api/v1/<owner>/<repo>[?topic=<t>]` → text/plain markdown
- Anonymous quota: **200 req/hr global pool** per `ratelimit-limit` header
- With `CONTEXT7_API_KEY` as `Authorization: Bearer`: per-key quota
- The MCP server (used by agents at runtime) is unaffected — the hook hits the HTTP API directly since shell hooks can't invoke MCP tools

## Safety properties

- `set -e` omitted (hook must emit `{"continue": true}` on all paths) — credential_hook_scaffold's own JSON output is preserved
- Atomic-rename writes (`mktemp + mv`) match `plugins/yellow-ci/hooks/scripts/session-start.sh:156-158`
- Skips cleanly when curl/jq missing, `CLAUDE_PLUGIN_DATA` unset, no lockfile found, or cache is fresh (< 24h since last warm)
- Fire-and-forget background subshell so cache failures never block session start
- Idempotent re-source via `_LC_CACHE_LOADED` guard (same pattern as `yellow-core/lib/validate-fs.sh`)

## Test plan

- [x] `pnpm validate:schemas` — 18 plugins, 79 agents, 272 markdown files
- [x] `pnpm test:unit` — 3 tests pass
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm release:check` — versions in sync
- [x] `bats plugins/yellow-research/tests/context7-cache.bats` — 14/14 pass
- [ ] Manual smoke: open a fresh Claude Code session in a project with a `package.json`, confirm `${CLAUDE_PLUGIN_DATA}/context7-cache-*.json` appears within ~2s and contains resolved library IDs
- [ ] Manual smoke: open a second session in the same project within 24h, confirm the hook skips (no new HTTP calls observable via `ratelimit-remaining` header in the next manual context7 query)
- [ ] Manual smoke: corrupt the cache JSON, open a new session, confirm clean re-warm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added asynchronous context7 documentation cache pre-warming during session start, automatically populating cached library data with credential authentication support and intelligent cache invalidation based on project dependencies.

* **Tests**
  * Comprehensive test suite added covering cache pre-warm, lookups, lockfile scanning, and edge cases including cache corruption and TTL expiration scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KingInYellows/yellow-plugins/pull/537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->