### PR TITLE
docs(solutions): backfill 2 compound-staging logic-error solution docs

### DIFF
--- a/docs/solutions/logic-errors/machine-generated-text-shell-gotchas.md
+++ b/docs/solutions/logic-errors/machine-generated-text-shell-gotchas.md
@@ -1,0 +1,212 @@
+---
+title: 'Machine-generated text foot-guns: empty-pattern grep and YAML apostrophe escaping'
+date: 2026-05-20
+category: logic-errors
+track: bug
+problem: 'grep -F "" matches every line, turning idempotency checks into false-positive skips; single-quoted YAML scalars with embedded apostrophes produce silent parse truncation in machine-generated frontmatter'
+tags:
+  - grep
+  - empty-pattern
+  - idempotency
+  - yaml
+  - frontmatter
+  - escaping
+  - machine-generated
+  - pipeline
+components:
+  - plugins/yellow-core/agents/workflow/staging-reviewer.md
+  - plugins/yellow-core/agents/workflow/staging-promoter.md
+---
+
+# Machine-generated text foot-guns: empty-pattern grep and YAML apostrophe escaping
+
+Two distinct bugs that surface specifically in pipelines that **generate** text
+programmatically rather than hardcode it. Each is a silent failure: no error is
+raised, the wrong result is returned, and forward progress is silently
+corrupted.
+
+---
+
+## 1. Empty-pattern grep false positive in idempotency checks
+
+### Problem
+
+An idempotency guard checks whether a solution path is already recorded in
+MEMORY.md before appending:
+
+```bash
+REL_SOLUTION_PATH="${SOLUTION_PATH#$GIT_ROOT/}"
+if grep -qF "$REL_SOLUTION_PATH" "$MEMORY_PATH"; then
+  log "already recorded, skipping"
+  return 0
+fi
+append_memory_entry
+```
+
+If `$SOLUTION_PATH` is empty (e.g., a bug causes the variable to not be set),
+then `$REL_SOLUTION_PATH` is also empty. `grep -F ""` matches **every line** of
+the file. The idempotency guard fires unconditionally — `"already recorded,
+skipping"` — and the MEMORY.md append is silently skipped for every subsequent
+entry.
+
+This is especially dangerous because it looks like correct behavior: the
+guard logs a plausible message, no error is raised, and the pipeline
+continues. The corruption (missing entries) is only visible when someone
+notices the MEMORY.md index is out of date.
+
+### Fix
+
+Guard every derived grep pattern with a fail-loud empty check immediately after
+derivation:
+
+```bash
+REL_SOLUTION_PATH="${SOLUTION_PATH#$GIT_ROOT/}"
+[ -z "$REL_SOLUTION_PATH" ] && {
+  printf '[knowledge-compounder] BUG: REL_SOLUTION_PATH is empty (SOLUTION_PATH=%s, GIT_ROOT=%s)\n' \
+    "$SOLUTION_PATH" "$GIT_ROOT" >&2
+  exit 1
+}
+if grep -qF "$REL_SOLUTION_PATH" "$MEMORY_PATH"; then
+  log "already recorded, skipping"
+  return 0
+fi
+```
+
+### General rule
+
+> `grep -F ""` matches every line. Any code path that constructs a grep pattern
+> from a derived variable must either:
+> 1. Guarantee the variable is non-empty by construction, or
+> 2. Guard with `[ -z "$VAR" ]` and fail loud before the grep call.
+>
+> Option (3) — `grep -F -e "$VAR"` — does NOT help; empty `-e ""` still matches
+> everything. The guard is the only fix.
+
+### Where this pattern is most dangerous
+
+Idempotency checks are the highest-risk location because:
+
+- An empty pattern causes the check to always return "already done."
+- The pipeline silently skips work rather than crashing.
+- The corruption accumulates over multiple runs before anyone notices.
+
+Other grep uses (counting, filtering, searching) fail more obviously when the
+pattern is empty. Prioritize auditing idempotency and "already done" guards
+first.
+
+### Detection
+
+```bash
+# Find grep calls that use a shell variable as the pattern
+# (candidates for the empty-pattern foot-gun)
+rg 'grep.*\$[A-Z_]+' plugins/ scripts/ --include='*.sh' --include='*.md'
+# Then audit each: is the variable guaranteed non-empty before this line?
+```
+
+---
+
+## 2. YAML apostrophe escaping in machine-generated frontmatter
+
+### Problem
+
+A pipeline generates YAML frontmatter by interpolating user-captured or
+model-generated text into single-quoted scalar values:
+
+```bash
+printf -- '---\ntitle: '\''%s'\''\n---\n' "$TITLE"
+```
+
+If `$TITLE` contains an apostrophe — e.g., `"don't break idempotency"` — the
+output is:
+
+```yaml
+---
+title: 'don't break idempotency'
+---
+```
+
+This is **invalid YAML**. Single-quoted scalars use `''` (doubled single quote)
+to escape an embedded apostrophe. If an apostrophe is not escaped, the
+single-quoted scalar terminates early, and compliant YAML 1.2 parsers should
+fail with a parse error (instead of accepting a truncated value). Common
+English words that trigger this: `don't`, `won't`, `can't`, `it's`, `there's`,
+`you're`.
+
+### Fix
+
+Before interpolating any user/captured string into a single-quoted YAML scalar,
+double all apostrophes:
+
+```bash
+# Escape for single-quoted YAML scalar: ' → ''
+yaml_escape_single() {
+  printf '%s' "$1" | sed "s/'/''/g"
+}
+
+TITLE_ESCAPED=$(yaml_escape_single "$TITLE")
+printf -- "---\ntitle: '%s'\n---\n" "$TITLE_ESCAPED"
+```
+
+Output for `"don't break idempotency"`:
+
+```yaml
+---
+title: 'don''t break idempotency'
+---
+```
+
+This is valid YAML. A parser reading it returns the string `don't break
+idempotency` with a single apostrophe.
+
+### Alternative: double-quoted scalars
+
+Double-quoted YAML scalars are also valid and use `\"` and `\\` as escapes:
+
+```bash
+# Escape for double-quoted YAML scalar: " → \", \ → \\
+yaml_escape_double() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+TITLE_ESCAPED=$(yaml_escape_double "$TITLE")
+printf -- '---\ntitle: "%s"\n---\n' "$TITLE_ESCAPED"
+```
+
+Pick one quoting strategy and document it. Mixing strategies per-field is a
+maintenance hazard.
+
+### What about `printf '%s' "$VAR" | python3 -c 'import yaml,sys; ...'`?
+
+If the pipeline already has Python available, letting a YAML serializer handle
+escaping is more robust than manual sed. But for shell scripts that deliberately
+avoid Python dependencies, the sed approach is sufficient and portable.
+
+### Detection
+
+```bash
+# Find shell scripts that write YAML frontmatter using single-quoted printf
+rg "printf.*title.*'%s'" plugins/ scripts/ --include='*.sh' --include='*.md'
+# Audit: is the interpolated value apostrophe-escaped before this call?
+```
+
+---
+
+## Combined prevention checklist
+
+For any pipeline that generates YAML frontmatter or uses grep with
+programmatically derived patterns:
+
+- [ ] Every grep idempotency guard checks `[ -z "$PATTERN_VAR" ]` fail-loud
+      immediately before the `grep` call.
+- [ ] Machine-generated YAML single-quoted scalars pass through an apostrophe
+      doubler (`sed "s/'/''/g"`) before interpolation.
+- [ ] One YAML quoting strategy (single or double) is chosen per file and
+      documented in a comment near the write function.
+- [ ] The quoting escape helper is defined once and reused — not inlined per
+      field.
+
+## Sources
+
+- PR #543 review rounds 1–2, compound-staging stack
+- `plugins/yellow-core/agents/workflow/staging-reviewer.md`
+- `plugins/yellow-core/agents/workflow/staging-promoter.md`

