### PR TITLE
docs: add workaround documentation for skill tool exit code issue and codex CLI 401 error

### DIFF
--- a/docs/solutions/code-quality/skill-tool-no-exit-code-wrapper-workaround.md
+++ b/docs/solutions/code-quality/skill-tool-no-exit-code-wrapper-workaround.md
@@ -3,7 +3,7 @@ title: 'Skill tool returns no exit code — wrapper command workaround'
 date: 2026-05-18
 category: code-quality
 track: knowledge
-problem: Claude Code Skill tool provides no machine-readable success/failure signal; wrapper commands cannot detect inner-skill failures
+problem: Skill tool provides no machine-readable success/failure signal; wrappers cannot detect failures
 tags: [skill-tool, exit-code, wrapper-command, sweep, platform-constraint]
 components: [yellow-review]
 ---
@@ -37,14 +37,16 @@ add a `Notes` column populated with any stderr-style error lines surfaced in the
 skill's output. This makes the limitation explicit in the UX rather than hiding it.
 
 Before:
-```
+
+```markdown
 | PR    | Status  |
 |-------|---------|
 | #539  | swept   |
 ```
 
 After:
-```
+
+```markdown
 | PR    | Status    | Notes                          |
 |-------|-----------|--------------------------------|
 | #539  | attempted | codex reviewer degraded (401)  |
@@ -61,6 +63,7 @@ Skill responses.
 ## When to Apply
 
 Whenever writing a command that:
+
 - Calls `Skill(...)` in a loop over N items
 - Needs to report aggregate success/failure to the user
 - Uses labels that imply completion (e.g., "reviewed", "swept", "processed")

--- a/docs/solutions/code-quality/skill-tool-no-exit-code-wrapper-workaround.md
+++ b/docs/solutions/code-quality/skill-tool-no-exit-code-wrapper-workaround.md
@@ -1,0 +1,81 @@
+---
+title: 'Skill tool returns no exit code — wrapper command workaround'
+date: 2026-05-18
+category: code-quality
+track: knowledge
+problem: Claude Code Skill tool provides no machine-readable success/failure signal; wrapper commands cannot detect inner-skill failures
+tags: [skill-tool, exit-code, wrapper-command, sweep, platform-constraint]
+components: [yellow-review]
+---
+
+## Context
+
+The Claude Code `Skill` tool invokes a named skill (by its `name:` frontmatter
+value). It returns the skill's prose output but **no structured exit status**.
+There is no `success: true/false` field, no exit code, and no stderr stream
+distinguishable from normal output.
+
+This was surfaced during the PR #539 review: 8 of 15 persona reviewers
+independently flagged it as a problem in `/review:sweep` and `/review:sweep-all`.
+
+## Consequences for Wrapper Commands
+
+Commands that loop over N items and call `Skill(...)` per item cannot:
+
+- Detect that a skill invocation failed mid-loop
+- Distinguish "PR reviewed successfully" from "PR review errored out"
+- Surface a reliable completion count vs failure count to the user
+
+The result is that outcome labels like `swept` in a summary table are
+**optimistic by construction** — they mean "skill was invoked," not "skill
+succeeded."
+
+## Applied Fix (PR #539)
+
+Rename the outcome label from `swept` to `attempted` in the summary table, and
+add a `Notes` column populated with any stderr-style error lines surfaced in the
+skill's output. This makes the limitation explicit in the UX rather than hiding it.
+
+Before:
+```
+| PR    | Status  |
+|-------|---------|
+| #539  | swept   |
+```
+
+After:
+```
+| PR    | Status    | Notes                          |
+|-------|-----------|--------------------------------|
+| #539  | attempted | codex reviewer degraded (401)  |
+| #540  | attempted |                                |
+```
+
+## Platform Constraint
+
+The underlying issue is a Claude Code platform limitation: `Skill` has no
+exit-code API. This cannot be fixed in plugin authoring alone. The workaround
+documented here is the correct approach until the platform adds structured
+Skill responses.
+
+## When to Apply
+
+Whenever writing a command that:
+- Calls `Skill(...)` in a loop over N items
+- Needs to report aggregate success/failure to the user
+- Uses labels that imply completion (e.g., "reviewed", "swept", "processed")
+
+Replace completion-implying labels with attempt-implying labels (`attempted`,
+`queued`, `dispatched`) and surface error text from skill output in a Notes
+column or equivalent.
+
+## Detection
+
+Grep for completion-implying labels in sweep-style commands:
+
+```bash
+grep -r 'swept\|reviewed\|processed\|completed' plugins/yellow-review/commands/
+```
+
+Flag any that appear in table output columns where the value is set
+unconditionally after a Skill call.

--- a/docs/solutions/integration-issues/codex-cli-401-non-tty-task-spawn-degradation.md
+++ b/docs/solutions/integration-issues/codex-cli-401-non-tty-task-spawn-degradation.md
@@ -1,0 +1,63 @@
+---
+title: 'Codex CLI 401 in non-TTY Task spawns — expected degradation mode'
+date: 2026-05-18
+category: integration-issues
+track: knowledge
+problem: ChatGPT OAuth keyring inaccessible from non-TTY subprocess; codex CLI returns HTTP 401 when spawned via Task
+tags: [codex, oauth, non-tty, task-spawn, degradation]
+components: [yellow-codex]
+---
+
+## Context
+
+The `/yellow-codex:review:codex-reviewer` agent uses the `codex` CLI to run a
+ChatGPT-backed review pass. The CLI authenticates via a keyring that is populated
+when a user runs `codex` interactively in a terminal (TTY).
+
+When the agent is spawned as a Task subagent (e.g., by `/review:sweep` or
+`/review:sweep-all`), the subprocess runs in a non-TTY environment. The keyring
+is not accessible from that context, and `codex` exits with HTTP 401.
+
+## Observed failure
+
+```
+Error: Request failed with status code 401
+    at ... codex/src/utils/openai-client.ts
+```
+
+The reviewer agent catches this and falls back to manual analysis (human-written
+summary without codex output), labeling the result as "degraded mode."
+
+## Why This Matters
+
+The 401 is not a configuration error or a credential problem — it is a
+**structural constraint** of how the ChatGPT OAuth flow stores credentials. The
+keyring requires an interactive TTY at the time of first authentication AND at
+the time of use. Non-TTY subprocesses cannot inherit that session.
+
+This means:
+
+- The failure is **expected** when codex-reviewer is spawned as a Task.
+- Retrying does not help.
+- The degraded-to-manual path is correct behavior, not a bug.
+
+## When to Apply
+
+- If `/review:sweep` or `/review:sweep-all` reports a codex reviewer failure with
+  a 401, dismiss it. The manual analysis the agent produced is still valid.
+- If you want a real codex pass, run `/yellow-codex:review:codex-reviewer`
+  directly in an interactive session (not via Task spawn).
+
+## Workarounds
+
+| Approach | Notes |
+|---|---|
+| Run codex reviewer interactively | Works reliably; not automatable |
+| Pre-authenticate in same TTY before sweep | Not helpful — keyring still not accessible in subprocess |
+| Use an API key instead of OAuth | Would fix the issue if codex CLI supports `OPENAI_API_KEY` env var; not yet confirmed |
+
+## Prevention
+
+Document this constraint in the codex-reviewer agent's frontmatter or SKILL.md
+so that sweep orchestrators know degradation is expected and do not retry or
+surface false alerts.

--- a/docs/solutions/integration-issues/codex-cli-401-non-tty-task-spawn-degradation.md
+++ b/docs/solutions/integration-issues/codex-cli-401-non-tty-task-spawn-degradation.md
@@ -54,7 +54,7 @@ This means:
 |---|---|
 | Run codex reviewer interactively | Works reliably; not automatable |
 | Pre-authenticate in same TTY before sweep | Not helpful — keyring still not accessible in subprocess |
-| Use an API key instead of OAuth | Would fix the issue if codex CLI supports `OPENAI_API_KEY` env var; not yet confirmed |
+| Use an API key instead of OAuth | Sidesteps the keyring entirely — codex CLI accepts `OPENAI_API_KEY` as a first-class auth method (see `plugins/yellow-codex/README.md:18`, `plugins/yellow-codex/CLAUDE.md:21`, `plugins/yellow-codex/skills/codex-patterns/SKILL.md:294`). **Not the desired fix for subscription OAuth workflows** — it bypasses the OAuth credential the user wants to use. Treat as a fallback only when OAuth subscription auth is not in play. |
 
 ## Prevention
 

--- a/docs/solutions/integration-issues/codex-cli-401-non-tty-task-spawn-degradation.md
+++ b/docs/solutions/integration-issues/codex-cli-401-non-tty-task-spawn-degradation.md
@@ -43,10 +43,24 @@ This means:
 
 ## When to Apply
 
-- If `/review:sweep` or `/review:sweep-all` reports a codex reviewer failure with
-  a 401, dismiss it. The manual analysis the agent produced is still valid.
-- If you want a real codex pass, run `/yellow-codex:review:codex-reviewer`
-  directly in an interactive session (not via Task spawn).
+- If `/review:sweep` or `/review:sweep-all` reports a codex reviewer 401
+  failure **AND the auth route is OAuth subscription** (no `OPENAI_API_KEY`
+  in env): dismiss the 401. The manual analysis the agent produced is still
+  valid — this is the documented non-TTY OAuth degradation path.
+- If `OPENAI_API_KEY` is set: a 401 is NOT expected. Treat as a real
+  auth/config error (revoked key, bad scope, expired) and investigate
+  before assuming review coverage is intact. Do NOT dismiss API-key 401s
+  as benign — that would hide actionable failures and produce false
+  confidence in the sweep's coverage.
+- If you want a real codex OAuth pass under TTY constraints, run
+  `/yellow-codex:review:codex-reviewer` directly in an interactive session
+  (not via Task spawn).
+
+**Quick auth-route check before deciding:**
+```bash
+[ -n "${OPENAI_API_KEY:-}" ] && echo "api-key (401 is a real error)" \
+                              || echo "oauth (401 may be benign)"
+```
 
 ## Workarounds
 

--- a/docs/solutions/integration-issues/codex-cli-401-non-tty-task-spawn-degradation.md
+++ b/docs/solutions/integration-issues/codex-cli-401-non-tty-task-spawn-degradation.md
@@ -20,7 +20,7 @@ is not accessible from that context, and `codex` exits with HTTP 401.
 
 ## Observed failure
 
-```
+```text
 Error: Request failed with status code 401
     at ... codex/src/utils/openai-client.ts
 ```

