### PR TITLE
feat(yellow-core): Stop + SessionStart hooks for background compounding

### DIFF
--- a/.changeset/pr540-stack-review-fixes.md
+++ b/.changeset/pr540-stack-review-fixes.md
@@ -1,0 +1,11 @@
+---
+"yellow-core": patch
+---
+
+Review fixes for PR #542:
+- session-start.sh: handle symlinked .drain-lock in deadlock recovery
+- session-start.sh: sanitize STAGING_DIR/CWD before fence interpolation in
+  drain prompt (strip CR/LF + escape literal close-delimiter)
+- compound-staging.sh: cs_drain_budget_warn takes optional live auth route
+  so route switches take effect immediately instead of waiting for the 5h
+  rolling window to roll

--- a/.changeset/yellow-core-compound-staging-hooks.md
+++ b/.changeset/yellow-core-compound-staging-hooks.md
@@ -1,0 +1,66 @@
+---
+'yellow-core': minor
+---
+
+feat(yellow-core): Stop + SessionStart hooks for background compounding
+
+Adds the hook infrastructure for an always-on background compounding
+pipeline (plans/background-compounding-triggers.md, stack item #1).
+
+**New files:**
+
+- `lib/compound-staging.sh` — sourceable helper library:
+  - `cs_derive_project_slug` / `cs_staging_dir_for_slug` — per-project
+    staging directory under `~/.claude/projects/<slug>/compound-staging/`
+  - `cs_atomic_jsonl_write` — sibling-tmp + rename atomicity
+    (`_lc_atomic_write` pattern, yellow-research precedent)
+  - `cs_redact_secrets` — self-contained subset of yellow-ci/lib/redact.sh
+    covering password=, token=, api_key=, Bearer, basic-auth URLs, GitHub
+    + Docker + npm + JWT tokens, PEM blocks
+  - `cs_read_drain_budget` / `cs_update_drain_budget` /
+    `cs_drain_budget_warn` — 5h rolling-window observability counter (no
+    hard ceiling under subscription auth)
+  - `cs_detect_auth_route` — ANTHROPIC_API_KEY → "api" else "subscription"
+- `hooks/scripts/stop.sh` — Stop hook (5s timeout, returns
+  `{"continue": true}` in < 500ms). Disowns a capture subshell that tails
+  the transcript, redacts secrets, and writes a JSONL entry to
+  `compound-staging/pending/<session_id>.jsonl`. Guards: recursion guard
+  via `COMPOUND_DRAIN_IN_PROGRESS=1`, `stop_hook_active` re-entrancy guard.
+- `hooks/scripts/_stop-capture-subshell.sh` — runs disowned after the
+  Stop hook parent exits. tail -100 + redact + sha256 + atomic JSONL write.
+- `hooks/scripts/session-start.sh` — SessionStart hook (3s timeout) with
+  reaper (orphan tmp >1h, stale `.drain-lock` >30min, PII TTL pending >7d,
+  crashed processing/ >1h requeued) and drain dispatcher. Thresholds:
+  count >= 5 OR oldest pending > 48h. Acquires `.drain-lock` via atomic
+  mkdir, spawns disowned `claude -p` subshell with
+  `COMPOUND_DRAIN_IN_PROGRESS=1` env var inherited.
+
+**Wired in plugin.json:** inline `hooks` block registering Stop (timeout 5)
+and SessionStart (timeout 3). No `async: true` — disowned-subshell pattern
+is the non-blocking mechanism (D4 in the plan).
+
+**Test coverage (44 new bats, all 83 in yellow-core suite green):**
+
+- `tests/compound-staging.bats` (24 tests) — lib helpers: slug derivation,
+  atomic write, redaction patterns, 5h budget rollover, auth-route detection,
+  idempotent source guard
+- `tests/compound-stop-hook.bats` (8 tests) — recursion guard,
+  stop_hook_active guard, capture happy path, secret redaction
+  (password + Bearer), content_hash dedup field, <500ms parent latency,
+  capture-subshell standalone with missing transcript
+- `tests/compound-session-start-hook.bats` (12 tests) — recursion guard,
+  first-run fast-exit, threshold gates (count=5, count=4, age>48h),
+  drain-lock honored + stale-lock reaped, PII TTL reap, crashed-processing
+  requeue, orphan tmp reap, JSON output contract
+
+**Stack context:** stack item #1 of 3
+(agent/feat/compound-staging-hooks). Item #2 adds the staging-reviewer +
+staging-scorer + staging-promoter agents the drain dispatches; item #3
+adds the `/compound:review-staged` manual override, MEMORY.md partition,
+RULE 14 lint, and docs.
+
+**Behavior on install:** without items #2-3, drains will dispatch on
+schedule but the drain `claude -p` session has no `staging-reviewer`
+agent to invoke. The drain will log a failure to `drain-logs/` and exit;
+pending entries accumulate (capped by 7-day TTL reap) until item #2 lands.
+This is the intentional shape of an additive stack.

--- a/.changeset/yellow-core-compound-staging-hooks.md
+++ b/.changeset/yellow-core-compound-staging-hooks.md
@@ -59,8 +59,9 @@ staging-scorer + staging-promoter agents the drain dispatches; item #3
 adds the `/compound:review-staged` manual override, MEMORY.md partition,
 RULE 14 lint, and docs.
 
-**Behavior on install:** without items #2-3, drains will dispatch on
-schedule but the drain `claude -p` session has no `staging-reviewer`
-agent to invoke. The drain will log a failure to `drain-logs/` and exit;
-pending entries accumulate (capped by 7-day TTL reap) until item #2 lands.
-This is the intentional shape of an additive stack.
+**Behavior on install:** without item #2, the SessionStart drain dispatcher
+checks for the staging-reviewer agent before spawning `claude -p` and
+short-circuits when it is absent. No drain session is started; no cost is
+incurred. Pending entries accumulate in `compound-staging/pending/` and are
+reaped under the 7-day PII TTL. The pipeline is operationally inert until
+item #2 lands — this is the intentional shape of an additive stack.

--- a/plugins/yellow-core/.claude-plugin/plugin.json
+++ b/plugins/yellow-core/.claude-plugin/plugin.json
@@ -25,7 +25,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/stop.sh",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/stop.sh",
             "timeout": 5
           }
         ]
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-start.sh",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-start.sh",
             "timeout": 3
           }
         ]

--- a/plugins/yellow-core/.claude-plugin/plugin.json
+++ b/plugins/yellow-core/.claude-plugin/plugin.json
@@ -17,5 +17,31 @@
     "python",
     "rust",
     "go"
-  ]
+  ],
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/stop.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-start.sh",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/plugins/yellow-core/hooks/scripts/_stop-capture-subshell.sh
+++ b/plugins/yellow-core/hooks/scripts/_stop-capture-subshell.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# _stop-capture-subshell.sh — runs inside the disowned subshell spawned by
+# stop.sh. Reads the transcript tail, redacts secrets, hashes, and writes
+# the JSONL pending entry atomically.
+#
+# Args:
+#   $1 — transcript path
+#   $2 — session id
+#   $3 — staging dir
+#   $4 — cwd (for logging context in the entry)
+#
+# Lifetime: this script runs after the Stop hook's parent exits. All output
+# is redirected to /dev/null by the parent's `& disown` wrapper. Exit code
+# is irrelevant — failures here cannot block Claude Code.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" 2>/dev/null && pwd -P)"
+
+# shellcheck source=../../lib/compound-staging.sh
+. "${SCRIPT_DIR}/../../lib/compound-staging.sh"
+
+TRANSCRIPT="${1:-}"
+SESSION_ID="${2:-}"
+STAGING_DIR="${3:-}"
+CWD="${4:-}"
+
+if [ -z "$TRANSCRIPT" ] || [ -z "$SESSION_ID" ] || [ -z "$STAGING_DIR" ]; then
+  exit 0
+fi
+
+# Require jq for JSON build.
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Read up to 100 lines of the transcript (PII cap per D12). The transcript
+# file may be missing or unreadable (race with Claude Code cleanup); silently
+# produce empty tail in that case.
+TAIL_RAW=""
+if [ -f "$TRANSCRIPT" ] && [ -r "$TRANSCRIPT" ]; then
+  TAIL_RAW=$(tail -n 100 -- "$TRANSCRIPT" 2>/dev/null || printf '')
+fi
+
+# Redact secrets BEFORE hashing or writing.
+TAIL_REDACTED=$(printf '%s' "$TAIL_RAW" | cs_redact_secrets 2>/dev/null || printf '')
+
+# Content hash (sha256) for fast dedup at drain time. Hash of the REDACTED
+# tail so identical post-redaction sessions collide.
+CONTENT_HASH=""
+if command -v sha256sum >/dev/null 2>&1; then
+  CONTENT_HASH=$(printf '%s' "$TAIL_REDACTED" | sha256sum 2>/dev/null | cut -d' ' -f1)
+elif command -v shasum >/dev/null 2>&1; then
+  CONTENT_HASH=$(printf '%s' "$TAIL_REDACTED" | shasum -a 256 2>/dev/null | cut -d' ' -f1)
+fi
+
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# Build JSONL entry. jq handles all escaping; we never embed user content
+# directly into a printf format string.
+ENTRY=$(jq -nc \
+  --arg ts "$TIMESTAMP" \
+  --arg sid "$SESSION_ID" \
+  --arg hash "$CONTENT_HASH" \
+  --arg cwd "$CWD" \
+  --arg tail "$TAIL_REDACTED" \
+  '{
+     schema: "1",
+     schema_min_reader: "1",
+     timestamp: $ts,
+     session_id: $sid,
+     content_hash: $hash,
+     cwd: $cwd,
+     transcript_tail: $tail
+   }') || exit 0
+
+# Atomic write: tmp/ then mv to pending/. The tmp/ and pending/ subdirs are
+# siblings under STAGING_DIR — guaranteed same filesystem — so rename(2) is
+# atomic. cs_atomic_jsonl_write handles the tmp + mv internally; we just
+# point it at the final destination.
+PENDING_PATH="${STAGING_DIR}/pending/${SESSION_ID}.jsonl"
+cs_atomic_jsonl_write "$PENDING_PATH" "$ENTRY" || exit 0

--- a/plugins/yellow-core/hooks/scripts/_stop-capture-subshell.sh
+++ b/plugins/yellow-core/hooks/scripts/_stop-capture-subshell.sh
@@ -28,6 +28,14 @@ if [ -z "$TRANSCRIPT" ] || [ -z "$SESSION_ID" ] || [ -z "$STAGING_DIR" ]; then
   exit 0
 fi
 
+# Sanitize SESSION_ID to a safe filename component. Replace anything that
+# isn't [A-Za-z0-9._-] with `_`. Defends against path traversal (`..`, `/`)
+# and shell-meta in the destination filename. Empty result is rejected.
+SESSION_ID=$(printf '%s' "$SESSION_ID" | tr -c 'A-Za-z0-9._-' '_')
+if [ -z "$SESSION_ID" ] || [ "$SESSION_ID" = "." ] || [ "$SESSION_ID" = ".." ]; then
+  exit 0
+fi
+
 # Require jq for JSON build.
 if ! command -v jq >/dev/null 2>&1; then
   exit 0
