### PR TITLE
feat(yellow-core): add /setup:claude-web command

### DIFF
--- a/.changeset/setup-claude-web-command.md
+++ b/.changeset/setup-claude-web-command.md
@@ -1,0 +1,37 @@
+---
+'yellow-core': minor
+---
+
+feat(yellow-core): add `/setup:claude-web` command
+
+Adds a new command at `plugins/yellow-core/commands/setup/claude-web.md`
+that prepares a repository for Claude Code Web (`claude.ai/code`). The web
+sandbox has no access to user-scope settings, `claude mcp add` entries, or
+locally installed plugins — everything an agent uses must live in the
+repository. This command audits and scaffolds the project-scope files
+that make a repo cloud-ready.
+
+The command runs in three tiers:
+
+- **Tier 1 (auto-write):** appends missing patterns to `.gitattributes`
+  (`* text=auto`, `*.sh eol=lf`) and `.gitignore` (`.env`, `.env.*`,
+  `*.pem`, `*.key`, `.aws/`, `.ssh/`, `secrets/`, `credentials/`); fixes
+  executable bits via `chmod +x` + `git update-index --chmod=+x` on
+  bootstrap scripts referenced by hooks.
+- **Tier 2 (AskUserQuestion gate):** scaffolds or merges into
+  `.claude/settings.json` (Python-based atomic write mirroring
+  `statusline/setup.md`); writes `scripts/install_pkgs.sh` from a
+  detected lockfile (pnpm > yarn > npm > uv > pip > cargo > bundler >
+  composer > go) with `CLAUDE_CODE_REMOTE=true` gate; writes
+  `.github/workflows/claude.yml` using the canonical
+  `anthropics/claude-code-action@v1` shape with `@claude`-mention
+  triggers across `issue_comment`, `pull_request_review_comment`, and
+  `issues` events.
+- **Tier 3 (warn-only):** flags STDIO MCP servers, oversized
+  `CLAUDE.md`, missing lockfiles, and the
+  `permissions.deny`-as-defense-in-depth pattern for sensitive paths.
+
+Re-running on a fully configured repository produces zero writes —
+idempotency is enforced via `grep -qF`-before-append for line additions
+and append-only Python merge for JSON keys. Includes README + CLAUDE.md
+updates (commands count `8 → 9`).

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ yellow-plugins/
 │   ├── yellow-ci/             # CI toolkit (4 agents, 8 commands, 2 skills, 1 hook)
 │   ├── yellow-codex/          # Codex CLI wrapper (3 agents, 4 commands, 1 skill)
 │   ├── yellow-composio/       # Composio MCP (2 commands, 1 skill, 1 MCP)
-│   ├── yellow-core/           # Dev toolkit (17 agents, 8 commands, 7 skills)
+│   ├── yellow-core/           # Dev toolkit (17 agents, 9 commands, 7 skills)
 │   ├── yellow-council/        # Cross-lineage code council (2 agents, 1 command, 1 skill)
 │   ├── yellow-debt/           # Debt audit (7 agents, 6 commands, 1 skill, 1 hook)
 │   ├── yellow-devin/          # Devin.AI (1 agent, 9 commands, 1 skill, 2 MCPs)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add the marketplace, then install individual plugins:
 | `yellow-ci`           | CI failure diagnosis, workflow linting, and runner health management for self-hosted GitHub Actions runners | 4 agents, 8 commands, 2 skills, 1 hook         |
 | `yellow-codex`        | OpenAI Codex CLI wrapper with review, rescue, and analysis agents for workflow integration                  | 3 agents, 4 commands, 1 skill                  |
 | `yellow-composio`     | Composio MCP integration with usage tracking and budget guardrails                                          | 2 commands, 1 skill, 1 MCP                     |
-| `yellow-core`         | Dev toolkit with review agents, research agents, and workflow commands for TS/Py/Rust/Go                    | 17 agents, 8 commands, 7 skills               |
+| `yellow-core`         | Dev toolkit with review agents, research agents, and workflow commands for TS/Py/Rust/Go                    | 17 agents, 9 commands, 7 skills               |
 | `yellow-council`      | On-demand cross-lineage code review fanning out to Codex, Gemini, and OpenCode CLIs in parallel             | 2 agents, 1 command, 1 skill                   |
 | `yellow-debt`         | Technical debt audit and remediation with parallel scanner agents for AI-generated code patterns            | 7 agents, 6 commands, 1 skill, 1 hook          |
 | `yellow-devin`        | Devin.AI V3 API integration — delegate tasks, manage sessions, research codebases via DeepWiki              | 1 agent, 9 commands, 1 skill, 2 MCPs           |