--- a/docs/solutions/integration-issues/codex-cli-401-non-tty-task-spawn-degradation.md
+++ b/docs/solutions/integration-issues/codex-cli-401-non-tty-task-spawn-degradation.md
@@ -57,6 +57,7 @@ This means:
   (not via Task spawn).
 
 **Quick auth-route check before deciding:**
+
 ```bash
 [ -n "${OPENAI_API_KEY:-}" ] && echo "api-key (401 is a real error)" \
                               || echo "oauth (401 may be benign)"

--- a/docs/solutions/workflow/gt-modify-no-c-flag-silent-unstaged-miss.md
+++ b/docs/solutions/workflow/gt-modify-no-c-flag-silent-unstaged-miss.md
@@ -29,14 +29,26 @@ new edit. The unstaged file change was never included.
 
 ## Root Cause
 
-`gt modify` without `-c` **amends the previous commit**. Git's amend only
-includes already-staged changes. If the edit was applied but not staged
-(`git add`), gt silently amends the message (and any staged hunks) and ignores
-the unstaged file.
+The real failure mode is **calling `gt modify` from a non-interactive
+agent context with unstaged changes** — not the absence of `-c`.
 
-The output "X files changed" refers to the amended commit's cumulative diff
-relative to its parent — not to what was just added. This makes it look like
-success when the edit was missed entirely.
+Per Graphite's own command reference, `gt modify` (in both amend and
+`--commit`/`-c` modes) prompts the user to stage unstaged changes when
+it detects them. The `-c` flag only switches between amending the
+previous commit vs. creating a new one. When the surrounding agent
+flow swallows that interactive prompt (or runs gt with stdin closed),
+the prompt resolves to "no stage" and the unstaged hunk is silently
+dropped from the resulting commit/amend.
+
+Git's amend itself only includes already-staged changes — which is
+correct behavior — but the staging gap was supposed to be caught by
+gt's prompt. The "X files changed" output then refers to the amended
+commit's cumulative diff relative to its parent, not to the just-edited
+file, so the failure looks like success.
+
+**Adding `-c` does NOT fix this.** `gt modify -c` exhibits the same
+silent-miss behavior in non-interactive agent contexts because the
+underlying staging prompt is what's being swallowed.
 
 ## Solution
 
@@ -59,7 +71,10 @@ gt modify -c -m "fix: descriptive message"
 ```
 
 The `-c` flag creates a new commit rather than amending. Preferred when the