--- a/docs/solutions/logic-errors/sentinel-mv-ordering-and-drain-classification.md
+++ b/docs/solutions/logic-errors/sentinel-mv-ordering-and-drain-classification.md
@@ -1,0 +1,221 @@
+---
+title: 'Sentinel-before-mv ordering and three-way drain file classification'
+date: 2026-05-20
+category: logic-errors
+track: bug
+problem: >-
+  Atomic rename + sentinel ordering creates unrecoverable ambiguous state when sentinel is written after mv;
+  concurrent-drain file cleanup misclassifies stale crashed-drain orphans as protected in-flight files
+tags:
+  - crash-recovery
+  - atomic-rename
+  - sentinel
+  - concurrent-drains
+  - idempotency
+  - pipeline
+  - two-phase-commit
+components:
+  - plugins/yellow-core/agents/workflow/staging-promoter.md
+  - plugins/yellow-core/agents/workflow/staging-reviewer.md
+---
+
+# Sentinel-before-mv ordering and three-way drain file classification
+
+Two interacting design bugs found during PR #543 review rounds 1–3 on the
+compound-staging pipeline. Both concern what happens when a drain crashes
+mid-operation and a subsequent drain tries to recover.
+
+---
+
+## 1. Sentinel-before-mv: write the sentinel BEFORE the atomic rename
+
+### Problem
+
+The natural implementation order for an atomic "write then promote" operation is:
+
+```bash
+# WRONG ordering
+mv "$TMP" "$FINAL_PATH"   # 1. make the file visible (atomic rename)
+printf '...' > "$SENTINEL" # 2. record that it is done
+```
+
+This creates an **unrecoverable ambiguous state**. If the process crashes between
+steps 1 and 2, the next drain invocation sees:
+
+- `$FINAL_PATH` exists
+- `$SENTINEL` does not exist
+
+It cannot tell whether:
+
+- (a) A prior drain promoted this entry and crashed before writing the sentinel
+  — do NOT re-promote.
+- (b) A different drain promoted a slug-colliding entry long ago, and this is a
+  fresh collision — rename and promote as a new slug.
+
+The filesystem contains identical evidence for both cases. Any decision the
+recovery logic makes is wrong for one of them.
+
+### Fix
+
+Write the sentinel **before** the atomic rename:
+
+```bash
+# CORRECT ordering
+printf '{"session_id":"%s","written_at":"%s"}\n' \
+  "$SESSION_ID" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  > "$SENTINEL"                    # 1. sentinel exists BEFORE final path is visible
+mv "$TMP_PATH" "$FINAL_PATH"       # 2. atomic promotion — now observable
+```
+
+The four observable states now map cleanly to exactly one interpretation:
+
+| State | Meaning | Recovery action |
+|---|---|---|
+| No sentinel + no tmp + no final | Never started | Start fresh |
+| No sentinel + tmp + no final | Crashed before sentinel write | Start fresh (retry from tmp) |
+| Sentinel + tmp + no final | Crashed between sentinel and mv | Resume: retry `mv` (idempotent) |
+| Sentinel + final | Done | Skip |
+| ~~No sentinel + final~~ | **IMPOSSIBLE** under this ordering | If observed: manual intervention |
+
+The "impossible" state (final exists, no sentinel) can still appear if someone
+manually promoted a file outside the pipeline. Treat it as ambiguous and log a
+warning rather than silently choosing a path.
+
+### Why the reverse ordering cannot be fixed with just a lock
+
+A lock prevents two drains from racing in steady state, but a crash releases
+the lock. The crash-recovery path by definition runs outside the lock that
+protected the original write. Ordering is the only property that survives a
+crash.
+
+### Sibling note: time-boundary alignment across phases (Pattern C)
+
+When multiple phases share a "is this file in-flight?" judgment, they must use
+the **same** constant for the age threshold. In the compound-staging pipeline,
+both Phase 2 (dedup deletion) and Phase 4 (scoring age guard) use 300 seconds
+(5 minutes) as the in-flight boundary. If Phase 2 used 60s while Phase 4 used
+300s, files in the 60s–300s window would be deleted by Phase 2 but scored by
+Phase 4 — two drains would see different "active" sets.
+
+**Rule:** extract the shared threshold to a named constant at the top of the
+script. Document which phases reference it and why the value was chosen.
+
+```bash
+# Shared threshold: align with Phase 4 in-flight age guard
+IN_FLIGHT_AGE_SECONDS=300
+```
+
+---
+
+## 2. Three-way file ownership classification in concurrent-drain cleanup
+
+### Problem
+
+Phase 2 of a multi-drain pipeline deletes hash-duplicate files from a shared
+`processing/` directory. The first fix (Round 2) used a binary classification:
+
+```bash
+# Round 2 approach — too broad
+if set_contains "$MOVED_THIS_DRAIN_FILE" "$f"; then
+  rm "$f"          # this drain moved it → safe to delete
+else
+  :                # not this drain → skip (protect concurrent drains)
+fi
+```
+
+This correctly protects files a concurrent drain holds. But it also protects
+**stale orphan files** left by a drain that crashed — files that no live drain
+holds and that will never be cleaned up otherwise. A crashed prior drain leaving
+two same-hash files in `processing/` produces duplicate solution promotions on
+subsequent drain invocations.
+
+### The third state
+
+Binary "this-drain vs not-this-drain" misses the abandoned class:
+
+| Classification | Condition | Correct action |
+|---|---|---|
+| **This-drain** | File is in `MOVED_THIS_DRAIN_FILE` set | Delete (this drain owns it) |
+| **In-flight** | Not this-drain AND mtime < threshold | Skip (concurrent drain holds it) |
+| **Stale orphan** | Not this-drain AND mtime >= threshold | Delete (crashed prior drain left it) |
+
+### Fix
+
+```bash
+IN_FLIGHT_AGE_SECONDS=300
+NOW=$(date +%s)
+
+for f in processing/*.jsonl; do
+  [ -f "$f" ] || continue
+
+  if set_contains "$MOVED_THIS_DRAIN_FILE" "$f"; then
+    rm "$f"
+    log "dedup: deleted this-drain duplicate: $f"
+    continue
+  fi
+
+  # Portable stat: Linux | BSD/macOS | fallback
+  # Fallback is printf '0' (epoch 0), NOT date +%s. A stat failure means
+  # mtime is unknown — treating age as 0 (now) would classify the file as
+  # in-flight and protect it indefinitely, masking the real problem. Epoch 0
+  # makes FILE_AGE enormous, so the file is treated as stale and cleaned up
+  # (fail-closed: unknown mtime → stale → remove, not in-flight → keep).
+  FILE_MTIME=$(stat -c '%Y' "$f" 2>/dev/null \
+    || stat -f '%m' "$f" 2>/dev/null \
+    || printf '0')
+  FILE_AGE=$(( NOW - FILE_MTIME ))
+
+  if [ "$FILE_AGE" -lt "$IN_FLIGHT_AGE_SECONDS" ]; then
+    log "dedup: skipping in-flight file (age ${FILE_AGE}s, concurrent drain): $f"
+  else
+    rm "$f"
+    log "dedup: deleted stale orphan (age ${FILE_AGE}s, crashed prior drain): $f"
+  fi
+done
+```
+
+### Why the age boundary works
+
+The threshold is intentionally the same value used by Phase 4's in-flight age
+guard (see sibling note in section 1). A file older than the threshold that is
+not owned by this drain was either:
+
+- Never picked up (anomalous — also safe to delete after threshold), or
+- Left by a crashed prior drain that held the lock but never completed.
+
+In both cases, no live drain is processing it. Deletion is safe.
+
+### General principle
+
+When deciding cleanup ownership in any pipeline with multiple concurrent workers:
+
+> **Always ask: what is the state of a file that belongs to neither this worker
+> nor any currently active worker?**
+
+The answer is always a third category — the abandoned/crashed-prior-actor state.
+Binary "mine vs not-mine" loses it. Enumerate all three before writing cleanup
+logic.
+
+---
+
+## Prevention checklist
+
+For any pipeline with atomic promotion and concurrent workers:
+
+- [ ] Sentinel is written **before** `mv`/rename, never after.
+- [ ] The four post-sentinel-ordering states (see table above) are documented
+      in a comment near the write path.
+- [ ] File cleanup uses three-way classification: this-actor / in-flight /
+      stale orphan. The age threshold is a named constant.
+- [ ] The in-flight age threshold is the same constant referenced by any
+      phase that also makes an in-flight judgment.
+- [ ] Portable `stat` dual-form is used for mtime: `stat -c '%Y' 2>/dev/null || stat -f '%m' 2>/dev/null`.
+- [ ] Log lines distinguish all three cleanup cases (include file age and
+      reason string).
+
+## Sources
+
+- PR #543 review rounds 1–3, compound-staging stack
+- `plugins/yellow-core/agents/workflow/staging-promoter.md`
+- `plugins/yellow-core/agents/workflow/staging-reviewer.md`
+- Related: `docs/solutions/logic-errors/two-phase-commit-idempotency-patterns.md`


### PR DESCRIPTION
Both files were referenced by MEMORY.md lines 364-365 but the files
themselves were never committed (orphaned local copies from the
PR #543 review rounds 1-3). Adding them resolves the broken links
and completes the docs/solutions/logic-errors/ set for the
background-compounding pipeline.

- machine-generated-text-shell-gotchas.md — empty-pattern grep
  false-positive in idempotency checks; YAML apostrophe escaping
  in machine-generated frontmatter

- sentinel-mv-ordering-and-drain-classification.md — sentinel
  must be written BEFORE atomic rename to avoid unrecoverable
  ambiguous state; concurrent-drain cleanup must classify files
  into three categories (this-drain / in-flight / stale-orphan),
  not binary

No code coupling — pure docs. Touches no plugins/ files, no
changeset required.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guide for machine-generated text shell handling, covering idempotency guard edge cases, YAML frontmatter corruption prevention, audit commands, and best-practice checklists.
  * Added guide for crash-recovery and concurrent drain classification in compound pipelines, including atomic ordering, observable states, recovery procedures, and cleanup principles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KingInYellows/yellow-plugins/pull/548?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->