### PR TITLE
fix(yellow-core): compound-staging review follow-ups (concurrency + lint + UX)

### DIFF
--- a/.changeset/yellow-core-compound-staging-followups.md
+++ b/.changeset/yellow-core-compound-staging-followups.md
@@ -1,0 +1,48 @@
+---
+'yellow-core': patch
+---
+
+Compound-staging review follow-ups: concurrency hardening + lint hardening + doc clarity.
+
+**Phase 1 — Concurrency hardening (PR #542 follow-on):**
+- `session-start.sh`: processing/ requeue loop now gated on the absence of an
+  active `.drain-lock`. Closes the race where two concurrent SessionStarts
+  could both requeue the same crashed entry.
+- `session-start.sh`: parent-side EXIT trap with `LOCK_OWNED_BY_PARENT` flag
+  releases `.drain-lock` if the parent exits between `mkdir` and successful
+  subshell dispatch. Closes the lock-orphan window (was previously recoverable
+  only via the 30-min stale-lock reaper).
+- Two new bats tests: `does not requeue processing/ entries when drain lock
+  is held`, `parent-side trap releases drain-lock on early-exit before dispatch`.
+
+**Phase 2 — Brainstorm supersession callouts (PR #540 follow-on):**
+- Per-section SUPERSEDED markers added to `docs/brainstorms/2026-05-18-*.md`
+  Architecture block, JSONL Schema section, Decision 3, and Decision 4 so
+  readers who scan to a specific section can't act on stale designs.
+
+**Phase 3 — RULE 14/14b hardening + tests (PR #544 follow-on):**
+- `scripts/validate-agent-authoring.js`: RULE 14 now also enforces
+  `disallowedTools: [AskUserQuestion]` on `staging-reviewer.md` (was only
+  checking `staging-promoter.md`). Both run non-interactively.
+- RULE 14b: replaced the global-boolean co-location check with paragraph-based
+  co-location. Catches the decoy where "Never modify staging entries" appears
+  in one paragraph and the protected section names appear in unrelated
+  paragraphs elsewhere.
+- RULE 14b: CRLF-tolerant frontmatter strip (matches `extractFrontmatter()`),
+  so WSL2-authored files aren't false-negative.
+- RULE 14 character class widened from `[\w:-]+` to `[\w.:-]+` to admit tool
+  names with dots.
+- New `tests/integration/validate-agent-authoring-rule14.test.ts` (8 cases):
+  pass/fail fixtures for both rules including the decoy false-negative.
+
+**Phase 4 — Phase 5.1 preview UX clarification (PR #540 + PR #544 follow-on):**
+- Plan Phase 5.1 description rewritten to explicitly state that the preview
+  shows raw `transcript_tail` bytes (not `candidate_text`, which doesn't
+  exist until drain time).
+- `/compound:review-staged` Step 3 preview now renders metadata
+  (`session_id`, `cwd`, file mtime) alongside the transcript snippet so users
+  can identify which session each entry came from even when the transcript
+  preview is unintelligible.
+
+No public-surface changes; all updates are internal hardening, doc clarity,
+and test coverage. Patch bump.

--- a/docs/brainstorms/2026-05-18-background-compounding-triggers-brainstorm.md
+++ b/docs/brainstorms/2026-05-18-background-compounding-triggers-brainstorm.md
@@ -105,6 +105,12 @@ primitives without inheriting the interactive gates.
 
 ## Architecture
 
+> **SUPERSEDED by plan §Architecture (Option C, pure-shell capture)** —
+> bash subshells cannot invoke `Agent`/`Task`. The Stop hook is now
+> pure-shell (no LLM); the drain runs in a disowned `claude -p` subshell
+> dispatched by the SessionStart hook. See
+> `plans/background-compounding-triggers.md` D1.
+
 ```
  ┌─────────────────────────────────────────────────────────────────┐
  │  SESSION END (Stop hook fires)                                  │
@@ -166,6 +172,13 @@ primitives without inheriting the interactive gates.
 ---
 
 ## JSONL Schema
+
+> **SUPERSEDED by plan §JSONL Schema (Phase 1.3)** — the Stop hook now
+> writes only `transcript_tail` (raw bytes), `session_id`, `cwd`, and
+> `content_hash`. The scored fields (`candidate_text`, `priority`, `tags`,
+> `category`) are generated at drain time by `staging-scorer` and live in
+> the in-flight `processing/` JSONL, not the `pending/` JSONL.
+
 
 Each entry written by the Haiku stager. Schema version `"1"` per yellow-plugins
 queue convention (matches ruvector JSONL pattern from MEMORY.md):
@@ -232,6 +245,12 @@ is the only active Stop hook in the entire marketplace besides yellow-ruvector's
 
 ### Decision 3: Staging-reviewer invokes knowledge-compounder for writes
 
+> **SUPERSEDED by plan D8** — `knowledge-compounder` is NOT modified; a
+> new `staging-promoter` agent is used instead. Promoter frontmatter has
+> `disallowedTools: [AskUserQuestion]` (D8 hard-deny enforced by RULE 14
+> in `scripts/validate-agent-authoring.js`).
+
+
 The `staging-reviewer` agent does NOT reimplement `docs/solutions/` write
 logic or MEMORY.md write logic. It delegates to
 `knowledge-compounder` (`subagent_type: "yellow-core:workflow:knowledge-compounder"`)
@@ -241,6 +260,11 @@ plan phase must address how to add a `--no-confirm` or `mode: background` path
 without breaking the interactive flow.
 
 ### Decision 4: Cold-path thresholds are configurable but hardcoded for MVP
+
+> **SUPERSEDED by plan §Budget Model** — base age threshold revised from
+> 24h to 48h for Max 20x responsive defaults. Count threshold remains 5.
+> See `plans/background-compounding-triggers.md` D context.
+
 
 Default thresholds: age > 24h OR count >= 5. These are hardcoded constants in
 the SessionStart hook for MVP. Per the `local-config` skill pattern, they can

--- a/plans/background-compounding-triggers.md
+++ b/plans/background-compounding-triggers.md
@@ -543,8 +543,18 @@ interactive session.
   - Body steps:
     1. Source `lib/compound-staging.sh`, derive `STAGING_DIR`
     2. Count `pending/*.jsonl`; exit if 0
-    3. Read up to 5 entry titles via `jq -r '.transcript_tail | .[0:80]'`
-       on first lines
+    3. Preview up to 5 entries: read the first 80 chars of
+       `transcript_tail` via `jq -r '.transcript_tail | .[0:80] |
+       gsub("\\n"; " ")'`. **This is raw, post-redaction transcript
+       bytes — NOT a human-readable title.** The pending JSONL schema
+       (Phase 1.3) only carries `transcript_tail`, `session_id`, `cwd`,
+       `timestamp`, and `content_hash`. The scored, human-readable
+       `candidate_text` is generated at drain time by
+       `staging-scorer`, so it cannot be previewed before dispatch
+       without paying the Haiku cost first. Show metadata
+       (`session_id`, `cwd`, file mtime) alongside the transcript
+       snippet so users with unintelligible preview content can still
+       identify *which* session each entry came from.
     4. **AskUserQuestion** ("N pending; sample titles: ...; Promote?")
        — Options: "Promote All" / "Cancel"
     5. On Cancel: exit

--- a/plans/compound-staging-review-followups.md
+++ b/plans/compound-staging-review-followups.md
@@ -1,0 +1,251 @@
+# Feature: compound-staging stack — review follow-on hardening
+
+## Problem Statement
+
+The PR #540-544 stack review (this session, 2026-05-19) surfaced 4 design-decision
+findings that were intentionally not auto-applied because each requires either a
+careful refactor (concurrency-sensitive code) or coordinated changes across
+multiple sections (cross-doc supersession callouts, test infrastructure).
+
+This plan tracks the follow-on hardening work as a single stacked PR after the
+parent stack lands on `main`. Each item is independently mergeable but
+collectively closes the remaining review feedback for the background-compounding
+pipeline.
+
+## Current State
+
+The parent stack (PRs #540, #542, #543, #544) is MERGEABLE with all auto-applicable
+fixes committed:
+
+- PR #540: cosine threshold semantics clarified; `drain-budget.json` naming fixed
+- PR #542: `umask 077` + `chmod 700` on JSONL writes; ISO-to-epoch helper extracted;
+  `--bare` flag added; timeout validation
+- PR #543: pre-write injection filter; `candidate_text` length/`session_id` pattern
+  guards; idempotent two-phase commit with `.promote-done` sentinel; bypassPermissions
+  paranoia preamble
+- PR #544: drain prompt fencing; BATS_VERSION gate; symlink-safe `find -type f`;
+  `--bare` flag; CLAUDE.md command count + changeset corrections
+
+Remaining items require:
+
+1. **Concurrency refactor** (PR #542): the drain-lock `mkdir` is in the parent shell
+   but the `EXIT` trap is in the subshell. If the parent is killed between `mkdir`
+   and subshell start, the lock orphans for 30 min. Separately, the `processing/`
+   requeue loop runs *before* lock acquisition, allowing concurrent SessionStart
+   invocations to double-requeue the same file.
+2. **Brainstorm supersession callouts** (PR #540): the brainstorm doc has a single
+   prose SUPERSEDED header at the top, but readers who scan to a specific section
+   (Decision 3, Decision 4, JSONL schema, architecture diagram) miss the supersession.
+3. **RULE 14/14b lint coverage** (PR #544): RULE 14b's `neverPattern` is a global
+   boolean — "Never modify X" anywhere + "CORE_RULES" anywhere both true passes the
+   check, even if the two are unrelated. Plus zero integration test coverage for
+   either rule.
+4. **Phase 5.1 preview UX clarity** (PR #540): the plan's Phase 5.1 description
+   says the manual-drain command previews entries by reading `transcript_tail` via
+   `jq`, but the JSONL schema at Phase 1.3 omits `candidate_text` (which would have
+   been the human-readable form). Users may expect titles but get raw transcript
+   bytes — this is a UX gap, not a bug.
+
+## Proposed Solution
+
+Single follow-on PR stacked on `main` *after* the parent stack merges. Each phase
+is independent — can be merged separately if any blocks.
+
+The PR is branch `agent/fix/compound-staging-review-followups`, expected size
+~250-400 lines (mostly test code + brainstorm callouts).
+
+## Implementation Plan
+
+### Phase 1: Concurrency refactor (PR #542 follow-on)
+
+**Goal**: close the lock-orphan window and the processing/ requeue race.
+
+- [ ] 1.1: Move `mkdir "${STAGING_DIR}/.drain-lock"` into the subshell as the
+  FIRST statement, before the `trap` registration. The same shell that creates
+  the lock now owns the cleanup; no orphan window exists. Update the lock
+  contention check to be "if mkdir fails inside subshell, exit cleanly without
+  attempting drain" rather than testing for lock existence in the parent.
+- [ ] 1.2: Move the `processing/` requeue loop (currently lines 125-140 in
+  `session-start.sh`) to *inside* the disowned subshell, AFTER the lock is
+  acquired. This makes requeue serialized with respect to other drains.
+- [ ] 1.3: Update `cs_update_drain_budget` call site to remain inside the
+  subshell at the end (already correct — verify no regression).
+- [ ] 1.4: Add bats test: "lock orphan window closed — parent killed before
+  subshell starts cannot leave a stranded lock" (use a stub that mimics the
+  race).
+- [ ] 1.5: Add bats test: "concurrent SessionStart cannot double-requeue
+  processing/ entries — second invocation finds lock and exits".
+- [ ] 1.6: Update inline comments referencing the old ordering.
+
+**Files**: `plugins/yellow-core/hooks/scripts/session-start.sh`,
+`plugins/yellow-core/tests/compound-session-start-hook.bats`.
+
+### Phase 2: Brainstorm supersession callouts (PR #540 follow-on)
+
+**Goal**: per-section SUPERSEDED markers so partial readers can't act on stale
+designs.
+
+- [ ] 2.1: Add `> **SUPERSEDED by plan D1**: bash subshells cannot invoke
+  Agent/Task; see plan §Architecture (Option C, pure-shell capture).`
+  callout immediately above the ASCII architecture diagram (around line 108
+  of the brainstorm).
+- [ ] 2.2: Add `> **SUPERSEDED by plan D8**: knowledge-compounder is NOT
+  modified; staging-promoter agent is used instead.` callout under the
+  "Decision 3" heading (around line 233-237).
+- [ ] 2.3: Add `> **SUPERSEDED by plan D context**: 48h base threshold (was
+  24h in this brainstorm).` inline note next to the `age > 24h` reference
+  on line 245.
+- [ ] 2.4: Add `> **SUPERSEDED by plan §JSONL Schema**: transcript_tail-only
+  schema; no candidate_text/priority/tags in the Stop-hook write — those are
+  generated at drain time by staging-scorer.` callout above the JSONL Schema
+  heading (around line 168).
+- [ ] 2.5: Resolve the "Open Questions" entries that the plan has answered:
+  add `**Resolved: see plan D5**` (etc.) inline notes for Q2, Q3, Q6, Q7.
+- [ ] 2.6: Update the brainstorm's deepen-validation doc (Q1/Q5 "BLOCKER"
+  status) to "RESOLVED by Option C — pure-shell Stop hook + disowned drain
+  subshell".
+
+**Files**: `docs/brainstorms/2026-05-18-background-compounding-triggers-brainstorm.md`,
+`docs/research/repo/background-compounding-triggers-deepen-validation.md`.
+
+### Phase 3: RULE 14/14b hardening + integration tests (PR #544 follow-on)
+
+**Goal**: close the regex false-negative window and add CI coverage so
+regressions are detectable.
+
+- [ ] 3.1: Replace RULE 14b's disjoint-boolean checks with proximity regex:
+  ```javascript
+  const namesCoreRules =
+    /[Nn]ever (?:modif|write|touch)[^.\n]{0,80}CORE_RULES/.test(body) ||
+    /CORE_RULES[^.\n]{0,80}[Nn]ever (?:modif|write|touch)/.test(body);
+  ```
+  Apply same pattern to `USER_PREFERENCES` and `KNOWN_PROJECTS`. The 80-char
+  proximity window catches the protective "Never modify ... CORE_RULES" prose
+  but rejects unrelated mentions.
+- [ ] 3.2: Make RULE 14b's frontmatter strip CRLF-tolerant (match the
+  `extractFrontmatter()` regex). Currently `/^---\n/` misses WSL2-created files.
+- [ ] 3.3: Extend RULE 14 to also enforce `disallowedTools: [AskUserQuestion]`
+  on `staging-reviewer.md` (currently only `staging-promoter.md`). Both agents
+  run non-interactively.
+- [ ] 3.4: Create `tests/integration/validate-agent-authoring-rule14.test.ts`
+  (mirrors existing pattern in `validate-agent-authoring-review-rule.test.ts`):
+  - Fixture: staging-promoter without `disallowedTools` → expect exit 1
+  - Fixture: staging-promoter with proper frontmatter → expect exit 0
+  - Fixture: missing staging-promoter.md entirely → expect exit 0 (graceful skip)
+  - Fixture: body missing "Never modify" → expect exit 1
+  - Fixture: body with "Never modify" elsewhere but missing CORE_RULES proximity
+    → expect exit 1 (catches the false-negative)
+  - Fixture: body satisfying all checks → expect exit 0
+- [ ] 3.5: Document RULE 14b's heuristic-vs-AST nature in
+  `scripts/validate-agent-authoring.js` header comment — explicitly call out
+  the V2-AST upgrade as a tracked TODO with reference to this plan.
+- [ ] 3.6: Update CLAUDE.md (root) to note RULE 14/14b exist and what they
+  enforce.
+
+**Files**: `scripts/validate-agent-authoring.js`,
+`tests/integration/validate-agent-authoring-rule14.test.ts` (new),
+`CLAUDE.md` (root).
+
+### Phase 4: Phase 5.1 preview UX clarification (PR #540 follow-on)
+
+**Goal**: align plan documentation with implemented behavior; surface the
+"raw transcript bytes" preview as an intentional design choice.
+
+- [ ] 4.1: Rewrite plan Phase 5.1 step 3 to explicitly state: "Preview shows
+  the first 80 chars of `transcript_tail` (raw, post-redaction). The
+  human-readable `candidate_text` is not yet computed at this point — it is
+  generated by `staging-scorer` during the drain itself. If the preview is
+  unintelligible, the user can either (a) approve and let the drain run to
+  see the scored output in `drain-logs/`, or (b) cancel and let the auto-drain
+  fire on next SessionStart."
+- [ ] 4.2: Add a UX-mitigation note: optionally show the entry's metadata
+  (`session_id`, `cwd`, file modification time) alongside the
+  transcript_tail snippet so a user with no readable preview content can
+  still identify *which* session is being drained.
+- [ ] 4.3: Update the `/compound:review-staged` command's Step 3 preview block
+  to render the metadata line (in addition to the existing
+  `basename: title` line).
+
+**Files**: `plans/background-compounding-triggers.md`,
+`plugins/yellow-core/commands/compound/review-staged.md`.
+
+## Technical Details
+
+### Files to Modify
+
+- `plugins/yellow-core/hooks/scripts/session-start.sh` — lock ordering refactor
+- `plugins/yellow-core/tests/compound-session-start-hook.bats` — 2 new tests
+- `docs/brainstorms/2026-05-18-background-compounding-triggers-brainstorm.md` — supersession callouts
+- `docs/research/repo/background-compounding-triggers-deepen-validation.md` — BLOCKER→RESOLVED
+- `scripts/validate-agent-authoring.js` — RULE 14 staging-reviewer coverage + RULE 14b proximity regex + CRLF
+- `CLAUDE.md` — document RULE 14/14b
+- `plans/background-compounding-triggers.md` — Phase 5.1 rewrite
+- `plugins/yellow-core/commands/compound/review-staged.md` — metadata in preview
+
+### Files to Create
+
+- `tests/integration/validate-agent-authoring-rule14.test.ts` — RULE 14/14b integration tests
+- `.changeset/yellow-core-compound-staging-followups.md` — patch bump (security hardening, no public-surface change)
+
+### Dependencies
+
+None. All changes use existing tooling.
+
+## Testing Strategy
+
+- **Phase 1**: 2 new bats tests in `compound-session-start-hook.bats`. Run via
+  `pnpm test:integration` (configured to pick up bats via the
+  `plugin-shell-tests` job).
+- **Phase 2**: No automated tests — content review only. Verify via
+  `pnpm validate:schemas` (catches any frontmatter regression).
+- **Phase 3**: New integration test file gives ~6 test cases. Run via
+  `pnpm test:integration -- validate-agent-authoring-rule14`.
+- **Phase 4**: Manual smoke test of `/compound:review-staged` to confirm
+  metadata renders.
+
+CI baseline gate must pass: `pnpm validate:schemas && pnpm test:unit && pnpm lint
+&& pnpm typecheck`.
+
+## Acceptance Criteria
+
+1. **Phase 1**: Bats tests demonstrate the lock-orphan window is closed and the
+   processing/ requeue race is gated by the drain lock. `bats
+   compound-session-start-hook.bats` shows 15/15 PASS (was 13/13 + 2 new).
+2. **Phase 2**: Brainstorm doc has visible per-section SUPERSEDED callouts; no
+   stale architectural claim is reachable without the supersession marker.
+3. **Phase 3**: `pnpm test:integration` includes the new rule14 test file and
+   it passes. RULE 14b's regex demonstrably rejects the "Never modify X /
+   CORE_RULES anywhere" decoy fixture.
+4. **Phase 4**: Plan Phase 5.1 description matches implementation behavior;
+   `/compound:review-staged` preview renders metadata alongside transcript
+   tail.
+
+## Edge Cases
+
+- **Phase 1**: a kill -9 between `mkdir` (now inside subshell) and the trap
+  registration is still theoretically possible — but the subshell's lifetime
+  is so short here that the 30-min stale-lock reaper remains the documented
+  worst-case recovery. Note this explicitly in the comment.
+- **Phase 3**: RULE 14b proximity window of 80 chars might be too tight for
+  multi-sentence security blocks. If the rule rejects legitimate phrasings
+  during this work, widen to 120 chars rather than going back to the global
+  boolean.
+- **Phase 4**: if `transcript_tail` is itself empty (capture edge case), the
+  preview shows `(empty)` rather than blanks — explicit fallback string.
+
+## References
+
+- Prior review session findings (this session, 2026-05-19) — surfaced in
+  `/yellow-review:review:review-all` aggregate summary
+- Parent plan: `plans/background-compounding-triggers.md`
+- Parent brainstorm: `docs/brainstorms/2026-05-18-background-compounding-triggers-brainstorm.md`
+- Docs research: `docs/solutions/code-quality/claude-code-bare-flag-and-hook-recursion-guard.md`
+- Related solutions:
+  - `docs/solutions/code-quality/hook-set-e-and-json-exit-pattern.md`
+  - `docs/solutions/code-quality/subagent-frontmatter-field-catalog.md`
+  - `docs/solutions/security-issues/prompt-injection-defense-layering-2026.md`
+- Stack PRs (all MERGEABLE):
+  - #540 `agent/docs/compound-staging-plan`
+  - #542 `agent/feat/compound-staging-hooks`
+  - #543 `agent/feat/compound-staging-agents`
+  - #544 `agent/feat/compound-staging-surface`

--- a/plugins/yellow-core/commands/compound/review-staged.md
+++ b/plugins/yellow-core/commands/compound/review-staged.md
@@ -97,9 +97,15 @@ Use this when:
      # after redaction).
      sid=$(jq -r '.session_id // "?"' "$f" 2>/dev/null || printf '?')
      cwd=$(jq -r '.cwd // "?"' "$f" 2>/dev/null || printf '?')
-     mtime=$(stat -c '%y' "$f" 2>/dev/null | cut -d. -f1 \
+     # GNU/BSD stat split: pipe to cut would swallow stat's exit (cut
+     # succeeds on empty input), so `|| stat -f` never fired on macOS
+     # and mtime came back empty. Capture stat output FIRST in a
+     # variable, then post-process — the fallback chain on the
+     # assignment line now actually triggers on macOS.
+     mtime_raw=$(stat -c '%y' "$f" 2>/dev/null \
        || stat -f '%Sm' -t '%Y-%m-%d %H:%M:%S' "$f" 2>/dev/null \
        || printf '?')
+     mtime=$(printf '%s' "$mtime_raw" | cut -d. -f1)
      # Strip CR/LF + truncate cwd — `cwd` comes from raw hook input and
      # isn't sanitized on write, so unusual directory names can contain
      # newlines/control chars that would otherwise bleed into the

--- a/plugins/yellow-core/commands/compound/review-staged.md
+++ b/plugins/yellow-core/commands/compound/review-staged.md
@@ -100,6 +100,13 @@ Use this when:
      mtime=$(stat -c '%y' "$f" 2>/dev/null | cut -d. -f1 \
        || stat -f '%Sm' -t '%Y-%m-%d %H:%M:%S' "$f" 2>/dev/null \
        || printf '?')
+     # Strip CR/LF + truncate cwd — `cwd` comes from raw hook input and
+     # isn't sanitized on write, so unusual directory names can contain
+     # newlines/control chars that would otherwise bleed into the
+     # AskUserQuestion prompt context.
+     sid=$(printf '%s' "$sid" | tr -d '\r\n' | cut -c1-64)
+     cwd=$(printf '%s' "$cwd" | tr -d '\r\n' | cut -c1-80)
+     title=$(printf '%s' "$title" | tr -d '\r\n' | cut -c1-80)
      SAMPLES="${SAMPLES}- $(basename -- "$f")  [session=${sid} cwd=${cwd} mtime=${mtime}]"$'\n'
      SAMPLES="${SAMPLES}    preview: ${title}"$'\n'
    done < <(printf '%s\n' "$PREVIEW_LIST")

--- a/plugins/yellow-core/commands/compound/review-staged.md
+++ b/plugins/yellow-core/commands/compound/review-staged.md
@@ -58,9 +58,15 @@ Use this when:
 
    If `PENDING_COUNT == 0`, exit. Do not proceed to the confirmation.
 
-3. **Preview up to 5 entry titles.** Read the first line of each of the
-   five oldest pending files; extract the first 80 chars of
-   `transcript_tail` for context.
+3. **Preview up to 5 entry titles + metadata.** Read the first line of
+   each of the five oldest pending files. The preview is **raw,
+   post-redaction transcript bytes (first 80 chars of `transcript_tail`)
+   — NOT a human-readable title.** The human-readable `candidate_text`
+   is generated at drain time by `staging-scorer`, so it cannot be
+   previewed without paying the Haiku cost first. Show metadata
+   (`session_id`, `cwd`, file mtime) alongside the snippet so users with
+   unintelligible preview content can still identify *which* session
+   each entry came from.
 
    ```bash
    # find -type f ! -type l with -printf mtime sort → oldest first.
@@ -85,7 +91,17 @@ Use this when:
      [ -L "$f" ] && continue   # skip symlinks — defense-in-depth
      title=$(jq -r '.transcript_tail | .[0:80] | gsub("\\n"; " ")' "$f" 2>/dev/null \
        || printf '(parse error)')
-     SAMPLES="${SAMPLES}- $(basename -- "$f"): ${title}"$'\n'
+     [ -z "$title" ] && title='(empty)'
+     # Metadata sidecar — helps user identify which session even if the
+     # transcript snippet is unintelligible (binary, garbled, or empty
+     # after redaction).
+     sid=$(jq -r '.session_id // "?"' "$f" 2>/dev/null || printf '?')
+     cwd=$(jq -r '.cwd // "?"' "$f" 2>/dev/null || printf '?')
+     mtime=$(stat -c '%y' "$f" 2>/dev/null | cut -d. -f1 \
+       || stat -f '%Sm' -t '%Y-%m-%d %H:%M:%S' "$f" 2>/dev/null \
+       || printf '?')
+     SAMPLES="${SAMPLES}- $(basename -- "$f")  [session=${sid} cwd=${cwd} mtime=${mtime}]"$'\n'
+     SAMPLES="${SAMPLES}    preview: ${title}"$'\n'
    done < <(printf '%s\n' "$PREVIEW_LIST")
    printf '%s\n' "$SAMPLES"
    ```

--- a/plugins/yellow-core/hooks/scripts/session-start.sh
+++ b/plugins/yellow-core/hooks/scripts/session-start.sh
@@ -200,8 +200,22 @@ LOCK_OWNED_BY_PARENT=1
 # would become syntactically invalid and the lock would leak. Reading
 # the value at run-time via ${STAGING_DIR} avoids the quoting issue.
 export STAGING_DIR
+# EXIT trap: idempotent cleanup; runs on every exit path including
+# normal completion, hook timeouts, and after the INT/TERM handlers
+# below propagate.
 # shellcheck disable=SC2016  # ${STAGING_DIR} expanded at trap-fire, not register
-trap '[ "$LOCK_OWNED_BY_PARENT" = 1 ] && rmdir "${STAGING_DIR}/.drain-lock" 2>/dev/null || true' EXIT INT TERM
+trap '[ "$LOCK_OWNED_BY_PARENT" = 1 ] && rmdir "${STAGING_DIR}/.drain-lock" 2>/dev/null || true' EXIT
+# INT/TERM: clean up AND exit. Without an explicit exit, bash continues
+# past the trap into subsequent commands (cleanup runs but the script
+# proceeds into dispatch logic and spawns a drain even though termination
+# was requested). Use the conventional 128+signal exit codes so the
+# parent shell sees the proper status. The EXIT trap above still fires
+# on the way out — clean up here is duplicate-but-safe (rmdir is
+# idempotent under the LOCK_OWNED_BY_PARENT guard).
+# shellcheck disable=SC2016  # ${STAGING_DIR} expanded at trap-fire, not register
+trap '[ "$LOCK_OWNED_BY_PARENT" = 1 ] && rmdir "${STAGING_DIR}/.drain-lock" 2>/dev/null; exit 130' INT
+# shellcheck disable=SC2016  # ${STAGING_DIR} expanded at trap-fire, not register
+trap '[ "$LOCK_OWNED_BY_PARENT" = 1 ] && rmdir "${STAGING_DIR}/.drain-lock" 2>/dev/null; exit 143' TERM
 
 # --- Requeue crashed processing entries (lock-protected) ---
 # Now that we own the drain lock, no concurrent SessionStart can race us

--- a/plugins/yellow-core/hooks/scripts/session-start.sh
+++ b/plugins/yellow-core/hooks/scripts/session-start.sh
@@ -118,33 +118,11 @@ if [ "${expired_count:-0}" -gt 0 ] 2>/dev/null; then
     || true
 fi
 
-# Processing/ entries older than 1h are crashed mid-drain; requeue them for
-# retry unless they also exceed the 7-day PII TTL, in which case purge them
-# to prevent stale PII from re-entering the pipeline. Younger files are
-# in-flight from a concurrent drain — leave them alone.
-#
-# Concurrency: only requeue when no drain is currently active. Without this
-# guard, a concurrent SessionStart could mv a processing/X.jsonl back to
-# pending/ while the active drain is still working on it, producing
-# duplicate work. The .drain-lock check is racy but defensive — the
-# active drain holds the lock through its EXIT trap, so a non-existent
-# lock means no concurrent drain is mid-flight.
-if [ -d "${STAGING_DIR}/processing" ] && [ ! -d "${STAGING_DIR}/.drain-lock" ]; then
-  while IFS= read -r f; do
-    [ -z "$f" ] && continue
-    base=$(basename -- "$f")
-    # Age-check: if the crashed entry is also older than 7 days, purge it
-    # instead of requeueing (PII TTL — same policy as pending/).
-    if find "$f" -name '*.jsonl' -mtime +7 -print 2>/dev/null | grep -q .; then
-      printf '[yellow-core] compound-staging: purging expired crashed entry %s (>7d PII TTL)\n' "$base" >&2
-      rm -f -- "$f" 2>/dev/null \
-        || printf '[yellow-core] compound-staging: failed to purge expired crashed entry %s\n' "$base" >&2
-    else
-      mv -- "$f" "${STAGING_DIR}/pending/${base}" 2>/dev/null \
-        || printf '[yellow-core] compound-staging: failed to requeue crashed entry %s\n' "$base" >&2
-    fi
-  done < <(find "${STAGING_DIR}/processing" -name '*.jsonl' -mmin +60 -print 2>/dev/null)
-fi
+# Processing/ entries older than 1h are crashed mid-drain — requeue them
+# below, AFTER acquiring the drain lock (Phase 1.2 of the plan). Doing it
+# pre-lock leaves a window where two concurrent SessionStart processes
+# both enter the requeue loop, producing duplicate `mv` operations. The
+# lock-protected version executes after line 196 (atomic mkdir) below.
 
 # --- Threshold check ---
 # count >= 5 OR oldest_age > 48h (Max 20x responsive defaults per plan §Budget Model).
@@ -201,8 +179,33 @@ fi
 # this trap — preventing it from rmdir'ing the lock while the subshell
 # still holds it.
 LOCK_OWNED_BY_PARENT=1
-# shellcheck disable=SC2064  # expand STAGING_DIR at trap-registration
-trap "[ \"\$LOCK_OWNED_BY_PARENT\" = 1 ] && rmdir '${STAGING_DIR}/.drain-lock' 2>/dev/null || true" EXIT INT TERM
+# Export STAGING_DIR so the trap can read it by name at execution time.
+# Single-quote interpolation at definition time would break for any
+# project path containing `'` (legal in Unix paths) — the trap payload
+# would become syntactically invalid and the lock would leak. Reading
+# the value at run-time via ${STAGING_DIR} avoids the quoting issue.
+export STAGING_DIR
+# shellcheck disable=SC2016  # ${STAGING_DIR} expanded at trap-fire, not register
+trap '[ "$LOCK_OWNED_BY_PARENT" = 1 ] && rmdir "${STAGING_DIR}/.drain-lock" 2>/dev/null || true' EXIT INT TERM
+
+# --- Requeue crashed processing entries (lock-protected) ---
+# Now that we own the drain lock, no concurrent SessionStart can race us
+# on the requeue mv. Entries older than 1h are crashed mid-drain; older
+# than 7 days hit the PII TTL and are purged instead.
+if [ -d "${STAGING_DIR}/processing" ]; then
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    base=$(basename -- "$f")
+    if find "$f" -name '*.jsonl' -mtime +7 -print 2>/dev/null | grep -q .; then
+      printf '[yellow-core] compound-staging: purging expired crashed entry %s (>7d PII TTL)\n' "$base" >&2
+      rm -f -- "$f" 2>/dev/null \
+        || printf '[yellow-core] compound-staging: failed to purge expired crashed entry %s\n' "$base" >&2
+    else
+      mv -- "$f" "${STAGING_DIR}/pending/${base}" 2>/dev/null \
+        || printf '[yellow-core] compound-staging: failed to requeue crashed entry %s\n' "$base" >&2
+    fi
+  done < <(find "${STAGING_DIR}/processing" -name '*.jsonl' -mmin +60 -print 2>/dev/null)
+fi
 
 # --- Resolve claude binary ---
 # Allow tests to override via COMPOUND_DRAIN_CMD env var, but ONLY

--- a/plugins/yellow-core/hooks/scripts/session-start.sh
+++ b/plugins/yellow-core/hooks/scripts/session-start.sh
@@ -372,9 +372,13 @@ DRAIN_TIMEOUT_S="${COMPOUND_DRAIN_TIMEOUT_S:-600}"
   fi
   cs_update_drain_budget "$STAGING_DIR" "$AUTH_ROUTE" || true
 ) >/dev/null 2>&1 &
-disown
-# Hand lock ownership to the subshell: disarm the parent-side safety-net
-# trap so its EXIT does not rmdir a lock the subshell still holds.
+# Hand lock ownership to the subshell immediately after `&` parses — the
+# child now owns the lock via its own EXIT/INT/TERM trap (set as its
+# first statement inside the subshell). Clearing the parent flag BEFORE
+# `disown` (rather than after) closes the INT/TERM window where the
+# parent trap would still match `LOCK_OWNED_BY_PARENT=1` and rmdir a
+# lock the running child still holds (concurrent-drain race).
 LOCK_OWNED_BY_PARENT=0
+disown
 
 json_exit

--- a/plugins/yellow-core/hooks/scripts/session-start.sh
+++ b/plugins/yellow-core/hooks/scripts/session-start.sh
@@ -163,6 +163,20 @@ else
   fi
 fi
 
+# Even when DISPATCH=0 (pending threshold not met), still proceed to lock +
+# requeue if processing/ has crashed entries older than 60 min. Otherwise
+# the common crash case (entries moved to processing/, then pending=0 on
+# next start) would leave the stale files unrecovered indefinitely.
+# REQUEUE_ONLY=1 signals: do the requeue then exit without firing drain.
+REQUEUE_ONLY=0
+if [ "$DISPATCH" -eq 0 ] && [ -d "${STAGING_DIR}/processing" ]; then
+  if find "${STAGING_DIR}/processing" -maxdepth 1 -name '*.jsonl' -mmin +60 \
+       -type f 2>/dev/null | head -1 | grep -q .; then
+    DISPATCH=1
+    REQUEUE_ONLY=1
+  fi
+fi
+
 if [ "$DISPATCH" -eq 0 ]; then
   json_exit
 fi
@@ -205,6 +219,13 @@ if [ -d "${STAGING_DIR}/processing" ]; then
         || printf '[yellow-core] compound-staging: failed to requeue crashed entry %s\n' "$base" >&2
     fi
   done < <(find "${STAGING_DIR}/processing" -name '*.jsonl' -mmin +60 -print 2>/dev/null)
+fi
+
+# If we entered the lock solely to requeue (pending threshold not met), release
+# the lock and exit without firing the drain. The requeued entries will be
+# picked up on the next SessionStart that meets the dispatch threshold.
+if [ "$REQUEUE_ONLY" = "1" ]; then
+  json_exit "requeue-only: stale processing entries restored to pending/"
 fi
 
 # --- Resolve claude binary ---

--- a/plugins/yellow-core/hooks/scripts/session-start.sh
+++ b/plugins/yellow-core/hooks/scripts/session-start.sh
@@ -130,9 +130,10 @@ PENDING_COUNT=$(find "${STAGING_DIR}/pending" -maxdepth 1 -name '*.jsonl' -type 
   | wc -l | tr -d '[:space:]')
 PENDING_COUNT="${PENDING_COUNT:-0}"
 
-if [ "$PENDING_COUNT" -eq 0 ] 2>/dev/null; then
-  json_exit
-fi
+# NOTE: do NOT early-exit on PENDING_COUNT==0 here. The REQUEUE_ONLY path
+# below needs to run even when pending/ is empty, otherwise crashed
+# processing/ entries stay stranded indefinitely under low-traffic
+# conditions (the original bug this PR's review-followups closed).
 
 DISPATCH=0
 if [ "$PENDING_COUNT" -ge 5 ] 2>/dev/null; then

--- a/plugins/yellow-core/hooks/scripts/session-start.sh
+++ b/plugins/yellow-core/hooks/scripts/session-start.sh
@@ -122,7 +122,14 @@ fi
 # retry unless they also exceed the 7-day PII TTL, in which case purge them
 # to prevent stale PII from re-entering the pipeline. Younger files are
 # in-flight from a concurrent drain — leave them alone.
-if [ -d "${STAGING_DIR}/processing" ]; then
+#
+# Concurrency: only requeue when no drain is currently active. Without this
+# guard, a concurrent SessionStart could mv a processing/X.jsonl back to
+# pending/ while the active drain is still working on it, producing
+# duplicate work. The .drain-lock check is racy but defensive — the
+# active drain holds the lock through its EXIT trap, so a non-existent
+# lock means no concurrent drain is mid-flight.
+if [ -d "${STAGING_DIR}/processing" ] && [ ! -d "${STAGING_DIR}/.drain-lock" ]; then
   while IFS= read -r f; do
     [ -z "$f" ] && continue
     base=$(basename -- "$f")
@@ -187,6 +194,15 @@ if ! mkdir "${STAGING_DIR}/.drain-lock" 2>/dev/null; then
   # Concurrent drain already in flight (or stale lock not yet reaped).
   json_exit
 fi
+# Parent-side EXIT trap: if this process dies between acquiring the lock
+# and successfully handing ownership to the subshell, release the lock so
+# the next SessionStart isn't blocked. Once the subshell registers its
+# own trap and starts running, we set LOCK_OWNED_BY_PARENT=0 to disarm
+# this trap — preventing it from rmdir'ing the lock while the subshell
+# still holds it.
+LOCK_OWNED_BY_PARENT=1
+# shellcheck disable=SC2064  # expand STAGING_DIR at trap-registration
+trap "[ \"\$LOCK_OWNED_BY_PARENT\" = 1 ] && rmdir '${STAGING_DIR}/.drain-lock' 2>/dev/null || true" EXIT INT TERM
 
 # --- Resolve claude binary ---
 # Allow tests to override via COMPOUND_DRAIN_CMD env var, but ONLY
@@ -203,7 +219,8 @@ if [ -z "$CLAUDE_BIN" ]; then
   CLAUDE_BIN=$(command -v claude 2>/dev/null || true)
 fi
 if [ -z "$CLAUDE_BIN" ] || [ ! -x "$CLAUDE_BIN" ]; then
-  rmdir "${STAGING_DIR}/.drain-lock" 2>/dev/null || true
+  # LOCK_OWNED_BY_PARENT is still 1 here — the EXIT trap will release the
+  # lock automatically when json_exit calls exit. No need to rmdir manually.
   json_exit "claude binary not found; skipping drain"
 fi
 
@@ -218,7 +235,7 @@ if [ -n "${COMPOUND_STAGING_REVIEWER_AGENT:-}" ] && [ -n "${BATS_VERSION:-}" ]; 
   STAGING_REVIEWER_PATH="$COMPOUND_STAGING_REVIEWER_AGENT"
 fi
 if [ ! -f "$STAGING_REVIEWER_PATH" ]; then
-  rmdir "${STAGING_DIR}/.drain-lock" 2>/dev/null || true
+  # EXIT trap will rmdir the lock since LOCK_OWNED_BY_PARENT is still 1.
   json_exit "staging-reviewer agent not yet deployed (stack item #2); deferring drain"
 fi
 
@@ -273,7 +290,7 @@ esac
 # (default 8 drains in rolling window); returns 1 when under or on subscription
 # auth (no cost gate). Release the lock + json_exit on the over-threshold path.
 if cs_drain_budget_warn "$STAGING_DIR" "$AUTH_ROUTE"; then
-  rmdir "${STAGING_DIR}/.drain-lock" 2>/dev/null || true
+  # EXIT trap will rmdir the lock since LOCK_OWNED_BY_PARENT is still 1.
   json_exit "drain budget over threshold; skipping dispatch"
 fi
 
@@ -317,5 +334,8 @@ DRAIN_TIMEOUT_S="${COMPOUND_DRAIN_TIMEOUT_S:-600}"
   cs_update_drain_budget "$STAGING_DIR" "$AUTH_ROUTE" || true
 ) >/dev/null 2>&1 &
 disown
+# Hand lock ownership to the subshell: disarm the parent-side safety-net
+# trap so its EXIT does not rmdir a lock the subshell still holds.
+LOCK_OWNED_BY_PARENT=0
 
 json_exit

--- a/plugins/yellow-core/tests/compound-session-start-hook.bats
+++ b/plugins/yellow-core/tests/compound-session-start-hook.bats
@@ -237,3 +237,44 @@ _plant_pending() {
   run bash "$SS_HOOK" <<< "$(_stdin_json)"
   echo "$output" | jq -e '.continue == true' >/dev/null
 }
+
+# --- Concurrency safety ---
+
+@test "session-start does not requeue processing/ entries when drain lock is held" {
+  # Simulates a concurrent SessionStart firing while another drain holds the
+  # lock: the requeue loop must be skipped (otherwise it could race the
+  # active drain's mv operations and produce duplicate pending entries).
+  mkdir -p "$STAGING/pending" "$STAGING/processing"
+  touch "$STAGING/processing/crashed.jsonl"
+  touch -t "$(date -d '90 minutes ago' +%Y%m%d%H%M 2>/dev/null \
+    || date -v-90M +%Y%m%d%H%M)" "$STAGING/processing/crashed.jsonl"
+  # Lock held by a "concurrent drain" (fresh mtime so it's NOT reaped as
+  # stale by the >30min reaper, and is treated as active).
+  mkdir "$STAGING/.drain-lock"
+
+  bash "$SS_HOOK" <<< "$(_stdin_json)" >/dev/null
+
+  # Lock survives (only the concurrent owner should release it).
+  [ -d "$STAGING/.drain-lock" ]
+  # Crashed entry stays in processing/ — was NOT requeued.
+  [ -f "$STAGING/processing/crashed.jsonl" ]
+  [ ! -f "$STAGING/pending/crashed.jsonl" ]
+}
+
+@test "session-start parent-side trap releases drain-lock on early-exit before dispatch" {
+  # If the parent exits between acquiring the lock and handing it to the
+  # subshell (e.g., staging-reviewer agent missing), the parent's EXIT
+  # trap must release the lock so the next SessionStart isn't blocked for
+  # 30 minutes by the stale-lock reaper.
+  mkdir -p "$STAGING/pending"
+  for i in 1 2 3 4 5; do
+    touch "$STAGING/pending/entry-$i.jsonl"
+  done
+  # Point at a non-existent staging-reviewer agent file so the parent
+  # exits via the "agent not yet deployed" path AFTER acquiring the lock.
+  COMPOUND_STAGING_REVIEWER_AGENT="/nonexistent/staging-reviewer.md" \
+    bash "$SS_HOOK" <<< "$(_stdin_json)" >/dev/null
+
+  # Lock should have been released by the parent's EXIT trap, not orphaned.
+  [ ! -d "$STAGING/.drain-lock" ]
+}

--- a/scripts/validate-agent-authoring.js
+++ b/scripts/validate-agent-authoring.js
@@ -464,17 +464,38 @@ function validateMemoryWriteSectionGate(agentFiles, errors) {
   const body = content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
 
   // RULE 14b heuristic: the body must document that
-  //  (a) writes target `## Session Notes` ONLY,
+  //  (a) writes target `## Session Notes` ONLY (with explicit write-
+  //      restriction phrasing, not a bare "Session Notes" mention),
   //  (b) the three protected sections (CORE_RULES, USER_PREFERENCES,
-  //      KNOWN_PROJECTS) are explicitly forbidden.
-  // Paragraph co-location prevents the global-boolean false negative where
-  // a "Never modify staging entries" sentence elsewhere in the body
-  // satisfies the rule without actually protecting any section. We require
-  // a SINGLE paragraph (text between blank lines) to contain a "Never
-  // modify|write|touch" verb AND name all three protected sections.
-  // This admits multi-line invariants ("Never touch `## CORE_RULES`,\n
-  // `## USER_PREFERENCES`, or `## KNOWN_PROJECTS`") while rejecting decoys.
-  const hasSessionNotesGate = /Session Notes/.test(body);
+  //      KNOWN_PROJECTS) are explicitly forbidden in a paragraph that
+  //      also contains a "Never modify|write|touch" verb.
+  //
+  // Session Notes gate (a): bare `/Session Notes/` would let any
+  // unrelated mention (e.g., "Session Notes section exists") satisfy
+  // the rule, so a body that talks about Session Notes without claiming
+  // write-restriction could pass. Bind the check to a write-restriction
+  // anchor within ±200 chars: `only|ONLY .* Session Notes`,
+  // `Session Notes .* section ONLY|never any other`, or
+  // `append .* Session Notes .* [Nn]ever`.
+  const sessionNotesGateRe = new RegExp(
+    // Form A: "ONLY ... Session Notes" within 200 chars
+    '(?:only|ONLY)[\\s\\S]{0,200}Session Notes' +
+      // Form B: "Session Notes ... section only / ONLY / never any|other"
+      '|Session Notes[\\s\\S]{0,200}(?:section\\s+only|ONLY|never\\s+(?:any|other))' +
+      // Form C: "append ... Session Notes ... Never" within 200 chars
+      '|append[\\s\\S]{0,200}Session Notes[\\s\\S]{0,200}[Nn]ever',
+    ''
+  );
+  const hasSessionNotesGate = sessionNotesGateRe.test(body);
+
+  // Never-modify invariant (b): paragraph co-location prevents the
+  // global-boolean false negative where a "Never modify staging entries"
+  // sentence elsewhere in the body satisfies the rule without actually
+  // protecting any section. A SINGLE paragraph (text between blank lines)
+  // must contain a "Never modify|write|touch" verb AND name all three
+  // protected sections. This admits multi-line invariants ("Never touch
+  // `## CORE_RULES`,\n `## USER_PREFERENCES`, or `## KNOWN_PROJECTS`")
+  // while rejecting decoys.
   const paragraphs = body.split(/\n\s*\n/);
   const hasNeverModifyInvariant = paragraphs.some(
     (p) =>

--- a/scripts/validate-agent-authoring.js
+++ b/scripts/validate-agent-authoring.js
@@ -486,7 +486,7 @@ function validateMemoryWriteSectionGate(agentFiles, errors) {
 
   if (!hasSessionNotesGate || !hasNeverModifyInvariant) {
     errors.push(
-      `${relative(promoter)}: RULE 14b — staging-promoter body must reference \`## Session Notes\` write gate AND state a "Never modify" invariant that enumerates ALL THREE protected sections (CORE_RULES, USER_PREFERENCES, KNOWN_PROJECTS) within 80 chars of the Never-verb (D9-L1 memory-partition enforcement)`
+      `${relative(promoter)}: RULE 14b — staging-promoter body must reference \`## Session Notes\` write gate AND state a "Never modify" invariant that enumerates ALL THREE protected sections (CORE_RULES, USER_PREFERENCES, KNOWN_PROJECTS) within the same paragraph as the Never-verb (D9-L1 memory-partition enforcement)`
     );
   }
 }

--- a/scripts/validate-agent-authoring.js
+++ b/scripts/validate-agent-authoring.js
@@ -395,38 +395,49 @@ function validateSubagentReferences(markdownFiles, ctx) {
 // in the loop). If a future edit removes the deny, the drain breaks
 // silently. RULE 14 turns that into a CI failure.
 function validateStagingPromoterFrontmatter(agentFiles, errors) {
-  const promoter = agentFiles.find(
-    (f) =>
-      f.endsWith(
-        `${path.sep}yellow-core${path.sep}agents${path.sep}workflow${path.sep}staging-promoter.md`
-      )
-  );
-  if (!promoter) {
-    // staging-promoter is not yet present (e.g., stack item #2 not merged).
-    // Don't fail; the agent itself is what's checked, not its absence.
-    return;
-  }
-  const content = fs.readFileSync(promoter, 'utf8');
-  const frontmatter = extractFrontmatter(content) || '';
+  // RULE 14 applies to BOTH staging-promoter AND staging-reviewer — both
+  // run non-interactively under bypassPermissions; both must hard-deny
+  // AskUserQuestion at the frontmatter level (prose-only enforcement is
+  // insufficient — see docs/solutions/code-quality/subagent-frontmatter-field-catalog.md).
+  const checkedAgents = [
+    'staging-promoter.md',
+    'staging-reviewer.md',
+  ];
 
-  // Use the parseList() helper to extract disallowedTools as a real
-  // string array, then check whether 'AskUserQuestion' is a complete
-  // entry. parseList handles both flow form (`[A, B]`) and block form
-  // (`- A\n- B`) and strips surrounding quotes. A `.includes()` test on
-  // the parsed array is impossible to fool with substring tricks —
-  // values like `'foo AskUserQuestion'`, `'AskUserQuestion(bar)'`, or
-  // `'AskUserQuestion-disabled'` parse to entries that are NOT equal to
-  // the bare string `'AskUserQuestion'`, so they fail the check.
-  // Earlier regex-only approaches (\b boundaries, then lookarounds) were
-  // repeatedly bypassed — see PR #544 round-1/round-2/round-3 review
-  // comments — because regex cannot cleanly distinguish "the entry IS
-  // AskUserQuestion" from "the entry CONTAINS AskUserQuestion". Parsing
-  // first sidesteps the entire problem.
-  const disallowed = parseList(frontmatter, 'disallowedTools');
-  if (!disallowed.includes('AskUserQuestion')) {
-    errors.push(
-      `${relative(promoter)}: RULE 14 — staging-promoter frontmatter MUST contain \`disallowedTools: [AskUserQuestion]\` (this is the load-bearing D8 enforcement for the background-compounding drain pipeline)`
+  for (const basename of checkedAgents) {
+    const agentPath = agentFiles.find(
+      (f) =>
+        f.endsWith(
+          `${path.sep}yellow-core${path.sep}agents${path.sep}workflow${path.sep}${basename}`
+        )
     );
+    if (!agentPath) {
+      // Agent not yet present (e.g., stack item #2 not merged).
+      // Don't fail; the agent itself is what's checked, not its absence.
+      continue;
+    }
+    const content = fs.readFileSync(agentPath, 'utf8');
+    const frontmatter = extractFrontmatter(content) || '';
+
+    // Use the parseList() helper to extract disallowedTools as a real
+    // string array, then check whether 'AskUserQuestion' is a complete
+    // entry. parseList handles both flow form (`[A, B]`) and block form
+    // (`- A\n- B`) and strips surrounding quotes. A `.includes()` test
+    // on the parsed array is impossible to fool with substring tricks —
+    // values like `'foo AskUserQuestion'`, `'AskUserQuestion(bar)'`, or
+    // `'AskUserQuestion-disabled'` parse to entries that are NOT equal
+    // to the bare string `'AskUserQuestion'`, so they fail the check.
+    // Earlier regex-only approaches (`\b` boundaries, then lookarounds)
+    // were repeatedly bypassed — see PR #544 round-1/round-2/round-3
+    // review comments — because regex cannot cleanly distinguish "the
+    // entry IS AskUserQuestion" from "the entry CONTAINS AskUserQuestion".
+    // Parsing first sidesteps the entire problem.
+    const disallowed = parseList(frontmatter, 'disallowedTools');
+    if (!disallowed.includes('AskUserQuestion')) {
+      errors.push(
+        `${relative(agentPath)}: RULE 14 — frontmatter MUST contain \`disallowedTools: [AskUserQuestion]\` (load-bearing D8 enforcement for background-compounding drain pipeline; staging-promoter and staging-reviewer both run non-interactively)`
+      );
+    }
   }
 }
 
@@ -446,51 +457,36 @@ function validateMemoryWriteSectionGate(agentFiles, errors) {
     return;
   }
   const content = fs.readFileSync(promoter, 'utf8');
-  // Strip frontmatter so we don't false-positive on metadata.
-  const body = content.replace(/^---\n[\s\S]*?\n---\n?/, '');
+  // Strip frontmatter so we don't false-positive on metadata. CRLF-tolerant:
+  // WSL2-authored files arrive with \r\n line endings before `.gitattributes`
+  // normalization, and this regex must match either form (mirrors the pattern
+  // used by extractFrontmatter()).
+  const body = content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
 
-  // Bind both checks to a local context window so generic prose mentioning
-  // `Session Notes` or the section names somewhere unrelated cannot satisfy
-  // the rule. Window = ±200 chars around the anchor phrase.
-  //
-  // Session Notes gate: must appear within 200 chars of a write-restriction
-  // phrase (`only.*Session Notes`, `Session Notes.*only`, `Never.*other.*section`,
-  // `write only to .* Session Notes`). A naked `Session Notes` mention is
-  // insufficient.
-  const sessionNotesGateRe = new RegExp(
-    // Form A: "ONLY ... Session Notes" within 200 chars
-    '(?:only|ONLY)[\\s\\S]{0,200}Session Notes' +
-      // Form B: "Session Notes ... only/ONLY/section ONLY" within 200 chars
-      '|Session Notes[\\s\\S]{0,200}(?:section\\s+only|ONLY|never\\s+(?:any|other))' +
-      // Form C: "append to ... Session Notes" + "NEVER" within 200 chars
-      '|append[\\s\\S]{0,200}Session Notes[\\s\\S]{0,200}[Nn]ever',
-    ''
+  // RULE 14b heuristic: the body must document that
+  //  (a) writes target `## Session Notes` ONLY,
+  //  (b) the three protected sections (CORE_RULES, USER_PREFERENCES,
+  //      KNOWN_PROJECTS) are explicitly forbidden.
+  // Paragraph co-location prevents the global-boolean false negative where
+  // a "Never modify staging entries" sentence elsewhere in the body
+  // satisfies the rule without actually protecting any section. We require
+  // a SINGLE paragraph (text between blank lines) to contain a "Never
+  // modify|write|touch" verb AND name all three protected sections.
+  // This admits multi-line invariants ("Never touch `## CORE_RULES`,\n
+  // `## USER_PREFERENCES`, or `## KNOWN_PROJECTS`") while rejecting decoys.
+  const hasSessionNotesGate = /Session Notes/.test(body);
+  const paragraphs = body.split(/\n\s*\n/);
+  const hasNeverModifyInvariant = paragraphs.some(
+    (p) =>
+      /[Nn]ever (?:modif|write|touch)/.test(p) &&
+      /CORE_RULES/.test(p) &&
+      /USER_PREFERENCES/.test(p) &&
+      /KNOWN_PROJECTS/.test(p)
   );
-  const hasSessionNotesGate = sessionNotesGateRe.test(body);
-
-  // Never-modify invariant: all three protected section names must appear
-  // in the same 400-char sliding window as a "Never modify/write/touch"
-  // phrase. Splitting them across the document (e.g., one in prose + one
-  // in code + one in references) would otherwise satisfy three independent
-  // global tests and let the actual invariant statement be silently removed.
-  const sectionContextRe =
-    /[Nn]ever[^.\n]{0,400}(?:CORE_RULES|USER_PREFERENCES|KNOWN_PROJECTS)[\s\S]{0,400}(?:CORE_RULES|USER_PREFERENCES|KNOWN_PROJECTS)[\s\S]{0,400}(?:CORE_RULES|USER_PREFERENCES|KNOWN_PROJECTS)/;
-  const hasNeverModifyInvariant = (() => {
-    const m = body.match(sectionContextRe);
-    if (!m) return false;
-    const span = m[0];
-    // All three names must appear within this single matched window.
-    return (
-      /CORE_RULES/.test(span) &&
-      /USER_PREFERENCES/.test(span) &&
-      /KNOWN_PROJECTS/.test(span) &&
-      /[Nn]ever (?:modif|write|touch)/.test(span)
-    );
-  })();
 
   if (!hasSessionNotesGate || !hasNeverModifyInvariant) {
     errors.push(
-      `${relative(promoter)}: RULE 14b — staging-promoter body must reference \`## Session Notes\` write gate AND state a "Never modify" invariant that enumerates ALL THREE protected sections (CORE_RULES, USER_PREFERENCES, KNOWN_PROJECTS) (D9-L1 memory-partition enforcement)`
+      `${relative(promoter)}: RULE 14b — staging-promoter body must reference \`## Session Notes\` write gate AND state a "Never modify" invariant that enumerates ALL THREE protected sections (CORE_RULES, USER_PREFERENCES, KNOWN_PROJECTS) within 80 chars of the Never-verb (D9-L1 memory-partition enforcement)`
     );
   }
 }

--- a/tests/integration/validate-agent-authoring-rule14.test.ts
+++ b/tests/integration/validate-agent-authoring-rule14.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Integration test for RULE 14 (staging-promoter/-reviewer frontmatter
+ * disallowedTools: [AskUserQuestion]) and RULE 14b (staging-promoter body
+ * Session-Notes write gate + Never-modify invariant naming all three
+ * protected memory sections) in scripts/validate-agent-authoring.js.
+ *
+ * Both rules are the load-bearing CI enforcement for D8 + D9-L1 in the
+ * background-compounding pipeline (PRs #540-544). Without these rules,
+ * a future edit could silently break the drain pipeline:
+ *   - RULE 14: removing disallowedTools allows AskUserQuestion calls,
+ *     blocking the non-interactive drain indefinitely.
+ *   - RULE 14b: removing the Never-modify invariant allows the promoter
+ *     to write to CORE_RULES, USER_PREFERENCES, or KNOWN_PROJECTS — the
+ *     three sections that MUST remain human-managed.
+ *
+ * The test parameterizes the validator via VALIDATE_PLUGINS_DIR so it
+ * never touches the real plugins/ tree.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { runValidator, writeAgent } from './helpers/validator-harness';
+
+// Frontmatter helpers — minimal fixtures that pass all OTHER validator
+// rules so we isolate RULE 14 / 14b behavior.
+
+const PROMOTER_FM_OK = `---
+name: staging-promoter
+description: Promoter test fixture. Use when verifying RULE 14/14b.
+model: inherit
+tools:
+  - Read
+  - Write
+  - Edit
+disallowedTools:
+  - AskUserQuestion
+---
+`;
+
+const PROMOTER_FM_MISSING_DENY = `---
+name: staging-promoter
+description: Promoter test fixture. Use when verifying RULE 14/14b.
+model: inherit
+tools:
+  - Read
+  - Write
+  - Edit
+---
+`;
+
+const REVIEWER_FM_OK = `---
+name: staging-reviewer
+description: Reviewer test fixture. Use when verifying RULE 14 staging-reviewer extension.
+model: inherit
+tools:
+  - Task
+  - Read
+disallowedTools:
+  - AskUserQuestion
+---
+
+Body for reviewer fixture.
+`;
+
+const REVIEWER_FM_MISSING_DENY = `---
+name: staging-reviewer
+description: Reviewer test fixture. Use when verifying RULE 14 staging-reviewer extension.
+model: inherit
+tools:
+  - Task
+  - Read
+---
+
+Body for reviewer fixture.
+`;
+
+// Body that satisfies RULE 14b: documents Session Notes gate AND has a
+// paragraph naming all three sections in a "Never modify|write|touch"
+// context.
+const PROMOTER_BODY_OK = `
+## Session Notes write gate
+
+Promoter writes ONLY to MEMORY.md's \`## Session Notes\` section.
+
+## Never modify these sections
+
+Never touch \`## CORE_RULES\`, \`## USER_PREFERENCES\`, or
+\`## KNOWN_PROJECTS\`. These are human-managed.
+`;
+
+// Body that mentions Session Notes but lacks the Never-modify invariant
+// — the typical drift after a refactor that removes the security rules.
+const PROMOTER_BODY_MISSING_INVARIANT = `
+## Session Notes write gate
+
+Promoter writes ONLY to MEMORY.md's \`## Session Notes\` section.
+
+Other sections exist (CORE_RULES, USER_PREFERENCES, KNOWN_PROJECTS) but
+this body does not explicitly forbid touching them.
+`;
+
+// Decoy body: has a "Never modify" sentence AND mentions all three
+// sections, but they are in different paragraphs — the global-boolean
+// check would pass this, but the paragraph-co-location check rejects it.
+const PROMOTER_BODY_DECOY = `
+## Session Notes
+
+Promoter writes to MEMORY.md's Session Notes section.
+
+Never modify staging entries after dispatch.
+
+A separate paragraph discussing CORE_RULES.
+
+Another paragraph about USER_PREFERENCES and KNOWN_PROJECTS in a totally
+non-protective context.
+`;
+
+let pluginsDir: string;
+
+beforeEach(() => {
+  pluginsDir = mkdtempSync(join(tmpdir(), 'validate-rule14-'));
+});
+
+afterEach(() => {
+  rmSync(pluginsDir, { recursive: true, force: true });
+});
+
+describe('validate-agent-authoring RULE 14 (disallowedTools frontmatter)', () => {
+  it('passes when staging-promoter has disallowedTools: [AskUserQuestion]', () => {
+    writeAgent(
+      pluginsDir,
+      'yellow-core/agents/workflow/staging-promoter.md',
+      PROMOTER_FM_OK + PROMOTER_BODY_OK
+    );
+    const result = runValidator(pluginsDir);
+    expect(result.status).toBe(0);
+  });
+
+  it('fails when staging-promoter frontmatter is missing disallowedTools', () => {
+    writeAgent(
+      pluginsDir,
+      'yellow-core/agents/workflow/staging-promoter.md',
+      PROMOTER_FM_MISSING_DENY + PROMOTER_BODY_OK
+    );
+    const result = runValidator(pluginsDir);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/RULE 14/);
+  });
+
+  it('passes when staging-promoter.md is absent (graceful skip)', () => {
+    // RULE 14 is conditional — if the agent file does not exist yet,
+    // the rule is a no-op (handles pre-merge stack state).
+    const result = runValidator(pluginsDir);
+    expect(result.status).toBe(0);
+  });
+
+  it('passes when staging-reviewer has disallowedTools: [AskUserQuestion]', () => {
+    writeAgent(
+      pluginsDir,
+      'yellow-core/agents/workflow/staging-reviewer.md',
+      REVIEWER_FM_OK
+    );
+    const result = runValidator(pluginsDir);
+    expect(result.status).toBe(0);
+  });
+
+  it('fails when staging-reviewer frontmatter is missing disallowedTools', () => {
+    writeAgent(
+      pluginsDir,
+      'yellow-core/agents/workflow/staging-reviewer.md',
+      REVIEWER_FM_MISSING_DENY
+    );
+    const result = runValidator(pluginsDir);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/RULE 14/);
+  });
+});
+
+describe('validate-agent-authoring RULE 14b (Session Notes write gate)', () => {
+  it('passes when promoter body has the Session-Notes gate AND a Never-modify paragraph with all three sections', () => {
+    writeAgent(
+      pluginsDir,
+      'yellow-core/agents/workflow/staging-promoter.md',
+      PROMOTER_FM_OK + PROMOTER_BODY_OK
+    );
+    const result = runValidator(pluginsDir);
+    expect(result.status).toBe(0);
+  });
+
+  it('fails when promoter body mentions Session Notes but lacks the Never-modify invariant', () => {
+    writeAgent(
+      pluginsDir,
+      'yellow-core/agents/workflow/staging-promoter.md',
+      PROMOTER_FM_OK + PROMOTER_BODY_MISSING_INVARIANT
+    );
+    const result = runValidator(pluginsDir);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/RULE 14b/);
+  });
+
+  it('fails on the decoy: "Never modify" elsewhere, sections in unrelated paragraphs', () => {
+    // This is the false-negative that the paragraph-co-location check
+    // is meant to catch — the previous global-boolean check passed
+    // this even though no actual protective statement existed.
+    writeAgent(
+      pluginsDir,
+      'yellow-core/agents/workflow/staging-promoter.md',
+      PROMOTER_FM_OK + PROMOTER_BODY_DECOY
+    );
+    const result = runValidator(pluginsDir);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/RULE 14b/);
+  });
+});


### PR DESCRIPTION
Implements plans/compound-staging-review-followups.md — closes the 4 design-decision
findings from the PR #540-544 stack review that were not auto-applied:

Phase 1 (PR #542 concurrency):
- session-start.sh: processing/ requeue gated on absence of .drain-lock
  (closes concurrent-SessionStart double-requeue race)
- session-start.sh: parent-side EXIT trap + LOCK_OWNED_BY_PARENT flag
  closes the lock-orphan window between mkdir and subshell dispatch
- 2 new bats tests cover both safety properties

Phase 2 (PR #540 brainstorm callouts):
- Per-section SUPERSEDED markers on Architecture / JSONL Schema /
  Decision 3 / Decision 4 so partial readers can't act on stale design

Phase 3 (PR #544 RULE 14/14b):
- RULE 14: extended to staging-reviewer.md (was promoter-only); widened
  tool-name character class to include dots
- RULE 14b: paragraph-based co-location replaces global-boolean check
  (catches the false-negative decoy); CRLF-tolerant frontmatter strip
- New tests/integration/validate-agent-authoring-rule14.test.ts (8 cases)

Phase 4 (PR #540 + #544 preview UX):
- Plan Phase 5.1 description clarifies that preview is raw transcript_tail
  bytes, not candidate_text (which doesn't exist until drain time)
- /compound:review-staged Step 3 renders session_id/cwd/mtime metadata
  alongside the snippet so users can identify which session each entry
  came from when the transcript preview is unintelligible

CI gates:
- pnpm validate:agents: PASS (82 agents, 280 markdown files)
- pnpm vitest tests/integration/validate-agent-authoring-rule14: 8/8 PASS
- bats compound-session-start-hook.bats: 15/15 PASS (13 + 2 new)
- bats compound-staging + compound-stop-hook: 38/38 PASS

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->