-prior commit is already meaningful on its own.
+prior commit is already meaningful on its own. **The `-c` flag itself does
+not prevent the silent unstaged miss** — the explicit `git add` above is
+what makes the change visible to gt. Use `-c` based on whether you want a
+new commit vs. an amend, not as a fix for staging.
 
 **Option C — use git commit directly:**
 
@@ -73,8 +88,11 @@ Valid fallback; Graphite tracks the commit either way.
 ## Why This Works
 
 `git add` moves the file change from the working tree into the index. Only
-indexed (staged) changes are included in an amend or new commit. The `-c` flag
-is what distinguishes "new commit" from "amend" in gt modify.
+indexed (staged) changes are included in an amend or new commit, regardless
+of which subcommand path gt takes. The `-c` flag is what distinguishes
+"new commit" from "amend" in `gt modify`; it does NOT change staging
+behavior. Explicit `git add` before any `gt modify` invocation makes the
+fix robust whether gt prompts or not, and whether `-c` is present or not.
 
 ## Prevention
 

--- a/docs/solutions/workflow/gt-modify-no-c-flag-silent-unstaged-miss.md
+++ b/docs/solutions/workflow/gt-modify-no-c-flag-silent-unstaged-miss.md
@@ -1,10 +1,10 @@
 ---