--- a/docs/brainstorms/2026-05-18-setup-claude-web-command-brainstorm.md
+++ b/docs/brainstorms/2026-05-18-setup-claude-web-command-brainstorm.md
@@ -1,0 +1,501 @@
+# Brainstorm: `setup:claude-web` Command
+
+**Date:** 2026-05-18
+**Topic:** How to design and build the `setup:claude-web` command in yellow-core
+**Research basis:** `docs/research/how-claude-code-web-works-and-repository.md`
+**Status:** Ready for `/workflows:plan`
+
+---
+
+## What We're Building
+
+A new command, `setup:claude-web`, that prepares a user's repository for use
+with Claude Code Web (the browser-hosted, cloud-VM execution surface at
+`claude.ai/code`). The command audits and scaffolds the configuration files that
+Claude Code Web requires — those that must live inside the repository because
+the web sandbox has no access to `~/.claude/settings.json`, user-scope MCP
+servers, or locally installed plugins. It lives at
+`plugins/yellow-core/commands/setup/claude-web.md` and is invoked as
+`/setup:claude-web`.
+
+The command runs against the current working repository (wherever the user invokes
+it). It does not accept a `--target` argument in v1.
+
+---
+
+## Why This Approach
+
+Claude Code Web's ephemeral VM model means that everything working locally —
+user-scope settings, shell exports, `claude mcp add` entries, locally installed
+plugins — is invisible in a cloud session. The failure mode is silent: the
+agent runs but without the tools and context the developer expects. A single
+idempotent setup command that audits and scaffolds the required project-scope
+files eliminates this class of surprise.
+
+Placement in `yellow-core/commands/setup/` is correct: yellow-core already owns
+the `setup:` namespace and `setup:all` aggregator. The command follows the same
+shape as `ci:setup` and `chatprd:setup` — Bash audit steps, tiered
+AskUserQuestion gates before any write, idempotency via detect-before-write.
+
+---
+
+## Key Decisions
+
+### 1. v1 Scope
+
+v1 implements all 11 checklist items from the research (Part C), tiered by
+risk:
+
+**Tier 1 — Auto-write (safe, additive-only, no existing content displaced):**
+- C.6: `.gitattributes` — append `* text=auto` and `*.sh eol=lf` only if missing
+- C.8: `.gitignore` — append missing sensitive-file patterns only
+- C.9: Executable bits — `chmod +x` + `git update-index --chmod=+x` for scripts
+  referenced in settings.json hooks that lack the bit
+
+**Tier 2 — AskUserQuestion before write (creates new files or modifies config):**
+- C.1: `.claude/settings.json` — scaffold if absent; merge if present
+- C.2: `scripts/install_pkgs.sh` — write if absent; inspect + warn if present
+- C.5: `.github/workflows/claude.yml` — scaffold if absent; skip if any
+  `claude-code-action` workflow exists
+
+**Tier 3 — Warn only (human judgment required):**
+- C.3: `.mcp.json` — audit STDIO server entries, warn but never rewrite
+- C.4: `enabledPlugins` / plugin userConfig — warn about missing env vars,
+  never modify
+- C.7: CLAUDE.md size — warn if >200 lines or >25 KB, never modify
+- C.10: Lockfile consistency — warn if package manager detected but lockfile
+  missing/gitignored, never modify
+
+**Tier 4 — Summary (always runs):**
+- C.11: Final summary block — files written, env vars needed, warnings, next steps
+
+**Rejected from v1:**
+- `--target <dir>` argument: YAGNI. Every real use case involves the current
+  repo. Can be added later without breaking the existing interface.
+- Dry-run mode: Adds flag-parsing complexity. Tier 2 AskUserQuestion gates
+  already achieve "review before write" at each step.
+- Marker file: Files written are self-evidencing; re-running the command detects
+  its own prior writes. A marker file adds state without adding value.
+- `claude mcp list` shell-out: The `claude` CLI is not guaranteed to be in PATH
+  in all invocation contexts. Read `.mcp.json` and user-scope `~/.claude.json`
+  directly instead (advisory only; user-scope servers cannot be moved
+  automatically).
+
+### 2. Interaction Model
+
+**Tiered** (not fully unattended, not fully interactive):
+
+The model follows `ci:setup` precedent: safe, additive file appends (Tier 1)
+execute without asking; file creation or config modification (Tier 2) requires
+AskUserQuestion confirmation; structural decisions (Tier 3) emit warnings only.
+
+Rationale: Tier 1 writes (gitattributes lines, gitignore entries, chmod) have
+zero destructive potential — they can only add, never subtract or overwrite.
+Tier 2 writes create new files or modify existing config, which can disrupt a
+carefully tuned setup. Confirmation gates here follow the M3 pattern already
+used by chatprd:setup (show what would be written, ask "Save this?" or "Write
+this file?"). AskUserQuestion must be used — not prose asking — for every
+Tier 2 prompt.
+
+### 3. File Structure
+
+**Location:** `plugins/yellow-core/commands/setup/claude-web.md`
+
+**Frontmatter:**
+
+```yaml
+---
+name: setup:claude-web
+description: "Prepare a repository for Claude Code Web: audit and scaffold .claude/settings.json, bootstrap script, .mcp.json transport compatibility, .gitattributes, .gitignore, and GitHub Actions workflow. Use when first enabling cloud sessions, after adding MCP servers, or when cloud sessions fail to find expected tools."
+argument-hint: ''
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - AskUserQuestion
+---
+```
+
+Notes on `allowed-tools`:
+- No `ToolSearch` needed: no deferred MCP tools are invoked.
+- `Edit` is listed because Step 5 (settings.json merge) may use Edit to add
+  keys to an existing file rather than wholesale-replacing it.
+- No MCP tool names needed: the command does not call any MCP servers.
+
+### 4. Step-by-Step Command Body Outline
+
+```
+Step 1: Detect Repo Root
+Step 2: Comprehensive Audit (single Bash call)
+Step 3: Classify and Display Audit Results
+Step 4: .gitattributes and .gitignore (Tier 1 — auto-write, no gate)
+Step 5: .claude/settings.json (Tier 2 — AskUserQuestion gate)
+Step 6: scripts/install_pkgs.sh + SessionStart hook wire-up (Tier 2 — AskUserQuestion gate)
+Step 7: .github/workflows/claude.yml (Tier 2 — AskUserQuestion gate, conditional)
+Step 8: Executable bits (Tier 1 — auto-fix)
+Step 9: Summary Output (always)
+```
+
+**Step 1: Detect Repo Root**
+
+Single Bash call:
+```bash
+repo_top=$(git rev-parse --show-toplevel 2>/dev/null || true)
+[ -n "$repo_top" ] && printf 'repo_top: %s\n' "$repo_top" || printf 'repo_top: NOT_FOUND\n'
+```
+
+If `repo_top` is NOT_FOUND: report "This command must be run from inside a git
+repository." and stop. Do not proceed.
+
+**Step 2: Comprehensive Audit**
+
+Single Bash call collecting all signals needed for Steps 3-8. Outputs a
+key-value report. Checks performed:
+
+- `.claude/settings.json` exists? Has `hooks.SessionStart`? Has
+  `permissions.allow`? Has `enabledPlugins`?
+- `scripts/install_pkgs.sh` exists? Has `CLAUDE_CODE_REMOTE` gate?
+- Package manager lockfiles: `pnpm-lock.yaml`, `yarn.lock`,
+  `package-lock.json`, `uv.lock`, `requirements.txt`, `Cargo.lock`,
+  `Gemfile.lock`, `composer.lock`, `go.sum`
+- `.mcp.json` exists? For each entry: `type` value (stdio vs http/sse);
+  for stdio entries: `command` value (npx/python/node = "maybe-ok" vs other =
+  "warn")
+- `.gitattributes` exists? Has `text=auto`? Has `*.sh eol=lf`?
+- `.gitignore` exists? Covers: `.env`, `.env.*`, `.env.local`, `*.pem`,
+  `*.key`, `.aws/`, `.ssh/`, `secrets/`, `credentials/`?
+- `.github/workflows/` contains any file with `anthropics/claude-code-action`?
+- `CLAUDE.md` line count and byte size
+- `~/.claude.json` exists? (user-scope MCP detection; advisory only)
+- For each `enabledPlugins` entry: corresponding plugin.json path in plugin
+  cache; `userConfig` keys without defaults
+
+The audit MUST run as a single Bash call (following `setup:all` precedent) to
+avoid PATH drift between calls and to keep the step count low.
+
+**Step 3: Classify and Display Audit Results**
+
+Print a compact audit table — one row per check area, status (OK / MISSING /
+WARN / NEEDS ATTENTION). Example:
+
+```text
+Claude Code Web Readiness Audit
+================================
+  .claude/settings.json      MISSING       Will scaffold
+  scripts/install_pkgs.sh    MISSING       Will scaffold (pnpm detected)
+  SessionStart hook          MISSING       Will add to settings.json
+  permissions.allow          MISSING       Will scaffold empty list
+  .mcp.json                  OK            No STDIO servers detected
+  .gitattributes             PARTIAL       Missing *.sh eol=lf
+  .gitignore                 PARTIAL       Missing: .env.*, *.key, .aws/, .ssh/
+  CLAUDE.md                  WARN          312 lines (>200 recommended)
+  GitHub Actions             MISSING       Will scaffold claude.yml
+  Lockfile                   OK            pnpm-lock.yaml present and tracked
+  Plugins (enabledPlugins)   N/A           No enabledPlugins in project settings
+```
+
+**Step 4: .gitattributes and .gitignore (Tier 1)**
+
+If `.gitattributes` is missing required entries: append them. Do not rewrite
+the file; use `printf >> file` pattern via Bash.
+
+If `.gitignore` is missing any of the sensitive-path patterns: append the
+missing ones under a `# Claude Code Web — sensitive file protection` comment
+block. Do not rewrite; append only.
+
+Both operations are automatic (no AskUserQuestion). Print what was appended.
+
+**Step 5: .claude/settings.json (Tier 2)**
+
+If file is absent: show the template that would be written. Ask via
+AskUserQuestion: "Write `.claude/settings.json` with a SessionStart hook
+template and empty permissions.allow?" Options: `[Write it]` / `[Skip]`.
+
+If file exists but is missing keys: show exactly which keys would be added
+(SessionStart hook entry, permissions.allow list, or env block). Ask via
+AskUserQuestion: "Merge these additions into existing `.claude/settings.json`?"
+Options: `[Merge]` / `[Skip]`.
+
+If file exists and already has all required keys: report "settings.json looks
+good" and skip.
+
+**Merge strategy for existing settings.json:**
+- `permissions.allow`: read existing array, append new entries if not already
+  present. Never remove entries.
+- `hooks.SessionStart`: read existing array. If `scripts/install_pkgs.sh` hook
+  not already present, append it. Do not replace existing hooks.
+- `permissions.deny`: append sensitive-path deny entries not already present.
+- `env`: only add `NODE_ENV: test` if no `env` block exists at all (do not add
+  if env block is present — user may have customized it).
+- All other existing keys: preserved unchanged.
+
+**Step 6: scripts/install_pkgs.sh + SessionStart wire-up (Tier 2)**
+
+Detect package manager from audit results (pnpm > yarn > npm > uv/pip > cargo
+> bundler > composer > go, in priority order; if multiple detected, report all
+and ask which to include in the script).
+
+If `scripts/install_pkgs.sh` exists:
+- Inspect for `CLAUDE_CODE_REMOTE` gate. If missing: warn
+  "[setup:claude-web] Warning: scripts/install_pkgs.sh is missing the
+  CLAUDE_CODE_REMOTE gate — it will run on every local session too." Do NOT
+  overwrite. User must fix manually.
+- If gate is present: report "Bootstrap script already exists and has
+  CLAUDE_CODE_REMOTE gate." Skip write.
+
+If `scripts/install_pkgs.sh` does not exist:
+- Show the script that would be written (with detected package manager install
+  command, CLAUDE_CODE_REMOTE gate, explicit `exit 0`).
+- Ask via AskUserQuestion: "Write `scripts/install_pkgs.sh`?" Options:
+  `[Write it]` / `[Skip]`.
+- If written: `chmod +x scripts/install_pkgs.sh` and
+  `git update-index --chmod=+x scripts/install_pkgs.sh` immediately after.
+
+Bootstrap script canonical template:
+```bash
+#!/bin/bash
+# Gate: only run full installs in cloud sessions
+if [ "$CLAUDE_CODE_REMOTE" != "true" ]; then
+  exit 0
+fi
+
+# Detected package manager: [pnpm|yarn|npm|pip|cargo|bundle|composer|go]
+[install command here]
+
+exit 0
+```
+
+The SessionStart hook entry for settings.json (also written in Step 5 if
+triggered):
+```json
+{
+  "type": "command",
+  "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/install_pkgs.sh"
+}
+```
+
+**Step 7: .github/workflows/claude.yml (Tier 2)**
+
+Run only if the repo has a `.github/workflows/` directory (i.e., it already
+uses GitHub Actions).
+
+If any workflow file already contains `anthropics/claude-code-action`: report
+"GitHub Actions workflow with claude-code-action already present. Skipping."
+and skip.
+
+If no such workflow exists: show the minimal template that would be written.
+Ask via AskUserQuestion: "Write `.github/workflows/claude.yml`?" Options:
+`[Write it]` / `[Skip]`.
+
+Template follows the canonical pattern from the research (Part B.8):
+- Triggers: `pull_request` (opened/synchronize/reopened) and `issue_comment`
+  (created, filtered to `@claude` mentions)
+- Permissions: `contents: write`, `pull-requests: write`, `issues: read`
+- Single job with `actions/checkout@v4` + `anthropics/claude-code-action@v1`
+- `ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}`
+- Comment at top: "# Note: Set ANTHROPIC_API_KEY in GitHub repository secrets"
+
+**Step 8: Executable Bits (Tier 1)**
+
+After all writes are complete, check every `*.sh` file referenced in
+`.claude/settings.json` hooks (the now-current version after Step 5):
+
+```bash
+git ls-files --format='%(objectmode) %(path)' -- '*.sh'
+```
+
+For any `.sh` file that is tracked by git but has mode `100644` (not executable):
+run `chmod +x <file>` and `git update-index --chmod=+x <file>`. Report which
+files were fixed.
+
+**Step 9: Summary Output**
+
+Always printed, regardless of what was written or skipped.
+
+```text
+Setup Complete — Claude Code Web Readiness
+==========================================
+
+Files written/modified:
+  [list or "none"]
+
+Env vars to set in cloud environment UI:
+  [list of plugin userConfig keys without defaults, with plugin name]
+  [list of MCP server env var placeholders found in .mcp.json]
+  ANTHROPIC_API_KEY  →  GitHub repository secrets (for claude.yml)
+
+Warnings requiring human review:
+  [CLAUDE.md size warning if applicable]
+  [STDIO MCP server warnings if applicable]
+  [Missing lockfile warnings if applicable]
+  [install_pkgs.sh missing CLAUDE_CODE_REMOTE gate if applicable]
+
+Next steps:
+  1. Set ANTHROPIC_API_KEY as a GitHub repository secret
+  2. Set any listed env vars in the cloud environment UI at claude.ai/code
+  3. Connect the Claude GitHub App (required for Auto-fix)
+  4. Test a cloud session: open claude.ai/code, select this repo
+```
+
+### 5. Idempotency Rules
+
+| Item | Detect | Action if already present |
+|---|---|---|
+| `.gitattributes` lines | `grep -qF` for each required line | Skip that line; append only missing ones |
+| `.gitignore` lines | `grep -qF` for each pattern | Skip that pattern; append only missing ones |
+| `settings.json` hooks.SessionStart | Check for `install_pkgs.sh` in existing hook commands | Skip if already wired; merge if not |
+| `settings.json` permissions.allow | Read existing array | Append only entries not already present |
+| `scripts/install_pkgs.sh` | `[ -f scripts/install_pkgs.sh ]` | Inspect for CLAUDE_CODE_REMOTE gate; never overwrite |
+| `.github/workflows/claude.yml` | `grep -rl 'claude-code-action'` in workflows dir | Skip if any match found |
+| Executable bits | `git ls-files --format='%(objectmode) %(path)'` | Fix only files with mode 100644 |
+
+Re-running the command on a fully configured repo produces: no writes, no
+warnings (other than CLAUDE.md size if applicable), and a "No changes needed"
+summary. This is the idempotency invariant.
+
+### 6. Conflict-Handling Policy
+
+**settings.json with an existing SessionStart hook that does something else:**
+Append a new entry to the `SessionStart` array rather than replacing. The array
+can have multiple hooks. Do not remove or reorder existing hooks. Warn if the
+existing hook uses `set -e` without the recommended workaround (MEMORY.md
+anti-pattern: `set -e` in hooks that must output JSON).
+
+**settings.json with existing permissions.allow entries:**
+Preserve all existing entries. Only append the new ones. Never remove entries
+the user may have added.
+
+**scripts/install_pkgs.sh already exists with different content:**
+Do not overwrite. Inspect and warn about missing CLAUDE_CODE_REMOTE gate if
+absent. Suggest the user review the script and add the gate manually.
+
+**CLAUDE.md is large:**
+Warn only. Never modify. Size reduction requires human judgment about what to
+keep.
+
+**.mcp.json with STDIO servers:**
+Warn with specifics (which server, which command value). Never rewrite. The
+user must decide whether to migrate to HTTP transport, add the binary to the
+bootstrap script, or accept the server won't work in cloud sessions.
+
+**No `.github/workflows/` directory:**
+Skip Step 7 entirely. Do not create the `.github/` directory tree. Only scaffold
+`claude.yml` if GitHub Actions is already in use.
+
+### 7. Naming and Namespace Decisions
+
+| Decision | Choice | Rejected alternatives |
+|---|---|---|
+| Command name | `setup:claude-web` | `setup:web` (ambiguous — could mean web app setup), `setup:remote` (not the term Anthropic uses), `web:setup` (breaks the `setup:` namespace convention) |
+| File location | `plugins/yellow-core/commands/setup/claude-web.md` | New top-level `web/` namespace (unnecessary fragmentation), separate plugin (YAGNI — yellow-core already owns setup:) |
+| `setup:all` delegation name | `setup:claude-web` | — |
+
+### 8. Integration Policy with `setup:all`
+
+**v1: Not integrated into `setup:all`.** Rationale:
+
+`setup:all` checks plugin-specific readiness (credentials, MCP visibility,
+local tool availability). `setup:claude-web` checks *repo-scope* configuration
+for cloud sessions. These are orthogonal concerns: a developer may have all
+plugins configured locally but have a repo that is cloud-unready, or vice versa.
+
+`setup:all` also runs per-user (it checks `~/.claude/settings.json` and tool
+paths). `setup:claude-web` runs per-repo (it writes files to the current git
+worktree). Mixing them would confuse the scope of each.
+
+Deferred to a follow-up: adding a "Cloud readiness" section to `setup:all`'s
+dashboard that reports on the current repo's cloud readiness using the same
+Bash probes from Step 2 of `setup:claude-web` — without invoking the setup
+command. This gives visibility without conflating the two concerns.
+
+### 9. v1 Out-of-Scope
+
+The following items were explicitly scoped out of v1:
+
+- `--target <dir>` argument for targeting a repo other than the CWD
+- Dry-run mode (`--dry-run` flag)
+- Marker file (`.claude/.web-setup-complete` or similar)
+- `claude mcp list` shell-out for user-scope MCP detection (too fragile — `claude`
+  CLI not guaranteed in PATH)
+- Scaffolding `.devcontainer/devcontainer.json` (research confirms: not consumed
+  by web sandbox)
+- Writing `AGENTS.md` or modifying `CLAUDE.md`
+- Docker-in-Docker or submodule detection (empirically unverified behavior)
+- Auto-migrating STDIO MCP servers to HTTP (requires user knowledge of the
+  server's HTTP endpoint)
+- Integration into `setup:all` dashboard
+- Automated testing of the cloud session itself (out of scope for a setup
+  command)
+- Setting `ANTHROPIC_API_KEY` directly (cannot be done from a command; must be
+  done in GitHub UI)
+
+---
+
+## Open Questions
+
+These are questions to validate before or during implementation — they do not
+block writing the command but affect specific behaviors:
+
+1. **Plugin marketplace format in `.claude/settings.json`**: The research (Part
+   B.5) notes that the exact key for plugin marketplace declarations in
+   `.claude/settings.json` (vs. the GitHub Action `plugin_marketplaces` param)
+   is unconfirmed. If `enabledPlugins` without a marketplace URL is insufficient
+   to install plugins in the web sandbox, the Tier 3 plugin audit warning needs
+   to be updated to also check for a marketplace URL. **Resolution:** Test a
+   live cloud session with a `settings.json` that has `enabledPlugins` but no
+   marketplace URL.
+
+2. **`CLAUDE_PROJECT_DIR` vs `$PWD` in hook command path**: The canonical hook
+   pattern from the research uses `"$CLAUDE_PROJECT_DIR"/scripts/install_pkgs.sh`.
+   Confirm this env var is reliably set when SessionStart hooks fire in the web
+   sandbox. MEMORY.md has a warning about unset `CLAUDE_PROJECT_DIR` with a
+   fallback to `$PWD` (from PR #72). The generated hook should include the
+   fallback advisory.
+
+3. **SessionStart hook matcher value**: The research (Part B.2) shows
+   `"matcher": "startup|resume"`. Confirm this is the correct matcher syntax
+   (pipe-separated vs array vs single string). If the matcher is wrong, the
+   hook silently never fires.
+
+4. **`git update-index --chmod=+x` cross-platform behavior**: Verify this works
+   correctly on WSL2 (where most users in this repo author code). This is the
+   safer alternative to relying on `chmod` alone for git-tracked executable bits.
+
+5. **`settings.json` JSON merge strategy**: The command uses Read + Edit (or
+   Read + jq + Write) to merge keys into an existing `settings.json`. Confirm
+   that `jq` is available in the web sandbox (research confirms yes — it is
+   pre-installed). The merge logic itself runs locally (at command invocation
+   time), but if the command is ever invoked from within a web session, jq
+   availability matters.
+
+6. **Tier 1 appends and CRLF**: Per MEMORY.md, files created via the Write
+   tool on WSL2 get CRLF. `.gitattributes` and `.gitignore` are text files
+   where CRLF could cause issues. Use `printf` via Bash for appends (not the
+   Write tool) to avoid CRLF introduction on WSL2.
+
+---
+
+## Implementation Notes for `/workflows:plan`
+
+When turning this into a plan:
+
+- The command body should follow the exact step structure above.
+- Each Tier 2 AskUserQuestion must use the pattern: show what would be
+  written, then ask. The "Cancel/Skip" branch must have an explicit stop
+  instruction (MEMORY.md anti-pattern: missing skip guards).
+- The `install_pkgs.sh` template must use `printf '%s'` for any variable
+  interpolation — never inline substitution in a heredoc (MEMORY.md anti-pattern:
+  heredoc delimiter collision). Use `__EOF_INSTALL_PKGS__` as the delimiter.
+- The settings.json merge must use `jq` with `--argjson` flags, not string
+  interpolation, to avoid producing invalid JSON.
+- After every Write call, the next step should `Read` the written file and verify
+  key fields are present (following chatprd:setup and ci:setup precedent).
+- The audit Bash block (Step 2) MUST be a single call. Do not split into
+  multiple Bash calls; this avoids PATH drift and keeps the command responsive.
+- `pnpm validate:agents` must pass before the PR. Key checks: `description:`
+  is single-line, `allowed-tools:` (not `allowed_tools:`), no `BASH_SOURCE`,
+  uses `${CLAUDE_PLUGIN_ROOT}` for any plugin-local file references, no
+  CRLF line endings.
+- A `pnpm changeset` is required before the PR (minor bump for yellow-core —
+  additive new command).

--- a/docs/research/how-claude-code-web-works-and-repository.md
+++ b/docs/research/how-claude-code-web-works-and-repository.md
@@ -1,0 +1,583 @@
+# Claude Code Web: How It Works and How to Configure Repositories for It
+
+**Date:** 2026-05-18
+**Sources:** code.claude.com/docs (official, multiple pages), docs.anthropic.com, EXA deep research (exa-research-pro), Perplexity deep research (sonar), Tavily pro research
+
+---
+
+## TL;DR
+
+- **Ephemeral Ubuntu 24.04 VMs, fresh clone per session.** Each run gets 4 vCPUs / 16 GB RAM / ~30 GB disk. Sessions are isolated per task; anything not committed to git is gone when the session ends. A filesystem snapshot cache from a setup script survives ~7 days before it is rebuilt.
+- **Everything the web agent can use must live in the repository.** User-level configs (`~/.claude/settings.json`, `~/.claude/CLAUDE.md`, `claude mcp add` entries that wrote to `~/.claude.json`) are not accessible. Project-committed files — `.mcp.json`, `.claude/settings.json`, `.claude/rules/`, `agents/`, `skills/`, `commands/` — are all loaded. Plugins declared in the repo's `.claude/settings.json` are installed at session start.
+- **STDIO MCP servers do not work in the web sandbox.** Only HTTP and SSE (Streamable HTTP) transports are reachable. Any MCP server wired via `claude mcp add --transport stdio` that only wrote to the user scope will not be available.
+- **No dedicated secrets store yet.** Secrets are set as environment variables in the cloud environment UI (per environment, not per repo). Interactive auth (AWS SSO, browser OAuth flows) cannot run in the sandbox. For CI via GitHub Actions, `ANTHROPIC_API_KEY` goes into GitHub repository secrets.
+- **A `setup:claude-web` command should focus on four things:** scaffolding `.claude/settings.json` with a `SessionStart` hook pointing to a bootstrap script; writing an idempotent `scripts/install_pkgs.sh` gated on `CLAUDE_CODE_REMOTE=true`; auditing `.mcp.json` for STDIO-only servers; and ensuring plugins and their required env vars are declared at project scope.
+- **Many important details are confirmed by official docs; a short list of specifics require empirical testing** — notably the exact byte-level CLAUDE.md size limit, whether docker-in-docker actually works end-to-end, and the precise behavior of branch protection rules with Auto-fix.
+
+---
+
+## Part A — How Claude Code Web Actually Works
+
+### A.1 Product Surface and Access Model
+
+Claude Code Web is the browser-hosted execution surface for Claude Code, accessible at `https://claude.ai/code`. As of May 2026 it is available to users on **Claude Pro, Max, Team, and Enterprise** plans (Enterprise requires premium or Chat + Claude Code seats). The agent can be invoked:
+
+- Directly from the browser at `claude.ai/code`
+- Via the local CLI with `claude --remote` to push a task to a cloud session
+- Via the `/schedule` command for periodic tasks
+- Via the mobile app (iOS/Android) to monitor and review running sessions
+- Via the GitHub Actions workflow using `anthropics/claude-code-action`
+
+**GitHub authentication** is established via one of two paths — the **Claude GitHub App** (recommended for teams, required for Auto-fix) or the **`/web-setup` command** which syncs a local `gh` CLI token to the account. Both grant access to all repositories the linked GitHub account can see; access is constrained by GitHub team/repo membership, not by a separate Claude-level allowlist. Team and Enterprise admins can disable `/web-setup` in `claude.ai/admin-settings/claude-code`. Organizations with Zero Data Retention enabled cannot use cloud session features at all.
+
+Sources: [code.claude.com/docs/en/claude-code-on-the-web](https://code.claude.com/docs/en/claude-code-on-the-web), [code.claude.com/docs/en/web-quickstart](https://code.claude.com/docs/en/web-quickstart)
+
+---
+
+### A.2 Execution Environment
+
+Each cloud session runs in a **fresh Anthropic-managed VM** provisioned on demand. Key specs confirmed by official docs:
+
+| Property | Value |
+|---|---|
+| OS | Ubuntu 24.04 |
+| vCPUs | 4 |
+| RAM | 16 GB |
+| Disk | ~30 GB ephemeral |
+| Session inactivity timeout | Session terminates; conversation history restored on reopen |
+| Setup script timeout | **5 minutes** — if exceeded, cache build fails |
+
+**Pre-installed tooling** (official docs, `code.claude.com/docs/en/claude-code-on-the-web`):
+
+- Python 3.x: pip, poetry, uv, black, mypy, pytest, ruff
+- Node.js 20, 21, 22 via nvm: npm, yarn, pnpm, bun, eslint, prettier
+- Ruby 3.1–3.3 with gem and rbenv
+- PHP 8.4 with Composer
+- OpenJDK 21 with Maven and Gradle
+- Go (latest stable), Rust (cargo), GCC, Clang, cmake, ninja, conan
+- Docker, dockerd, docker compose (available but with known limitations — Docker-in-Docker behavior in the sandbox is not fully documented; community reports note partial functionality)
+- PostgreSQL 16 and Redis 7 (pre-installed, not running by default — must be started via hook or instruction)
+- git, jq, yq, ripgrep, tmux, vim, nano
+
+**Ephemeral model:** The VM is provisioned fresh per session. A session "persists" in the sense that the conversation transcript and the repository state (via git commits) survive; the running processes, installed packages (unless cached), and any in-memory state do not.
+
+**Caching:** When a cloud environment's setup script runs successfully, Anthropic snapshots the filesystem. Subsequent sessions start from this snapshot rather than re-running the script. The cache expires after ~7 days, or when the setup script or allowed network hosts change.
+
+---
+
+### A.3 Repo Connection Model
+
+- Cloud sessions perform a **fresh `git clone`** of the repository at session start.
+- Authentication for the clone goes through **an Anthropic-hosted GitHub proxy** — the git credential never lives inside the VM. Inside the sandbox, git authenticates with a scoped, short-lived credential; the proxy translates it to the user's actual GitHub token.
+- Access scope: any repository visible to the connected GitHub account.
+- **Monorepo limitation (confirmed, open GitHub issue #23627):** The platform assumes one session = one repository = one branch = one PR. Subdirectory targeting within a monorepo is not natively supported. The `--add-dir` flag can grant access to additional directories, but CLAUDE.md files from those directories do not load by default without `CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1`.
+- Non-GitHub remotes (GitLab, Bitbucket) can be sent as a local bundle (`< 100 MB` constraint) but the session cannot push back without GitHub authentication.
+- Self-hosted GitHub Enterprise Server is supported for Team and Enterprise plans.
+
+Sources: [code.claude.com/docs/en/claude-code-on-the-web](https://code.claude.com/docs/en/claude-code-on-the-web), GitHub issue [#23627](https://github.com/anthropics/claude-code/issues/23627)
+
+---
+
+### A.4 Git / Branch / PR Flow
+
+Claude Code Web integrates native GitHub tools that route through Anthropic's GitHub proxy:
+
+- **Commits** are authored under the connected GitHub identity. The agent stages changes, writes commit messages, creates branches, and pushes.
+- **PRs** are opened via the GitHub App token; PR descriptions are generated from commit context. Teams can specify conventions (Conventional Commits, naming patterns) in CLAUDE.md.
+- **Auto-fix:** When enabled (requires GitHub App, not just `/web-setup`), Claude subscribes to PR webhooks. On CI failure or review comment, it investigates and pushes a fix if one is unambiguous. Architecturally significant comments trigger a confirmation ask rather than an automatic push.
+- **Branch protection:** The platform respects GitHub branch protection rules; it cannot bypass them. Known limitation: branch protection rules using wildcard patterns are incompatible with GitHub merge queues (GitHub community issue [#154383](https://github.com/orgs/community/discussions/154383)).
+- **`GH_TOKEN` env var:** For advanced `gh` CLI commands (beyond what the built-in GitHub tools cover), set `GH_TOKEN` as an environment variable in the cloud environment UI.
+
+---
+
+### A.5 Network and Secrets Posture
+
+**Network access levels** (configured per cloud environment in the UI):
+
+| Level | Behavior |
+|---|---|
+| `None` | No outbound network except Anthropic API |
+| `Trusted` (default) | Package registries (npm, PyPI, RubyGems, crates.io, Docker Hub, ghcr.io), Anthropic services, major cloud platforms |
+| `Custom` | User-defined allowlist, supports `*.subdomain.example.com` wildcards |
+| `Full` | Any domain |
+
+GitHub operations use a separate proxy independent of the network access level setting. MCP connector traffic routes through Anthropic's servers, so enabled connectors work without being added to the allowed domains list.
+
+**Secrets:** There is **no dedicated secrets store** as of May 2026. Environment variables are set per cloud environment in the UI (not per-repo; per-environment). They are visible to anyone with edit access to the environment. What is explicitly not supported: interactive auth (AWS SSO, browser-based OAuth), `~/.aws/credentials`, anything in the user's local filesystem. For CI runs, `ANTHROPIC_API_KEY` is stored as a GitHub repository secret.
+
+Sources: [code.claude.com/docs/en/claude-code-on-the-web](https://code.claude.com/docs/en/claude-code-on-the-web), [code.claude.com/docs/en/security](https://code.claude.com/docs/en/security)
+
+---
+
+### A.6 MCP Servers in the Web Sandbox
+
+**Confirmed from official docs (code.claude.com/docs/en/claude-code-on-the-web):**
+
+> MCP servers you added with `claude mcp add` — **No.** Those write to your local user config, not the repo. Declare the server in `.mcp.json` instead.
+
+**Transport support in the web sandbox:**
+- HTTP (Streamable HTTP) — supported
+- SSE — supported (deprecated but still functional; prefer HTTP)
+- **STDIO — NOT supported in the web sandbox.** STDIO servers require a locally spawned process, which cannot run inside the cloud VM without the binary being available and being declared in `.mcp.json` with an executable command.
+
+Caveat: STDIO servers *can* technically be declared in `.mcp.json` with a `command:` entry if the binary is pre-installed in the cloud environment (e.g., `npx`, `python`, `node`). What doesn't work is connecting to a process running on the developer's local machine. The official MCP connector docs at `platform.claude.com/docs/en/agents-and-tools/mcp-connector` state: "The server must be publicly exposed through HTTP. Local STDIO servers cannot be connected directly."
+
+MCP servers from user scope (`~/.claude.json`, added via `claude mcp add` without `--scope project`) are not available in the web sandbox. Only project-scope entries in the committed `.mcp.json` are loaded.
+
+---
+
+### A.7 Plugins in the Web Sandbox
+
+**Confirmed availability table from official docs:**
+
+| Config | Available in web? | Reason |
+|---|---|---|
+| Repo's `CLAUDE.md` | Yes | Part of the clone |
+| Repo's `.claude/settings.json` hooks | Yes | Part of the clone |
+| Repo's `.mcp.json` MCP servers | Yes | Part of the clone |
+| Repo's `.claude/rules/`, `skills/`, `agents/`, `commands/` | Yes | Part of the clone |
+| Plugins declared in `.claude/settings.json` | Yes | Installed at session start from declared marketplace. Requires network access to marketplace source. |
+| User's `~/.claude/CLAUDE.md` | No | Lives on local machine |
+| Plugins in `~/.claude/settings.json` (`enabledPlugins`) | No | User-scoped; not in repo |
+
+**UserConfig / API keys for plugins:** Since there is no dedicated secrets store, plugin userConfig values (e.g., API keys) must be provided as environment variables in the cloud environment UI. Plugins that require interactive OAuth or browser-based configuration cannot be provisioned in the web sandbox. For repos using `yellow-research` or similar plugins that need API keys, those keys must be pre-set in the cloud environment's environment variables.
+
+---
+
+### A.8 Failure Modes Specific to the Web Sandbox
+
+These are confirmed or commonly reported failure modes that do not typically occur in local CLI usage:
+
+1. **Setup script timeout:** Script must complete in under 5 minutes. Large or slow installs that run serially will time out, leaving the cache unbuilt. Every subsequent session incurs the full install cost until the script is fixed.
+2. **Missing `CLAUDE_CODE_REMOTE` gate:** Bootstrap scripts that run unconditionally will execute on every local session too. Always gate with `if [ "$CLAUDE_CODE_REMOTE" != "true" ]; then exit 0; fi`.
+3. **STDIO MCP server silently missing:** An MCP server declared only in user scope or using a binary not available in the sandbox will fail to connect. The agent proceeds without that server, and the failure may not be obvious unless `/mcp` is checked.
+4. **Plugin install network failure:** Plugins from a marketplace require the marketplace host to be reachable. If network access is set to `None` or the marketplace domain isn't in the trusted list, plugin install silently fails.
+5. **User settings not loaded:** Anything in `~/.claude/settings.json` (including `enabledPlugins`) is absent. This is the single most common misconfiguration when a setup that works locally fails in the web sandbox.
+6. **Interactive auth blocked:** AWS SSO, GitHub OAuth device flow, and any other browser-redirect auth cannot complete in the sandbox. The call either hangs or errors.
+7. **Session expiry loses ephemeral state:** If the session times out before changes are committed, all non-git state is lost. Resumed sessions restore conversation history but start a fresh VM.
+8. **Large repo clone timeout:** Very large repositories can time out during the initial clone. Community workaround: use `.gitignore`/`.claudeignore` to reduce what is accessible to the agent, and keep binary assets in external storage.
+9. **CRLF line endings in shell scripts:** WSL2-authored scripts committed with CRLF will fail with `bad interpreter` errors in the Ubuntu-based sandbox.
+10. **`host_not_allowed` errors:** Outbound calls to hosts not in the trusted/allowed list return `x-deny-reason: host_not_allowed`. Common with private registries, internal APIs, or niche package sources.
+11. **Context window overflow from large CLAUDE.md:** The first 200 lines (or 25 KB, whichever comes first) of `MEMORY.md` applies analogously to CLAUDE.md in practice. Excessively large CLAUDE.md files consume context headroom on every session. No official hard byte limit is documented; community guidance treats 200 lines as the threshold.
+
+Sources: [code.claude.com/docs/en/errors](https://code.claude.com/docs/en/errors), [code.claude.com/docs/en/web-quickstart](https://code.claude.com/docs/en/web-quickstart), GitHub issues #29885, #29515, community reports.
+
+---
+
+## Part B — How to Configure a Repository for Claude Code Web
+
+### B.1 CLAUDE.md and AGENTS.md
+
+**What to include for cloud agent use:**
+
+- Keep CLAUDE.md **under ~200 lines** (official recommendation). The file is loaded at every session start; oversized files eat context budget immediately.
+- Add an explicit **"Bootstrap"** or **"Environment setup"** section that tells the agent where its setup script is and what it does. The web agent cannot interactively ask you where to find things.
+- Add a **"Cloud-session notes"** section documenting which env vars are needed (names, not values) and where they should be set (cloud environment UI), which plugins are required, and which MCP servers are available in the web sandbox vs. local-only.
+- If your project has a monorepo structure, add explicit path-based guidance since monorepo navigation is not natively scoped. Use `.claude/rules/` path-scoped files for per-subdirectory conventions rather than putting everything in root CLAUDE.md.
+- **Do not include** secrets, tokens, or local machine paths. Do not use YAML folded scalars in frontmatter; do not include instructions that assume an interactive user is present (e.g., "press enter to confirm").
+
+**AGENTS.md:** Not a Claude Code Web-specific file; this is a project-convention file. Include it if your repo defines agent authoring rules (as `yellow-plugins` does). The web agent will load it as part of the clone.
+
+---
+
+### B.2 Setup / Bootstrap Scripts
+
+**Two mechanisms, different scopes:**
+
+| | Setup scripts | SessionStart hooks |
+|---|---|---|
+| Configured in | Cloud environment UI | `.claude/settings.json` in repo |
+| Runs | Before Claude Code launches; only when no cached environment is available | After Claude Code launches; on every session including resumed |
+| Can install OS packages | Yes (`apt install`) — root access | No — user-space only |
+| Cached | Yes (~7 days) | No — runs every session (keep fast) |
+| Available locally | No — cloud only | Yes — also runs on local CLI |
+
+**Recommended pattern:** Use a **SessionStart hook** pointing to a script in the repo for dependency installation (npm/pip/cargo/etc.). Use a cloud environment **setup script** (configured in the UI, not committed) for OS-level package installs.
+
+**Canonical file name and location:** No single mandated name. Official docs use `scripts/install_pkgs.sh`. Commit it to the repo, reference it from `.claude/settings.json`.
+
+**SessionStart hook structure (from official docs):**
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/install_pkgs.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Bootstrap script canonical pattern:**
+
+```bash
+#!/bin/bash
+# Gate: only run full installs in cloud sessions
+if [ "$CLAUDE_CODE_REMOTE" != "true" ]; then
+  exit 0
+fi
+
+npm ci
+pip install -r requirements.txt
+exit 0
+```
+
+Key rules:
+- Always gate on `CLAUDE_CODE_REMOTE=true`
+- Always `exit 0` explicitly on all paths (SessionStart must output `{"continue": true}` — the command type does this automatically, but a non-zero exit will block the session)
+- Use `npm ci` not `npm install` for reproducibility
+- Keep the script under 5 minutes total runtime
+- Run independent installs in parallel with `&` + `wait` if the script is slow
+
+Source: [code.claude.com/docs/en/claude-code-on-the-web](https://code.claude.com/docs/en/claude-code-on-the-web), [code.claude.com/docs/en/hooks](https://code.claude.com/docs/en/hooks)
+
+---
+
+### B.3 Dev Container / Environment Hints
+
+**What Claude Code Web actually consumes:**
+
+| File | Consumed by web agent? | Notes |
+|---|---|---|
+| `.claude/settings.json` | Yes | Loaded at session start |
+| `.mcp.json` | Yes | Project-scope MCP servers |
+| `CLAUDE.md` | Yes | Loaded at session start |
+| `.claude/rules/`, `agents/`, `skills/`, `commands/` | Yes | Loaded per-scope |
+| `.devcontainer/devcontainer.json` | **Not confirmed** | Potentially consumed for environment hints, but no official doc confirms the web agent reads devcontainer.json. Community sources treat it as local-dev-only. |
+| `.github/workflows/*` | Not directly | The agent can read them as code; CI is not auto-triggered by the agent reading workflow files |
+| `Dockerfile` | Not consumed | Not used to provision the sandbox |
+| `mise.toml`, `.tool-versions`, `.nvmrc`, `.node-version` | Not confirmed as auto-read | Version managers may need explicit invocation in bootstrap |
+| `package.json#engines` | Not consumed by sandbox provisioning | |
+| `.gitattributes` | Respected by git clone | Affects line ending handling |
+
+**Practical implication:** The `devcontainer.json` file is useful for **local developer onboarding** and to document the intended environment (especially `containerEnv` variables), but it does not provision the web sandbox. The web sandbox OS and tooling come from Anthropic's base image. Customization goes through the cloud environment UI's setup script (OS packages) and the repo's SessionStart hook (language packages).
+
+---
+
+### B.4 Settings and Permissions
+
+**`.claude/settings.json` keys that matter most in the web sandbox:**
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run lint)",
+      "Bash(npm test)",
+      "Bash(pnpm validate:schemas)"
+    ],
+    "deny": [
+      "Read(**/.ssh/**)",
+      "Read(**/.aws/**)"
+    ]
+  },
+  "env": {
+    "NODE_ENV": "test"
+  },
+  "hooks": {
+    "SessionStart": [...]
+  }
+}
+```
+
+**Cloud-specific considerations:**
+
+- **`permissions.allow` is critical for unattended runs.** In interactive local use, the agent can ask for approval. In the web sandbox (especially when triggered by `/schedule` or Auto-fix), no human is available to respond to permission prompts. Pre-approve all Bash commands the agent needs to run.
+- **`permissions.deny` for sensitive paths.** The web sandbox clones the full repo; if `.env` files or secret files end up committed (they shouldn't, but defense in depth matters), deny rules prevent them from being read.
+- **`env` for non-secret variables.** Safe to commit non-sensitive env vars (e.g., `NODE_ENV`, `LOG_LEVEL`) here. Never commit secret values.
+- **User-scope settings are ignored.** `~/.claude/settings.json` and `settings.local.json` do not exist in the web sandbox.
+
+Source: [code.claude.com/docs/en/settings](https://code.claude.com/docs/en/settings), [code.claude.com/docs/en/claude-code-on-the-web](https://code.claude.com/docs/en/claude-code-on-the-web)
+
+---
+
+### B.5 Plugin / Marketplace Declaration
+
+**From official docs:** Plugins are declared in the repo's `.claude/settings.json` under `enabledPlugins` (not in user settings). They are installed at session start from the declared marketplace, requiring network access to the marketplace source.
+
+The `yellow-plugins` repo's `.claude-plugin/marketplace.json` is the source-of-truth for plugins distributed from this repo, but for a *consuming* repo, plugins are declared as:
+
+```json
+{
+  "enabledPlugins": ["plugin-name-1", "plugin-name-2"]
+}
+```
+
+with a corresponding marketplace declaration pointing to the plugin source. The exact key and format for `plugin_marketplaces` as used in the GitHub Action is documented at [code.claude.com/docs/en/github-actions](https://code.claude.com/docs/en/github-actions).
+
+**`CLAUDE_CODE_PLUGIN_SEED_DIR`:** For CI or containerized environments, set this env var to a directory containing a pre-populated plugins directory, so Claude Code starts with plugins already available without cloning them at runtime.
+
+**UserConfig / API keys for plugins:** No automatic injection. Each plugin that needs an API key requires that key to be set as an environment variable in the cloud environment UI. The setup command should detect what userConfig keys each enabled plugin needs and emit a warning listing which env vars must be pre-configured.
+
+---
+
+### B.6 MCP Server Declarations
+
+**Where to declare for web agent access:** `.mcp.json` at the repository root, committed to version control.
+
+**Format:**
+
+```json
+{
+  "mcpServers": {
+    "my-http-server": {
+      "type": "http",
+      "url": "${MCP_SERVER_URL}",
+      "headers": {
+        "Authorization": "Bearer ${MCP_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+**Scope hierarchy:** local > project > user. In the web sandbox, only project-scope (`.mcp.json`) is available.
+
+**What works / what doesn't:**
+
+| Transport | Works in web sandbox? |
+|---|---|
+| `type: http` (Streamable HTTP) | Yes |
+| `type: sse` | Yes (deprecated but functional) |
+| `type: stdio` with `command: "npx ..."` where `npx` is pre-installed | **Conditional** — the binary must be available in the sandbox. Works for Node-based servers, may work for Python-based servers. Does NOT work for servers that require native binaries not pre-installed. |
+| `type: stdio` pointing to local machine process | No |
+| User-scope servers (`~/.claude.json`) | No |
+
+**`${VAR}` expansion** is supported in `.mcp.json` for `command`, `args`, `env`, `url`, and `headers` fields. Use this pattern to avoid committing credentials.
+
+Source: [code.claude.com/docs/en/mcp](https://code.claude.com/docs/en/mcp), [code.claude.com/docs/en/claude-code-on-the-web](https://code.claude.com/docs/en/claude-code-on-the-web)
+
+---
+
+### B.7 Secrets / Env Vars
+
+**Recommended patterns:**
+
+| Secret type | Where to put it |
+|---|---|
+| `ANTHROPIC_API_KEY` (CI/Actions) | GitHub repository secret |
+| Plugin API keys, MCP server tokens | Cloud environment UI (env vars) |
+| Non-secret env vars | `.claude/settings.json` `env` block (committed) |
+| Personal/local overrides | `.claude/settings.local.json` (gitignored) |
+| Long-lived API keys for cloud agent | Cloud environment UI — no other option currently |
+
+**`.claude/settings.local.json`** should be in `.gitignore`. It is never loaded in the web sandbox.
+
+**`CLAUDE_ENV_FILE`:** Available in SessionStart and Setup hooks. Write `export KEY=value` lines to `$CLAUDE_ENV_FILE` from a hook script to persist environment variables into the Claude process environment for the remainder of the session.
+
+**What to add to `.gitignore`:** `.env`, `.env.local`, `.env.*`, `*.pem`, `*.key`, `.aws/`, `.ssh/`, `secrets/`, `credentials/`. Community security research ([knostic.ai](https://knostic.ai/blog/claude-loads-secrets-without-permission)) has shown Claude Code reads `.env` files by default unless blocked — add `permissions.deny` entries for these paths as defense in depth.
+
+---
+
+### B.8 CI Integration
+
+**Canonical file:** `.github/workflows/claude.yml`
+
+**Official action:** `anthropics/claude-code-action@v1`
+
+**Required parameters:** `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}`
+
+**Minimal workflow pattern:**
+
+```yaml
+name: Claude Code
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+
+jobs:
+  claude:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+**Auto-fix pattern:** Requires the Claude GitHub App installed (not just `/web-setup`). When Auto-fix is active, the web agent monitors the PR for CI failures and review comments and pushes fixes automatically. No workflow file change is needed to enable Auto-fix — it is activated from the session or via `/autofix-pr` on the branch.
+
+**CI interaction from the agent:** The agent can read CI status via the GitHub API and respond to failures. It does not trigger CI directly — CI triggers from git pushes as normal.
+
+Source: [code.claude.com/docs/en/github-actions](https://code.claude.com/docs/en/github-actions)
+
+---
+
+### B.9 Repo Hygiene That Matters More in the Cloud
+
+- **LF line endings.** The sandbox is Ubuntu 24.04. Shell scripts with CRLF produce `bad interpreter` errors. Ensure `.gitattributes` sets `* text=auto` and `*.sh eol=lf`. This matters more in the cloud than locally because WSL2 is a common authoring environment that silently introduces CRLF.
+- **`.gitignore` coverage.** The full repo is cloned. Anything committed is accessible to the agent. Sensitive files that are present but gitignored on the developer's machine are not in the clone — but files accidentally committed are.
+- **Lockfile consistency.** The bootstrap script uses `npm ci` (not `npm install`) to respect lockfiles. Missing or stale lockfiles (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `uv.lock`, `Cargo.lock`) cause non-reproducible installs. Ensure lockfiles are committed.
+- **Large binary files.** Large assets in the repo slow down or time out the initial clone. Use Git LFS or external storage. There is no built-in Git LFS support documented for the web sandbox — if your repo uses LFS, verify it works; this is an empirical question.
+- **Submodules.** Not specifically documented for the web sandbox. Treat as high-risk; test empirically.
+- **Executable bits on scripts.** Scripts called via SessionStart hooks must be executable (`chmod +x`). Since git preserves executable bits, set them before committing.
+- **CLAUDE.md size.** No documented hard limit in bytes, but the "~200 lines" recommendation is official. Large CLAUDE.md files degrade session quality by consuming context budget.
+
+---
+
+## Part C — Design Implications for a `setup:claude-web` Command
+
+Below is a concrete checklist of checks the command should run, with detection logic, what to write/modify if missing, and idempotency strategy. Items are marked **[CONFIRMED]** (backed by official docs), **[COMMUNITY]** (backed by community sources), or **[ASSUMPTION]** (logical inference, needs empirical validation).
+
+---
+
+### C.1 `.claude/settings.json` — Permissions and Hooks
+
+- **Detect:** Does `.claude/settings.json` exist? Does it have a `permissions.allow` block? Does it have a `hooks.SessionStart` entry?
+- **Write if missing:** Scaffold a minimum-viable `settings.json` with an empty `permissions.allow` list and a commented-out SessionStart hook template.
+- **Idempotency:** Read and merge — do not overwrite existing keys. Use a JSON merge strategy.
+- **[CONFIRMED]**
+
+---
+
+### C.2 Bootstrap Script — Detect Package Manager and Write `scripts/install_pkgs.sh`
+
+- **Detect:** Presence of lockfiles in repo root:
+  - `pnpm-lock.yaml` → pnpm (`pnpm install --frozen-lockfile`)
+  - `yarn.lock` → yarn (`yarn install --frozen-lockfile`)
+  - `package-lock.json` → npm (`npm ci`)
+  - `uv.lock` or `requirements.txt` → Python (`uv sync` or `pip install -r requirements.txt`)
+  - `Cargo.lock` → Rust (`cargo build`)
+  - `Gemfile.lock` → Ruby (`bundle install`)
+  - `composer.lock` → PHP (`composer install --no-interaction`)
+  - `go.sum` → Go (`go mod download`)
+- **Write if missing:** `scripts/install_pkgs.sh` gated on `CLAUDE_CODE_REMOTE=true`, using the detected package manager. Always `chmod +x`.
+- **Wire into `.claude/settings.json`:** Add or update the `SessionStart` hook to call `"$CLAUDE_PROJECT_DIR"/scripts/install_pkgs.sh`.
+- **Idempotency:** Check if `scripts/install_pkgs.sh` already exists; if so, inspect it for the `CLAUDE_CODE_REMOTE` gate and warn if missing. Don't overwrite a user-customized script.
+- **[CONFIRMED]**
+
+---
+
+### C.3 MCP Servers — Audit `.mcp.json` for Sandbox Incompatibility
+
+- **Detect:** Does `.mcp.json` exist? For each entry, check `type`:
+  - `"stdio"` with `command` pointing to a binary not in the pre-installed tooling list → warn: "this MCP server uses stdio transport with a binary that may not be available in the web sandbox"
+  - `"stdio"` with `command: "npx"` or `command: "python"` → note: "may work if the package is installable; add package install to scripts/install_pkgs.sh"
+  - User-scope servers (not in `.mcp.json`, but detectable via `claude mcp list` output or `~/.claude.json`) → warn: "these servers are not available in the web sandbox; move them to `.mcp.json` with project scope if needed"
+- **Write if missing:** If no `.mcp.json` exists and the user has user-scope MCP servers they want in the web agent, scaffold a template `.mcp.json` with `${VAR}` placeholders.
+- **Idempotency:** Only append new entries; never remove existing ones.
+- **[CONFIRMED for transport rules, ASSUMPTION for binary detection logic]**
+
+---
+
+### C.4 Plugins — Audit `enabledPlugins` and Warn About Missing Env Vars
+
+- **Detect:** Is `enabledPlugins` in `.claude/settings.json`? (Note: may also be `~/.claude/settings.json` for user-local-only plugins.) For each enabled plugin, check its `plugin.json` for `userConfig` entries that have no `default` value.
+- **If user-scope only:** Warn that these plugins won't load in the web sandbox; suggest moving the declaration to `.claude/settings.json`.
+- **For each required `userConfig` key without a default:** Emit a warning listing the env var name the user must configure in the cloud environment UI.
+- **[CONFIRMED for the "user-scope not available" rule; ASSUMPTION for the userConfig env-var-name mapping]**
+
+---
+
+### C.5 `.github/workflows/claude.yml` — CI Integration
+
+- **Detect:** Does `.github/workflows/claude.yml` exist (or any workflow using `anthropics/claude-code-action`)?
+- **Write if missing and repo has GitHub Actions workflows:** Scaffold a minimal `claude.yml` using `anthropics/claude-code-action@v1`. Include a comment noting `ANTHROPIC_API_KEY` must be set as a repository secret.
+- **Idempotency:** Don't overwrite an existing workflow. If a workflow exists but doesn't use `anthropics/claude-code-action`, note it and skip.
+- **[CONFIRMED for the action and its required parameters]**
+
+---
+
+### C.6 `.gitattributes` — LF Line Endings
+
+- **Detect:** Does `.gitattributes` exist? Does it contain `* text=auto` and `*.sh eol=lf`?
+- **Write if missing:** Add minimum entries. If file exists but missing shell script rule, append.
+- **Idempotency:** Check before appending; never duplicate lines.
+- **[COMMUNITY + confirmed WSL2 behavior in this repo]**
+
+---
+
+### C.7 CLAUDE.md Size Check
+
+- **Detect:** Count lines in `CLAUDE.md`. Count bytes.
+- **Warn if:** > 200 lines or > 25 KB (conservative threshold; no official byte limit is documented).
+- **Do not modify** — size reduction requires human judgment.
+- **[COMMUNITY for the 200-line recommendation; ASSUMPTION for 25 KB byte threshold]**
+
+---
+
+### C.8 `.gitignore` — Sensitive File Coverage
+
+- **Detect:** Is `.gitignore` present? Does it cover: `.env`, `.env.*`, `.env.local`, `*.pem`, `*.key`, `.aws/`, `.ssh/`, `secrets/`?
+- **Write if missing:** Add missing patterns.
+- **Also emit:** Suggest adding `permissions.deny` entries to `.claude/settings.json` for the same paths as defense-in-depth.
+- **[COMMUNITY — community security research; official docs recommend deny rules for sensitive paths]**
+
+---
+
+### C.9 Script Executable Bits
+
+- **Detect:** For every `*.sh` file referenced in `.claude/settings.json` hooks, check if it has executable bit set (via `git ls-files --format='%(objectmode) %(path)'`).
+- **Fix:** `chmod +x` + re-add to git index if executable bit is missing.
+- **[ASSUMPTION — inferred from how SessionStart hooks invoke scripts; no explicit official guidance on this]**
+
+---
+
+### C.10 Lockfile Consistency
+
+- **Detect:** If a package manager was detected (step C.2), does its lockfile exist and is it tracked by git?
+- **Warn if:** `package.json` exists but no lockfile, or lockfile is in `.gitignore`.
+- **[CONFIRMED as best practice; implied by `npm ci` usage in official docs]**
+
+---
+
+### C.11 Summary Output
+
+The command should emit:
+1. A list of files created/modified
+2. A list of env vars that must be manually configured in the cloud environment UI (with plugin/MCP server names)
+3. A list of warnings for items that need human review (large CLAUDE.md, STDIO MCP servers with unknown binaries, etc.)
+4. A "Next steps" block with: link to cloud environment setup UI, instruction to install Claude GitHub App if not done, instruction to set `ANTHROPIC_API_KEY` as a GitHub secret
+
+---
+
+## Open Questions / What to Verify Empirically
+
+| Question | Risk | How to Verify |
+|---|---|---|
+| Does `.devcontainer/devcontainer.json` affect the web sandbox environment in any way? | Low-medium — if yes, we're missing a configuration point | Create a test repo with a devcontainer; inspect the sandbox environment variables |
+| What is the exact CLAUDE.md byte limit before context degradation is measurable? | Medium | Run sessions with CLAUDE.md at 5K, 10K, 25K bytes; measure effective context |
+| Do STDIO MCP servers with `command: "npx"` reliably work in the sandbox if the package is npm-installable? | High — this affects many community MCP servers | Test `npx -y @modelcontextprotocol/server-filesystem` in a live web session |
+| Does Docker-in-Docker work end-to-end (not just docker CLI available, but dockerd actually running)? | High — many repos use `docker compose up` in their dev flow | Run a `docker compose up` from a SessionStart hook; check if the daemon is accessible |
+| Does Git LFS work in the web sandbox clone? | Medium | Clone a repo with LFS assets; check whether they are available |
+| How do submodules behave during the fresh clone? | Medium | Clone a repo with submodules and verify recursive initialization |
+| What is the exact format for declaring plugin marketplaces in `.claude/settings.json` (vs. the GitHub Action `plugin_marketplaces` param)? | High for `setup:claude-web` correctness | Read a live session's settings with `/status`; inspect what keys are honored |
+| Can the `CLAUDE_CODE_PLUGIN_SEED_DIR` approach be used in the web sandbox environment (i.e., is it settable in the cloud env UI)? | Medium | Set the variable in the cloud env UI and verify plugin pre-population |
+| When a setup script times out, does the session start with no packages at all, or with partial state? | High for debugging | Let a slow script run past 5 minutes; observe session state |
+
+---
+
+## Sources
+
+- [Use Claude Code on the web](https://code.claude.com/docs/en/claude-code-on-the-web) — primary reference for execution environment, availability table, SessionStart hooks, network access, secrets posture. Official Anthropic docs (2025–2026).
+- [Hooks reference](https://code.claude.com/docs/en/hooks) — SessionStart event definition, matcher values, `CLAUDE_ENV_FILE`, hook types. Official Anthropic docs.
+- [MCP — Connect to tools](https://code.claude.com/docs/en/mcp) — `.mcp.json` format, scope hierarchy, transport types, `${VAR}` expansion. Official Anthropic docs.
+- [Settings](https://code.claude.com/docs/en/settings) — `permissions.allow/deny`, `env`, hooks structure, settings precedence. Official Anthropic docs.
+- [Security](https://code.claude.com/docs/en/security) — credential protection, proxy architecture, deny patterns for sensitive files. Official Anthropic docs.
+- [GitHub Actions](https://code.claude.com/docs/en/github-actions) — `claude-code-action@v1` parameters, required secrets, permissions. Official Anthropic docs.
+- [Web quickstart](https://code.claude.com/docs/en/web-quickstart) — troubleshooting setup failures, session management. Official Anthropic docs.
+- [Plugin marketplaces](https://code.claude.com/docs/en/plugin-marketplaces) — marketplace configuration, `CLAUDE_CODE_PLUGIN_SEED_DIR`, restriction policies. Official Anthropic docs.
+- [Errors reference](https://code.claude.com/docs/en/errors) — `host_not_allowed`, session expiry patterns. Official Anthropic docs.
+- [MCP connector (platform)](https://platform.claude.com/docs/en/agents-and-tools/mcp-connector) — HTTP-only constraint for remote MCP. Official Anthropic platform docs.
+- [GitHub issue #23627](https://github.com/anthropics/claude-code/issues/23627) — monorepo one-session-one-repo limitation. Community (Anthropic repo).
+- [GitHub community discussion #154383](https://github.com/orgs/community/discussions/154383) — merge queue wildcard branch protection incompatibility. Community.
+- [knostic.ai — Claude loads secrets without permission](https://knostic.ai/blog/claude-loads-secrets-without-permission) — `.env` file default read behavior. Community security research.
+- EXA deep research report (exa-research-pro, 2026-05-18) — synthesized from official docs and community sources.

--- a/plans/setup-claude-web-command.md
+++ b/plans/setup-claude-web-command.md
@@ -1,0 +1,847 @@
+# Feature: `setup:claude-web` Command
+
+**Plan date:** 2026-05-18
+**Brainstorm:** `docs/brainstorms/2026-05-18-setup-claude-web-command-brainstorm.md`
+**Research:** `docs/research/how-claude-code-web-works-and-repository.md`
+**Detail level:** STANDARD
+**Target plugin:** `yellow-core` (minor bump — additive command)
+
+---
+
+## Problem Statement
+
+Claude Code Web (the browser-hosted cloud agent at `claude.ai/code`) runs in
+ephemeral Ubuntu VMs that have no access to a developer's `~/.claude/`
+settings, user-scope MCP servers, or locally-installed plugins. Everything the
+web agent can use must live in the repository. The failure mode is silent: an
+agent that works perfectly locally runs in a cloud session without the tools
+and context the developer expects, and there is no obvious diagnostic path
+from the symptom ("CI failed") back to the cause ("settings.json missing
+`enabledPlugins`").
+
+A single command that audits the current repo and scaffolds the project-scope
+files Claude Code Web needs eliminates this class of surprise — and gives the
+yellow-plugins ecosystem a canonical answer for downstream repos that want
+cloud-session readiness without reading the research doc.
+
+---
+
+## Current State
+
+- `yellow-core` already owns the `setup:` namespace via two commands:
+  `setup/all.md` (the marketplace-wide dashboard aggregator) and
+  `statusline/setup.md` (status line installer).
+- No command currently scaffolds `.claude/settings.json`, bootstrap scripts,
+  `.gitattributes`/`.gitignore` patterns, or `.github/workflows/claude.yml`.
+- Existing setup-command precedents the new command will mirror:
+  - `plugins/yellow-chatprd/commands/chatprd/setup.md` — M3 AskUserQuestion
+    gate before write, post-write Read verification
+  - `plugins/yellow-ci/commands/ci/setup.md` — tiered interactivity, optional
+    section gates, multi-step audit
+  - `plugins/yellow-core/commands/statusline/setup.md` — atomic
+    Python-based settings.json merge
+  - `plugins/yellow-ruvector/commands/ruvector/setup.md` — `.gitignore`
+    idempotent append pattern
+- `validate-setup-all.js` does NOT enumerate `commands/setup/*.md` and does
+  NOT require new commands to appear in `setup:all` — confirmed by reading
+  the validator's `loadCommandNames` function and `COMMAND_PLUGIN_MAP`.
+
+---
+
+## Proposed Solution
+
+A single new command, `setup:claude-web`, at
+`plugins/yellow-core/commands/setup/claude-web.md`. The command:
+
+1. Audits the current git repo for Claude Code Web readiness via a
+   single-pass Bash block that emits `key: value` lines.
+2. Displays the audit as a status table.
+3. Tier 1 — Auto-writes safe additive edits (`.gitattributes` and
+   `.gitignore` line appends) without prompting.
+4. Tier 2 — Uses AskUserQuestion to confirm before creating new files
+   (`.claude/settings.json`, `scripts/install_pkgs.sh`,
+   `.github/workflows/claude.yml`) or merging into existing config.
+5. Tier 3 — Emits warnings (CLAUDE.md size, STDIO MCP incompatibility,
+   plugin env vars, lockfile gaps) without writing or prompting.
+6. Fixes executable bits on bootstrap scripts.
+7. Always emits a summary block listing files changed, env vars the user
+   must set manually, warnings, and next steps.
+
+The command runs against the current git worktree (no `--target` argument
+in v1). Re-running on a fully-configured repo produces zero writes —
+idempotency is the invariant.
+
+### Key design decisions (locked from brainstorm)
+
+| Decision | Choice |
+|---|---|
+| File location | `plugins/yellow-core/commands/setup/claude-web.md` |
+| Command name | `setup:claude-web` |
+| Interaction model | Tiered (auto / AskUserQuestion / warn) |
+| Settings.json merge | Python-based atomic write (mirrors `statusline/setup.md`) |
+| `setup:all` integration | Deferred (orthogonal scopes) |
+| Marker file | None (files self-evidence) |
+| Dry-run flag | None (Tier 2 gates serve the same role) |
+| `--target` flag | None (CWD only) |
+
+### Open questions resolved during research
+
+- **SessionStart matcher syntax:** Use `"matcher": "*"`. Confirmed by
+  reading all 9 existing yellow-plugins plugin.json SessionStart entries
+  (`yellow-ci`, `yellow-ruvector`, `yellow-research`, …) — all use `"*"`.
+  Official docs (`code.claude.com/docs/en/hooks`) confirm `*` is the
+  universal wildcard.
+- **Step 8 scope:** Only scripts referenced in `.claude/settings.json`
+  hooks get their executable bits fixed. Not all tracked `*.sh` files
+  in the repo. Narrower scope avoids surprising mutation of unrelated
+  scripts.
+- **`[Skip]` semantics:** Per `ci:setup.md` precedent — skip this step
+  only, proceed to next step. Never abort the command on a single skip.
+- **`CLAUDE_PROJECT_DIR` fallback:** Generated hook command uses
+  `"${CLAUDE_PROJECT_DIR:-$PWD}"/scripts/install_pkgs.sh` to defend
+  against the env var being unset in non-standard invocation contexts.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Foundation
+
+- [ ] **1.1** Branch off main via Graphite:
+      `gt branch create agent/feat/setup-claude-web-command`
+- [ ] **1.2** Create `plugins/yellow-core/commands/setup/claude-web.md`
+      with frontmatter only (no body yet) to confirm validator passes
+      before filling in step content:
+      ```yaml
+      ---
+      name: setup:claude-web
+      description: "Prepare a repository for Claude Code Web: audit and scaffold .claude/settings.json, bootstrap script, .mcp.json transport compatibility, .gitattributes, .gitignore, and GitHub Actions workflow. Use when first enabling cloud sessions, after adding MCP servers, or when cloud sessions fail to find expected tools."
+      argument-hint: ''
+      allowed-tools:
+        - Bash
+        - Read
+        - Write
+        - AskUserQuestion
+      ---
+      ```
+- [ ] **1.3** Run `pnpm validate:agents` against the empty-body file
+      to confirm frontmatter is accepted. Expected: passes (no rules
+      apply to command-body content yet).
+- [ ] **1.4** Normalize line endings: `sed -i 's/\r$//'
+      plugins/yellow-core/commands/setup/claude-web.md`
+
+### Phase 2: Command Body Implementation
+
+The body follows a 9-step structure that mirrors `ci:setup.md`. Each
+step is a numbered section in the markdown.
+
+#### 2.1 — Step 1: Detect Repo Root
+
+Single Bash block:
+- Check `command -v git >/dev/null 2>&1` first; if missing, emit
+  `[setup:claude-web] Error: git is not installed.` and stop.
+- Run `git rev-parse --show-toplevel 2>/dev/null` to find repo root.
+- If empty: emit `This command must be run from inside a git repository.`
+  and stop.
+- Detect worktree state: compare `git rev-parse --git-dir` to
+  `git rev-parse --git-common-dir`. If they differ, emit a warning:
+  `[setup:claude-web] Note: running inside a git worktree. Files will be
+  written to this worktree.`
+- Output: `repo_top: <path>` for use by Step 2.
+
+#### 2.2 — Step 2: Comprehensive Audit (single Bash call)
+
+One Bash block that emits `key: value` lines under section headers
+(`=== Settings ===`, `=== Git Attributes ===`, etc.). Vocabulary for
+values: `ok | missing | present | corrupt | error | yes | no`.
+
+Audit checks (in order):
+
+```
+=== Settings ===
+settings_json: exists | missing
+settings_json_valid: yes | no | n/a       (jq empty exit code)
+settings_has_session_start: yes | no | n/a
+settings_has_allow: yes | no | n/a
+settings_has_deny: yes | no | n/a
+settings_has_env: yes | no | n/a
+settings_session_start_has_install_pkgs: yes | no | n/a
+
+=== Bootstrap ===
+install_pkgs_exists: yes | no
+install_pkgs_has_remote_gate: yes | no | n/a
+install_pkgs_exec_bit: yes | no | n/a
+
+=== Lockfiles ===
+pkg_manager_pnpm: yes | no
+pkg_manager_yarn: yes | no
+pkg_manager_npm: yes | no
+pkg_manager_uv: yes | no
+pkg_manager_pip: yes | no
+pkg_manager_cargo: yes | no
+pkg_manager_bundler: yes | no
+pkg_manager_composer: yes | no
+pkg_manager_go: yes | no
+
+=== Git Attributes ===
+gitattributes_exists: yes | no
+gitattributes_text_auto: present | missing
+gitattributes_sh_eol: present | missing
+
+=== Git Ignore ===
+gitignore_exists: yes | no
+gitignore_env: present | missing
+(repeats for: .env.*, .env.local, *.pem, *.key, .aws/, .ssh/, secrets/, credentials/)
+
+=== MCP ===
+mcp_json_exists: yes | no
+mcp_json_valid: yes | no | n/a
+mcp_stdio_count: <integer>
+mcp_stdio_servers: <space-separated names>
+
+=== GitHub Actions ===
+workflows_dir: yes | no
+claude_action_present: yes | no | n/a
+
+=== CLAUDE.md ===
+claude_md_lines: <integer>
+claude_md_bytes: <integer>
+
+=== Pathology ===
+claude_dir_is_file: yes | no                (.claude exists but is not a directory)
+scripts_dir_is_file: yes | no               (scripts/ exists but is not a directory)
+```
+
+**Defensive patterns required (per MEMORY.md):**
+- Every `jq` call captures exit code: `jq ... 2>/dev/null || printf 'key:
+  error\n'`. No `2>/dev/null` standalone.
+- `~/.claude.json` read guarded by `[ -r ~/.claude.json ]`.
+- File-size guard on `.gitignore` / `.gitattributes`: skip pattern checks
+  if file is > 1 MiB and emit `gitignore_size: too_large`.
+
+- [ ] **2.2.1** Write the audit Bash block (one fenced code block, single
+      `tool: Bash` call in the command body).
+- [ ] **2.2.2** Verify the audit produces clean key-value output on a
+      fixture: an empty git repo, a partially-configured repo, and a
+      fully-configured repo. Adjust outputs to use consistent vocabulary.
+
+#### 2.3 — Step 3: Display Audit Table
+
+LLM step (no tool call beyond text output). The command body instructs
+the agent to parse the audit's key-value output and emit a markdown
+table with columns: Component | Status | Action. Status values:
+`OK | MISSING | PARTIAL | WARN | NEEDS ATTENTION | CORRUPT`. Action
+text describes what Step 4–8 will do.
+
+Mark items "→ will auto-fix" in the Action column for Tier 1 items, so
+the user sees the projected end-state from the audit table before
+prompts begin.
+
+#### 2.4 — Step 4: `.gitattributes` and `.gitignore` (Tier 1, no gate)
+
+Single Bash block. Uses these idempotent-append helpers:
+
+```bash
+_ensure_trailing_newline() {
+  local f="$1"
+  [ -f "$f" ] && [ -s "$f" ] && \
+    tail -c1 "$f" | od -An -c | tr -d ' ' | grep -q '\\n' || \
+    printf '\n' >> "$f"
+}
+
+_append_if_missing() {
+  local f="$1" line="$2"
+  grep -qF -- "$line" "$f" 2>/dev/null || {
+    _ensure_trailing_newline "$f"
+    printf '%s\n' "$line" >> "$f"
+  }
+}
+```
+
+Items to append:
+
+**`.gitattributes`:**
+- `* text=auto`
+- `*.sh eol=lf`
+
+**`.gitignore`:**
+- `.env`
+- `.env.*`
+- `.env.local`
+- `*.pem`
+- `*.key`
+- `.aws/`
+- `.ssh/`
+- `secrets/`
+- `credentials/`
+
+Group `.gitignore` additions under a `# Claude Code Web — sensitive
+file protection` comment block if any are missing.
+
+Output a per-file summary: `[setup:claude-web] .gitattributes: appended
+2 lines | .gitignore: appended 4 lines | no changes needed`.
+
+#### 2.5 — Step 5: `.claude/settings.json` (Tier 2, AskUserQuestion gate)
+
+**5a — If `claude_dir_is_file: yes`:**
+Emit `[setup:claude-web] Error: .claude exists as a regular file, not
+a directory. Manual repair required.` and skip to Step 6.
+
+**5b — If `settings_json: missing`:**
+Show the scaffold template (full JSON, pretty-printed) as a code block in
+the response. Then:
+```
+AskUserQuestion:
+  question: "Write `.claude/settings.json` with a SessionStart hook template
+  and empty permissions.allow?"
+  options: ["Write it", "Skip"]
+```
+- If `[Write it]`: write via Python-based atomic write (mirrors
+  `statusline/setup.md:439-484` — write to `.tmp`, validate with
+  `json.load`, `os.replace` to target).
+- If `[Skip]`: emit `[setup:claude-web] Skipping .claude/settings.json
+  scaffold.` and proceed to Step 6. Do NOT execute any write commands.
+
+**5c — If `settings_json: exists` AND `settings_json_valid: no`:**
+Emit `[setup:claude-web] Warning: .claude/settings.json is not valid JSON
+(jq cannot parse it; may contain comments). Skipping settings merge.
+Manual repair required before re-running.` Skip to Step 6.
+
+**5d — If `settings_json: exists` AND `settings_json_valid: yes` AND
+all required keys present:**
+Emit `[setup:claude-web] .claude/settings.json: all required keys present.`
+Skip to Step 6.
+
+**5e — If `settings_json: exists` AND `settings_json_valid: yes` AND
+some keys missing:**
+Show a diff-style summary: "Will add: hooks.SessionStart entry,
+permissions.allow entries (N), permissions.deny entries (N), env block
+(only if absent)." Then:
+```
+AskUserQuestion:
+  question: "Merge these additions into existing `.claude/settings.json`?"
+  options: ["Merge", "Skip"]
+```
+- If `[Merge]`: run Python atomic merge with these rules:
+  - `permissions.allow`: append entries not already present (preserve
+    order of existing).
+  - `permissions.deny`: append entries not already present.
+  - `hooks.SessionStart`: append a new entry IF no existing entry's
+    `hooks[].command` matches `*install_pkgs.sh*` (substring).
+  - `env`: set `{"NODE_ENV": "test"}` only if `env` key is absent at all.
+    Do NOT touch existing `env` block.
+- If `[Skip]`: emit `[setup:claude-web] Skipping settings.json merge.`
+  Proceed to Step 6.
+
+**Post-write verification (5f):**
+- Bash: `jq -e '.hooks.SessionStart | length > 0' .claude/settings.json
+  && jq -e '.permissions.allow | type == "array"' .claude/settings.json`
+- If non-zero exit: emit `[setup:claude-web] Error: settings.json write
+  verification failed.` and stop.
+- Then use Read tool: confirm the SessionStart entry's `command` field
+  contains `install_pkgs.sh`.
+
+**SessionStart hook entry template (used in merge):**
+```json
+{
+  "matcher": "*",
+  "hooks": [
+    {
+      "type": "command",
+      "command": "\"${CLAUDE_PROJECT_DIR:-$PWD}\"/scripts/install_pkgs.sh"
+    }
+  ]
+}
+```
+
+**`permissions.allow` defaults to seed (only added if missing):**
+- `Bash(<detected install command>)`
+- `Bash(git status)`
+- `Bash(git diff)`
+- `Bash(git log)`
+
+**`permissions.deny` defaults:**
+- `Read(**/.ssh/**)`
+- `Read(**/.aws/**)`
+- `Read(**/.env)`
+- `Read(**/.env.*)`
+
+#### 2.6 — Step 6: `scripts/install_pkgs.sh` + SessionStart wire-up (Tier 2)
+
+**6a — Package manager detection logic:**
+
+Priority order (first match wins by default): `pnpm > yarn > npm > uv >
+pip > cargo > bundler > composer > go`.
+
+If multiple lockfiles detected:
+```
+AskUserQuestion:
+  question: "Multiple package managers detected: [list]. Which install
+  command should the bootstrap script run?"
+  options: [each detected manager, "Run all (sequential)", "Skip"]
+```
+- If `[Skip]`: skip Step 6 entirely.
+- Otherwise: use the user's choice.
+
+**6b — If `scripts_dir_is_file: yes`:**
+Emit `[setup:claude-web] Error: scripts exists as a regular file, not
+a directory. Manual repair required.` and skip to Step 7.
+
+**6c — If `install_pkgs_exists: yes`:**
+- If `install_pkgs_has_remote_gate: yes`: emit `[setup:claude-web]
+  scripts/install_pkgs.sh exists and has CLAUDE_CODE_REMOTE gate.` Skip
+  to Step 7.
+- If `install_pkgs_has_remote_gate: no`: emit a warning with the exact
+  fix instruction:
+  ```
+  [setup:claude-web] Warning: scripts/install_pkgs.sh exists but lacks
+  the CLAUDE_CODE_REMOTE gate. Without it, the script will run on every
+  local session too.
+
+  Add this at line 2 of your script:
+      if [ "$CLAUDE_CODE_REMOTE" != "true" ]; then exit 0; fi
+  ```
+  Do NOT overwrite the user's script. Skip to Step 7.
+
+**6d — If `install_pkgs_exists: no`:**
+Build the install command from the detected (or user-chosen) package
+manager. Show the script that would be written. Then:
+```
+AskUserQuestion:
+  question: "Write `scripts/install_pkgs.sh` (package manager: <name>)?"
+  options: ["Write it", "Skip"]
+```
+- If `[Write it]`:
+  ```bash
+  mkdir -p scripts
+  INSTALL_CMD="<derived from detection>"
+  cat > "scripts/install_pkgs.sh" << __EOF_INSTALL_PKGS__
+  #!/bin/bash
+  # Note: -e omitted intentionally — hook must exit 0 on all gate paths
+  set -uo pipefail
+
+  # Gate: only run full installs in cloud sessions
+  if [ "\$CLAUDE_CODE_REMOTE" != "true" ]; then
+    exit 0
+  fi
+
+  # Project root with safe fallback
+  PROJECT_DIR="\${CLAUDE_PROJECT_DIR:-\$PWD}"
+  cd "\$PROJECT_DIR" || exit 1
+
+  # Detected package manager: ${INSTALL_CMD}
+  ${INSTALL_CMD}
+
+  exit 0
+  __EOF_INSTALL_PKGS__
+  chmod +x scripts/install_pkgs.sh
+  git update-index --chmod=+x scripts/install_pkgs.sh
+  printf '[setup:claude-web] Wrote scripts/install_pkgs.sh\n'
+  ```
+  (`\$VAR` escapes preserve literal dollar signs; `${INSTALL_CMD}`
+  expands at write time. Use unquoted heredoc per
+  `composio:setup.md:190` precedent.)
+- If `[Skip]`: emit `[setup:claude-web] Skipping scripts/install_pkgs.sh.`
+  Proceed to Step 7.
+
+**6e — Post-write verification:**
+- Bash: `[ -f scripts/install_pkgs.sh ] && grep -q 'CLAUDE_CODE_REMOTE'
+  scripts/install_pkgs.sh && grep -q 'exit 0' scripts/install_pkgs.sh`
+- If non-zero exit: emit error and stop.
+- Then Read tool: confirm gate and install command lines are present.
+
+#### 2.7 — Step 7: `.github/workflows/claude.yml` (Tier 2, conditional)
+
+**7a — If `workflows_dir: no`:**
+Emit `[setup:claude-web] No .github/workflows/ directory found. Skipping
+claude.yml (GitHub Actions not in use in this repo).` Proceed to Step 8.
+
+**7b — If `claude_action_present: yes`:**
+Emit `[setup:claude-web] Workflow using anthropics/claude-code-action
+already present. Skipping.` Proceed to Step 8.
+
+**7c — Otherwise:**
+Show the workflow template (full YAML). Then:
+```
+AskUserQuestion:
+  question: "Write `.github/workflows/claude.yml`?"
+  options: ["Write it", "Skip"]
+```
+- If `[Write it]`: write the workflow via Write tool, then `sed -i
+  's/\r$//' .github/workflows/claude.yml` to strip any CRLF.
+- If `[Skip]`: emit skip message. Proceed to Step 8.
+
+**Workflow template:**
+```yaml
+# Set ANTHROPIC_API_KEY in GitHub repository secrets before this runs.
+# Adjust `permissions` to match your security policy — contents: write is
+# needed for auto-fix push behavior.
+name: Claude Code
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+
+jobs:
+  claude:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+<!-- deepen-plan: external -->
+> **Research (2026-05-18):** The template above diverges from Anthropic's
+> canonical `claude-code-action@v1` shape in four ways the implementer
+> should fix before writing:
+>
+> 1. **`if:` filter triggers Claude unconditionally on every PR.** The
+>    `github.event_name == 'pull_request'` arm fires on every open/sync/
+>    reopen with no `@claude` guard. Anthropic's canonical pattern gates
+>    every trigger on `contains(...body, '@claude')`. Replace the bare PR
+>    arm with a `pull_request_review_comment` arm that includes the same
+>    `@claude` substring check.
+> 2. **Missing `pull_request_review_comment` trigger.** Anthropic's
+>    canonical form subscribes to three comment surfaces: `issue_comment`,
+>    `pull_request_review_comment`, and `issues`. The scaffolded `on:`
+>    block should add `pull_request_review_comment: { types: [created] }`.
+> 3. **`issues: read` should be `issues: write`.** Anthropic's
+>    recommended permissions block for the `@claude`-mention workflow is
+>    `contents: write`, `pull-requests: write`, `issues: write`. Optional:
+>    add `actions: read` if the workflow needs to query check-run state.
+> 4. **`@v1` is current** (latest tag v1.0.124, August 2025). The input
+>    name `anthropic_api_key` (underscores) is correct. There is **no**
+>    `system_prompt:` input in v1 — do not emit one. For instruction
+>    injection use `claude_args: --append-system-prompt "..."`.
+>
+> Canonical references:
+> - https://github.com/anthropics/claude-code-action (README + releases)
+> - https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+> - https://code.claude.com/docs/en/github-actions
+<!-- /deepen-plan -->
+
+#### 2.8 — Step 8: Executable Bits (Tier 1, scoped to hook-referenced scripts)
+
+After Step 5 has finalized settings.json, scope the chmod fix to ONLY
+scripts referenced in `.claude/settings.json` hooks:
+
+```bash
+# Extract all hook command paths from settings.json
+HOOK_SCRIPTS=$(jq -r '
+  [.hooks // {} | to_entries[].value[]?.hooks[]?.command]
+  | map(select(. != null))
+  | map(capture("(?<path>[^\"]+\\.sh)"; "g") | .path)
+  | flatten
+  | unique
+  | .[]
+' .claude/settings.json 2>/dev/null)
+
+for raw_path in $HOOK_SCRIPTS; do
+  # Strip "$CLAUDE_PROJECT_DIR" or ${CLAUDE_PROJECT_DIR:-$PWD} prefix
+  rel=$(printf '%s' "$raw_path" | sed -E 's|.*\}/||; s|.*"/||; s|.*\$PWD"/||')
+  full="$repo_top/$rel"
+  if [ -f "$full" ] && git ls-files --error-unmatch -- "$rel" >/dev/null 2>&1; then
+    mode=$(git ls-files --format='%(objectmode) %(path)' -- "$rel" | awk '{print $1}')
+    if [ "$mode" = "100644" ]; then
+      chmod +x "$full"
+      git update-index --chmod=+x "$rel"
+      printf '[setup:claude-web] Fixed executable bit: %s\n' "$rel"
+    fi
+  fi
+done
+```
+
+If no hook-referenced scripts found, skip silently. Print no output.
+
+#### 2.9 — Step 9: Summary Output
+
+LLM step. Always emitted. Aggregates information from Steps 2–8:
+
+```text
+═══════════════════════════════════════════════════════════
+  Claude Code Web Setup — Summary
+═══════════════════════════════════════════════════════════
+
+Files written/modified:
+  ✓ .gitattributes — appended N lines
+  ✓ .gitignore — appended N lines
+  ✓ .claude/settings.json — scaffolded (or merged)
+  ✓ scripts/install_pkgs.sh — created
+  ✓ .github/workflows/claude.yml — created
+  (or "none — no changes needed")
+
+🔑 REQUIRED MANUAL ACTION
+   Set ANTHROPIC_API_KEY as a GitHub repository secret:
+   https://github.com/<repo>/settings/secrets/actions
+
+Env vars to set in cloud environment UI at claude.ai/code:
+  - <plugin>.<key> (for plugin '<plugin>')
+  - <mcp server> env vars (from .mcp.json placeholders)
+  (or "none")
+
+Warnings requiring human review:
+  ⚠ CLAUDE.md is N lines (>200 recommended for cloud agent context)
+  ⚠ .mcp.json contains STDIO server '<name>' — may not work in web sandbox
+  ⚠ scripts/install_pkgs.sh exists but lacks CLAUDE_CODE_REMOTE gate
+  (or "none")
+
+Next steps:
+  1. Set ANTHROPIC_API_KEY as a GitHub repository secret
+  2. Set the env vars listed above in the cloud environment UI
+  3. Install the Claude GitHub App (required for Auto-fix)
+  4. Test a cloud session: open claude.ai/code and select this repo
+
+For details on Claude Code Web architecture:
+  docs/research/how-claude-code-web-works-and-repository.md
+```
+
+Note: the "🔑 REQUIRED MANUAL ACTION" block is visually prominent
+(separate from "Next steps") because missing the secret is the most
+common cause of subsequent CI failures.
+
+### Phase 3: Quality & Documentation
+
+- [ ] **3.1** Update `plugins/yellow-core/CLAUDE.md` "Commands" count
+      and list (e.g., `### Commands (8)` → `### Commands (9)`, add the
+      new bullet).
+- [ ] **3.2** Update `plugins/yellow-core/README.md` Commands table
+      (add a new row).
+- [ ] **3.3** Run `pnpm changeset`:
+      - Plugin: `yellow-core`
+      - Bump: `minor`
+      - Message: `feat(yellow-core): add /setup:claude-web command to
+        scaffold Claude Code Web readiness in any repo`
+- [ ] **3.4** Run validators:
+      - `pnpm validate:agents` (must pass)
+      - `pnpm validate:plugins`
+      - `pnpm validate:setup-all` (confirm no failure from absence)
+      - `pnpm test:unit`
+      - `pnpm typecheck`
+      - `pnpm lint`
+- [ ] **3.5** CRLF normalize: `sed -i 's/\r$//'
+      plugins/yellow-core/commands/setup/claude-web.md`
+- [ ] **3.6** Manual smoke test on a fresh fixture repo (see test
+      matrix below): minimum two scenarios from Phase 4 (fresh repo +
+      fully-configured repo) before commit.
+- [ ] **3.7** Commit: `gt commit create -m "feat(yellow-core): add
+      /setup:claude-web command"`
+- [ ] **3.8** Submit: `gt stack submit`
+
+---
+
+## Technical Details
+
+### Files to create
+
+| Path | Purpose |
+|---|---|
+| `plugins/yellow-core/commands/setup/claude-web.md` | The command itself |
+| `.changeset/<auto-named>.md` | Minor bump for yellow-core |
+
+### Files to modify
+
+| Path | Change |
+|---|---|
+| `plugins/yellow-core/CLAUDE.md` | Commands count (8 → 9), add bullet, optional "Cloud Sessions" section |
+| `plugins/yellow-core/README.md` | Commands table row |
+
+### Dependencies
+
+No new dependencies. The command uses only Bash, jq, Python 3, and git —
+all of which are universally available in development environments and
+the Claude Code Web sandbox per official docs.
+
+### `plugin.json`
+
+`plugins/yellow-core/.claude-plugin/plugin.json` has NO `commands:`
+array — Claude Code auto-discovers from the file tree. No manifest
+edit required.
+
+### Validators that will run on this change
+
+- `validate-agent-authoring.js` — `validateCommandFiles` scans all
+  `commands/*.md` for `BASH_SOURCE` usage. We don't use it. Passes.
+- `validate-plugin.js` — only validates `plugin.json`. Unchanged.
+  Passes.
+- `validate-setup-all.js` — confirmed via `loadCommandNames` that it
+  does NOT require new `setup:*` commands to be listed in
+  `setup:all.md`. Passes.
+
+---
+
+## Acceptance Criteria
+
+15 testable criteria; every one should pass before the PR merges:
+
+1. Fresh git repo with no `.claude/` and answering `[Write it]` to all
+   Tier 2 prompts produces: valid `.claude/settings.json`, executable
+   `scripts/install_pkgs.sh`, updated `.gitattributes`, updated
+   `.gitignore`, and `claude.yml` (if `.github/workflows/` exists).
+2. `[Skip]` for all Tier 2 prompts still executes Tier 1 writes and
+   produces the summary block.
+3. Re-running on a fully configured repo produces zero file writes
+   and zero Tier 2 prompts.
+4. Existing `.claude/settings.json` with partial config triggers merge
+   prompt; merging preserves all existing keys.
+5. Outside a git repo: clear error message, no writes.
+6. Corrupt JSON in settings.json: warning emitted, merge skipped,
+   remaining steps continue.
+7. Two lockfiles (pnpm + npm): AskUserQuestion prompts user to pick.
+8. STDIO MCP warnings never block the command.
+9. Tier 1 appends are idempotent: second run does not duplicate lines.
+10. Step 8 executable-bit fix applies ONLY to scripts referenced in
+    settings.json hooks (not all tracked `*.sh` files).
+11. Settings.json `env` block: only added if absent; never mutated.
+12. `claude.yml` skipped silently if no `.github/workflows/` directory.
+13. After `install_pkgs.sh` write: `git ls-files --format` shows mode
+    `100755`.
+14. Step 9 summary block always prints.
+15. `permissions.deny` entries appended, never replaced.
+
+---
+
+## Edge Cases & Error Handling
+
+| Scenario | Handling |
+|---|---|
+| `.claude` exists as a regular file | Error in Step 5; skip to Step 6 |
+| `scripts` exists as a regular file | Error in Step 6; skip to Step 7 |
+| `.claude/settings.json` is JSONC (comments) | Warning; skip merge; continue |
+| `.claude/settings.json` is corrupt JSON | Warning; skip merge; continue |
+| `.mcp.json` is invalid JSON | Audit emits `mcp_json_valid: no`; warn in summary; continue |
+| `.gitignore` > 1 MiB | Skip pattern checks; emit `gitignore_size: too_large` warning |
+| Git not in PATH | Step 1 errors out cleanly |
+| Git worktree invocation | Step 1 emits warning; continues |
+| Multiple lockfiles | Step 6 AskUserQuestion picks one |
+| `~/.claude.json` permission denied | Audit emits `user_mcp_readable: no`; advisory only |
+| `install_pkgs.sh` has inverted gate | Warning with fix; no overwrite |
+| `.gitattributes` already has `*.sh text` | Append `*.sh eol=lf`; note that last rule wins |
+| Org restricts allowed Actions | Summary mentions org-policy considerations |
+
+---
+
+## Security Notes
+
+- Audit MUST NOT echo values from `.mcp.json` or `~/.claude.json` — only
+  keys, server names, and types. Implementation rule: use
+  `jq -r '.mcpServers | keys[]'` and `.mcpServers[].type`, never `[]`
+  alone (which would dump nested env blocks).
+- All user inputs are enum picks from AskUserQuestion — no free-text
+  interpolated into file writes or shell commands.
+- Generated `claude.yml` header comment explicitly notes that
+  `contents: write` permission is needed for auto-fix and should be
+  reviewed against the org's security policy.
+- Generated `install_pkgs.sh` uses hardcoded install commands from a
+  finite set of detected lockfiles — no user-typed input becomes part
+  of the script body.
+
+---
+
+## Performance Notes
+
+- Single-pass audit (Step 2) reads ~15 small files and runs ~30 grep/jq
+  invocations. Bounded constant work for a typical repo.
+- Step 8 chmod loop is bounded by number of hook-referenced scripts
+  (usually 0–3, never more than a handful).
+- `.gitattributes` / `.gitignore` size guard: skip pattern check if
+  file > 1 MiB to defend against pathological inputs.
+
+---
+
+## Test Matrix (manual smoke tests)
+
+Run at least the bolded scenarios before commit. Document outcomes in
+the PR description.
+
+| # | Fixture | Expected | Priority |
+|---|---|---|---|
+| 1 | **Empty dir (no `.git`)** | Early exit with "must be run from inside a git repository" | **MUST** |
+| 2 | **Fresh git repo, no `.claude/`, no lockfiles** | Tier 1 writes succeed; Tier 2 prompts; skips claude.yml | **MUST** |
+| 3 | Fresh git repo with `pnpm-lock.yaml` only | Bootstrap script uses `pnpm install --frozen-lockfile` | SHOULD |
+| 4 | Fresh git repo with `pnpm-lock.yaml` AND `package-lock.json` | AskUserQuestion prompts user to pick | SHOULD |
+| 5 | Existing valid settings.json, no hooks | Merge prompt; merge adds SessionStart entry; preserves existing keys | SHOULD |
+| 6 | Existing settings.json with invalid JSON | Warning; merge skipped; remaining steps continue | SHOULD |
+| 7 | Existing settings.json as JSONC (with `//` comments) | Same as invalid JSON | OPTIONAL |
+| 8 | Existing `install_pkgs.sh` WITH correct gate | "Already exists" reported; no write | SHOULD |
+| 9 | Existing `install_pkgs.sh` WITHOUT gate | Warning with exact fix; no overwrite | SHOULD |
+| 10 | `.github/workflows/` with `anthropics/claude-code-action` already | Skip; no prompt | SHOULD |
+| 11 | No `.github/workflows/` directory | Step 7 skipped silently | MUST |
+| 12 | **Fully configured repo** | Zero writes; zero Tier 2 prompts; "No changes needed" | **MUST** |
+| 13 | `.mcp.json` with `type: stdio` `command: "npx"` | "may work" warning | OPTIONAL |
+| 14 | `.mcp.json` with `type: stdio` custom binary | "will not work" warning | OPTIONAL |
+| 15 | `.mcp.json` invalid JSON | Warning; MCP audit skipped | SHOULD |
+| 16 | `.claude` as a regular file | Error in Step 5; continue to Step 6 | SHOULD |
+| 17 | Worktree invocation | Warning shown before writes begin | OPTIONAL |
+| 18 | CLAUDE.md > 200 lines | Tier 3 warning in summary | SHOULD |
+
+---
+
+## v1 Out of Scope (deferred to follow-ups)
+
+- `--target <dir>` argument
+- `--dry-run` flag
+- Marker file (`.claude/.web-setup-complete`)
+- `claude mcp list` shell-out
+- Scaffolding `.devcontainer/devcontainer.json`
+- Auto-migrating STDIO MCP servers to HTTP
+- Integration into `setup:all` dashboard ("Cloud readiness" section)
+- Automated testing of live cloud sessions
+- Setting `ANTHROPIC_API_KEY` directly (requires GitHub UI)
+- Modifying `CLAUDE.md` or writing `AGENTS.md` for the target repo
+
+---
+
+## References
+
+- Brainstorm: `docs/brainstorms/2026-05-18-setup-claude-web-command-brainstorm.md`
+- Research: `docs/research/how-claude-code-web-works-and-repository.md`
+- Precedent command — atomic settings.json merge: `plugins/yellow-core/commands/statusline/setup.md:439-484`
+- Precedent command — post-write Read verification: `plugins/yellow-chatprd/commands/chatprd/setup.md:140-149`
+- Precedent command — tiered interactivity + audit: `plugins/yellow-ci/commands/ci/setup.md`
+- Precedent command — `.gitignore` idempotent append: `plugins/yellow-ruvector/commands/ruvector/setup.md:75`
+- Precedent command — heredoc delimiter `__EOF_<CONTEXT>__`: `plugins/yellow-composio/commands/composio/setup.md:190-209`
+- Validator surface: `scripts/validate-agent-authoring.js`, `scripts/validate-plugin.js`, `scripts/validate-setup-all.js`
+- Official Claude Code Web docs: `code.claude.com/docs/en/claude-code-on-the-web`, `code.claude.com/docs/en/hooks`
+- Bash anti-patterns reference: `MEMORY.md` "Command File Anti-Patterns" and "Bash Hook & Validation Patterns" sections
+
+<!-- deepen-plan: external -->
+> **Research (2026-05-18):** Verified-current Anthropic sources for the
+> primitives this command scaffolds:
+>
+> - **`anthropics/claude-code-action` (v1.0.124, Aug 2025)** —
+>   https://github.com/anthropics/claude-code-action
+>   (canonical workflow, input names, permissions guidance)
+> - **GitHub Actions integration docs** —
+>   https://code.claude.com/docs/en/github-actions
+>   (migration table, claude_args replacement for custom_instructions)
+> - **Hooks reference** —
+>   https://code.claude.com/docs/en/hooks
+>   (SessionStart matcher syntax: `"*"`, `""`, pipe-separated
+>   `"startup|resume"` all valid; array form NOT supported)
+> - **Cloud session env vars** —
+>   https://code.claude.com/docs/en/claude-code-on-the-web
+>   (`CLAUDE_CODE_REMOTE=true` confirmed canonical; sibling
+>   `CLAUDE_CODE_REMOTE_SESSION_ID` available for transcript URLs but
+>   not used as a gate)
+> - **Env vars reference** —
+>   https://code.claude.com/docs/en/env-vars
+>   (confirms `CLAUDE_CODE_WEB` / `CLAUDE_CLOUD_SESSION` are NOT
+>   public — do not branch on them)
+>
+> Prior-art check (2026-05-18): Anthropic has NOT shipped a
+> `claude code init` / `claude code web-init` equivalent; no community
+> plugin in the marketplace scaffolds cloud-session readiness. This
+> command does not duplicate existing tooling.
+<!-- /deepen-plan -->
+

--- a/plugins/yellow-core/CLAUDE.md
+++ b/plugins/yellow-core/CLAUDE.md
@@ -57,7 +57,7 @@ Comprehensive dev toolkit for TypeScript, Python, Rust, and Go projects.
   via Reciprocal Rank Fusion. Secret redaction (AWS keys, GitHub tokens,
   API keys, JWTs, PEM blocks) before excerpts are returned
 
-### Commands (8)
+### Commands (9)
 
 - `/workflows:brainstorm` — explore requirements through dialogue and research before planning
 - `/workflows:plan` — transform feature descriptions into structured plans
@@ -68,6 +68,12 @@ Comprehensive dev toolkit for TypeScript, Python, Rust, and Go projects.
 - `/workflows:compound` — document a recently solved problem to compound knowledge
 - `/statusline:setup` — generate and install an adaptive statusline showing context, git, MCP health
 - `/setup:all` — run setup for all installed marketplace plugins with unified dashboard
+- `/setup:claude-web` — audit a repository and scaffold the files Claude Code
+  Web needs (`.claude/settings.json`, `scripts/install_pkgs.sh`,
+  `.gitattributes`, `.gitignore`, `.github/workflows/claude.yml`). Tiered
+  interaction: auto-write safe additive edits, AskUserQuestion gate before
+  new files / config merges, warn-only for STDIO MCP and oversized
+  CLAUDE.md
 - `/worktree:cleanup` — scan git worktrees, classify by state, and remove stale worktrees with safeguards
 
 ### Skills (13)

--- a/plugins/yellow-core/README.md
+++ b/plugins/yellow-core/README.md
@@ -26,6 +26,7 @@ TypeScript, Python, Rust, and Go.
 | `/workflows:compound`   | Document a recently solved problem to compound knowledge           |
 | `/statusline:setup`     | Generate and install an adaptive statusline for plugins            |
 | `/setup:all`            | Run setup for all installed marketplace plugins with unified dashboard |
+| `/setup:claude-web`     | Audit a repository and scaffold files Claude Code Web needs (`.claude/settings.json`, `scripts/install_pkgs.sh`, `.gitattributes`, `.gitignore`, `.github/workflows/claude.yml`) |
 
 ## Agents
 

--- a/plugins/yellow-core/commands/setup/claude-web.md
+++ b/plugins/yellow-core/commands/setup/claude-web.md
@@ -416,6 +416,8 @@ default_allow = [
 if not isinstance(cfg.get("permissions"), dict):
     cfg["permissions"] = {}
 existing_allow = cfg["permissions"].get("allow", [])
+if not isinstance(existing_allow, list):
+    existing_allow = []
 for entry in default_allow:
     if entry not in existing_allow:
         existing_allow.append(entry)
@@ -429,6 +431,8 @@ default_deny = [
     "Read(**/.env.*)",
 ]
 existing_deny = cfg["permissions"].get("deny", [])
+if not isinstance(existing_deny, list):
+    existing_deny = []
 for entry in default_deny:
     if entry not in existing_deny:
         existing_deny.append(entry)
@@ -439,8 +443,13 @@ if "env" not in cfg:
     cfg["env"] = {"NODE_ENV": "test"}
 
 # hooks.SessionStart (append-only; do not duplicate install_pkgs.sh wire-up)
-cfg.setdefault("hooks", {})
+# Guard against pre-existing `"hooks": null` or other non-dict — setdefault
+# would leave the value in place, then `.get(...)` raises AttributeError.
+if not isinstance(cfg.get("hooks"), dict):
+    cfg["hooks"] = {}
 session_start = cfg["hooks"].get("SessionStart", [])
+if not isinstance(session_start, list):
+    session_start = []
 already_wired = False
 for entry in session_start:
     for hook in entry.get("hooks", []):

--- a/plugins/yellow-core/commands/setup/claude-web.md
+++ b/plugins/yellow-core/commands/setup/claude-web.md
@@ -386,7 +386,10 @@ default_allow = [
     "Bash(git diff:*)",
     "Bash(git log:*)",
 ]
-cfg.setdefault("permissions", {})
+# Guard against pre-existing `"permissions": null` — setdefault would
+# leave None in place, then `.get("allow", [])` raises AttributeError.
+if not isinstance(cfg.get("permissions"), dict):
+    cfg["permissions"] = {}
 existing_allow = cfg["permissions"].get("allow", [])
 for entry in default_allow:
     if entry not in existing_allow:
@@ -487,7 +490,7 @@ the CLAUDE_CODE_REMOTE gate. Without it, the script runs on every local
 session too.
 
 Add this at line 2 of your script:
-    if [ "$CLAUDE_CODE_REMOTE" != "true" ]; then exit 0; fi
+    if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then exit 0; fi
 ```
 Do NOT overwrite the existing script. Proceed to Step 7.
 
@@ -547,8 +550,10 @@ cat > "scripts/install_pkgs.sh" <<__EOF_INSTALL_PKGS__
 # Note: -e omitted intentionally — hook must exit 0 on the gate path.
 set -uo pipefail
 
-# Gate: only run full installs in cloud sessions
-if [ "\$CLAUDE_CODE_REMOTE" != "true" ]; then
+# Gate: only run full installs in cloud sessions.
+# Use \${VAR:-} default expansion so set -u does not abort when
+# CLAUDE_CODE_REMOTE is unset (the common local-session case).
+if [ "\${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 

--- a/plugins/yellow-core/commands/setup/claude-web.md
+++ b/plugins/yellow-core/commands/setup/claude-web.md
@@ -64,8 +64,13 @@ proceed.
 ### Step 2: Comprehensive Audit
 
 Run a single Bash block that reads every signal Steps 3–8 need. Output
-follows a `key: value` vocabulary using only these values:
-`ok | missing | present | corrupt | error | yes | no | n/a | too_large`.
+follows a `key: value` vocabulary. Core values: `ok | missing | present |
+corrupt | error | yes | no | n/a | too_large`. Some keys carry extended
+values: file-existence keys (`settings_json`, `mcp_json`, `gitattributes`,
+`gitignore`) use `exists` or `missing`; the remote-gate detection key
+(`install_pkgs_has_remote_gate`) also uses `present_unclear`; STDIO server
+lists (`mcp_stdio_servers`) are space-separated server names or `none`;
+size/count keys (`claude_md_lines`, `claude_md_bytes`) are integers.
 
 ```bash
 REPO_TOP=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
@@ -83,15 +88,24 @@ fi
 
 if [ -f .claude/settings.json ]; then
   printf 'settings_json: exists\n'
-  if [ "$JQ_OK" = yes ] && jq empty .claude/settings.json >/dev/null 2>&1; then
-    printf 'settings_json_valid: yes\n'
-    printf 'settings_has_session_start: %s\n' "$(jq -r 'if (.hooks.SessionStart // [] | length) > 0 then "yes" else "no" end' .claude/settings.json 2>/dev/null || printf 'error')"
-    printf 'settings_has_allow: %s\n' "$(jq -r 'if (.permissions.allow // [] | length) > 0 then "yes" else "no" end' .claude/settings.json 2>/dev/null || printf 'error')"
-    printf 'settings_has_deny: %s\n' "$(jq -r 'if (.permissions.deny // [] | length) > 0 then "yes" else "no" end' .claude/settings.json 2>/dev/null || printf 'error')"
-    printf 'settings_has_env: %s\n' "$(jq -r 'if (.env // {} | length) > 0 then "yes" else "no" end' .claude/settings.json 2>/dev/null || printf 'error')"
-    printf 'settings_session_start_has_install_pkgs: %s\n' "$(jq -r '[.hooks.SessionStart // [] | .[].hooks // [] | .[].command] | map(select(. != null and contains("install_pkgs.sh"))) | if length > 0 then "yes" else "no" end' .claude/settings.json 2>/dev/null || printf 'error')"
+  if [ "$JQ_OK" = yes ]; then
+    if jq empty .claude/settings.json >/dev/null 2>&1; then
+      printf 'settings_json_valid: yes\n'
+      printf 'settings_has_session_start: %s\n' "$(jq -r 'if (.hooks.SessionStart // [] | length) > 0 then "yes" else "no" end' .claude/settings.json 2>/dev/null || printf 'error')"
+      printf 'settings_has_allow: %s\n' "$(jq -r 'if (.permissions.allow // [] | length) > 0 then "yes" else "no" end' .claude/settings.json 2>/dev/null || printf 'error')"
+      printf 'settings_has_deny: %s\n' "$(jq -r 'if (.permissions.deny // [] | length) > 0 then "yes" else "no" end' .claude/settings.json 2>/dev/null || printf 'error')"
+      printf 'settings_has_env: %s\n' "$(jq -r 'if (.env // {} | length) > 0 then "yes" else "no" end' .claude/settings.json 2>/dev/null || printf 'error')"
+      printf 'settings_session_start_has_install_pkgs: %s\n' "$(jq -r '[.hooks.SessionStart // [] | .[].hooks // [] | .[].command] | map(select(. != null and contains("install_pkgs.sh"))) | if length > 0 then "yes" else "no" end' .claude/settings.json 2>/dev/null || printf 'error')"
+    else
+      printf 'settings_json_valid: no\n'
+      printf 'settings_has_session_start: n/a\n'
+      printf 'settings_has_allow: n/a\n'
+      printf 'settings_has_deny: n/a\n'
+      printf 'settings_has_env: n/a\n'
+      printf 'settings_session_start_has_install_pkgs: n/a\n'
+    fi
   else
-    printf 'settings_json_valid: no\n'
+    printf 'settings_json_valid: n/a\n'
     printf 'settings_has_session_start: n/a\n'
     printf 'settings_has_allow: n/a\n'
     printf 'settings_has_deny: n/a\n'
@@ -116,7 +130,8 @@ else
 fi
 if [ -f scripts/install_pkgs.sh ]; then
   printf 'install_pkgs_exists: yes\n'
-  if grep -qE 'CLAUDE_CODE_REMOTE.*!=.*"true".*exit 0|exit 0.*CLAUDE_CODE_REMOTE.*!=.*"true"' scripts/install_pkgs.sh 2>/dev/null; then
+  if grep -qE 'CLAUDE_CODE_REMOTE.*!=' scripts/install_pkgs.sh 2>/dev/null && \
+     grep -q 'exit 0' scripts/install_pkgs.sh 2>/dev/null; then
     printf 'install_pkgs_has_remote_gate: yes\n'
   elif grep -q 'CLAUDE_CODE_REMOTE' scripts/install_pkgs.sh 2>/dev/null; then
     printf 'install_pkgs_has_remote_gate: present_unclear\n'
@@ -185,16 +200,21 @@ fi
 printf '\n=== MCP ===\n'
 if [ -f .mcp.json ]; then
   printf 'mcp_json: exists\n'
-  if [ "$JQ_OK" = yes ] && jq empty .mcp.json >/dev/null 2>&1; then
-    printf 'mcp_json_valid: yes\n'
-    STDIO=$(jq -r '[.mcpServers // {} | to_entries[] | select(.value.type == "stdio") | .key] | join(" ")' .mcp.json 2>/dev/null)
-    if [ -n "$STDIO" ]; then
-      printf 'mcp_stdio_servers: %s\n' "$STDIO"
+  if [ "$JQ_OK" = yes ]; then
+    if jq empty .mcp.json >/dev/null 2>&1; then
+      printf 'mcp_json_valid: yes\n'
+      STDIO=$(jq -r '[.mcpServers // {} | to_entries[] | select(.value.type == "stdio") | .key] | join(" ")' .mcp.json 2>/dev/null)
+      if [ -n "$STDIO" ]; then
+        printf 'mcp_stdio_servers: %s\n' "$STDIO"
+      else
+        printf 'mcp_stdio_servers: none\n'
+      fi
     else
-      printf 'mcp_stdio_servers: none\n'
+      printf 'mcp_json_valid: no\n'
+      printf 'mcp_stdio_servers: n/a\n'
     fi
   else
-    printf 'mcp_json_valid: no\n'
+    printf 'mcp_json_valid: n/a\n'
     printf 'mcp_stdio_servers: n/a\n'
   fi
 else
@@ -298,8 +318,13 @@ for PAT in '.env' '.env.*' '.env.local' '*.pem' '*.key' '.aws/' '.ssh/' 'secrets
 done
 if [ "$NEEDS_HEADER" = yes ]; then
   _ensure_trailing_newline .gitignore
-  grep -qF '# Claude Code Web — sensitive file protection' .gitignore 2>/dev/null || \
-    printf '\n# Claude Code Web — sensitive file protection\n' >> .gitignore
+  if ! grep -qF '# Claude Code Web — sensitive file protection' .gitignore 2>/dev/null; then
+    if [ -s .gitignore ]; then
+      printf '\n# Claude Code Web — sensitive file protection\n' >> .gitignore
+    else
+      printf '# Claude Code Web — sensitive file protection\n' >> .gitignore
+    fi
+  fi
 fi
 for PAT in '.env' '.env.*' '.env.local' '*.pem' '*.key' '.aws/' '.ssh/' 'secrets/' 'credentials/'; do
   _append_if_missing .gitignore "$PAT"
@@ -333,7 +358,7 @@ Show the scaffold template to the user as a code block. Then ask:
 
 ```
 AskUserQuestion:
-  question: "Write `.claude/settings.json` with a SessionStart hook for scripts/install_pkgs.sh, default permissions.allow / .deny entries, and env.NODE_ENV?"
+  question: "Write `.claude/settings.json` with a SessionStart hook for scripts/install_pkgs.sh (guarded by a `-x` test so a missing script does not block session startup), default permissions.allow / .deny entries, and env.NODE_ENV?"
   options: ["Write it", "Skip"]
 ```
 
@@ -348,7 +373,7 @@ Show a diff-style summary of what would be added. Then ask:
 
 ```
 AskUserQuestion:
-  question: "Merge missing keys into existing `.claude/settings.json` (preserve all existing entries; only append)?"
+  question: "Merge missing keys into existing `.claude/settings.json` (preserve all existing entries; only append)? The SessionStart hook is guarded by a `-x` test so a missing scripts/install_pkgs.sh does not block session startup."
   options: ["Merge", "Skip"]
 ```
 
@@ -430,7 +455,7 @@ if not already_wired:
         "matcher": "*",
         "hooks": [{
             "type": "command",
-            "command": "\"${CLAUDE_PROJECT_DIR:-$PWD}\"/scripts/install_pkgs.sh"
+            "command": "[ -x \"${CLAUDE_PROJECT_DIR:-$PWD}/scripts/install_pkgs.sh\" ] && \"${CLAUDE_PROJECT_DIR:-$PWD}/scripts/install_pkgs.sh\" || true"
         }]
     })
 cfg["hooks"]["SessionStart"] = session_start
@@ -563,6 +588,11 @@ cd "\$PROJECT_DIR" || exit 1
 
 # Detected package manager: ${PKG_NAME}
 ${INSTALL_CMD}
+INSTALL_RC=\$?
+if [ "\$INSTALL_RC" -ne 0 ]; then
+  printf '[install_pkgs] Warning: ${PKG_NAME} install exited %d — cloud session may be missing dependencies\n' \
+    "\$INSTALL_RC" >&2
+fi
 
 exit 0
 __EOF_INSTALL_PKGS__
@@ -692,12 +722,14 @@ HOOK_SCRIPTS=$(jq -r '
 
 printf '%s\n' "$HOOK_SCRIPTS" | while IFS= read -r raw_path; do
   [ -z "$raw_path" ] && continue
-  # Extract a .sh path from the command string. Hook commands typically look
-  # like "${CLAUDE_PROJECT_DIR:-$PWD}"/scripts/foo.sh — grep captures the
-  # path tail after the variable expansion, then sed strips leading `/` or
-  # `./` to produce a repo-relative path.
+  # Extract a .sh path from the command string. Hook commands may take several
+  # forms: "${CLAUDE_PROJECT_DIR:-$PWD}"/scripts/foo.sh (quoted expansion),
+  # ${CLAUDE_PROJECT_DIR:-$PWD}/scripts/foo.sh (unquoted), or $VAR/scripts/foo.sh.
+  # Strip any leading variable-expansion prefix first so the grep only sees
+  # the bare path tail.
   rel=$(printf '%s' "$raw_path" \
-    | grep -oE '[^"$ ]+\.sh' \
+    | sed -E 's|^"?\$\{[^}]+\}"?/||; s|^"?\$[A-Z_][A-Z_0-9]*"?/||' \
+    | grep -oE '\.?/?[^" ]+\.sh' \
     | head -1 \
     | sed -E 's|^/||; s|^\./||')
   [ -z "$rel" ] && continue

--- a/plugins/yellow-core/commands/setup/claude-web.md
+++ b/plugins/yellow-core/commands/setup/claude-web.md
@@ -1,0 +1,798 @@
+---
+name: setup:claude-web
+description: "Prepare a repository for Claude Code Web: audit and scaffold .claude/settings.json, scripts/install_pkgs.sh bootstrap, .gitattributes, .gitignore, and .github/workflows/claude.yml. Use when first enabling cloud sessions, after adding MCP servers, or when cloud sessions fail to find expected tools."
+argument-hint: ''
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - AskUserQuestion
+---
+
+# Set Up Repository for Claude Code Web
+
+Audit and scaffold the files Claude Code Web (`claude.ai/code`) needs to run
+agents against this repository. Claude Code Web runs in ephemeral Ubuntu VMs
+that have no access to user-scope settings (`~/.claude/`), `claude mcp add`
+entries, or locally-installed plugins — everything must live in the
+repository itself.
+
+This command operates in three tiers:
+
+- **Tier 1 — Auto-write (no prompt):** safe, additive edits to
+  `.gitattributes` and `.gitignore`; executable-bit fixes on bootstrap
+  scripts referenced by hooks.
+- **Tier 2 — AskUserQuestion gate:** creates or merges into
+  `.claude/settings.json`, `scripts/install_pkgs.sh`, and
+  `.github/workflows/claude.yml`.
+- **Tier 3 — Warn only:** STDIO MCP compatibility, plugin env-var
+  requirements, oversized `CLAUDE.md`, missing lockfiles.
+
+Re-running on a fully configured repository produces zero writes.
+
+The command runs against the current git worktree. It does not accept a
+`--target` argument.
+
+## Workflow
+
+### Step 1: Detect Repo Root
+
+```bash
+if ! command -v git >/dev/null 2>&1; then
+  printf '[setup:claude-web] Error: git is not installed.\n' >&2
+  exit 1
+fi
+
+REPO_TOP=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [ -z "$REPO_TOP" ]; then
+  printf '[setup:claude-web] Error: this command must be run from inside a git repository.\n' >&2
+  exit 1
+fi
+
+GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
+GIT_COMMON=$(git rev-parse --git-common-dir 2>/dev/null)
+if [ "$GIT_DIR" != "$GIT_COMMON" ]; then
+  printf '[setup:claude-web] Note: running inside a git worktree. Files will be written here, not in the main working tree.\n' >&2
+fi
+
+printf 'repo_top: %s\n' "$REPO_TOP"
+```
+
+If the script exits non-zero, stop with the printed error message. Do not
+proceed.
+
+### Step 2: Comprehensive Audit
+
+Run a single Bash block that reads every signal Steps 3–8 need. Output
+follows a `key: value` vocabulary using only these values:
+`ok | missing | present | corrupt | error | yes | no | n/a | too_large`.
+
+```bash
+REPO_TOP=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_TOP" || exit 1
+
+JQ_OK=yes
+command -v jq >/dev/null 2>&1 || JQ_OK=no
+
+printf '=== Settings ===\n'
+if [ -e .claude ] && [ ! -d .claude ]; then
+  printf 'claude_dir_is_file: yes\n'
+else
+  printf 'claude_dir_is_file: no\n'
+fi
+
+if [ -f .claude/settings.json ]; then
+  printf 'settings_json: exists\n'
+  if [ "$JQ_OK" = yes ] && jq empty .claude/settings.json >/dev/null 2>&1; then
+    printf 'settings_json_valid: yes\n'
+    printf 'settings_has_session_start: %s\n' "$(jq -r 'if (.hooks.SessionStart // [] | length) > 0 then "yes" else "no" end' .claude/settings.json 2>/dev/null || printf 'error')"
+    printf 'settings_has_allow: %s\n' "$(jq -r 'if (.permissions.allow // [] | length) > 0 then "yes" else "no" end' .claude/settings.json 2>/dev/null || printf 'error')"
+    printf 'settings_has_deny: %s\n' "$(jq -r 'if (.permissions.deny // [] | length) > 0 then "yes" else "no" end' .claude/settings.json 2>/dev/null || printf 'error')"
+    printf 'settings_has_env: %s\n' "$(jq -r 'if (.env // {} | length) > 0 then "yes" else "no" end' .claude/settings.json 2>/dev/null || printf 'error')"
+    printf 'settings_session_start_has_install_pkgs: %s\n' "$(jq -r '[.hooks.SessionStart // [] | .[].hooks // [] | .[].command] | map(select(. != null and contains("install_pkgs.sh"))) | if length > 0 then "yes" else "no" end' .claude/settings.json 2>/dev/null || printf 'error')"
+  else
+    printf 'settings_json_valid: no\n'
+    printf 'settings_has_session_start: n/a\n'
+    printf 'settings_has_allow: n/a\n'
+    printf 'settings_has_deny: n/a\n'
+    printf 'settings_has_env: n/a\n'
+    printf 'settings_session_start_has_install_pkgs: n/a\n'
+  fi
+else
+  printf 'settings_json: missing\n'
+  printf 'settings_json_valid: n/a\n'
+  printf 'settings_has_session_start: n/a\n'
+  printf 'settings_has_allow: n/a\n'
+  printf 'settings_has_deny: n/a\n'
+  printf 'settings_has_env: n/a\n'
+  printf 'settings_session_start_has_install_pkgs: n/a\n'
+fi
+
+printf '\n=== Bootstrap ===\n'
+if [ -e scripts ] && [ ! -d scripts ]; then
+  printf 'scripts_dir_is_file: yes\n'
+else
+  printf 'scripts_dir_is_file: no\n'
+fi
+if [ -f scripts/install_pkgs.sh ]; then
+  printf 'install_pkgs_exists: yes\n'
+  if grep -qE 'CLAUDE_CODE_REMOTE.*!=.*"true".*exit 0|exit 0.*CLAUDE_CODE_REMOTE.*!=.*"true"' scripts/install_pkgs.sh 2>/dev/null; then
+    printf 'install_pkgs_has_remote_gate: yes\n'
+  elif grep -q 'CLAUDE_CODE_REMOTE' scripts/install_pkgs.sh 2>/dev/null; then
+    printf 'install_pkgs_has_remote_gate: present_unclear\n'
+  else
+    printf 'install_pkgs_has_remote_gate: no\n'
+  fi
+  if git ls-files --error-unmatch scripts/install_pkgs.sh >/dev/null 2>&1; then
+    MODE=$(git ls-files --format='%(objectmode) %(path)' -- scripts/install_pkgs.sh 2>/dev/null | awk '{print $1}')
+    [ "$MODE" = "100755" ] && printf 'install_pkgs_exec_bit: yes\n' || printf 'install_pkgs_exec_bit: no\n'
+  else
+    printf 'install_pkgs_exec_bit: n/a\n'
+  fi
+else
+  printf 'install_pkgs_exists: no\n'
+  printf 'install_pkgs_has_remote_gate: n/a\n'
+  printf 'install_pkgs_exec_bit: n/a\n'
+fi
+
+printf '\n=== Lockfiles ===\n'
+[ -f pnpm-lock.yaml ]    && printf 'pkg_pnpm: yes\n'    || printf 'pkg_pnpm: no\n'
+[ -f yarn.lock ]         && printf 'pkg_yarn: yes\n'    || printf 'pkg_yarn: no\n'
+[ -f package-lock.json ] && printf 'pkg_npm: yes\n'     || printf 'pkg_npm: no\n'
+[ -f uv.lock ]           && printf 'pkg_uv: yes\n'      || printf 'pkg_uv: no\n'
+[ -f requirements.txt ]  && printf 'pkg_pip: yes\n'     || printf 'pkg_pip: no\n'
+[ -f Cargo.lock ]        && printf 'pkg_cargo: yes\n'   || printf 'pkg_cargo: no\n'
+[ -f Gemfile.lock ]      && printf 'pkg_bundler: yes\n' || printf 'pkg_bundler: no\n'
+[ -f composer.lock ]     && printf 'pkg_composer: yes\n' || printf 'pkg_composer: no\n'
+[ -f go.sum ]            && printf 'pkg_go: yes\n'      || printf 'pkg_go: no\n'
+
+printf '\n=== Git Attributes ===\n'
+if [ -f .gitattributes ]; then
+  SIZE=$(wc -c < .gitattributes 2>/dev/null || echo 0)
+  if [ "$SIZE" -gt 1048576 ]; then
+    printf 'gitattributes: exists\n'
+    printf 'gitattributes_size: too_large\n'
+    printf 'gitattributes_text_auto: n/a\n'
+    printf 'gitattributes_sh_eol: n/a\n'
+  else
+    printf 'gitattributes: exists\n'
+    grep -qF '* text=auto' .gitattributes 2>/dev/null && printf 'gitattributes_text_auto: present\n' || printf 'gitattributes_text_auto: missing\n'
+    grep -qF '*.sh eol=lf' .gitattributes 2>/dev/null && printf 'gitattributes_sh_eol: present\n' || printf 'gitattributes_sh_eol: missing\n'
+  fi
+else
+  printf 'gitattributes: missing\n'
+  printf 'gitattributes_text_auto: n/a\n'
+  printf 'gitattributes_sh_eol: n/a\n'
+fi
+
+printf '\n=== Git Ignore ===\n'
+if [ -f .gitignore ]; then
+  SIZE=$(wc -c < .gitignore 2>/dev/null || echo 0)
+  if [ "$SIZE" -gt 1048576 ]; then
+    printf 'gitignore: exists\n'
+    printf 'gitignore_size: too_large\n'
+  else
+    printf 'gitignore: exists\n'
+    for PAT in '.env' '.env.*' '.env.local' '*.pem' '*.key' '.aws/' '.ssh/' 'secrets/' 'credentials/'; do
+      KEY=$(printf '%s' "$PAT" | tr -c 'a-zA-Z0-9' '_')
+      grep -qF -- "$PAT" .gitignore 2>/dev/null && printf 'gitignore_%s: present\n' "$KEY" || printf 'gitignore_%s: missing\n' "$KEY"
+    done
+  fi
+else
+  printf 'gitignore: missing\n'
+fi
+
+printf '\n=== MCP ===\n'
+if [ -f .mcp.json ]; then
+  printf 'mcp_json: exists\n'
+  if [ "$JQ_OK" = yes ] && jq empty .mcp.json >/dev/null 2>&1; then
+    printf 'mcp_json_valid: yes\n'
+    STDIO=$(jq -r '[.mcpServers // {} | to_entries[] | select(.value.type == "stdio") | .key] | join(" ")' .mcp.json 2>/dev/null)
+    if [ -n "$STDIO" ]; then
+      printf 'mcp_stdio_servers: %s\n' "$STDIO"
+    else
+      printf 'mcp_stdio_servers: none\n'
+    fi
+  else
+    printf 'mcp_json_valid: no\n'
+    printf 'mcp_stdio_servers: n/a\n'
+  fi
+else
+  printf 'mcp_json: missing\n'
+  printf 'mcp_json_valid: n/a\n'
+  printf 'mcp_stdio_servers: n/a\n'
+fi
+
+printf '\n=== GitHub Actions ===\n'
+if [ -d .github/workflows ]; then
+  printf 'workflows_dir: yes\n'
+  if grep -rlF 'anthropics/claude-code-action' .github/workflows/ >/dev/null 2>&1; then
+    printf 'claude_action_present: yes\n'
+  else
+    printf 'claude_action_present: no\n'
+  fi
+else
+  printf 'workflows_dir: no\n'
+  printf 'claude_action_present: n/a\n'
+fi
+
+printf '\n=== CLAUDE.md ===\n'
+if [ -f CLAUDE.md ]; then
+  printf 'claude_md_lines: %s\n' "$(wc -l < CLAUDE.md)"
+  printf 'claude_md_bytes: %s\n' "$(wc -c < CLAUDE.md)"
+else
+  printf 'claude_md_lines: 0\n'
+  printf 'claude_md_bytes: 0\n'
+fi
+```
+
+The audit MUST run as a single Bash call. Do NOT split into multiple Bash
+blocks — each block is a fresh subprocess and variables (`REPO_TOP`,
+`JQ_OK`) would not survive.
+
+If `jq` is not installed: every settings.json / .mcp.json check returns
+`n/a` and the user is warned in Step 9.
+
+### Step 3: Display Audit Results
+
+Parse the audit output and emit a markdown table to the user. Mark Tier 1
+items with `→ will auto-fix` and Tier 2 items with `→ will prompt`. Status
+vocabulary: `OK | MISSING | PARTIAL | WARN | CORRUPT | NEEDS ATTENTION`.
+
+Example:
+
+```text
+Claude Code Web Readiness Audit
+================================
+  .claude/settings.json      MISSING       → will prompt (scaffold)
+  scripts/install_pkgs.sh    MISSING       → will prompt (pnpm detected)
+  .gitattributes             PARTIAL       → will auto-fix (append *.sh eol=lf)
+  .gitignore                 PARTIAL       → will auto-fix (append 4 patterns)
+  .mcp.json                  OK            no STDIO servers detected
+  CLAUDE.md                  OK            150 lines
+  .github/workflows/         not in use    skip claude.yml
+  Lockfile                   OK            pnpm-lock.yaml present
+```
+
+### Step 4: `.gitattributes` and `.gitignore` (Tier 1 — auto-write)
+
+Single Bash block. Append-if-missing using `grep -qF` + `printf >>`. No
+AskUserQuestion. No use of the Write tool (Write may emit CRLF on WSL2;
+Bash `printf` writes LF only).
+
+```bash
+REPO_TOP=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_TOP" || exit 1
+
+_ensure_trailing_newline() {
+  local f="$1"
+  if [ -f "$f" ] && [ -s "$f" ]; then
+    LAST=$(tail -c1 "$f" | od -An -c | tr -d ' ')
+    case "$LAST" in
+      '\n') : ;;
+      *)    printf '\n' >> "$f" ;;
+    esac
+  fi
+}
+
+_append_if_missing() {
+  local f="$1" line="$2"
+  grep -qF -- "$line" "$f" 2>/dev/null && return 0
+  _ensure_trailing_newline "$f"
+  printf '%s\n' "$line" >> "$f"
+  printf '[setup:claude-web] %s: appended %s\n' "$f" "$line"
+}
+
+# .gitattributes
+for LINE in '* text=auto' '*.sh eol=lf'; do
+  _append_if_missing .gitattributes "$LINE"
+done
+
+# .gitignore (under a single header comment if any are missing)
+NEEDS_HEADER=no
+for PAT in '.env' '.env.*' '.env.local' '*.pem' '*.key' '.aws/' '.ssh/' 'secrets/' 'credentials/'; do
+  if ! grep -qF -- "$PAT" .gitignore 2>/dev/null; then
+    NEEDS_HEADER=yes
+    break
+  fi
+done
+if [ "$NEEDS_HEADER" = yes ]; then
+  _ensure_trailing_newline .gitignore
+  grep -qF '# Claude Code Web — sensitive file protection' .gitignore 2>/dev/null || \
+    printf '\n# Claude Code Web — sensitive file protection\n' >> .gitignore
+fi
+for PAT in '.env' '.env.*' '.env.local' '*.pem' '*.key' '.aws/' '.ssh/' 'secrets/' 'credentials/'; do
+  _append_if_missing .gitignore "$PAT"
+done
+```
+
+If `gitattributes_size: too_large` or `gitignore_size: too_large` was
+reported in Step 2: skip the corresponding file entirely and warn the user
+that the file exceeds 1 MiB.
+
+### Step 5: `.claude/settings.json` (Tier 2 — AskUserQuestion gate)
+
+Behavior depends on audit results:
+
+**5a — `claude_dir_is_file: yes`:**
+Print `[setup:claude-web] Error: .claude exists as a regular file, not a
+directory. Manual repair required.` and proceed to Step 6.
+
+**5b — `settings_json: exists` AND `settings_json_valid: no`:**
+Print `[setup:claude-web] Warning: .claude/settings.json is not valid
+JSON (may contain comments or syntax errors). Skipping settings merge.
+Manual repair required before re-running.` Proceed to Step 6.
+
+**5c — `settings_json: exists` AND all required keys present (allow, deny,
+env, session_start_has_install_pkgs all `yes`):**
+Print `[setup:claude-web] .claude/settings.json: all required keys
+already present.` Proceed to Step 6.
+
+**5d — `settings_json: missing`:**
+Show the scaffold template to the user as a code block. Then ask:
+
+```
+AskUserQuestion:
+  question: "Write `.claude/settings.json` with a SessionStart hook for scripts/install_pkgs.sh, default permissions.allow / .deny entries, and env.NODE_ENV?"
+  options: ["Write it", "Skip"]
+```
+
+If the user picks `[Skip]`: print `[setup:claude-web] Skipping
+.claude/settings.json scaffold.` and proceed to Step 6. Do NOT execute
+any write commands for this step.
+
+If the user picks `[Write it]`: run the Python atomic-write block below.
+
+**5e — `settings_json: exists` AND some keys missing:**
+Show a diff-style summary of what would be added. Then ask:
+
+```
+AskUserQuestion:
+  question: "Merge missing keys into existing `.claude/settings.json` (preserve all existing entries; only append)?"
+  options: ["Merge", "Skip"]
+```
+
+If `[Skip]`: print skip message and proceed to Step 6. Do NOT execute
+any merge commands.
+
+If `[Merge]`: run the Python atomic-merge block below.
+
+#### Python atomic-write/merge block
+
+Mirrors the canonical pattern from `plugins/yellow-core/commands/statusline/setup.md`
+(read JSON → mutate in memory → write `.tmp` → validate → `os.replace`).
+
+```bash
+python3 - <<'__EOF_SETTINGS_MERGE__'
+import json, os, sys
+
+target = '.claude/settings.json'
+tmp = target + '.tmp'
+os.makedirs('.claude', exist_ok=True)
+
+if os.path.isfile(target):
+    try:
+        with open(target) as f:
+            cfg = json.load(f)
+    except Exception as e:
+        print(f"[setup:claude-web] Error: cannot parse {target}: {e}", file=sys.stderr)
+        sys.exit(1)
+else:
+    cfg = {}
+
+# permissions.allow (append-only)
+default_allow = [
+    "Bash(git status)",
+    "Bash(git diff:*)",
+    "Bash(git log:*)",
+]
+cfg.setdefault("permissions", {})
+existing_allow = cfg["permissions"].get("allow", [])
+for entry in default_allow:
+    if entry not in existing_allow:
+        existing_allow.append(entry)
+cfg["permissions"]["allow"] = existing_allow
+
+# permissions.deny (append-only)
+default_deny = [
+    "Read(**/.ssh/**)",
+    "Read(**/.aws/**)",
+    "Read(**/.env)",
+    "Read(**/.env.*)",
+]
+existing_deny = cfg["permissions"].get("deny", [])
+for entry in default_deny:
+    if entry not in existing_deny:
+        existing_deny.append(entry)
+cfg["permissions"]["deny"] = existing_deny
+
+# env (only add NODE_ENV if NO env block exists at all)
+if "env" not in cfg:
+    cfg["env"] = {"NODE_ENV": "test"}
+
+# hooks.SessionStart (append-only; do not duplicate install_pkgs.sh wire-up)
+cfg.setdefault("hooks", {})
+session_start = cfg["hooks"].get("SessionStart", [])
+already_wired = False
+for entry in session_start:
+    for hook in entry.get("hooks", []):
+        cmd = hook.get("command", "") or ""
+        if "install_pkgs.sh" in cmd:
+            already_wired = True
+            break
+    if already_wired:
+        break
+if not already_wired:
+    session_start.append({
+        "matcher": "*",
+        "hooks": [{
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR:-$PWD}\"/scripts/install_pkgs.sh"
+        }]
+    })
+cfg["hooks"]["SessionStart"] = session_start
+
+# Atomic write: tmp → validate → rename
+with open(tmp, 'w') as f:
+    json.dump(cfg, f, indent=2)
+    f.write('\n')
+with open(tmp) as f:
+    json.load(f)  # raises on invalid JSON
+os.replace(tmp, target)
+print(f"[setup:claude-web] Wrote {target}")
+__EOF_SETTINGS_MERGE__
+```
+
+#### Post-write verification (Step 5f)
+
+If `jq` is available, run the structured check first:
+
+```bash
+if command -v jq >/dev/null 2>&1; then
+  jq -e '.hooks.SessionStart | length > 0' .claude/settings.json >/dev/null && \
+    jq -e '.permissions.allow | type == "array"' .claude/settings.json >/dev/null && \
+    jq -e '.permissions.deny | type == "array"' .claude/settings.json >/dev/null
+else
+  # Fallback when jq isn't installed: verify the file is non-empty and
+  # contains the expected key markers. The Python write already validated
+  # JSON shape via json.load() before os.replace().
+  [ -s .claude/settings.json ] && \
+    grep -q '"SessionStart"' .claude/settings.json && \
+    grep -q '"allow"' .claude/settings.json
+fi
+```
+
+If this exits non-zero: print `[setup:claude-web] Error: settings.json
+write verification failed.` and stop the command.
+
+Then use the Read tool to read `.claude/settings.json` and confirm the
+SessionStart entry's `command` field contains `install_pkgs.sh`. If it
+does not: print the same error and stop.
+
+### Step 6: `scripts/install_pkgs.sh` (Tier 2)
+
+**6a — `scripts_dir_is_file: yes`:**
+Print `[setup:claude-web] Error: scripts exists as a regular file, not a
+directory. Manual repair required.` Proceed to Step 7.
+
+**6b — `install_pkgs_exists: yes` AND `install_pkgs_has_remote_gate: yes`:**
+Print `[setup:claude-web] scripts/install_pkgs.sh exists and has the
+CLAUDE_CODE_REMOTE gate.` Proceed to Step 7.
+
+**6c — `install_pkgs_exists: yes` AND `install_pkgs_has_remote_gate: no` (or `present_unclear`):**
+Print:
+```text
+[setup:claude-web] Warning: scripts/install_pkgs.sh exists but is missing
+the CLAUDE_CODE_REMOTE gate. Without it, the script runs on every local
+session too.
+
+Add this at line 2 of your script:
+    if [ "$CLAUDE_CODE_REMOTE" != "true" ]; then exit 0; fi
+```
+Do NOT overwrite the existing script. Proceed to Step 7.
+
+**6d — `install_pkgs_exists: no`:**
+
+Determine the package manager from Step 2's lockfile detection. Priority
+order: `pnpm > yarn > npm > uv > pip > cargo > bundler > composer > go`.
+
+If exactly one is detected, use it. If two or more are detected, ask:
+
+```
+AskUserQuestion:
+  question: "Multiple package manager lockfiles detected: <list>. Which install command should the bootstrap script run?"
+  options: [each detected manager, "Skip"]
+```
+
+If `[Skip]`: print skip message and proceed to Step 7. Do NOT write the
+script.
+
+If none detected: print `[setup:claude-web] No package manager lockfile
+detected. Skipping bootstrap script.` and proceed to Step 7.
+
+Map the selected manager to its install command:
+
+| Lockfile           | Manager  | Install command                       |
+|--------------------|----------|---------------------------------------|
+| `pnpm-lock.yaml`   | pnpm     | `pnpm install --frozen-lockfile`      |
+| `yarn.lock`        | yarn     | `yarn install --frozen-lockfile`      |
+| `package-lock.json`| npm      | `npm ci`                              |
+| `uv.lock`          | uv       | `uv sync --frozen`                    |
+| `requirements.txt` | pip      | `pip install -r requirements.txt`     |
+| `Cargo.lock`       | cargo    | `cargo build --frozen`                |
+| `Gemfile.lock`     | bundler  | `bundle install --deployment`         |
+| `composer.lock`    | composer | `composer install --no-interaction`   |
+| `go.sum`           | go       | `go mod download`                     |
+
+Show the script template that would be written. Then ask:
+
+```
+AskUserQuestion:
+  question: "Write `scripts/install_pkgs.sh` (package manager: <name>)?"
+  options: ["Write it", "Skip"]
+```
+
+If `[Skip]`: print skip message and proceed to Step 7. Do NOT write
+the script.
+
+If `[Write it]`: run the write block below, substituting the actual
+install command for `<INSTALL_CMD>`.
+
+```bash
+mkdir -p scripts
+INSTALL_CMD="<INSTALL_CMD>"   # e.g. pnpm install --frozen-lockfile
+PKG_NAME="<PKG_NAME>"         # e.g. pnpm
+cat > "scripts/install_pkgs.sh" <<__EOF_INSTALL_PKGS__
+#!/bin/bash
+# Note: -e omitted intentionally — hook must exit 0 on the gate path.
+set -uo pipefail
+
+# Gate: only run full installs in cloud sessions
+if [ "\$CLAUDE_CODE_REMOTE" != "true" ]; then
+  exit 0
+fi
+
+# Project root with safe fallback
+PROJECT_DIR="\${CLAUDE_PROJECT_DIR:-\$PWD}"
+cd "\$PROJECT_DIR" || exit 1
+
+# Detected package manager: ${PKG_NAME}
+${INSTALL_CMD}
+
+exit 0
+__EOF_INSTALL_PKGS__
+chmod +x scripts/install_pkgs.sh
+git update-index --chmod=+x scripts/install_pkgs.sh 2>/dev/null || \
+  printf '[setup:claude-web] Warning: could not stage executable bit for scripts/install_pkgs.sh (filesystem chmod succeeded; subsequent commit may not preserve +x)\n' >&2
+printf '[setup:claude-web] Wrote scripts/install_pkgs.sh\n'
+```
+
+The heredoc is **unquoted** so `${INSTALL_CMD}` and `${PKG_NAME}` expand at
+write time. Variables that must remain literal in the output script
+(`$CLAUDE_CODE_REMOTE`, `$CLAUDE_PROJECT_DIR`, `$PWD`) are escaped with
+`\$`. The closing delimiter `__EOF_INSTALL_PKGS__` follows the
+`__EOF_<CONTEXT>__` convention from `plugins/yellow-composio/commands/composio/setup.md`.
+
+**Post-write verification (6e):**
+
+```bash
+[ -f scripts/install_pkgs.sh ] && \
+  grep -q 'CLAUDE_CODE_REMOTE' scripts/install_pkgs.sh && \
+  grep -q 'exit 0' scripts/install_pkgs.sh
+```
+
+If this exits non-zero: print `[setup:claude-web] Error: install_pkgs.sh
+write verification failed.` and stop the command. Otherwise use the Read
+tool to confirm the gate line and install command are present.
+
+### Step 7: `.github/workflows/claude.yml` (Tier 2, conditional)
+
+**7a — `workflows_dir: no`:**
+Print `[setup:claude-web] No .github/workflows/ directory found —
+GitHub Actions not in use in this repo. Skipping claude.yml.` Proceed to
+Step 8.
+
+**7b — `claude_action_present: yes`:**
+Print `[setup:claude-web] A workflow already uses
+anthropics/claude-code-action. Skipping claude.yml.` Proceed to Step 8.
+
+**7c — Otherwise:**
+Show the workflow template to the user. Then ask:
+
+```
+AskUserQuestion:
+  question: "Write `.github/workflows/claude.yml`? (Requires ANTHROPIC_API_KEY in GitHub repository secrets.)"
+  options: ["Write it", "Skip"]
+```
+
+If `[Skip]`: print skip message and proceed to Step 8. Do NOT write the
+workflow.
+
+If `[Write it]`: use the Write tool to create `.github/workflows/claude.yml`
+with the canonical template below, then strip any CRLF the Write tool may
+have introduced:
+
+```bash
+sed -i 's/\r$//' .github/workflows/claude.yml
+```
+
+#### Workflow template
+
+This template follows Anthropic's canonical shape for
+`anthropics/claude-code-action@v1` (currently latest tag v1.0.124, August
+2025). Every trigger event is gated on `@claude` substring match — there
+is no unconditional PR trigger.
+
+```yaml
+# Claude Code GitHub Action — set ANTHROPIC_API_KEY in repo secrets
+# before this workflow runs:
+#   https://github.com/<owner>/<repo>/settings/secrets/actions
+#
+# Adjust `permissions` to match your security policy. The block below is
+# Anthropic's recommended set for the @claude-mention workflow. Drop any
+# permission you do not need.
+name: Claude Code
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  claude:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+### Step 8: Executable Bits (Tier 1, scoped to hook-referenced scripts)
+
+After Step 5 has finalized `.claude/settings.json`, scope the chmod fix
+to ONLY scripts referenced in `hooks` commands — not all tracked `*.sh`
+files in the repo.
+
+```bash
+REPO_TOP=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_TOP" || exit 1
+
+if [ ! -f .claude/settings.json ]; then
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf '[setup:claude-web] Warning: jq not installed — skipping hook-script executable-bit check.\n' >&2
+  exit 0
+fi
+
+# Extract all hook command paths from settings.json
+HOOK_SCRIPTS=$(jq -r '
+  [.hooks // {} | to_entries[].value[]? | .hooks[]? | .command]
+  | map(select(. != null))
+  | .[]
+' .claude/settings.json 2>/dev/null)
+
+printf '%s\n' "$HOOK_SCRIPTS" | while IFS= read -r raw_path; do
+  [ -z "$raw_path" ] && continue
+  # Extract a .sh path from the command string. Hook commands typically look
+  # like "${CLAUDE_PROJECT_DIR:-$PWD}"/scripts/foo.sh — grep captures the
+  # path tail after the variable expansion, then sed strips leading `/` or
+  # `./` to produce a repo-relative path.
+  rel=$(printf '%s' "$raw_path" \
+    | grep -oE '[^"$ ]+\.sh' \
+    | head -1 \
+    | sed -E 's|^/||; s|^\./||')
+  [ -z "$rel" ] && continue
+  [ -f "$rel" ] || continue
+  if git ls-files --error-unmatch -- "$rel" >/dev/null 2>&1; then
+    MODE=$(git ls-files --format='%(objectmode) %(path)' -- "$rel" 2>/dev/null | awk 'NR==1 {print $1}')
+    if [ "$MODE" = "100644" ]; then
+      chmod +x "$rel" 2>/dev/null || \
+        printf '[setup:claude-web] Warning: chmod +x failed for %s (filesystem may not support exec bit)\n' "$rel" >&2
+      git update-index --chmod=+x "$rel" 2>/dev/null || \
+        printf '[setup:claude-web] Warning: could not stage executable bit for %s (commit will not preserve +x)\n' "$rel" >&2
+      printf '[setup:claude-web] Fixed executable bit: %s\n' "$rel"
+    fi
+  fi
+done
+```
+
+If no hook-referenced scripts are found, this step is a no-op.
+
+### Step 9: Summary Output
+
+Always emitted, regardless of what was written or skipped. Aggregate
+information from Steps 2–8.
+
+```text
+═══════════════════════════════════════════════════════════
+  Claude Code Web Setup — Summary
+═══════════════════════════════════════════════════════════
+
+Files written/modified:
+  <list of writes from Steps 4-8, or "none — no changes needed">
+
+🔑 REQUIRED MANUAL ACTION
+   Set ANTHROPIC_API_KEY as a GitHub repository secret:
+   https://github.com/<owner>/<repo>/settings/secrets/actions
+   (Only required if claude.yml was written or already present.)
+
+Env vars to set in the cloud environment UI at claude.ai/code:
+  <list of plugin userConfig keys and MCP env-var placeholders, or "none">
+
+Warnings requiring human review:
+  <list, or "none">
+
+Next steps:
+  1. Set ANTHROPIC_API_KEY as a GitHub repository secret (if claude.yml is in use)
+  2. Configure any env vars listed above in the cloud environment UI
+  3. Install the Claude GitHub App (required for Auto-fix)
+  4. Test a cloud session: open claude.ai/code and select this repo
+
+Reference: see your repository's docs/research/ folder or
+https://code.claude.com/docs/en/claude-code-on-the-web
+```
+
+Warnings to surface in the summary:
+
+- `CLAUDE.md is N lines (>200 recommended for cloud sessions — large
+  CLAUDE.md consumes context budget on every session start).`
+- `.mcp.json contains STDIO server '<name>' — may not work in the web
+  sandbox; consider migrating to HTTP transport.` (Distinguish `npx`-based
+  STDIO servers, which often work, from custom-binary STDIO servers,
+  which never will.)
+- `scripts/install_pkgs.sh exists but lacks the CLAUDE_CODE_REMOTE gate.`
+- `Package manager detected but no lockfile committed — cloud sessions
+  cannot reproduce dependencies.`
+- `.gitattributes or .gitignore exceeds 1 MiB — skipped pattern checks.`
+
+## Error Handling
+
+| Scenario                                       | Behavior                                         |
+| ---------------------------------------------- | ------------------------------------------------ |
+| `git` not installed                            | Step 1 exits with clear error                    |
+| Not in a git repo                              | Step 1 exits with clear error                    |
+| `.claude` exists as a regular file             | Step 5 prints error and skips to Step 6          |
+| `scripts` exists as a regular file             | Step 6 prints error and skips to Step 7          |
+| `.claude/settings.json` is invalid JSON        | Step 5 warns and skips merge; remaining steps continue |
+| `.mcp.json` is invalid JSON                    | Audit reports `mcp_json_valid: no`; warn in Step 9 |
+| `jq` not installed                             | All JSON-dependent audit checks return `n/a`; warn in Step 9 |
+| User picks `[Skip]` at any Tier 2 prompt       | That step is skipped; command continues to the next step |
+| Hook-referenced script is outside the worktree | Step 8 skips it silently (no `git ls-files` match) |
+
+## Security Notes
+
+- The audit MUST NOT echo values from `.mcp.json` or `~/.claude.json` —
+  only keys, server names, and `type` fields. The `jq` filters in Step 2
+  extract `mcpServers | keys[]` and `.type` only; no value fields are
+  read or printed.
+- All user input is enum picks from AskUserQuestion. No free-text input
+  is interpolated into file writes or shell commands.
+- The generated `claude.yml` header comment notes that `contents: write`
+  is needed for Auto-fix and should be reviewed against the repo's
+  security policy.
+- The generated `install_pkgs.sh` uses install commands from a fixed
+  table (Step 6d) based on detected lockfiles — no user-typed string
+  becomes part of the script body.
+
+## Idempotency Invariant
+
+Re-running on a fully configured repo produces:
+
+- zero file writes
+- zero Tier 2 AskUserQuestion prompts
+- a Step 9 summary showing `Files written/modified: none — no changes needed`
+- only Tier 3 informational warnings (CLAUDE.md size, etc.) if applicable


### PR DESCRIPTION
Adds a new command at plugins/yellow-core/commands/setup/claude-web.md that
audits and scaffolds the repository-scope files Claude Code Web needs to
run cloud sessions: .claude/settings.json, scripts/install_pkgs.sh,
.gitattributes, .gitignore, and .github/workflows/claude.yml.

The web sandbox has no access to user-scope settings (~/.claude/),
'claude mcp add' entries, or locally-installed plugins, so everything an
agent uses must live in the repository. The command runs in three tiers:

- Tier 1 auto-write: appends missing .gitattributes lines (* text=auto,
  *.sh eol=lf) and .gitignore sensitive-path patterns (.env, *.pem,
  *.key, .aws/, .ssh/, secrets/, credentials/); fixes executable bits
  via chmod + git update-index --chmod=+x on bootstrap scripts referenced
  by hooks.
- Tier 2 AskUserQuestion gate: scaffolds or merges into
  .claude/settings.json (Python-based atomic write mirroring
  statusline/setup.md precedent); writes scripts/install_pkgs.sh from a
  detected lockfile (pnpm > yarn > npm > uv > pip > cargo > bundler >
  composer > go) with CLAUDE_CODE_REMOTE=true gate; writes
  .github/workflows/claude.yml using the canonical
  anthropics/claude-code-action@v1 shape with @claude-mention triggers
  across issue_comment, pull_request_review_comment, and issues events.
- Tier 3 warn-only: flags STDIO MCP servers, oversized CLAUDE.md,
  missing lockfiles, and permissions.deny defense-in-depth gaps.

Re-running on a fully configured repo produces zero writes -
idempotency is enforced via grep-before-append for line additions and
append-only Python merge for JSON keys.

Includes the original design trail under docs/ and plans/ - research
report (Anthropic-official source citations), iterative brainstorm, and
the STANDARD implementation plan that was deepened with one external
research pass that surfaced the canonical claude-code-action@v1 shape.

Updates plugins/yellow-core/CLAUDE.md commands count (8 -> 9) and adds
the new command to plugins/yellow-core/README.md commands table.

Changeset: yellow-core minor bump.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the /setup:claude-web command to audit repositories and scaffold/configure files needed for Claude Code Web sessions.

* **Documentation**
  * Added comprehensive docs describing web session behavior, configuration guidance, and failure modes.
  * Added design, plan, brainstorm, and command-specification docs for the new setup command.
  * Updated plugin README/command listings and command count to include the new command.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KingInYellows/yellow-plugins/pull/545?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->