@@ -78,4 +86,8 @@ ENTRY=$(jq -nc \
 # atomic. cs_atomic_jsonl_write handles the tmp + mv internally; we just
 # point it at the final destination.
 PENDING_PATH="${STAGING_DIR}/pending/${SESSION_ID}.jsonl"
-cs_atomic_jsonl_write "$PENDING_PATH" "$ENTRY" || exit 0
+# JSONL requires each entry terminated by a newline. cs_atomic_jsonl_write
+# does not append \n on its own (the helper is content-agnostic), so the
+# caller is responsible for line termination.
+cs_atomic_jsonl_write "$PENDING_PATH" "${ENTRY}
+" || exit 0

--- a/plugins/yellow-core/hooks/scripts/session-start.sh
+++ b/plugins/yellow-core/hooks/scripts/session-start.sh
@@ -218,16 +218,40 @@ mkdir -p -- "${STAGING_DIR}/drain-logs" 2>/dev/null || true
 DRAIN_LOG="${STAGING_DIR}/drain-logs/$(date +%Y%m%d-%H%M%S).log"
 AUTH_ROUTE=$(cs_detect_auth_route)
 
+# Budget gate: skip dispatch when drain-budget.json indicates over-threshold on
+# API billing. Returns 0 (success) when over the COMPOUND_DRAIN_API_THRESHOLD
+# (default 8 drains in rolling window); returns 1 when under or on subscription
+# auth (no cost gate). Release the lock + json_exit on the over-threshold path.
+if cs_drain_budget_warn "$STAGING_DIR"; then
+  rmdir "${STAGING_DIR}/.drain-lock" 2>/dev/null || true
+  json_exit "drain budget over threshold; skipping dispatch"
+fi
+
+# Wall-clock cap on the drain subshell. Without this, a hung `claude -p`
+# (model loop, network stall) holds .drain-lock until the 30-min stale-lock
+# reaper fires on a future SessionStart, suppressing all drains in between.
+# `timeout` is GNU coreutils; gracefully fall through if unavailable.
+DRAIN_TIMEOUT_BIN=$(command -v timeout 2>/dev/null || true)
+DRAIN_TIMEOUT_S="${COMPOUND_DRAIN_TIMEOUT_S:-600}"
+
 (
   trap 'rmdir "'"${STAGING_DIR}"'/.drain-lock" 2>/dev/null || true' EXIT INT TERM
   export COMPOUND_DRAIN_IN_PROGRESS=1
-  printf '[yellow-core] compound-staging: drain dispatch %s (auth=%s, pending=%s)\n' \
-    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$AUTH_ROUTE" "$PENDING_COUNT" >> "$DRAIN_LOG" 2>/dev/null
-  "$CLAUDE_BIN" -p "$DRAIN_PROMPT" \
-    --max-turns 50 \
-    --permission-mode bypassPermissions \
-    --output-format json \
-    >> "$DRAIN_LOG" 2>&1
+  printf '[yellow-core] compound-staging: drain dispatch %s (auth=%s, pending=%s, timeout=%s)\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$AUTH_ROUTE" "$PENDING_COUNT" "$DRAIN_TIMEOUT_S" >> "$DRAIN_LOG" 2>/dev/null
+  if [ -n "$DRAIN_TIMEOUT_BIN" ]; then
+    "$DRAIN_TIMEOUT_BIN" "$DRAIN_TIMEOUT_S" "$CLAUDE_BIN" -p "$DRAIN_PROMPT" \
+      --max-turns 50 \
+      --permission-mode bypassPermissions \
+      --output-format json \
+      >> "$DRAIN_LOG" 2>&1
+  else
+    "$CLAUDE_BIN" -p "$DRAIN_PROMPT" \
+      --max-turns 50 \
+      --permission-mode bypassPermissions \
+      --output-format json \
+      >> "$DRAIN_LOG" 2>&1
+  fi
   cs_update_drain_budget "$STAGING_DIR" "$AUTH_ROUTE" || true
 ) >/dev/null 2>&1 &
 disown

--- a/plugins/yellow-core/hooks/scripts/session-start.sh
+++ b/plugins/yellow-core/hooks/scripts/session-start.sh
@@ -281,14 +281,21 @@ DRAIN_TIMEOUT_S="${COMPOUND_DRAIN_TIMEOUT_S:-600}"
   export COMPOUND_DRAIN_IN_PROGRESS=1
   printf '[yellow-core] compound-staging: drain dispatch %s (auth=%s, pending=%s, timeout=%s)\n' \
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$AUTH_ROUTE" "$PENDING_COUNT" "$DRAIN_TIMEOUT_S" >> "$DRAIN_LOG" 2>/dev/null
+  # --bare is the primary hook-recursion guard: it skips auto-discovery
+  # of hooks, skills, plugins, MCP servers, and CLAUDE.md in the child
+  # session. Without it, the child fires its own SessionStart hook and
+  # cascades. COMPOUND_DRAIN_IN_PROGRESS env var is defense-in-depth.
+  # See docs/solutions/code-quality/claude-code-bare-flag-and-hook-recursion-guard.md.
   if [ -n "$DRAIN_TIMEOUT_BIN" ]; then
     "$DRAIN_TIMEOUT_BIN" "$DRAIN_TIMEOUT_S" "$CLAUDE_BIN" -p "$DRAIN_PROMPT" \
+      --bare \
       --max-turns 50 \
       --permission-mode bypassPermissions \
       --output-format json \
       >> "$DRAIN_LOG" 2>&1
   else
     "$CLAUDE_BIN" -p "$DRAIN_PROMPT" \
+      --bare \
       --max-turns 50 \
       --permission-mode bypassPermissions \
       --output-format json \

--- a/plugins/yellow-core/hooks/scripts/session-start.sh
+++ b/plugins/yellow-core/hooks/scripts/session-start.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# session-start.sh — yellow-core SessionStart hook: drain dispatcher for the
+# background compounding pipeline.
+#
+# Reads pending/ in the per-project staging dir; if thresholds are met,
+# spawns a disowned `claude -p` drain subshell (env-var-guarded against
+# recursion) that processes pending entries asynchronously. Returns
+# {"continue": true} within the 3s hook timeout.
+#
+# Note: -e omitted intentionally — hook must output {"continue": true} on
+# all paths. With -e, any unexpected non-zero would exit before JSON is
+# printed, blocking session startup.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" 2>/dev/null && pwd -P)"
+
+# shellcheck source=../../lib/compound-staging.sh
+. "${SCRIPT_DIR}/../../lib/compound-staging.sh"
+
+json_exit() {
+  local msg="${1:-}"
+  [ -n "$msg" ] && printf '[yellow-core] compound-staging: %s\n' "$msg" >&2
+  printf '{"continue": true}\n'
+  exit 0
+}
+
+# --- Recursion guard ---
+# Drain `claude -p` sessions inherit this env var; their SessionStart hook
+# fires too and would otherwise fire a nested drain.
+if [ "${COMPOUND_DRAIN_IN_PROGRESS:-}" = "1" ]; then
+  json_exit
+fi
+
+# --- jq dependency ---
+if ! command -v jq >/dev/null 2>&1; then
+  json_exit "jq not installed; cannot evaluate drain thresholds"
+fi
+
+# --- Parse stdin ---
+INPUT=$(cat)
+CWD=""
+if [ -n "$INPUT" ]; then
+  # shellcheck disable=SC2154
+  eval "$(printf '%s' "$INPUT" | jq -r '@sh "CWD=\(.cwd // "")"' 2>/dev/null)" \
+    || CWD=""
+fi
+if [ -z "$CWD" ]; then
+  CWD="${CLAUDE_PROJECT_DIR:-$PWD}"
+fi
+
+PROJECT_SLUG=$(cs_derive_project_slug "$CWD")
+if [ -z "$PROJECT_SLUG" ]; then
+  json_exit
+fi
+STAGING_DIR=$(cs_staging_dir_for_slug "$PROJECT_SLUG")
+
+# First-run fast-exit: if pending/ doesn't exist yet, there's nothing to
+# drain and nothing to reap.
+if [ ! -d "${STAGING_DIR}/pending" ]; then
+  json_exit
+fi
+
+# --- Reaper (defense against undrained data) ---
+# Each find runs independently so one failure doesn't suppress the others.
+# Errors are non-fatal — log to stderr only.
+
+# Orphan tmp/*.jsonl > 1h: leftover from crashed atomic writes.
+find "${STAGING_DIR}/tmp" -name '*.jsonl.tmp.*' -mmin +60 -delete 2>/dev/null \
+  || true
+
+# Stale .drain-lock: dir-style lock. If mtime > 30 min, previous drain
+# crashed without releasing — reap so a fresh drain can fire.
+if [ -d "${STAGING_DIR}/.drain-lock" ]; then
+  lock_age_min=999
+  if lock_mtime=$(stat -c '%Y' "${STAGING_DIR}/.drain-lock" 2>/dev/null \
+    || stat -f '%m' "${STAGING_DIR}/.drain-lock" 2>/dev/null); then
+    now_epoch=$(date +%s)
+    lock_age_min=$(( (now_epoch - lock_mtime) / 60 ))
+  fi
+  if [ "$lock_age_min" -gt 30 ] 2>/dev/null; then
+    rmdir "${STAGING_DIR}/.drain-lock" 2>/dev/null \
+      || printf '[yellow-core] compound-staging: stale lock rmdir failed\n' >&2
+  fi
+fi
+
+# PII TTL: delete pending/*.jsonl older than 7 days. Log when reaping so
+# the user sees that undrained PII was purged.
+expired_count=$(find "${STAGING_DIR}/pending" -name '*.jsonl' -mtime +7 \
+  -print 2>/dev/null | wc -l | tr -d '[:space:]')
+if [ "${expired_count:-0}" -gt 0 ] 2>/dev/null; then
+  printf '[yellow-core] compound-staging: reaping %s pending entries older than 7 days\n' \
+    "$expired_count" >&2
+  find "${STAGING_DIR}/pending" -name '*.jsonl' -mtime +7 -delete 2>/dev/null \
+    || true
+fi
+
+# Processing/ entries older than 1h are crashed mid-drain; move them back
+# to pending/ so they get retried. Younger files are in-flight from a
+# concurrent drain — leave them alone.
+if [ -d "${STAGING_DIR}/processing" ]; then
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    base=$(basename -- "$f")
+    mv -- "$f" "${STAGING_DIR}/pending/${base}" 2>/dev/null \
+      || printf '[yellow-core] compound-staging: failed to requeue crashed entry %s\n' "$base" >&2
+  done < <(find "${STAGING_DIR}/processing" -name '*.jsonl' -mmin +60 -print 2>/dev/null)
+fi
+
+# --- Threshold check ---
+# count >= 5 OR oldest_age > 48h (Max 20x responsive defaults per plan §Budget Model).
+PENDING_COUNT=$(find "${STAGING_DIR}/pending" -maxdepth 1 -name '*.jsonl' -type f 2>/dev/null \
+  | wc -l | tr -d '[:space:]')
+PENDING_COUNT="${PENDING_COUNT:-0}"
+
+if [ "$PENDING_COUNT" -eq 0 ] 2>/dev/null; then
+  json_exit
+fi
+
+DISPATCH=0
+if [ "$PENDING_COUNT" -ge 5 ] 2>/dev/null; then
+  DISPATCH=1
+else
+  # Check oldest mtime. Linux stat first, BSD/macOS stat second.
+  oldest_epoch=""
+  oldest_file=$(find "${STAGING_DIR}/pending" -maxdepth 1 -name '*.jsonl' -type f \
+    -printf '%T@ %p\n' 2>/dev/null | sort -n | head -1 | awk '{print $2}')
+  if [ -z "$oldest_file" ]; then
+    # BSD find doesn't support -printf. Fall back to stat per-file.
+    oldest_epoch=$(find "${STAGING_DIR}/pending" -maxdepth 1 -name '*.jsonl' -type f \
+      -exec stat -f '%m' {} \; 2>/dev/null | sort -n | head -1)
+  else
+    oldest_epoch=$(stat -c '%Y' "$oldest_file" 2>/dev/null) || oldest_epoch=""
+  fi
+  if [ -n "$oldest_epoch" ]; then
+    now_epoch=$(date +%s)
+    age_hours=$(( (now_epoch - oldest_epoch) / 3600 ))
+    if [ "$age_hours" -gt 48 ] 2>/dev/null; then
+      DISPATCH=1
+    fi
+  fi
+fi
+
+if [ "$DISPATCH" -eq 0 ]; then
+  json_exit
+fi
+
+# --- Acquire drain lock (atomic mkdir) ---
+if ! mkdir "${STAGING_DIR}/.drain-lock" 2>/dev/null; then
+  # Concurrent drain already in flight (or stale lock not yet reaped).
+  json_exit
+fi
+
+# --- Resolve claude binary ---
+# Allow tests to override via COMPOUND_DRAIN_CMD env var.
+CLAUDE_BIN="${COMPOUND_DRAIN_CMD:-}"
+if [ -z "$CLAUDE_BIN" ]; then
+  CLAUDE_BIN=$(command -v claude 2>/dev/null || true)
+fi
+if [ -z "$CLAUDE_BIN" ] || [ ! -x "$CLAUDE_BIN" ]; then
+  rmdir "${STAGING_DIR}/.drain-lock" 2>/dev/null || true
+  json_exit "claude binary not found; skipping drain"
+fi
+
+# --- Build drain prompt ---
+# Heredoc with single-quoted delimiter so $STAGING_DIR etc. are NOT
+# interpreted here — values are substituted via the inline expansion in
+# the printf format.
+DRAIN_PROMPT=$(printf '%s\n' \
+  'Invoke the staging-reviewer agent (yellow-core:workflow:staging-reviewer) via Task.' \
+  '' \
+  'Goal: drain the compound-staging ledger and promote eligible entries.' \
+  '' \
+  "Staging dir: ${STAGING_DIR}" \
+  "Project: ${CWD}" \
+  '' \
+  'Do NOT ask the user any questions. This drain is non-interactive.' \
+  'On completion, write a one-line summary to stdout and exit.')
+
+# --- Spawn disowned drain subshell ---
+mkdir -p -- "${STAGING_DIR}/drain-logs" 2>/dev/null || true
+DRAIN_LOG="${STAGING_DIR}/drain-logs/$(date +%Y%m%d-%H%M%S).log"
+AUTH_ROUTE=$(cs_detect_auth_route)
+
+(
+  trap 'rmdir "'"${STAGING_DIR}"'/.drain-lock" 2>/dev/null || true' EXIT INT TERM
+  export COMPOUND_DRAIN_IN_PROGRESS=1
+  printf '[yellow-core] compound-staging: drain dispatch %s (auth=%s, pending=%s)\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$AUTH_ROUTE" "$PENDING_COUNT" >> "$DRAIN_LOG" 2>/dev/null
+  "$CLAUDE_BIN" -p "$DRAIN_PROMPT" \
+    --max-turns 50 \
+    --permission-mode bypassPermissions \
+    --output-format json \
+    >> "$DRAIN_LOG" 2>&1
+  cs_update_drain_budget "$STAGING_DIR" "$AUTH_ROUTE" || true
+) >/dev/null 2>&1 &
+disown
+
+json_exit

--- a/plugins/yellow-core/hooks/scripts/session-start.sh
+++ b/plugins/yellow-core/hooks/scripts/session-start.sh
@@ -241,9 +241,23 @@ DRAIN_PROMPT=$(printf '%s\n' \
   'On completion, write a one-line summary to stdout and exit.')
 
 # --- Spawn disowned drain subshell ---
+# Drain log captures full model JSON output, which may re-contain
+# transcript fragments past redaction. Constrain to owner-only (0600/0700)
+# to prevent disclosure to other users on shared/CI systems.
 mkdir -p -- "${STAGING_DIR}/drain-logs" 2>/dev/null || true
+chmod 700 -- "${STAGING_DIR}/drain-logs" 2>/dev/null || true
 DRAIN_LOG="${STAGING_DIR}/drain-logs/$(date +%Y%m%d-%H%M%S).log"
+# Pre-create with restrictive perms so subsequent appends preserve 0600.
+( umask 077; : > "$DRAIN_LOG" ) 2>/dev/null || true
 AUTH_ROUTE=$(cs_detect_auth_route)
+
+# Validate COMPOUND_DRAIN_TIMEOUT_S is a positive integer (>0) to prevent
+# DoS via env-injected non-numeric value (timeout(1) exits 125 on bad
+# input, short-circuiting every drain) or "0" (which disables the timeout
+# entirely and lets a hung claude -p hold the lock until stale-reap).
+case "${COMPOUND_DRAIN_TIMEOUT_S:-600}" in
+  ''|*[!0-9]*|0) COMPOUND_DRAIN_TIMEOUT_S=600 ;;
+esac
 
 # Budget gate: skip dispatch when drain-budget.json indicates over-threshold on
 # API billing. Returns 0 (success) when over the COMPOUND_DRAIN_API_THRESHOLD

--- a/plugins/yellow-core/hooks/scripts/session-start.sh
+++ b/plugins/yellow-core/hooks/scripts/session-start.sh
@@ -83,7 +83,7 @@ done
 # a non-yellow-core process). mkdir would always fail (EEXIST) and
 # rmdir cannot remove non-directories — without explicit handling we
 # would deadlock drain dispatch permanently. Remove the file first.
-if [ -f "${STAGING_DIR}/.drain-lock" ]; then
+if [ -f "${STAGING_DIR}/.drain-lock" ] || [ -L "${STAGING_DIR}/.drain-lock" ]; then
   printf '[yellow-core] compound-staging: removing non-directory .drain-lock (deadlock recovery)\n' >&2
   rm -f -- "${STAGING_DIR}/.drain-lock" 2>/dev/null \
     || printf '[yellow-core] compound-staging: non-dir lock rm failed\n' >&2
@@ -223,18 +223,27 @@ if [ ! -f "$STAGING_REVIEWER_PATH" ]; then
 fi
 
 # --- Build drain prompt ---
-# P2: STAGING_DIR and CWD are untrusted filesystem paths (a malicious
-# repo name could contain newlines or prompt-like text). Fence them with
-# begin/end delimiters so the model treats them as reference data only,
-# not as additional instructions.
+# P1: STAGING_DIR and CWD are untrusted filesystem paths (a malicious
+# repo name could contain newlines or prompt-like text). Two-layer defense:
+#   1. Strip CR/LF and substitute the literal close-delimiter so a path
+#      containing `--- end paths ---` cannot terminate the fence.
+#   2. Encode each value on a single fenced line so any residual prompt-like
+#      text is treated as reference data, not instructions.
+# Pattern source: yellow-core/skills/security-fencing — orchestrator-level
+# fence sanitization for untrusted text interpolated into prompts.
+sanitize_fence_value() {
+  printf '%s' "$1" | tr -d '\r\n' | sed 's/--- end paths ---/[ESCAPED] end paths/g'
+}
+STAGING_DIR_SAFE=$(sanitize_fence_value "$STAGING_DIR")
+CWD_SAFE=$(sanitize_fence_value "$CWD")
 DRAIN_PROMPT=$(printf '%s\n' \
   'Invoke the staging-reviewer agent (yellow-core:workflow:staging-reviewer) via Task.' \
   '' \
   'Goal: drain the compound-staging ledger and promote eligible entries.' \
   '' \
   '--- begin paths (reference only) ---' \
-  "Staging dir: ${STAGING_DIR}" \
-  "Project: ${CWD}" \
+  "Staging dir: ${STAGING_DIR_SAFE}" \
+  "Project: ${CWD_SAFE}" \
   '--- end paths ---' \
   '' \
   'Do NOT ask the user any questions. This drain is non-interactive.' \
@@ -263,7 +272,7 @@ esac
 # API billing. Returns 0 (success) when over the COMPOUND_DRAIN_API_THRESHOLD
 # (default 8 drains in rolling window); returns 1 when under or on subscription
 # auth (no cost gate). Release the lock + json_exit on the over-threshold path.
-if cs_drain_budget_warn "$STAGING_DIR"; then
+if cs_drain_budget_warn "$STAGING_DIR" "$AUTH_ROUTE"; then
   rmdir "${STAGING_DIR}/.drain-lock" 2>/dev/null || true
   json_exit "drain budget over threshold; skipping dispatch"
 fi

--- a/plugins/yellow-core/hooks/scripts/session-start.sh
+++ b/plugins/yellow-core/hooks/scripts/session-start.sh
@@ -45,6 +45,9 @@ if [ -n "$INPUT" ]; then
     || CWD=""
 fi
 if [ -z "$CWD" ]; then
+  if [ -z "${CLAUDE_PROJECT_DIR:-}" ]; then
+    printf '[yellow-core] compound-staging: Warning: CLAUDE_PROJECT_DIR unset; falling back to PWD (%s)\n' "$PWD" >&2
+  fi
   CWD="${CLAUDE_PROJECT_DIR:-$PWD}"
 fi
 
@@ -70,12 +73,28 @@ find "${STAGING_DIR}/tmp" -name '*.jsonl.tmp.*' -mmin +60 -delete 2>/dev/null \
 
 # Stale .drain-lock: dir-style lock. If mtime > 30 min, previous drain
 # crashed without releasing — reap so a fresh drain can fire.
+#
+# Edge case: .drain-lock as a regular file (created by accident or by
+# a non-yellow-core process). mkdir would always fail (EEXIST) and
+# rmdir cannot remove non-directories — without explicit handling we
+# would deadlock drain dispatch permanently. Remove the file first.
+if [ -f "${STAGING_DIR}/.drain-lock" ]; then
+  printf '[yellow-core] compound-staging: removing non-directory .drain-lock (deadlock recovery)\n' >&2
+  rm -f -- "${STAGING_DIR}/.drain-lock" 2>/dev/null \
+    || printf '[yellow-core] compound-staging: non-dir lock rm failed\n' >&2
+fi
 if [ -d "${STAGING_DIR}/.drain-lock" ]; then
-  lock_age_min=999
+  # Default lock_age_min to -1 (skip reap) when stat fails for any reason
+  # other than missing file. Defaulting to 999 (treat as stale) would
+  # blow away a live lock owned by another concurrent drain whenever
+  # stat returned non-zero for a reason other than absence.
+  lock_age_min=-1
   if lock_mtime=$(stat -c '%Y' "${STAGING_DIR}/.drain-lock" 2>/dev/null \
     || stat -f '%m' "${STAGING_DIR}/.drain-lock" 2>/dev/null); then
     now_epoch=$(date +%s)
     lock_age_min=$(( (now_epoch - lock_mtime) / 60 ))
+  else
+    printf '[yellow-core] compound-staging: Warning: stat failed on .drain-lock; skipping stale-lock reap this cycle\n' >&2
   fi
   if [ "$lock_age_min" -gt 30 ] 2>/dev/null; then
     rmdir "${STAGING_DIR}/.drain-lock" 2>/dev/null \
@@ -131,7 +150,10 @@ else
   else
     oldest_epoch=$(stat -c '%Y' "$oldest_file" 2>/dev/null) || oldest_epoch=""
   fi
-  if [ -n "$oldest_epoch" ]; then
+  # Guard against epoch-0 (stat failure) or non-numeric output that
+  # would compute a huge fake age and trigger drain on every session
+  # forever. Only dispatch when we have a positive epoch.
+  if [ -n "$oldest_epoch" ] && [ "$oldest_epoch" -gt 0 ] 2>/dev/null; then
     now_epoch=$(date +%s)
     age_hours=$(( (now_epoch - oldest_epoch) / 3600 ))
     if [ "$age_hours" -gt 48 ] 2>/dev/null; then
@@ -151,8 +173,16 @@ if ! mkdir "${STAGING_DIR}/.drain-lock" 2>/dev/null; then
 fi
 
 # --- Resolve claude binary ---
-# Allow tests to override via COMPOUND_DRAIN_CMD env var.
-CLAUDE_BIN="${COMPOUND_DRAIN_CMD:-}"
+# Allow tests to override via COMPOUND_DRAIN_CMD env var, but ONLY
+# inside a bats test process (bats exports BATS_VERSION to every test
+# subprocess). Without this gate, the override would be a
+# production-available drain-hijack vector — anyone who can set the
+# env var before Claude Code starts could redirect the drain to an
+# arbitrary binary running with bypassPermissions.
+CLAUDE_BIN=""
+if [ -n "${COMPOUND_DRAIN_CMD:-}" ] && [ -n "${BATS_VERSION:-}" ]; then
+  CLAUDE_BIN="$COMPOUND_DRAIN_CMD"
+fi
 if [ -z "$CLAUDE_BIN" ]; then
   CLAUDE_BIN=$(command -v claude 2>/dev/null || true)
 fi

--- a/plugins/yellow-core/hooks/scripts/session-start.sh
+++ b/plugins/yellow-core/hooks/scripts/session-start.sh
@@ -290,21 +290,25 @@ DRAIN_TIMEOUT_S="${COMPOUND_DRAIN_TIMEOUT_S:-600}"
   export COMPOUND_DRAIN_IN_PROGRESS=1
   printf '[yellow-core] compound-staging: drain dispatch %s (auth=%s, pending=%s, timeout=%s)\n' \
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$AUTH_ROUTE" "$PENDING_COUNT" "$DRAIN_TIMEOUT_S" >> "$DRAIN_LOG" 2>/dev/null
-  # --bare is the primary hook-recursion guard: it skips auto-discovery
-  # of hooks, skills, plugins, MCP servers, and CLAUDE.md in the child
-  # session. Without it, the child fires its own SessionStart hook and
-  # cascades. COMPOUND_DRAIN_IN_PROGRESS env var is defense-in-depth.
-  # See docs/solutions/code-quality/claude-code-bare-flag-and-hook-recursion-guard.md.
+  # NOTE: --bare CANNOT be used here. The drain prompt invokes the
+  # yellow-core:workflow:staging-reviewer agent via Task, and --bare
+  # skips plugin auto-discovery — the child session would not have the
+  # staging-reviewer agent registered and the drain would fail at the
+  # very first turn. COMPOUND_DRAIN_IN_PROGRESS env-var sentinel
+  # (exported above, checked at the top of stop.sh and session-start.sh)
+  # IS the recursion guard for this specific pattern. The env-var
+  # approach is the documented fallback when plugin agents must remain
+  # reachable in the child session.
+  # See docs/solutions/code-quality/claude-code-bare-flag-and-hook-recursion-guard.md
+  # — "Defense-in-depth alternative when --bare is incompatible".
   if [ -n "$DRAIN_TIMEOUT_BIN" ]; then
     "$DRAIN_TIMEOUT_BIN" "$DRAIN_TIMEOUT_S" "$CLAUDE_BIN" -p "$DRAIN_PROMPT" \
-      --bare \
       --max-turns 50 \
       --permission-mode bypassPermissions \
       --output-format json \
       >> "$DRAIN_LOG" 2>&1
   else
     "$CLAUDE_BIN" -p "$DRAIN_PROMPT" \
-      --bare \
       --max-turns 50 \
       --permission-mode bypassPermissions \
       --output-format json \

--- a/plugins/yellow-core/hooks/scripts/session-start.sh
+++ b/plugins/yellow-core/hooks/scripts/session-start.sh
@@ -67,9 +67,14 @@ fi
 # Each find runs independently so one failure doesn't suppress the others.
 # Errors are non-fatal — log to stderr only.
 
-# Orphan tmp/*.jsonl > 1h: leftover from crashed atomic writes.
-find "${STAGING_DIR}/tmp" -name '*.jsonl.tmp.*' -mmin +60 -delete 2>/dev/null \
-  || true
+# Orphan *.jsonl.tmp.* > 1h: leftover from crashed atomic writes.
+# cs_atomic_jsonl_write writes sibling tmp files in the DESTINATION dir
+# (not under tmp/), so reap from pending/, processing/, drain-budget.json's dir.
+for reap_dir in "${STAGING_DIR}/pending" "${STAGING_DIR}/processing" "${STAGING_DIR}"; do
+  [ -d "$reap_dir" ] || continue
+  find "$reap_dir" -maxdepth 1 -name '*.tmp.*' -type f -mmin +60 -delete 2>/dev/null \
+    || true
+done
 
 # Stale .drain-lock: dir-style lock. If mtime > 30 min, previous drain
 # crashed without releasing — reap so a fresh drain can fire.
@@ -141,8 +146,10 @@ if [ "$PENDING_COUNT" -ge 5 ] 2>/dev/null; then
 else
   # Check oldest mtime. Linux stat first, BSD/macOS stat second.
   oldest_epoch=""
+  # Use cut -d' ' -f2- to preserve paths containing spaces (awk '{print $2}'
+  # truncates after the first space).
   oldest_file=$(find "${STAGING_DIR}/pending" -maxdepth 1 -name '*.jsonl' -type f \
-    -printf '%T@ %p\n' 2>/dev/null | sort -n | head -1 | awk '{print $2}')
+    -printf '%T@ %p\n' 2>/dev/null | sort -n | head -1 | cut -d' ' -f2-)
   if [ -z "$oldest_file" ]; then
     # BSD find doesn't support -printf. Fall back to stat per-file.
     oldest_epoch=$(find "${STAGING_DIR}/pending" -maxdepth 1 -name '*.jsonl' -type f \

--- a/plugins/yellow-core/hooks/scripts/session-start.sh
+++ b/plugins/yellow-core/hooks/scripts/session-start.sh
@@ -118,15 +118,24 @@ if [ "${expired_count:-0}" -gt 0 ] 2>/dev/null; then
     || true
 fi
 
-# Processing/ entries older than 1h are crashed mid-drain; move them back
-# to pending/ so they get retried. Younger files are in-flight from a
-# concurrent drain — leave them alone.
+# Processing/ entries older than 1h are crashed mid-drain; requeue them for
+# retry unless they also exceed the 7-day PII TTL, in which case purge them
+# to prevent stale PII from re-entering the pipeline. Younger files are
+# in-flight from a concurrent drain — leave them alone.
 if [ -d "${STAGING_DIR}/processing" ]; then
   while IFS= read -r f; do
     [ -z "$f" ] && continue
     base=$(basename -- "$f")
-    mv -- "$f" "${STAGING_DIR}/pending/${base}" 2>/dev/null \
-      || printf '[yellow-core] compound-staging: failed to requeue crashed entry %s\n' "$base" >&2
+    # Age-check: if the crashed entry is also older than 7 days, purge it
+    # instead of requeueing (PII TTL — same policy as pending/).
+    if find "$f" -name '*.jsonl' -mtime +7 -print 2>/dev/null | grep -q .; then
+      printf '[yellow-core] compound-staging: purging expired crashed entry %s (>7d PII TTL)\n' "$base" >&2
+      rm -f -- "$f" 2>/dev/null \
+        || printf '[yellow-core] compound-staging: failed to purge expired crashed entry %s\n' "$base" >&2
+    else
+      mv -- "$f" "${STAGING_DIR}/pending/${base}" 2>/dev/null \
+        || printf '[yellow-core] compound-staging: failed to requeue crashed entry %s\n' "$base" >&2
+    fi
   done < <(find "${STAGING_DIR}/processing" -name '*.jsonl' -mmin +60 -print 2>/dev/null)
 fi
 
@@ -198,17 +207,35 @@ if [ -z "$CLAUDE_BIN" ] || [ ! -x "$CLAUDE_BIN" ]; then
   json_exit "claude binary not found; skipping drain"
 fi
 
+# --- P1 guard: staging-reviewer agent must exist before dispatch ---
+# The agent lands in stack item #2. If it is absent, leave entries in
+# pending/ so they are drained once the agent is deployed; never silently
+# discard them.
+STAGING_REVIEWER_PATH="${SCRIPT_DIR}/../../agents/workflow/staging-reviewer.md"
+# Test-only override, gated on BATS_VERSION like COMPOUND_DRAIN_CMD above,
+# so the bats suite can point the guard at a stub agent file.
+if [ -n "${COMPOUND_STAGING_REVIEWER_AGENT:-}" ] && [ -n "${BATS_VERSION:-}" ]; then
+  STAGING_REVIEWER_PATH="$COMPOUND_STAGING_REVIEWER_AGENT"
+fi
+if [ ! -f "$STAGING_REVIEWER_PATH" ]; then
+  rmdir "${STAGING_DIR}/.drain-lock" 2>/dev/null || true
+  json_exit "staging-reviewer agent not yet deployed (stack item #2); deferring drain"
+fi
+
 # --- Build drain prompt ---
-# Heredoc with single-quoted delimiter so $STAGING_DIR etc. are NOT
-# interpreted here — values are substituted via the inline expansion in
-# the printf format.
+# P2: STAGING_DIR and CWD are untrusted filesystem paths (a malicious
+# repo name could contain newlines or prompt-like text). Fence them with
+# begin/end delimiters so the model treats them as reference data only,
+# not as additional instructions.
 DRAIN_PROMPT=$(printf '%s\n' \
   'Invoke the staging-reviewer agent (yellow-core:workflow:staging-reviewer) via Task.' \
   '' \
   'Goal: drain the compound-staging ledger and promote eligible entries.' \
   '' \
+  '--- begin paths (reference only) ---' \
   "Staging dir: ${STAGING_DIR}" \
   "Project: ${CWD}" \
+  '--- end paths ---' \
   '' \
   'Do NOT ask the user any questions. This drain is non-interactive.' \
   'On completion, write a one-line summary to stdout and exit.')
@@ -235,7 +262,8 @@ DRAIN_TIMEOUT_BIN=$(command -v timeout 2>/dev/null || true)
 DRAIN_TIMEOUT_S="${COMPOUND_DRAIN_TIMEOUT_S:-600}"
 
 (
-  trap 'rmdir "'"${STAGING_DIR}"'/.drain-lock" 2>/dev/null || true' EXIT INT TERM
+  DRAIN_LOCK_PATH="${STAGING_DIR}/.drain-lock"
+  trap 'rmdir "$DRAIN_LOCK_PATH" 2>/dev/null || true' EXIT INT TERM
   export COMPOUND_DRAIN_IN_PROGRESS=1
   printf '[yellow-core] compound-staging: drain dispatch %s (auth=%s, pending=%s, timeout=%s)\n' \
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$AUTH_ROUTE" "$PENDING_COUNT" "$DRAIN_TIMEOUT_S" >> "$DRAIN_LOG" 2>/dev/null

--- a/plugins/yellow-core/hooks/scripts/stop.sh
+++ b/plugins/yellow-core/hooks/scripts/stop.sh
@@ -41,9 +41,13 @@ if [ -z "$INPUT" ]; then
   json_exit
 fi
 
+TRANSCRIPT=""
+SESSION_ID=""
+CWD=""
+STOP_HOOK_ACTIVE="false"
 # shellcheck disable=SC2154
 eval "$(printf '%s' "$INPUT" | jq -r '@sh "TRANSCRIPT=\(.transcript_path // "") SESSION_ID=\(.session_id // "") CWD=\(.cwd // "") STOP_HOOK_ACTIVE=\(.stop_hook_active // false)"' 2>/dev/null)" \
-  || json_exit "failed to parse hook input"
+  || { TRANSCRIPT=""; SESSION_ID=""; CWD=""; STOP_HOOK_ACTIVE="false"; }
 
 # Per Anthropic hook docs: stop_hook_active=true means the hook is firing
 # in re-entrant context (Claude was woken up by another Stop hook). Don't

--- a/plugins/yellow-core/hooks/scripts/stop.sh
+++ b/plugins/yellow-core/hooks/scripts/stop.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# stop.sh — yellow-core Stop hook: capture session transcript tail for the
+# background compounding pipeline.
+#
+# Receives hook input as JSON on stdin. Must emit `{"continue": true}` on
+# every code path and return well under 500ms (the disowned subshell does
+# the I/O after parent exits).
+#
+# Note: -e omitted intentionally — hook must output {"continue": true} on
+# all paths. Any unexpected non-zero would otherwise exit before the JSON
+# is printed.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" 2>/dev/null && pwd -P)"
+
+# shellcheck source=../../lib/compound-staging.sh
+. "${SCRIPT_DIR}/../../lib/compound-staging.sh"
+
+json_exit() {
+  local msg="${1:-}"
+  [ -n "$msg" ] && printf '[yellow-core] compound-staging: %s\n' "$msg" >&2
+  printf '{"continue": true}\n'
+  exit 0
+}
+
+# --- Recursion guard ---
+# Drain `claude -p` sessions inherit this env var; their Stop hook fires too
+# and would otherwise capture the drain transcript as a new pending entry.
+if [ "${COMPOUND_DRAIN_IN_PROGRESS:-}" = "1" ]; then
+  json_exit
+fi
+
+# --- jq dependency ---
+if ! command -v jq >/dev/null 2>&1; then
+  json_exit "jq not installed; cannot capture transcript"
+fi
+
+# --- Parse stdin ---
+INPUT=$(cat)
+if [ -z "$INPUT" ]; then
+  json_exit
+fi
+
+# shellcheck disable=SC2154
+eval "$(printf '%s' "$INPUT" | jq -r '@sh "TRANSCRIPT=\(.transcript_path // "") SESSION_ID=\(.session_id // "") CWD=\(.cwd // "") STOP_HOOK_ACTIVE=\(.stop_hook_active // false)"' 2>/dev/null)" \
+  || json_exit "failed to parse hook input"
+
+# Per Anthropic hook docs: stop_hook_active=true means the hook is firing
+# in re-entrant context (Claude was woken up by another Stop hook). Don't
+# double-capture.
+if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+  json_exit
+fi
+
+if [ -z "$SESSION_ID" ] || [ -z "$TRANSCRIPT" ]; then
+  json_exit
+fi
+
+# --- Derive paths ---
+PROJECT_SLUG=$(cs_derive_project_slug "$CWD")
+if [ -z "$PROJECT_SLUG" ]; then
+  json_exit "could not derive project slug"
+fi
+STAGING_DIR=$(cs_staging_dir_for_slug "$PROJECT_SLUG")
+
+# --- Spawn disowned capture subshell ---
+# The subshell calls _stop-capture-subshell.sh which does the tail+redact+
+# write work. Parent exits within ms; subshell continues independently.
+# Invoke via `bash` explicitly so the script does NOT need its executable
+# bit set — `core.fileMode = false` in this repo (and many WSL2 setups)
+# strips exec bits at commit time, which would otherwise break the hook
+# on fresh clones.
+CAPTURE_SCRIPT="${SCRIPT_DIR}/_stop-capture-subshell.sh"
+if [ ! -f "$CAPTURE_SCRIPT" ]; then
+  json_exit "capture subshell script missing: $CAPTURE_SCRIPT"
+fi
+
+(
+  bash "$CAPTURE_SCRIPT" "$TRANSCRIPT" "$SESSION_ID" "$STAGING_DIR" "$CWD"
+) >/dev/null 2>&1 &
+disown
+
+json_exit

--- a/plugins/yellow-core/lib/compound-staging.sh
+++ b/plugins/yellow-core/lib/compound-staging.sh
@@ -57,6 +57,20 @@ cs_staging_dir_for_slug() {
   printf '%s/.claude/projects/%s/compound-staging' "$HOME" "$slug"
 }
 
+# Convert an ISO-8601 timestamp (e.g., 2026-05-19T12:34:56Z) to a Unix
+# epoch on stdout. GNU `date -d` works on Linux; macOS/BSD needs the
+# explicit `-jf` format spec. Returns "0" if both attempts fail so
+# callers can numerically compare without a parse-error branch.
+#
+# Args:
+#   $1 — ISO-8601 timestamp string
+cs_iso_to_epoch() {
+  local ts="$1"
+  date -u -d "$ts" +%s 2>/dev/null \
+    || date -ujf '%Y-%m-%dT%H:%M:%SZ' "$ts" +%s 2>/dev/null \
+    || printf '0'
+}
+
 # Atomic write: write to a sibling tmp file in the same dir, then rename.
 # rename(2) is atomic when source and target are on the same filesystem,
 # which is guaranteed because the tmp file lives in the same directory as
@@ -65,6 +79,12 @@ cs_staging_dir_for_slug() {
 # -name '*.tmp.*' glob so orphan temp files are reaped on next session start.
 # Pattern matches _lc_atomic_write
 # (plugins/yellow-research/hooks/lib/context7-cache.sh:166-172).
+#
+# Permissions: writes are wrapped in `umask 077` so pending JSONL files
+# (which contain post-redaction transcript fragments — potentially
+# sensitive) and drain-budget state default to owner-only (0600) on
+# multi-user systems (CI, shared dev boxes, WSL2 with non-default umask).
+# The directory is also chmod'd to 0700 to keep listings private.
 #
 # Args:
 #   $1 — destination path
@@ -77,8 +97,11 @@ cs_atomic_jsonl_write() {
   local dir
   dir=$(dirname -- "$path")
   mkdir -p -- "$dir" 2>/dev/null || return 1
+  chmod 700 -- "$dir" 2>/dev/null || true
   local tmp="${path}.tmp.$$"
-  printf '%s' "$content" > "$tmp" 2>/dev/null || { rm -f -- "$tmp" 2>/dev/null; return 1; }
+  # Subshell scopes umask to the write only; sibling shell state untouched.
+  ( umask 077; printf '%s' "$content" > "$tmp" ) 2>/dev/null \
+    || { rm -f -- "$tmp" 2>/dev/null; return 1; }
   mv -- "$tmp" "$path" 2>/dev/null || { rm -f -- "$tmp" 2>/dev/null; return 1; }
 }
 
@@ -181,10 +204,7 @@ cs_update_drain_budget() {
   local reset=1
   if [ -n "$window_start" ]; then
     local window_epoch
-    # Try GNU date first (Linux); fall back to BSD date (macOS).
-    window_epoch=$(date -u -d "$window_start" +%s 2>/dev/null \
-      || date -ujf '%Y-%m-%dT%H:%M:%SZ' "$window_start" +%s 2>/dev/null \
-      || echo 0)
+    window_epoch=$(cs_iso_to_epoch "$window_start")
     if [ "$window_epoch" -gt 0 ] && [ $((now_epoch - window_epoch)) -lt 18000 ]; then
       reset=0
     fi
@@ -221,9 +241,7 @@ cs_drain_budget_warn() {
   if [ -n "$window_start" ]; then
     local now_epoch window_epoch
     now_epoch=$(date -u +%s 2>/dev/null) || now_epoch=0
-    window_epoch=$(date -u -d "$window_start" +%s 2>/dev/null \
-      || date -ujf '%Y-%m-%dT%H:%M:%SZ' "$window_start" +%s 2>/dev/null \
-      || echo 0)
+    window_epoch=$(cs_iso_to_epoch "$window_start")
     # Window has rolled — persisted counter belongs to a past window; treat as fresh.
     if [ "$window_epoch" -gt 0 ] && [ $((now_epoch - window_epoch)) -ge 18000 ]; then
       return 1

--- a/plugins/yellow-core/lib/compound-staging.sh
+++ b/plugins/yellow-core/lib/compound-staging.sh
@@ -94,6 +94,12 @@ cs_redact_secrets() {
     -e 's/ghs_[A-Za-z0-9_]\{36,255\}/[REDACTED:github-token]/g' \
     -e 's/github_pat_[A-Za-z0-9_]\{22,255\}/[REDACTED:github-pat]/g' \
     -e 's/AKIA[0-9A-Z]\{16\}/[REDACTED:aws-access-key]/g' \
+    -e 's/sk-ant-api[A-Za-z0-9_-]\{20,\}/[REDACTED:anthropic-key]/g' \
+    -e 's/sk-[A-Za-z0-9]\{48\}/[REDACTED:openai-key]/g' \
+    -e 's/xox[baprsu]-[A-Za-z0-9-]\{10,\}/[REDACTED:slack-token]/g' \
+    -e 's/sk_live_[A-Za-z0-9]\{24,\}/[REDACTED:stripe-key]/g' \
+    -e 's/rk_live_[A-Za-z0-9]\{24,\}/[REDACTED:stripe-key]/g' \
+    -e 's/hf_[A-Za-z0-9]\{20,\}/[REDACTED:huggingface-token]/g' \
     -e 's/Bearer[[:space:]]\+[A-Za-z0-9._-]\{20,\}/Bearer [REDACTED]/g' \
     -e 's/eyJ[A-Za-z0-9_-]\{10,500\}\.eyJ[A-Za-z0-9_-]\{10,500\}\.[A-Za-z0-9_-]\{10,500\}/[REDACTED:jwt]/g' \
     -e 's/dckr_pat_[A-Za-z0-9_-]\{32,\}/[REDACTED:docker-token]/g' \
@@ -101,6 +107,8 @@ cs_redact_secrets() {
     -e 's/\(https\?\):\/\/[^:[:space:]]\+:[^@[:space:]]\+@/\1:\/\/[REDACTED:basic-auth]@/g' \
     -e 's/\([?&]\)\(token\|api_key\|secret\|key\|password\)=[^&[:space:]]*/\1\2=[REDACTED:url-param]/gI' \
     -e '/-----BEGIN.*PRIVATE KEY-----/,/-----END.*PRIVATE KEY-----/c\[REDACTED:ssh-key]' \
+    -e 's/\("\(password\|secret\|token\|api_key\|credential\)"[[:space:]]*:[[:space:]]*"\)[^"]*"/\1[REDACTED]"/gI' \
+    -e "s/\\('\\(password\\|secret\\|token\\|api_key\\|credential\\)'[[:space:]]*:[[:space:]]*'\\)[^']*'/\\1[REDACTED]'/gI" \
     -e 's/\(password\|secret\|token\|api_key\|credential\)[[:space:]]*[=:][[:space:]]*[^[:space:]"'"'"']\{4,\}/\1=[REDACTED]/gI' \
   ) || {
     printf '[yellow-core] compound-staging: redaction pipeline failed; suppressing output\n' >&2

--- a/plugins/yellow-core/lib/compound-staging.sh
+++ b/plugins/yellow-core/lib/compound-staging.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# yellow-core: compound-staging helper library.
+#
+# Source from yellow-core's Stop and SessionStart hooks (and their drained
+# subshells) to manage the per-project compound-staging ledger described in
+# plans/background-compounding-triggers.md.
+#
+# Usage:
+#   . "${SCRIPT_DIR}/../../lib/compound-staging.sh"        # from hooks/scripts/
+#   slug=$(cs_derive_project_slug "$cwd")
+#   staging_dir=$(cs_staging_dir_for_slug "$slug")
+#   cs_atomic_jsonl_write "$staging_dir/pending/$session_id.jsonl" "$json_line"
+#
+# Contract:
+#   - Sourced library only — never invoked as a script.
+#   - Functions exit non-zero on failure but do not abort the caller via set -e.
+#   - Never echoes secrets; redact_secrets is the gate before any disk write.
+#   - All disk writes are atomic (sibling tmp + rename in same filesystem).
+#
+# Note: this file MUST NOT set top-level shell options (no `set -e`, `set -u`,
+# `set -o pipefail`) — doing so changes the caller's hook semantics and can
+# block the required `{"continue": true}` emission.
+
+# Idempotent source guard.
+if [ -n "${_COMPOUND_STAGING_LOADED:-}" ]; then
+  return 0 2>/dev/null || exit 0
+fi
+_COMPOUND_STAGING_LOADED=1
+
+# Derive the per-project slug used as the staging-dir basename.
+# Matches knowledge-compounder.md line 44 derivation exactly:
+# git toplevel if inside a repo, otherwise $PWD. Slashes become hyphens so
+# the result is a single filesystem component under ~/.claude/projects/.
+#
+# Args:
+#   $1 — cwd (optional; defaults to $PWD). Caller should pass the hook's
+#        parsed `.cwd` field so the slug matches Claude Code's project dir.
+cs_derive_project_slug() {
+  local cwd="${1:-$PWD}"
+  local toplevel
+  toplevel=$(cd -- "$cwd" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null)
+  if [ -z "$toplevel" ]; then
+    toplevel="$cwd"
+  fi
+  printf '%s' "$toplevel" | tr '/' '-'
+}
+
+# Resolve the staging directory path for a given project slug.
+#
+# Args:
+#   $1 — project slug (from cs_derive_project_slug)
+cs_staging_dir_for_slug() {
+  local slug="$1"
+  if [ -z "$slug" ]; then
+    return 1
+  fi
+  printf '%s/.claude/projects/%s/compound-staging' "$HOME" "$slug"
+}
+
+# Atomic write: write to a sibling tmp file in the same dir, then rename.
+# rename(2) is atomic when source and target are on the same filesystem,
+# which is guaranteed because the tmp file lives in the same directory as
+# the target. Pattern matches _lc_atomic_write
+# (plugins/yellow-research/hooks/lib/context7-cache.sh:166-172).
+#
+# Args:
+#   $1 — destination path
+#   $2 — content (passed via printf %s; no trailing newline added)
+cs_atomic_jsonl_write() {
+  local path="$1" content="$2"
+  if [ -z "$path" ]; then
+    return 1
+  fi
+  local dir
+  dir=$(dirname -- "$path")
+  mkdir -p -- "$dir" 2>/dev/null || return 1
+  local tmp="${path}.tmp.$$"
+  printf '%s' "$content" > "$tmp" 2>/dev/null || { rm -f -- "$tmp" 2>/dev/null; return 1; }
+  mv -- "$tmp" "$path" 2>/dev/null || { rm -f -- "$tmp" 2>/dev/null; return 1; }
+}
+
+# Redact secrets from stdin, write to stdout.
+# Self-contained subset of yellow-ci's lib/redact.sh — the patterns Brad
+# called out in the plan (D12): password=, token=, api_key=, secret=,
+# Bearer, basic auth, plus the high-value vendor token prefixes and
+# PEM key blocks. Streaming via sed (constant memory).
+#
+# Future consolidation: when yellow-ci's redact.sh is relocated to a
+# shared yellow-core/lib/redact.sh, this wrapper can `. ` that file.
+cs_redact_secrets() {
+  local output
+  output=$(sed \
+    -e 's/ghp_[A-Za-z0-9_]\{36,255\}/[REDACTED:github-token]/g' \
+    -e 's/ghs_[A-Za-z0-9_]\{36,255\}/[REDACTED:github-token]/g' \
+    -e 's/github_pat_[A-Za-z0-9_]\{22,255\}/[REDACTED:github-pat]/g' \
+    -e 's/AKIA[0-9A-Z]\{16\}/[REDACTED:aws-access-key]/g' \
+    -e 's/Bearer[[:space:]]\+[A-Za-z0-9._-]\{20,\}/Bearer [REDACTED]/g' \
+    -e 's/eyJ[A-Za-z0-9_-]\{10,500\}\.eyJ[A-Za-z0-9_-]\{10,500\}\.[A-Za-z0-9_-]\{10,500\}/[REDACTED:jwt]/g' \
+    -e 's/dckr_pat_[A-Za-z0-9_-]\{32,\}/[REDACTED:docker-token]/g' \
+    -e 's/npm_[A-Za-z0-9]\{36\}/[REDACTED:npm-token]/g' \
+    -e 's/\(https\?\):\/\/[^:[:space:]]\+:[^@[:space:]]\+@/\1:\/\/[REDACTED:basic-auth]@/g' \
+    -e 's/\([?&]\)\(token\|api_key\|secret\|key\|password\)=[^&[:space:]]*/\1\2=[REDACTED:url-param]/gI' \
+    -e '/-----BEGIN.*PRIVATE KEY-----/,/-----END.*PRIVATE KEY-----/c\[REDACTED:ssh-key]' \
+    -e 's/\(password\|secret\|token\|api_key\|credential\)[[:space:]]*[=:][[:space:]]*[^[:space:]"'"'"']\{4,\}/\1=[REDACTED]/gI' \
+  ) || {
+    printf '[yellow-core] compound-staging: redaction pipeline failed; suppressing output\n' >&2
+    printf '[REDACTED: sanitization failed]\n'
+    return 1
+  }
+  printf '%s\n' "$output"
+}
+
+# Read the drain-budget JSON file. Emits a single-line JSON object on stdout.
+# Fail-open: missing or corrupted file returns the empty/zeroed object so the
+# caller never blocks on a budget-state read.
+#
+# Args:
+#   $1 — staging dir
+cs_read_drain_budget() {
+  local staging="$1"
+  local path="${staging}/drain-budget.json"
+  local empty='{"window_start_iso":"","drains_in_window":0,"last_drain_iso":"","auth_route":"unknown"}'
+  if [ ! -f "$path" ]; then
+    printf '%s' "$empty"
+    return 0
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    printf '%s' "$empty"
+    return 0
+  fi
+  local parsed
+  parsed=$(jq -c '.' < "$path" 2>/dev/null) || {
+    printf '%s' "$empty"
+    return 0
+  }
+  printf '%s' "$parsed"
+}
+
+# Update the drain-budget JSON with a new drain event. 5h rolling window:
+# if `now - window_start_iso > 5h`, reset window_start and drains_in_window=1;
+# otherwise increment drains_in_window. Always update last_drain_iso to now.
+# Atomic write via cs_atomic_jsonl_write.
+#
+# Args:
+#   $1 — staging dir
+#   $2 — auth route hint ("subscription" or "api")
+cs_update_drain_budget() {
+  local staging="$1" auth_route="${2:-unknown}"
+  if [ -z "$staging" ]; then
+    return 1
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    return 1
+  fi
+  local now
+  now=$(date -u +%Y-%m-%dT%H:%M:%SZ) || return 1
+  local now_epoch
+  now_epoch=$(date -u +%s) || return 1
+  local current
+  current=$(cs_read_drain_budget "$staging")
+  local window_start
+  window_start=$(printf '%s' "$current" | jq -r '.window_start_iso // ""')
+  local drains
+  drains=$(printf '%s' "$current" | jq -r '.drains_in_window // 0')
+  local reset=1
+  if [ -n "$window_start" ]; then
+    local window_epoch
+    # Try GNU date first (Linux); fall back to BSD date (macOS).
+    window_epoch=$(date -u -d "$window_start" +%s 2>/dev/null \
+      || date -ujf '%Y-%m-%dT%H:%M:%SZ' "$window_start" +%s 2>/dev/null \
+      || echo 0)
+    if [ "$window_epoch" -gt 0 ] && [ $((now_epoch - window_epoch)) -lt 18000 ]; then
+      reset=0
+    fi
+  fi
+  local next
+  if [ "$reset" -eq 1 ]; then
+    next=$(jq -nc --arg ws "$now" --arg lt "$now" --arg ar "$auth_route" \
+      '{window_start_iso: $ws, drains_in_window: 1, last_drain_iso: $lt, auth_route: $ar}')
+  else
+    next=$(jq -nc --argjson d "$drains" --arg lt "$now" --arg ar "$auth_route" --arg ws "$window_start" \
+      '{window_start_iso: $ws, drains_in_window: ($d + 1), last_drain_iso: $lt, auth_route: $ar}')
+  fi
+  cs_atomic_jsonl_write "${staging}/drain-budget.json" "$next"
+}
+
+# Decide whether to surface a drain-budget warning. Under subscription auth,
+# always returns 1 (false) — there is no hard ceiling. Under API-key route,
+# returns 0 (true) when drains_in_window exceeds the soft threshold (default 8
+# per 5h window, configurable via COMPOUND_DRAIN_API_THRESHOLD).
+#
+# Args:
+#   $1 — staging dir
+cs_drain_budget_warn() {
+  local staging="$1"
+  local current
+  current=$(cs_read_drain_budget "$staging")
+  local auth_route
+  auth_route=$(printf '%s' "$current" | jq -r '.auth_route // "unknown"' 2>/dev/null)
+  if [ "$auth_route" != "api" ]; then
+    return 1
+  fi
+  local drains
+  drains=$(printf '%s' "$current" | jq -r '.drains_in_window // 0' 2>/dev/null)
+  local threshold="${COMPOUND_DRAIN_API_THRESHOLD:-8}"
+  if [ "$drains" -ge "$threshold" ] 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+# Detect the auth route this drain will use. ANTHROPIC_API_KEY in env means
+# `claude -p` will route to API billing; otherwise it uses the existing
+# subscription OAuth token. Printed as a short string for logging.
+cs_detect_auth_route() {
+  if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    printf '%s' "api"
+  else
+    printf '%s' "subscription"
+  fi
+}

--- a/plugins/yellow-core/lib/compound-staging.sh
+++ b/plugins/yellow-core/lib/compound-staging.sh
@@ -89,27 +89,34 @@ cs_atomic_jsonl_write() {
 # shared yellow-core/lib/redact.sh, this wrapper can `. ` that file.
 cs_redact_secrets() {
   local output
-  output=$(sed \
-    -e 's/ghp_[A-Za-z0-9_]\{36,255\}/[REDACTED:github-token]/g' \
-    -e 's/ghs_[A-Za-z0-9_]\{36,255\}/[REDACTED:github-token]/g' \
-    -e 's/github_pat_[A-Za-z0-9_]\{22,255\}/[REDACTED:github-pat]/g' \
-    -e 's/AKIA[0-9A-Z]\{16\}/[REDACTED:aws-access-key]/g' \
-    -e 's/sk-ant-api[A-Za-z0-9_-]\{20,\}/[REDACTED:anthropic-key]/g' \
-    -e 's/sk-[A-Za-z0-9]\{48\}/[REDACTED:openai-key]/g' \
-    -e 's/xox[baprsu]-[A-Za-z0-9-]\{10,\}/[REDACTED:slack-token]/g' \
-    -e 's/sk_live_[A-Za-z0-9]\{24,\}/[REDACTED:stripe-key]/g' \
-    -e 's/rk_live_[A-Za-z0-9]\{24,\}/[REDACTED:stripe-key]/g' \
-    -e 's/hf_[A-Za-z0-9]\{20,\}/[REDACTED:huggingface-token]/g' \
-    -e 's/Bearer[[:space:]]\+[A-Za-z0-9._-]\{20,\}/Bearer [REDACTED]/g' \
-    -e 's/eyJ[A-Za-z0-9_-]\{10,500\}\.eyJ[A-Za-z0-9_-]\{10,500\}\.[A-Za-z0-9_-]\{10,500\}/[REDACTED:jwt]/g' \
-    -e 's/dckr_pat_[A-Za-z0-9_-]\{32,\}/[REDACTED:docker-token]/g' \
-    -e 's/npm_[A-Za-z0-9]\{36\}/[REDACTED:npm-token]/g' \
-    -e 's/\(https\?\):\/\/[^:[:space:]]\+:[^@[:space:]]\+@/\1:\/\/[REDACTED:basic-auth]@/g' \
-    -e 's/\([?&]\)\(token\|api_key\|secret\|key\|password\)=[^&[:space:]]*/\1\2=[REDACTED:url-param]/gI' \
-    -e '/-----BEGIN.*PRIVATE KEY-----/,/-----END.*PRIVATE KEY-----/c\[REDACTED:ssh-key]' \
-    -e 's/\("\(password\|secret\|token\|api_key\|credential\)"[[:space:]]*:[[:space:]]*"\)[^"]*"/\1[REDACTED]"/gI' \
-    -e "s/\\('\\(password\\|secret\\|token\\|api_key\\|credential\\)'[[:space:]]*:[[:space:]]*'\\)[^']*'/\\1[REDACTED]'/gI" \
-    -e 's/\(password\|secret\|token\|api_key\|credential\)[[:space:]]*[=:][[:space:]]*[^[:space:]"'"'"']\{4,\}/\1=[REDACTED]/gI' \
+  # Use sed -E (ERE) for portable alternation `(a|b|c)` across GNU + BSD sed.
+  # POSIX BRE `\|` is a GNU extension; BSD/macOS sed silently misses it.
+  # Case-insensitive matching is achieved by enumerating both cases
+  # explicitly in the keyword groups — the GNU `I` flag is non-portable.
+  output=$(sed -E \
+    -e 's/ghp_[A-Za-z0-9_]{36,255}/[REDACTED:github-token]/g' \
+    -e 's/ghs_[A-Za-z0-9_]{36,255}/[REDACTED:github-token]/g' \
+    -e 's/github_pat_[A-Za-z0-9_]{22,255}/[REDACTED:github-pat]/g' \
+    -e 's/AKIA[0-9A-Z]{16}/[REDACTED:aws-access-key]/g' \
+    -e 's/(aws_secret_access_key|AWS_SECRET_ACCESS_KEY)[[:space:]]*[=:][[:space:]]*[A-Za-z0-9/+=]{40}/\1=[REDACTED:aws-secret]/g' \
+    -e 's/sk-ant-api[A-Za-z0-9_-]{20,}/[REDACTED:anthropic-key]/g' \
+    -e 's/sk-(admin|proj|svcacct)-[A-Za-z0-9_-]{20,}/[REDACTED:openai-key]/g' \
+    -e 's/sk-[A-Za-z0-9]{48}/[REDACTED:openai-key]/g' \
+    -e 's/xox[baprsu]-[A-Za-z0-9-]{10,}/[REDACTED:slack-token]/g' \
+    -e 's/sk_live_[A-Za-z0-9]{24,}/[REDACTED:stripe-key]/g' \
+    -e 's/rk_live_[A-Za-z0-9]{24,}/[REDACTED:stripe-key]/g' \
+    -e 's/hf_[A-Za-z0-9]{20,}/[REDACTED:huggingface-token]/g' \
+    -e 's/Bearer[[:space:]]+[A-Za-z0-9._-]{20,}/Bearer [REDACTED]/g' \
+    -e 's/eyJ[A-Za-z0-9_-]{10,500}\.eyJ[A-Za-z0-9_-]{10,500}\.[A-Za-z0-9_-]{10,500}/[REDACTED:jwt]/g' \
+    -e 's/dckr_pat_[A-Za-z0-9_-]{32,}/[REDACTED:docker-token]/g' \
+    -e 's/npm_[A-Za-z0-9]{36}/[REDACTED:npm-token]/g' \
+    -e 's,(https?)://[^:[:space:]]+:[^@[:space:]]+@,\1://[REDACTED:basic-auth]@,g' \
+    -e 's/([?&])(token|api_key|secret|key|password|Token|API_KEY|Secret|Key|Password|TOKEN|SECRET|KEY|PASSWORD)=[^&[:space:]]*/\1\2=[REDACTED:url-param]/g' \
+    -e '/-----BEGIN.*PRIVATE KEY-----/,/-----END.*PRIVATE KEY-----/c\
+[REDACTED:ssh-key]' \
+    -e 's/("(password|secret|token|api_key|credential|Password|Secret|Token|API_KEY|Credential|PASSWORD|SECRET|TOKEN|CREDENTIAL)"[[:space:]]*:[[:space:]]*")[^"]*"/\1[REDACTED]"/g' \
+    -e "s/('(password|secret|token|api_key|credential|Password|Secret|Token|API_KEY|Credential|PASSWORD|SECRET|TOKEN|CREDENTIAL)'[[:space:]]*:[[:space:]]*')[^']*'/\\1[REDACTED]'/g" \
+    -e 's/(password|secret|token|api_key|credential|Password|Secret|Token|API_KEY|Credential|PASSWORD|SECRET|TOKEN|CREDENTIAL)[[:space:]]*[=:][[:space:]]*[^[:space:]"'"'"']{4,}/\1=[REDACTED]/g' \
   ) || {
     printf '[yellow-core] compound-staging: redaction pipeline failed; suppressing output\n' >&2
     printf '[REDACTED: sanitization failed]\n'

--- a/plugins/yellow-core/lib/compound-staging.sh
+++ b/plugins/yellow-core/lib/compound-staging.sh
@@ -60,7 +60,10 @@ cs_staging_dir_for_slug() {
 # Atomic write: write to a sibling tmp file in the same dir, then rename.
 # rename(2) is atomic when source and target are on the same filesystem,
 # which is guaranteed because the tmp file lives in the same directory as
-# the target. Pattern matches _lc_atomic_write
+# the target (not under tmp/). The SessionStart reaper covers these sibling
+# directories (pending/, processing/, and the staging root) with a
+# -name '*.tmp.*' glob so orphan temp files are reaped on next session start.
+# Pattern matches _lc_atomic_write
 # (plugins/yellow-research/hooks/lib/context7-cache.sh:166-172).
 #
 # Args:
@@ -83,17 +86,16 @@ cs_atomic_jsonl_write() {
 # Self-contained subset of yellow-ci's lib/redact.sh — the patterns Brad
 # called out in the plan (D12): password=, token=, api_key=, secret=,
 # Bearer, basic auth, plus the high-value vendor token prefixes and
-# PEM key blocks. Streaming via sed (constant memory).
+# PEM key blocks. Streams sed directly to stdout (constant memory).
 #
 # Future consolidation: when yellow-ci's redact.sh is relocated to a
 # shared yellow-core/lib/redact.sh, this wrapper can `. ` that file.
 cs_redact_secrets() {
-  local output
   # Use sed -E (ERE) for portable alternation `(a|b|c)` across GNU + BSD sed.
   # POSIX BRE `\|` is a GNU extension; BSD/macOS sed silently misses it.
   # Case-insensitive matching is achieved by enumerating both cases
   # explicitly in the keyword groups — the GNU `I` flag is non-portable.
-  output=$(sed -E \
+  sed -E \
     -e 's/ghp_[A-Za-z0-9_]{36,255}/[REDACTED:github-token]/g' \
     -e 's/ghs_[A-Za-z0-9_]{36,255}/[REDACTED:github-token]/g' \
     -e 's/github_pat_[A-Za-z0-9_]{22,255}/[REDACTED:github-pat]/g' \
@@ -117,12 +119,11 @@ cs_redact_secrets() {
     -e 's/("(password|secret|token|api_key|credential|Password|Secret|Token|API_KEY|Credential|PASSWORD|SECRET|TOKEN|CREDENTIAL)"[[:space:]]*:[[:space:]]*")[^"]*"/\1[REDACTED]"/g' \
     -e "s/('(password|secret|token|api_key|credential|Password|Secret|Token|API_KEY|Credential|PASSWORD|SECRET|TOKEN|CREDENTIAL)'[[:space:]]*:[[:space:]]*')[^']*'/\\1[REDACTED]'/g" \
     -e 's/(password|secret|token|api_key|credential|Password|Secret|Token|API_KEY|Credential|PASSWORD|SECRET|TOKEN|CREDENTIAL)[[:space:]]*[=:][[:space:]]*[^[:space:]"'"'"']{4,}/\1=[REDACTED]/g' \
-  ) || {
+  || {
     printf '[yellow-core] compound-staging: redaction pipeline failed; suppressing output\n' >&2
     printf '[REDACTED: sanitization failed]\n'
     return 1
   }
-  printf '%s\n' "$output"
 }
 
 # Read the drain-budget JSON file. Emits a single-line JSON object on stdout.
@@ -214,6 +215,19 @@ cs_drain_budget_warn() {
   auth_route=$(printf '%s' "$current" | jq -r '.auth_route // "unknown"' 2>/dev/null)
   if [ "$auth_route" != "api" ]; then
     return 1
+  fi
+  local window_start
+  window_start=$(printf '%s' "$current" | jq -r '.window_start_iso // ""' 2>/dev/null)
+  if [ -n "$window_start" ]; then
+    local now_epoch window_epoch
+    now_epoch=$(date -u +%s 2>/dev/null) || now_epoch=0
+    window_epoch=$(date -u -d "$window_start" +%s 2>/dev/null \
+      || date -ujf '%Y-%m-%dT%H:%M:%SZ' "$window_start" +%s 2>/dev/null \
+      || echo 0)
+    # Window has rolled — persisted counter belongs to a past window; treat as fresh.
+    if [ "$window_epoch" -gt 0 ] && [ $((now_epoch - window_epoch)) -ge 18000 ]; then
+      return 1
+    fi
   fi
   local drains
   drains=$(printf '%s' "$current" | jq -r '.drains_in_window // 0' 2>/dev/null)

--- a/plugins/yellow-core/lib/compound-staging.sh
+++ b/plugins/yellow-core/lib/compound-staging.sh
@@ -227,12 +227,18 @@ cs_update_drain_budget() {
 #
 # Args:
 #   $1 — staging dir
+#   $2 — live auth route ("api"|"subscription"|"unknown"); preferred over the
+#        persisted value so route switches take effect immediately. Falls back
+#        to the persisted drain-budget.json auth_route when omitted.
 cs_drain_budget_warn() {
   local staging="$1"
+  local live_route="${2:-}"
   local current
   current=$(cs_read_drain_budget "$staging")
-  local auth_route
-  auth_route=$(printf '%s' "$current" | jq -r '.auth_route // "unknown"' 2>/dev/null)
+  local auth_route="$live_route"
+  if [ -z "$auth_route" ]; then
+    auth_route=$(printf '%s' "$current" | jq -r '.auth_route // "unknown"' 2>/dev/null)
+  fi
   if [ "$auth_route" != "api" ]; then
     return 1
   fi

--- a/plugins/yellow-core/tests/compound-session-start-hook.bats
+++ b/plugins/yellow-core/tests/compound-session-start-hook.bats
@@ -27,6 +27,13 @@ STUB
 
   export COMPOUND_DRAIN_CMD="$STUB_BIN"
 
+  # Stub staging-reviewer agent so the dispatch guard passes — the real
+  # agent lands in stack item #2. The guard honors this override only
+  # under bats (BATS_VERSION set).
+  STAGING_REVIEWER_STUB="$STUB_DIR/staging-reviewer.md"
+  printf '%s\n' '---' 'name: staging-reviewer' '---' 'stub' > "$STAGING_REVIEWER_STUB"
+  export COMPOUND_STAGING_REVIEWER_AGENT="$STAGING_REVIEWER_STUB"
+
   # Resolve the staging dir the hook will use.
   . "$BATS_TEST_DIRNAME/../lib/compound-staging.sh"
   PROJECT_SLUG=$(cs_derive_project_slug "$PROJECT_DIR")
@@ -40,6 +47,7 @@ teardown() {
     fi
   done
   unset COMPOUND_DRAIN_CMD
+  unset COMPOUND_STAGING_REVIEWER_AGENT
 }
 
 _stdin_json() {
@@ -118,6 +126,21 @@ _plant_pending() {
   sleep 0.5
   # No dispatch because count<5 and entries are fresh (mtime ~now).
   [ ! -f "$STUB_MARKER" ]
+}
+
+# --- P1 guard: staging-reviewer agent absent ---
+
+@test "session-start defers drain when staging-reviewer agent is absent" {
+  _plant_pending 5
+  export COMPOUND_STAGING_REVIEWER_AGENT="$STUB_DIR/no-such-agent.md"
+  run bash "$SS_HOOK" <<< "$(_stdin_json)"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q '"continue": true'
+  sleep 0.5
+  # Guard short-circuits before dispatch; the stub claude is never invoked.
+  [ ! -f "$STUB_MARKER" ]
+  # Entries remain in pending/ for a future drain once the agent ships.
+  [ -f "$STAGING/pending/s1.jsonl" ]
 }
 
 # --- Threshold: age ---

--- a/plugins/yellow-core/tests/compound-session-start-hook.bats
+++ b/plugins/yellow-core/tests/compound-session-start-hook.bats
@@ -188,12 +188,24 @@ _plant_pending() {
 # --- Orphan tmp reaper ---
 
 @test "session-start reaps orphan tmp files > 60min old" {
-  mkdir -p "$STAGING/pending" "$STAGING/tmp"
-  touch "$STAGING/tmp/orphan.jsonl.tmp.123"
-  touch -t "$(date -d '90 minutes ago' +%Y%m%d%H%M 2>/dev/null \
-    || date -v-90M +%Y%m%d%H%M)" "$STAGING/tmp/orphan.jsonl.tmp.123"
+  # cs_atomic_jsonl_write creates sibling .tmp.PID files in the destination
+  # directory (pending/, processing/, or STAGING root for drain-budget.json).
+  # The reaper scans those locations, NOT a separate tmp/ subdir.
+  mkdir -p "$STAGING/pending" "$STAGING/processing"
+  touch "$STAGING/pending/orphan.jsonl.tmp.123"
+  touch "$STAGING/processing/orphan.jsonl.tmp.456"
+  touch "$STAGING/drain-budget.json.tmp.789"
+  for f in \
+    "$STAGING/pending/orphan.jsonl.tmp.123" \
+    "$STAGING/processing/orphan.jsonl.tmp.456" \
+    "$STAGING/drain-budget.json.tmp.789"; do
+    touch -t "$(date -d '90 minutes ago' +%Y%m%d%H%M 2>/dev/null \
+      || date -v-90M +%Y%m%d%H%M)" "$f"
+  done
   bash "$SS_HOOK" <<< "$(_stdin_json)" >/dev/null
-  [ ! -f "$STAGING/tmp/orphan.jsonl.tmp.123" ]
+  [ ! -f "$STAGING/pending/orphan.jsonl.tmp.123" ]
+  [ ! -f "$STAGING/processing/orphan.jsonl.tmp.456" ]
+  [ ! -f "$STAGING/drain-budget.json.tmp.789" ]
 }
 
 # --- Output contract ---

--- a/plugins/yellow-core/tests/compound-session-start-hook.bats
+++ b/plugins/yellow-core/tests/compound-session-start-hook.bats
@@ -46,10 +46,13 @@ _stdin_json() {
   jq -nc --arg c "$PROJECT_DIR" '{cwd: $c}'
 }
 
-# Wait briefly for the drain subshell to start the stub.
+# Wait briefly for the drain subshell to start the stub. `timeout` is in
+# seconds (matches _wait_for_file). Polls every 100ms; converts to
+# deciseconds for the loop bound so the wait actually lasts N seconds.
 _wait_for_stub() {
   local timeout="${1:-3}" elapsed=0
-  while [ ! -f "$STUB_MARKER" ] && [ "$elapsed" -lt "$timeout" ]; do
+  local max_iters=$((timeout * 10))
+  while [ ! -f "$STUB_MARKER" ] && [ "$elapsed" -lt "$max_iters" ]; do
     sleep 0.1
     elapsed=$((elapsed + 1))
   done

--- a/plugins/yellow-core/tests/compound-session-start-hook.bats
+++ b/plugins/yellow-core/tests/compound-session-start-hook.bats
@@ -1,0 +1,201 @@
+#!/usr/bin/env bats
+# Tests for hooks/scripts/session-start.sh — drain dispatcher.
+
+SS_HOOK="$BATS_TEST_DIRNAME/../hooks/scripts/session-start.sh"
+
+setup() {
+  STAGING_TEST_HOME="$(mktemp -d)"
+  export HOME="$STAGING_TEST_HOME"
+
+  PROJECT_DIR=$(mktemp -d)
+
+  # Stub for `claude -p`: a script that records its invocation to a marker file.
+  STUB_DIR=$(mktemp -d)
+  STUB_MARKER="$STUB_DIR/claude-invoked"
+  STUB_BIN="$STUB_DIR/claude"
+  cat > "$STUB_BIN" <<'STUB'
+#!/usr/bin/env bash
+# Record that we were invoked and exit fast.
+printf 'invoked with args: %s\n' "$*" > "$STUB_MARKER_PATH"
+printf '{"result": "stub", "is_error": false}\n'
+exit 0
+STUB
+  sed -i "s|\$STUB_MARKER_PATH|$STUB_MARKER|g" "$STUB_BIN" 2>/dev/null \
+    || sed -i.bak "s|\$STUB_MARKER_PATH|$STUB_MARKER|g" "$STUB_BIN"
+  rm -f "$STUB_BIN.bak"
+  chmod +x "$STUB_BIN"
+
+  export COMPOUND_DRAIN_CMD="$STUB_BIN"
+
+  # Resolve the staging dir the hook will use.
+  . "$BATS_TEST_DIRNAME/../lib/compound-staging.sh"
+  PROJECT_SLUG=$(cs_derive_project_slug "$PROJECT_DIR")
+  STAGING="$(cs_staging_dir_for_slug "$PROJECT_SLUG")"
+}
+
+teardown() {
+  for d in "$STAGING_TEST_HOME" "$PROJECT_DIR" "$STUB_DIR"; do
+    if [ -n "${d:-}" ] && [ -d "$d" ]; then
+      rm -rf "$d"
+    fi
+  done
+  unset COMPOUND_DRAIN_CMD
+}
+
+_stdin_json() {
+  jq -nc --arg c "$PROJECT_DIR" '{cwd: $c}'
+}
+
+# Wait briefly for the drain subshell to start the stub.
+_wait_for_stub() {
+  local timeout="${1:-3}" elapsed=0
+  while [ ! -f "$STUB_MARKER" ] && [ "$elapsed" -lt "$timeout" ]; do
+    sleep 0.1
+    elapsed=$((elapsed + 1))
+  done
+}
+
+# Plant N pending entries with current mtime.
+_plant_pending() {
+  local n="$1"
+  mkdir -p "$STAGING/pending"
+  for i in $(seq 1 "$n"); do
+    printf '{"schema":"1","session_id":"s%s","transcript_tail":"x"}\n' "$i" \
+      > "$STAGING/pending/s$i.jsonl"
+  done
+}
+
+# --- Recursion guard ---
+
+@test "session-start exits silently when COMPOUND_DRAIN_IN_PROGRESS=1" {
+  _plant_pending 10
+  run env COMPOUND_DRAIN_IN_PROGRESS=1 bash "$SS_HOOK" <<< "$(_stdin_json)"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q '"continue": true'
+  sleep 0.5
+  [ ! -f "$STUB_MARKER" ]
+}
+
+# --- First-run fast exit ---
+
+@test "session-start fast-exits when pending dir missing" {
+  # No staging dir created yet.
+  run bash "$SS_HOOK" <<< "$(_stdin_json)"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q '"continue": true'
+  sleep 0.3
+  [ ! -f "$STUB_MARKER" ]
+}
+
+# --- Zero pending ---
+
+@test "session-start does not dispatch when no pending entries" {
+  mkdir -p "$STAGING/pending"
+  run bash "$SS_HOOK" <<< "$(_stdin_json)"
+  [ "$status" -eq 0 ]
+  sleep 0.3
+  [ ! -f "$STUB_MARKER" ]
+}
+
+# --- Threshold: count ---
+
+@test "session-start dispatches when count >= 5" {
+  _plant_pending 5
+  run bash "$SS_HOOK" <<< "$(_stdin_json)"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q '"continue": true'
+  _wait_for_stub 3
+  [ -f "$STUB_MARKER" ]
+}
+
+@test "session-start does NOT dispatch at count=4" {
+  _plant_pending 4
+  run bash "$SS_HOOK" <<< "$(_stdin_json)"
+  [ "$status" -eq 0 ]
+  sleep 0.5
+  # No dispatch because count<5 and entries are fresh (mtime ~now).
+  [ ! -f "$STUB_MARKER" ]
+}
+
+# --- Threshold: age ---
+
+@test "session-start dispatches when single entry > 48h old" {
+  _plant_pending 1
+  # Backdate by 49 hours.
+  touch -t "$(date -d '49 hours ago' +%Y%m%d%H%M 2>/dev/null \
+    || date -v-49H +%Y%m%d%H%M)" "$STAGING/pending/s1.jsonl"
+  run bash "$SS_HOOK" <<< "$(_stdin_json)"
+  [ "$status" -eq 0 ]
+  _wait_for_stub 3
+  [ -f "$STUB_MARKER" ]
+}
+
+# --- Drain lock ---
+
+@test "session-start respects existing .drain-lock" {
+  _plant_pending 5
+  mkdir -p "$STAGING/.drain-lock"
+  run bash "$SS_HOOK" <<< "$(_stdin_json)"
+  [ "$status" -eq 0 ]
+  sleep 0.5
+  [ ! -f "$STUB_MARKER" ]
+  # Lock untouched.
+  [ -d "$STAGING/.drain-lock" ]
+}
+
+@test "session-start reaps a stale .drain-lock (>30min) and dispatches" {
+  _plant_pending 5
+  mkdir -p "$STAGING/.drain-lock"
+  # Backdate lock by 35 minutes.
+  touch -t "$(date -d '35 minutes ago' +%Y%m%d%H%M 2>/dev/null \
+    || date -v-35M +%Y%m%d%H%M)" "$STAGING/.drain-lock"
+  run bash "$SS_HOOK" <<< "$(_stdin_json)"
+  [ "$status" -eq 0 ]
+  _wait_for_stub 3
+  [ -f "$STUB_MARKER" ]
+}
+
+# --- PII TTL reaper ---
+
+@test "session-start reaps pending entries older than 7 days" {
+  _plant_pending 1
+  touch -t "$(date -d '10 days ago' +%Y%m%d%H%M 2>/dev/null \
+    || date -v-10d +%Y%m%d%H%M)" "$STAGING/pending/s1.jsonl"
+  run bash "$SS_HOOK" <<< "$(_stdin_json)"
+  [ "$status" -eq 0 ]
+  # The TTL reaper deleted s1.jsonl; with 0 pending afterwards, no dispatch.
+  [ ! -f "$STAGING/pending/s1.jsonl" ]
+}
+
+# --- Crashed processing/ retry ---
+
+@test "session-start requeues crashed processing entries > 1h old" {
+  mkdir -p "$STAGING/pending" "$STAGING/processing"
+  printf '{"schema":"1","session_id":"crashed","transcript_tail":"x"}\n' \
+    > "$STAGING/processing/crashed.jsonl"
+  touch -t "$(date -d '2 hours ago' +%Y%m%d%H%M 2>/dev/null \
+    || date -v-2H +%Y%m%d%H%M)" "$STAGING/processing/crashed.jsonl"
+  run bash "$SS_HOOK" <<< "$(_stdin_json)"
+  [ "$status" -eq 0 ]
+  # File moved from processing/ to pending/.
+  [ -f "$STAGING/pending/crashed.jsonl" ]
+  [ ! -f "$STAGING/processing/crashed.jsonl" ]
+}
+
+# --- Orphan tmp reaper ---
+
+@test "session-start reaps orphan tmp files > 60min old" {
+  mkdir -p "$STAGING/pending" "$STAGING/tmp"
+  touch "$STAGING/tmp/orphan.jsonl.tmp.123"
+  touch -t "$(date -d '90 minutes ago' +%Y%m%d%H%M 2>/dev/null \
+    || date -v-90M +%Y%m%d%H%M)" "$STAGING/tmp/orphan.jsonl.tmp.123"
+  bash "$SS_HOOK" <<< "$(_stdin_json)" >/dev/null
+  [ ! -f "$STAGING/tmp/orphan.jsonl.tmp.123" ]
+}
+
+# --- Output contract ---
+
+@test "session-start always outputs {continue: true} JSON" {
+  run bash "$SS_HOOK" <<< "$(_stdin_json)"
+  echo "$output" | jq -e '.continue == true' >/dev/null
+}

--- a/plugins/yellow-core/tests/compound-staging.bats
+++ b/plugins/yellow-core/tests/compound-staging.bats
@@ -109,6 +109,41 @@ teardown() {
   echo "$result" | grep -q 'REDACTED:github-token'
 }
 
+@test "redact_secrets strips Anthropic API keys (vendor-tagged when bare)" {
+  result=$(printf 'log line containing sk-ant-api03-abcdefghijklmnopqrstuvwxyz0123 inline\n' | cs_redact_secrets)
+  echo "$result" | grep -q 'REDACTED:anthropic-key'
+  ! echo "$result" | grep -q 'sk-ant-api03-abcdefghijkl'
+}
+
+@test "redact_secrets redacts Anthropic API keys via key= form too" {
+  result=$(printf 'API_KEY=sk-ant-api03-abcdefghijklmnopqrstuvwxyz0123\n' | cs_redact_secrets)
+  # Either the vendor-tagged form OR the generic [REDACTED] form is acceptable;
+  # what matters is the secret value is gone.
+  ! echo "$result" | grep -q 'sk-ant-api03-abcdefghijkl'
+  echo "$result" | grep -q '\[REDACTED'
+}
+
+@test "redact_secrets strips Slack tokens (vendor-tagged when bare)" {
+  # Build the prefix at runtime so GitHub secret scanning does not flag
+  # the literal token in the bats source. The runtime concatenation
+  # produces a valid prefix that exercises the redaction regex.
+  prefix=$(printf 'xox%s-' 'b')
+  result=$(printf 'webhook url contains %sTESTTOKENPLACEHOLDER-NOTREALCREDS somewhere\n' "$prefix" | cs_redact_secrets)
+  echo "$result" | grep -q 'REDACTED:slack-token'
+}
+
+@test "redact_secrets strips Stripe live keys" {
+  prefix=$(printf 'sk_%s_' 'live')
+  result=$(printf 'STRIPE=%sTESTPLACEHOLDERvalue1234NOTREAL\n' "$prefix" | cs_redact_secrets)
+  echo "$result" | grep -q 'REDACTED:stripe-key'
+}
+
+@test "redact_secrets strips JSON-formatted secrets (double-quoted)" {
+  result=$(printf '{"api_key": "sk-test-1234567890abcdef"}\n' | cs_redact_secrets)
+  echo "$result" | grep -q '\[REDACTED\]'
+  ! echo "$result" | grep -q 'sk-test-1234567890abcdef'
+}
+
 @test "redact_secrets handles basic-auth URLs" {
   result=$(printf 'https://user:pass@host/x\n' | cs_redact_secrets)
   echo "$result" | grep -q '\[REDACTED:basic-auth\]'

--- a/plugins/yellow-core/tests/compound-staging.bats
+++ b/plugins/yellow-core/tests/compound-staging.bats
@@ -196,10 +196,23 @@ teardown() {
 }
 
 @test "drain_budget_warn returns true under api route when over threshold" {
-  printf '{"window_start_iso":"2026-05-18T00:00:00Z","drains_in_window":20,"last_drain_iso":"2026-05-18T00:00:00Z","auth_route":"api"}\n' \
-    > "$STAGING_TEST_ROOT/drain-budget.json"
+  # Window must be current — an expired window resets the budget (next test).
+  now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  printf '{"window_start_iso":"%s","drains_in_window":20,"last_drain_iso":"%s","auth_route":"api"}\n' \
+    "$now" "$now" > "$STAGING_TEST_ROOT/drain-budget.json"
   run cs_drain_budget_warn "$STAGING_TEST_ROOT"
   [ "$status" -eq 0 ]
+}
+
+@test "drain_budget_warn returns false under api route when window has expired" {
+  # Over threshold, but the 5h rolling window already rolled — the persisted
+  # counter belongs to a past window, so no warning should fire.
+  old=$(date -u -d '6 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -v-6H +%Y-%m-%dT%H:%M:%SZ)
+  printf '{"window_start_iso":"%s","drains_in_window":20,"last_drain_iso":"%s","auth_route":"api"}\n' \
+    "$old" "$old" > "$STAGING_TEST_ROOT/drain-budget.json"
+  run cs_drain_budget_warn "$STAGING_TEST_ROOT"
+  [ "$status" -ne 0 ]
 }
 
 # --- cs_detect_auth_route ---

--- a/plugins/yellow-core/tests/compound-staging.bats
+++ b/plugins/yellow-core/tests/compound-staging.bats
@@ -1,0 +1,190 @@
+#!/usr/bin/env bats
+# Tests for lib/compound-staging.sh — background-compounding helper lib.
+
+setup() {
+  . "$BATS_TEST_DIRNAME/../lib/compound-staging.sh"
+
+  STAGING_TEST_ROOT="$(mktemp -d)"
+  mkdir -p "$STAGING_TEST_ROOT/pending" "$STAGING_TEST_ROOT/tmp"
+}
+
+teardown() {
+  if [ -n "${STAGING_TEST_ROOT:-}" ] && [ -d "$STAGING_TEST_ROOT" ]; then
+    rm -rf "$STAGING_TEST_ROOT"
+  fi
+}
+
+# --- cs_derive_project_slug ---
+
+@test "derive_project_slug uses git toplevel inside a repo" {
+  REPO=$(mktemp -d)
+  (cd "$REPO" && git init -q && git config user.email t@t && git config user.name t)
+  result=$(cs_derive_project_slug "$REPO")
+  [ -n "$result" ]
+  # Slug derived from toplevel — must contain no slashes.
+  case "$result" in
+    */*) false ;;
+    *) true ;;
+  esac
+  rm -rf "$REPO"
+}
+
+@test "derive_project_slug falls back to cwd outside a repo" {
+  NONREPO=$(mktemp -d)
+  result=$(cs_derive_project_slug "$NONREPO")
+  [ -n "$result" ]
+  case "$result" in
+    */*) false ;;
+    *) true ;;
+  esac
+  rm -rf "$NONREPO"
+}
+
+@test "derive_project_slug converts slashes to dashes" {
+  result=$(cs_derive_project_slug "/a/b/c")
+  [ "$result" = "-a-b-c" ]
+}
+
+# --- cs_staging_dir_for_slug ---
+
+@test "staging_dir_for_slug builds the canonical path" {
+  result=$(cs_staging_dir_for_slug "-test-project")
+  [ "$result" = "$HOME/.claude/projects/-test-project/compound-staging" ]
+}
+
+@test "staging_dir_for_slug rejects empty slug" {
+  run cs_staging_dir_for_slug ""
+  [ "$status" -ne 0 ]
+}
+
+# --- cs_atomic_jsonl_write ---
+
+@test "atomic_jsonl_write creates the destination directory" {
+  target="$STAGING_TEST_ROOT/pending/abc123.jsonl"
+  run cs_atomic_jsonl_write "$target" '{"k":"v"}'
+  [ "$status" -eq 0 ]
+  [ -f "$target" ]
+  grep -q '"k":"v"' "$target"
+}
+
+@test "atomic_jsonl_write leaves no tmp file on success" {
+  target="$STAGING_TEST_ROOT/pending/clean.jsonl"
+  cs_atomic_jsonl_write "$target" '{"k":"v"}'
+  # No .tmp.* siblings.
+  remnants=$(find "$STAGING_TEST_ROOT/pending" -name '*.tmp.*' 2>/dev/null | wc -l | tr -d ' ')
+  [ "$remnants" = "0" ]
+}
+
+# --- cs_redact_secrets ---
+
+@test "redact_secrets strips password= values" {
+  result=$(printf 'password=hunter2\n' | cs_redact_secrets)
+  echo "$result" | grep -q 'password=\[REDACTED\]'
+  ! echo "$result" | grep -q 'hunter2'
+}
+
+@test "redact_secrets strips token= values" {
+  result=$(printf 'token=abcdef1234567890\n' | cs_redact_secrets)
+  echo "$result" | grep -q 'token=\[REDACTED\]'
+  ! echo "$result" | grep -q 'abcdef1234567890'
+}
+
+@test "redact_secrets strips api_key= values" {
+  result=$(printf 'api_key=sk-test123456789\n' | cs_redact_secrets)
+  echo "$result" | grep -q 'api_key=\[REDACTED\]'
+}
+
+@test "redact_secrets strips Bearer tokens" {
+  result=$(printf 'Authorization: Bearer abc123def456ghi789jkl\n' | cs_redact_secrets)
+  echo "$result" | grep -q 'Bearer \[REDACTED\]'
+}
+
+@test "redact_secrets is case-insensitive on Password=" {
+  result=$(printf 'Password=hunter2longvalue\n' | cs_redact_secrets)
+  ! echo "$result" | grep -q 'hunter2longvalue'
+}
+
+@test "redact_secrets strips GitHub token prefixes" {
+  result=$(printf 'export GH=ghp_abcdefghijklmnopqrstuvwxyz0123456789\n' | cs_redact_secrets)
+  echo "$result" | grep -q 'REDACTED:github-token'
+}
+
+@test "redact_secrets handles basic-auth URLs" {
+  result=$(printf 'https://user:pass@host/x\n' | cs_redact_secrets)
+  echo "$result" | grep -q '\[REDACTED:basic-auth\]'
+  ! echo "$result" | grep -q 'user:pass'
+}
+
+@test "redact_secrets passes innocuous text through unchanged" {
+  result=$(printf 'hello world\n' | cs_redact_secrets)
+  [ "$result" = "hello world" ]
+}
+
+# --- drain budget ---
+
+@test "read_drain_budget returns zeroed object when file missing" {
+  result=$(cs_read_drain_budget "$STAGING_TEST_ROOT")
+  drains=$(printf '%s' "$result" | jq -r '.drains_in_window')
+  [ "$drains" = "0" ]
+}
+
+@test "update_drain_budget creates the file with drains_in_window=1" {
+  cs_update_drain_budget "$STAGING_TEST_ROOT" "subscription"
+  [ -f "$STAGING_TEST_ROOT/drain-budget.json" ]
+  drains=$(jq -r '.drains_in_window' "$STAGING_TEST_ROOT/drain-budget.json")
+  [ "$drains" = "1" ]
+}
+
+@test "update_drain_budget increments within the 5h window" {
+  cs_update_drain_budget "$STAGING_TEST_ROOT" "subscription"
+  cs_update_drain_budget "$STAGING_TEST_ROOT" "subscription"
+  drains=$(jq -r '.drains_in_window' "$STAGING_TEST_ROOT/drain-budget.json")
+  [ "$drains" = "2" ]
+}
+
+@test "update_drain_budget resets when window_start is older than 5h" {
+  # Seed a budget file with a window_start 6h ago.
+  old=$(date -u -d '6 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -v-6H +%Y-%m-%dT%H:%M:%SZ)
+  printf '{"window_start_iso":"%s","drains_in_window":4,"last_drain_iso":"%s","auth_route":"subscription"}\n' \
+    "$old" "$old" > "$STAGING_TEST_ROOT/drain-budget.json"
+  cs_update_drain_budget "$STAGING_TEST_ROOT" "subscription"
+  drains=$(jq -r '.drains_in_window' "$STAGING_TEST_ROOT/drain-budget.json")
+  [ "$drains" = "1" ]
+}
+
+@test "drain_budget_warn returns false under subscription auth regardless of count" {
+  printf '{"window_start_iso":"2026-05-18T00:00:00Z","drains_in_window":50,"last_drain_iso":"2026-05-18T00:00:00Z","auth_route":"subscription"}\n' \
+    > "$STAGING_TEST_ROOT/drain-budget.json"
+  run cs_drain_budget_warn "$STAGING_TEST_ROOT"
+  [ "$status" -ne 0 ]
+}
+
+@test "drain_budget_warn returns true under api route when over threshold" {
+  printf '{"window_start_iso":"2026-05-18T00:00:00Z","drains_in_window":20,"last_drain_iso":"2026-05-18T00:00:00Z","auth_route":"api"}\n' \
+    > "$STAGING_TEST_ROOT/drain-budget.json"
+  run cs_drain_budget_warn "$STAGING_TEST_ROOT"
+  [ "$status" -eq 0 ]
+}
+
+# --- cs_detect_auth_route ---
+
+@test "detect_auth_route returns subscription when ANTHROPIC_API_KEY unset" {
+  unset ANTHROPIC_API_KEY
+  result=$(cs_detect_auth_route)
+  [ "$result" = "subscription" ]
+}
+
+@test "detect_auth_route returns api when ANTHROPIC_API_KEY set" {
+  ANTHROPIC_API_KEY=fake-key cs_detect_auth_route > "$STAGING_TEST_ROOT/route"
+  result=$(cat "$STAGING_TEST_ROOT/route")
+  [ "$result" = "api" ]
+}
+
+# --- idempotent source guard ---
+
+@test "library is safe to source twice" {
+  . "$BATS_TEST_DIRNAME/../lib/compound-staging.sh"
+  . "$BATS_TEST_DIRNAME/../lib/compound-staging.sh"
+  [ "${_COMPOUND_STAGING_LOADED:-}" = "1" ]
+}

--- a/plugins/yellow-core/tests/compound-stop-hook.bats
+++ b/plugins/yellow-core/tests/compound-stop-hook.bats
@@ -1,0 +1,141 @@
+#!/usr/bin/env bats
+# Tests for hooks/scripts/stop.sh — pure-shell Stop hook + disowned capture.
+
+STOP_HOOK="$BATS_TEST_DIRNAME/../hooks/scripts/stop.sh"
+CAPTURE_SCRIPT="$BATS_TEST_DIRNAME/../hooks/scripts/_stop-capture-subshell.sh"
+
+setup() {
+  STAGING_TEST_HOME="$(mktemp -d)"
+  export HOME="$STAGING_TEST_HOME"
+
+  # Project dir + a fake transcript file.
+  PROJECT_DIR=$(mktemp -d)
+  TRANSCRIPT_FILE="$PROJECT_DIR/transcript.jsonl"
+  SESSION_ID="bats-session-$$"
+  : > "$TRANSCRIPT_FILE"
+}
+
+teardown() {
+  if [ -n "${STAGING_TEST_HOME:-}" ] && [ -d "$STAGING_TEST_HOME" ]; then
+    rm -rf "$STAGING_TEST_HOME"
+  fi
+  if [ -n "${PROJECT_DIR:-}" ] && [ -d "$PROJECT_DIR" ]; then
+    rm -rf "$PROJECT_DIR"
+  fi
+}
+
+# Derive the staging path the hook will write to.
+_expected_staging_dir() {
+  . "$BATS_TEST_DIRNAME/../lib/compound-staging.sh"
+  local slug
+  slug=$(cs_derive_project_slug "$PROJECT_DIR")
+  cs_staging_dir_for_slug "$slug"
+}
+
+# Helper: build stdin JSON for the hook.
+_hook_stdin() {
+  jq -nc \
+    --arg t "$TRANSCRIPT_FILE" \
+    --arg s "$SESSION_ID" \
+    --arg c "$PROJECT_DIR" \
+    '{transcript_path: $t, session_id: $s, cwd: $c, stop_hook_active: false}'
+}
+
+# Helper: wait up to N seconds for a file to appear.
+_wait_for_file() {
+  local path="$1" timeout="${2:-3}" elapsed=0
+  while [ ! -f "$path" ] && [ "$elapsed" -lt "$timeout" ]; do
+    sleep 0.1
+    elapsed=$((elapsed + 1))
+  done
+  [ -f "$path" ]
+}
+
+# --- Recursion guard ---
+
+@test "stop hook exits silently when COMPOUND_DRAIN_IN_PROGRESS=1" {
+  STAGING=$(_expected_staging_dir)
+  run env COMPOUND_DRAIN_IN_PROGRESS=1 bash "$STOP_HOOK" <<< "$(_hook_stdin)"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q '"continue": true'
+  # No staging dir created.
+  [ ! -d "$STAGING/pending" ]
+}
+
+# --- stop_hook_active guard ---
+
+@test "stop hook exits when stop_hook_active is true" {
+  STAGING=$(_expected_staging_dir)
+  reentrant=$(jq -nc \
+    --arg t "$TRANSCRIPT_FILE" --arg s "$SESSION_ID" --arg c "$PROJECT_DIR" \
+    '{transcript_path: $t, session_id: $s, cwd: $c, stop_hook_active: true}')
+  run bash "$STOP_HOOK" <<< "$reentrant"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q '"continue": true'
+  [ ! -f "$STAGING/pending/$SESSION_ID.jsonl" ]
+}
+
+# --- Capture happy path ---
+
+@test "stop hook captures transcript tail to pending JSONL" {
+  printf 'line one\nline two with normal text\n' > "$TRANSCRIPT_FILE"
+  STAGING=$(_expected_staging_dir)
+  run bash "$STOP_HOOK" <<< "$(_hook_stdin)"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q '"continue": true'
+  _wait_for_file "$STAGING/pending/$SESSION_ID.jsonl" 5
+  # JSONL contains schema and session_id.
+  jq -e '.schema == "1" and .session_id != ""' "$STAGING/pending/$SESSION_ID.jsonl"
+}
+
+@test "stop hook redacts secrets before writing JSONL" {
+  printf 'config:\npassword=hunter2longvalue\nend\n' > "$TRANSCRIPT_FILE"
+  STAGING=$(_expected_staging_dir)
+  bash "$STOP_HOOK" <<< "$(_hook_stdin)" >/dev/null
+  _wait_for_file "$STAGING/pending/$SESSION_ID.jsonl" 5
+  tail=$(jq -r '.transcript_tail' "$STAGING/pending/$SESSION_ID.jsonl")
+  echo "$tail" | grep -q 'password=\[REDACTED\]'
+  ! echo "$tail" | grep -q 'hunter2longvalue'
+}
+
+@test "stop hook redacts Bearer tokens" {
+  printf 'header: Bearer abc123def456ghi789jkl0\n' > "$TRANSCRIPT_FILE"
+  STAGING=$(_expected_staging_dir)
+  bash "$STOP_HOOK" <<< "$(_hook_stdin)" >/dev/null
+  _wait_for_file "$STAGING/pending/$SESSION_ID.jsonl" 5
+  tail=$(jq -r '.transcript_tail' "$STAGING/pending/$SESSION_ID.jsonl")
+  echo "$tail" | grep -q 'Bearer \[REDACTED\]'
+}
+
+@test "stop hook writes content_hash for dedup" {
+  printf 'consistent input\n' > "$TRANSCRIPT_FILE"
+  STAGING=$(_expected_staging_dir)
+  bash "$STOP_HOOK" <<< "$(_hook_stdin)" >/dev/null
+  _wait_for_file "$STAGING/pending/$SESSION_ID.jsonl" 5
+  hash=$(jq -r '.content_hash' "$STAGING/pending/$SESSION_ID.jsonl")
+  # sha256 is 64 hex chars.
+  [ "${#hash}" -eq 64 ]
+}
+
+# --- Performance ---
+
+@test "stop hook returns within 500ms (parent only)" {
+  STAGING=$(_expected_staging_dir)
+  start=$(date +%s%N)
+  bash "$STOP_HOOK" <<< "$(_hook_stdin)" >/dev/null
+  end=$(date +%s%N)
+  elapsed_ms=$(( (end - start) / 1000000 ))
+  # Parent should be very fast; subshell does the I/O asynchronously.
+  [ "$elapsed_ms" -lt 500 ]
+}
+
+# --- Capture subshell standalone ---
+
+@test "capture subshell handles missing transcript gracefully" {
+  STAGING=$(_expected_staging_dir)
+  bash "$CAPTURE_SCRIPT" "/nonexistent/transcript.jsonl" "$SESSION_ID" "$STAGING" "$PROJECT_DIR"
+  # Should still write a JSONL with empty transcript_tail.
+  [ -f "$STAGING/pending/$SESSION_ID.jsonl" ]
+  tail=$(jq -r '.transcript_tail' "$STAGING/pending/$SESSION_ID.jsonl")
+  [ "$tail" = "" ]
+}

--- a/plugins/yellow-core/tests/compound-stop-hook.bats
+++ b/plugins/yellow-core/tests/compound-stop-hook.bats
@@ -125,12 +125,23 @@ _wait_for_file() {
 
 @test "stop hook returns within 500ms (parent only)" {
   STAGING=$(_expected_staging_dir)
-  start=$(date +%s%N)
-  bash "$STOP_HOOK" <<< "$(_hook_stdin)" >/dev/null
-  end=$(date +%s%N)
-  elapsed_ms=$(( (end - start) / 1000000 ))
-  # Parent should be very fast; subshell does the I/O asynchronously.
-  [ "$elapsed_ms" -lt 500 ]
+  # date +%s%N is GNU-only; %N outputs a literal 'N' on BSD/macOS.
+  # Use Python 3 for millisecond precision when available; fall back to whole
+  # seconds with a coarser 5-second bound so the test stays meaningful on
+  # both platforms.
+  if command -v python3 >/dev/null 2>&1; then
+    start=$(python3 -c 'import time; print(int(time.monotonic() * 1000))')
+    bash "$STOP_HOOK" <<< "$(_hook_stdin)" >/dev/null
+    end=$(python3 -c 'import time; print(int(time.monotonic() * 1000))')
+    elapsed_ms=$(( end - start ))
+    [ "$elapsed_ms" -lt 500 ]
+  else
+    start=$(date +%s)
+    bash "$STOP_HOOK" <<< "$(_hook_stdin)" >/dev/null
+    end=$(date +%s)
+    elapsed_s=$(( end - start ))
+    [ "$elapsed_s" -lt 5 ]
+  fi
 }
 
 # --- Capture subshell standalone ---

--- a/plugins/yellow-core/tests/compound-stop-hook.bats
+++ b/plugins/yellow-core/tests/compound-stop-hook.bats
@@ -41,10 +41,14 @@ _hook_stdin() {
     '{transcript_path: $t, session_id: $s, cwd: $c, stop_hook_active: false}'
 }
 
-# Helper: wait up to N seconds for a file to appear.
+# Helper: wait up to N seconds for a file to appear. `timeout` is in seconds.
+# Polls every 100ms; converts seconds to deciseconds for the loop bound so
+# the wait actually lasts the documented N seconds (the prior version
+# counted iterations, waiting 10x less than intended).
 _wait_for_file() {
   local path="$1" timeout="${2:-3}" elapsed=0
-  while [ ! -f "$path" ] && [ "$elapsed" -lt "$timeout" ]; do
+  local max_iters=$((timeout * 10))
+  while [ ! -f "$path" ] && [ "$elapsed" -lt "$max_iters" ]; do
     sleep 0.1
     elapsed=$((elapsed + 1))
   done


### PR DESCRIPTION
Stack item #1 of plans/background-compounding-triggers.md.

Adds the pure-shell hook infrastructure for an always-on background
compounding pipeline:

- lib/compound-staging.sh: helper library (slug derivation, atomic
  JSONL writes, secret redaction, 5h-rolling-window drain-budget
  observability counter, auth-route detection). Idempotent source guard.
- hooks/scripts/stop.sh: Stop hook (5s timeout) that disowns a capture
  subshell. Guards: COMPOUND_DRAIN_IN_PROGRESS recursion guard,
  stop_hook_active re-entrancy guard. Parent returns in <500ms.
- hooks/scripts/_stop-capture-subshell.sh: tails transcript (cap 100
  lines), redacts secrets, sha256-hashes, atomically writes JSONL to
  pending/<session_id>.jsonl. Runs after parent exit.
- hooks/scripts/session-start.sh: SessionStart hook (3s timeout) with
  reaper (orphan tmp >1h, stale .drain-lock >30min, PII TTL pending >7d,
  crashed processing/ requeue) and drain dispatcher. Thresholds:
  count >= 5 OR oldest pending > 48h. Atomic mkdir drain-lock.
  Disowned 'claude -p' subshell with bypassPermissions + max-turns 50
  and COMPOUND_DRAIN_IN_PROGRESS=1 inherited to drain process.
- plugin.json: inline hooks block (Stop + SessionStart). No async:true
  (D4 in plan: schema field unsupported; disowned-subshell is the
  non-blocking mechanism).

44 new bats tests (24 lib + 8 stop + 12 SessionStart); full yellow-core
suite is 83/83 green. Tests cover recursion guards, redaction patterns,
threshold gates, lock reaping, PII TTL, crashed-processing requeue,
output JSON contract, <500ms parent latency.

Stack item #2 (drain agents) and #3 (manual override + lint + docs)
follow on top of this branch. Pipeline is no-op until #2 lands.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->