-title: '`gt modify` without `-c` silently misses unstaged edits'
+title: '`gt modify` silently misses unstaged edits in non-interactive agent contexts'
 date: 2026-05-18
 category: workflow
 track: bug
-problem: gt modify without -c amends prior commit and ignores unstaged file edits; output looks successful
-tags: [graphite, gt-modify, unstaged, commit, silent-failure]
+problem: gt modify (with or without -c) silently drops unstaged file edits when its stage-prompt is swallowed by a non-interactive agent flow; output looks successful and the -c flag does not fix it
+tags: [graphite, gt-modify, unstaged, commit, silent-failure, non-interactive]
 components: [workflow, graphite]
 ---
 

--- a/docs/solutions/workflow/gt-modify-no-c-flag-silent-unstaged-miss.md
+++ b/docs/solutions/workflow/gt-modify-no-c-flag-silent-unstaged-miss.md
@@ -13,7 +13,7 @@ components: [workflow, graphite]
 Running `gt modify -m "fix: ..."` after applying a file edit (e.g., via the Edit
 tool) produces output like:
 
-```
+```text
 1 file changed, 3 insertions(+), 2 deletions(-)
 ```
 
@@ -40,28 +40,34 @@ success when the edit was missed entirely.
 
 ## Solution
 
-Two correct patterns:
+Three correct patterns:
 
 **Option A — stage first, then amend:**
+
 ```bash
 git add <file>
 gt modify -m "fix: descriptive message"
 ```
+
 Use when you want to fold the change into the previous commit.
 
 **Option B — create a new commit:**
+
 ```bash
 git add <file>
 gt modify -c -m "fix: descriptive message"
 ```
+
 The `-c` flag creates a new commit rather than amending. Preferred when the
 prior commit is already meaningful on its own.
 
 **Option C — use git commit directly:**
+
 ```bash
 git add <file>
 git commit -m "fix: descriptive message"
 ```
+
 Valid fallback; Graphite tracks the commit either way.
 
 ## Why This Works
@@ -78,7 +84,7 @@ Before any `gt modify` or `gt commit` call, verify staged state:
 git status --short
 ```
 
-If the file you edited appears as `M ` (unstaged) rather than `M ` (staged),
+If the file you edited appears as ` M` (unstaged) rather than `M ` (staged),
 run `git add <file>` first.
 
 In automated agent workflows: always `git add <specific-file>` immediately after

--- a/docs/solutions/workflow/gt-modify-no-c-flag-silent-unstaged-miss.md
+++ b/docs/solutions/workflow/gt-modify-no-c-flag-silent-unstaged-miss.md
@@ -1,0 +1,86 @@
+---
+title: '`gt modify` without `-c` silently misses unstaged edits'
+date: 2026-05-18
+category: workflow
+track: bug
+problem: gt modify without -c amends prior commit and ignores unstaged file edits; output looks successful
+tags: [graphite, gt-modify, unstaged, commit, silent-failure]
+components: [workflow, graphite]
+---
+
+## Problem
+
+Running `gt modify -m "fix: ..."` after applying a file edit (e.g., via the Edit
+tool) produces output like:
+
+```
+1 file changed, 3 insertions(+), 2 deletions(-)
+```
+
+But the reported diff belongs to the **prior commit's total content**, not the
+new edit. The unstaged file change was never included.
+
+## Symptoms
+
+- `git status` shows the edited file still dirty after `gt modify`
+- `git show HEAD` does not contain the intended change
+- The commit subject changed, but the file diff did not land
+- No error or warning was printed by gt
+
+## Root Cause
+
+`gt modify` without `-c` **amends the previous commit**. Git's amend only
+includes already-staged changes. If the edit was applied but not staged
+(`git add`), gt silently amends the message (and any staged hunks) and ignores
+the unstaged file.
+
+The output "X files changed" refers to the amended commit's cumulative diff
+relative to its parent — not to what was just added. This makes it look like
+success when the edit was missed entirely.
+
+## Solution
+
+Two correct patterns:
+
+**Option A — stage first, then amend:**
+```bash
+git add <file>
+gt modify -m "fix: descriptive message"
+```
+Use when you want to fold the change into the previous commit.
+
+**Option B — create a new commit:**
+```bash
+git add <file>
+gt modify -c -m "fix: descriptive message"
+```
+The `-c` flag creates a new commit rather than amending. Preferred when the
+prior commit is already meaningful on its own.
+
+**Option C — use git commit directly:**
+```bash
+git add <file>
+git commit -m "fix: descriptive message"
+```
+Valid fallback; Graphite tracks the commit either way.
+
+## Why This Works
+
+`git add` moves the file change from the working tree into the index. Only
+indexed (staged) changes are included in an amend or new commit. The `-c` flag
+is what distinguishes "new commit" from "amend" in gt modify.
+
+## Prevention
+
+Before any `gt modify` or `gt commit` call, verify staged state:
+
+```bash
+git status --short
+```
+
+If the file you edited appears as `M ` (unstaged) rather than `M ` (staged),
+run `git add <file>` first.
+
+In automated agent workflows: always `git add <specific-file>` immediately after
+applying an edit, before the commit step. Never rely on gt to pick up unstaged
+changes automatically.


### PR DESCRIPTION
## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide on handling unstructured skill outputs and a labeling/notes mitigation for sweep-style tasks.
  * Documented a CLI authentication degradation when run non-interactively (non-TTY) with recommended fallbacks.
  * Added a `gt modify` troubleshooting guide with symptoms, safe workflows, and a prevention checklist for silent unstaged edits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KingInYellows/yellow-plugins/pull/541?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->