### PR TITLE
docs(solution-docs): foundation plan + brainstorm + Jaccard calibration

### DIFF
--- a/docs/brainstorms/2026-05-21-solution-doc-git-workflow-brainstorm.md
+++ b/docs/brainstorms/2026-05-21-solution-doc-git-workflow-brainstorm.md
@@ -347,7 +347,7 @@ widely-adopted OSS pattern for this exact flow, but adjacent patterns exist.
    Source: [Claude PR Reviewer — GitHub Marketplace](https://github.com/marketplace/actions/claude-pr-reviewer)
 
 2. **PR template enforces postmortem link.** A simpler pattern: add a checkbox
-   to `.github/PULL_REQUEST_TEMPLATE.md`:
+   to `.github/pull_request_template.md`:
 
    ```markdown
    - [ ] If this PR closes a P0/P1 issue, I have added or updated a solution

--- a/docs/brainstorms/2026-05-21-solution-doc-git-workflow-brainstorm.md
+++ b/docs/brainstorms/2026-05-21-solution-doc-git-workflow-brainstorm.md
@@ -1,0 +1,476 @@
+# Solution Doc Git Workflow
+
+**Status:** Closed (brainstorm). See plans/ for any follow-up implementation plan.
+**Date:** 2026-05-21
+**Topic:** When and how to commit solution docs to git — default patterns, conflict detection, skip criteria, CI enforcement, and MEMORY.md authoring flow.
+
+## Problem
+
+Four distinct commit patterns are in active use across the repo with no documented policy:
+
+- **Co-shipped** (`db4547d5`): solution doc committed in the same PR as the fix that generated it.
+- **Dedicated post-PR** (`9a51dde1`, `f7f35ee5`): separate `docs(solutions):` PR that references the resolved PR number.
+- **Session capture** (`dd30b68d`, `ce3bb8b3`): committed via `/workflows:compound` with no PR anchor.
+- **Backfill** (`959a2cd5`, PR #548): orphaned local files referenced by MEMORY.md lines that were never committed.
+
+The orphan-doc gap is the most concrete failure mode: MEMORY.md accumulates pointers to docs that do not exist in the repository, making the memory system unreliable. CONTRIBUTING.md, AGENTS.md, and docs/CLAUDE.md contain zero mention of solution doc policy. The knowledge-compounder agent handles file creation but has no commit-timing guidance. The compound-lifecycle skill performs retroactive dedup (BM25 + cosine) but not write-time conflict detection. No CI gate exists for solution docs today.
+
+## Decisions
+
+1. **Default pattern: In-PR.** Solution docs are committed in the same PR as the code change that generated the learning. This eliminates the orphan-doc problem by making the doc and the fix atomic. Post-PR dedicated PRs are a valid exception for insights that emerge during review or after merge, but they require explicit justification in the PR description. Session-capture commits without a PR anchor are deprecated.
+
+2. **Conflict detection: Proactive (write-time).** Before committing a new solution doc, a slug/keyword match check runs against existing docs in `docs/solutions/`. False positives are acceptable — the author resolves them by updating the existing doc instead of creating a sibling. The check warns rather than blocks, giving the author the choice. This is implemented as a pre-commit heuristic or CI warning, not a hard gate.
+
+3. **Skip criteria.** A solution doc is NOT required when the change meets any of the following:
+   - **Reversible or trivial**: one-liner fix, typo correction, version bump with no behavioral implication.
+   - **Already documented**: proactive conflict detection flagged a duplicate — in that case, update the existing doc rather than creating a new one.
+   - **Subjective preference**: pure style or taste choice with no concrete failure mode that the doc would prevent.
+
+   PR-specific learnings (e.g., "this particular API shape caused confusion") are NOT a skip reason — file them. The bar is whether the learning could recur and cause wasted time.
+
+4. **CI enforcement.** Three distinct rules, each with a different severity:
+   - **Non-blocking warn**: heuristic check for PRs that resolve issues labeled `bug` or `P0/P1` with no change under `docs/solutions/`. Emits a warning in CI output; does not fail the build. Author acknowledges or adds the doc.
+   - **Blocking duplicate-by-slug**: if a new file in `docs/solutions/` shares a slug or a high keyword-overlap score with an existing file, CI fails with both paths listed. Author must either update the existing doc or rename the new one with a disambiguating suffix.
+   - **No block on broken MEMORY.md refs**: orphan references in MEMORY.md are informational. Backfill PRs (like #548) remain acceptable and are not blocked. This prevents the backfill mechanism itself from becoming a CI bottleneck.
+
+5. **MEMORY.md flow: Same PR, agent-written.** When a solution doc is created, the knowledge-compounder agent drafts the one-line MEMORY.md index entry and the doc frontmatter in the same PR. The author reviews both before merge. This keeps the doc and its MEMORY.md pointer atomic — the primary mechanism for preventing orphaned references going forward.
+
+## Implications / Open Follow-Ups
+
+- **New script: `validate-solutions.js`** (or extension of `validate-plugin.js`) implementing the blocking duplicate-by-slug check and the non-blocking missing-doc heuristic. Needs a concrete keyword/label list for the heuristic trigger (e.g., git log subject matching `fix:`, `fix!:`, issue labels `bug`/`P0`/`P1`).
+- **knowledge-compounder modification**: add an in-PR mode where it drafts the solution doc and MEMORY.md line during the PR and surfaces them to the author for review, rather than running post-hoc in a separate session.
+- **CONTRIBUTING.md update**: codify this policy under a "Solution Docs" section so it is discoverable without reading a brainstorm.
+- **Slug-overlap threshold tuning**: cosine cutoff and shared-token count for the duplicate check need calibration against the existing doc corpus. Defer to the implementation plan — wrong thresholds produce too many false positives and the author starts ignoring them.
+- **Backwards-compat**: existing orphan refs in MEMORY.md (e.g., the lines 364-365 case that prompted PR #548) — decide between a one-time backfill sweep or accepting them as historical noise. Low urgency since the in-PR flow prevents new ones.
+
+## Non-Goals
+
+- Retroactive dedup of existing solution docs (separate effort, not in scope here).
+- Auto-generation of MEMORY.md as a build artifact (decided against in Q5 — agent-authored with human review is the chosen model).
+- Blocking PRs for missing solution docs (Q4 explicitly non-blocking for the missing-doc heuristic).
+
+## Next Step
+
+To turn this into an implementation plan, run:
+`/workflows:plan docs/brainstorms/2026-05-21-solution-doc-git-workflow-brainstorm.md`
+
+---
+
+## Research Findings
+
+*Added 2026-05-21 to support implementation of `validate-solutions.js` and the
+CI warning job. Five focus areas. Sources cited inline.*
+
+---
+
+### 1. Slug/Keyword Duplicate Detection
+
+**Decision context:** The blocking duplicate-by-slug check in Decision 4 needs a
+concrete algorithm. This repo's docs corpus is small (85 files as of today) and
+will remain in the low hundreds. Authors write short slugs and titles
+(`heredoc-delimiter-collision`, `hook-set-e-and-json-exit-pattern`). The check
+runs in CI Node.js, so no Python ML stack is available.
+
+**Algorithm comparison:**
+
+| Algorithm | Strengths | Weaknesses | Fit for this repo |
+|---|---|---|---|
+| **Exact slug match** | Zero false positives | Misses synonyms (`crlf` vs `line-endings`) | Always run as first pass |
+| **Token Jaccard** | No dependencies, fast, interpretable | Sensitive to vocabulary mismatch; short slugs have high variance | Good for slug-vs-slug; threshold ~0.5 |
+| **TF-IDF cosine** | Handles full body; weights rare terms | Needs corpus IDF table; overkill for 100 docs | Optional for body comparison |
+| **BM25** | Best ranking for full-body retrieval | Needs tunable K1; adds complexity | Only if false-positive rate from cosine proves too high |
+| **SimHash/MinHash** | Web-scale dedup (millions of docs) | Complexity out of proportion | Not appropriate here |
+
+**Practical recommendations from research:**
+
+1. **Two-pass check: exact slug first, then token overlap.**
+   Exact slug match on the filename stem (e.g., `heredoc-delimiter-collision`)
+   catches the most obvious duplicate. Cost: one `fs.readdirSync` call.
+   Source: standard practice; no external dependency needed.
+
+2. **Jaccard on tokenized titles with threshold 0.5 for the warn path.**
+   Split title/slug on `-` and common stop-words. Jaccard = |A ∩ B| / |A ∪ B|.
+   At 0.5, two slugs sharing half their tokens get flagged. Empirically, thresholds
+   of 0.5–0.6 are used for near-duplicate title detection in ADR tooling and doc
+   corpora (source: Ben Frederickson's analysis of distance metrics shows Jaccard
+   works well when corpus items are sets of discrete tokens, not frequency-weighted
+   text). This is the right granularity for 3–6 word kebab-case slugs.
+
+3. **Do NOT compare full body in CI.** Full-body cosine similarity requires
+   building a corpus TF-IDF table at CI time — expensive and fragile for a
+   growing doc set. The body comparison belongs in the compound-lifecycle skill
+   (which already does BM25 + cosine for retroactive dedup), not in the
+   blocking CI check. The CI check should operate only on frontmatter
+   (`title:`, `problem:`, `tags:`) plus the filename slug.
+
+4. **Threshold tuning guidance:**
+   - Jaccard >= 0.6 on slug tokens → **block** (near-certain duplicate)
+   - Jaccard 0.4–0.59 on slug + title tokens → **warn** (possible duplicate,
+     author resolves)
+   - Jaccard < 0.4 → pass silently
+   These bands avoid alert fatigue while catching the real cases (e.g.,
+   `prompt-injection-fence-breakout-literal-delimiter` vs
+   `prompt-injection-fence-delimiter-escape` — both exist in the corpus and
+   could have been caught at write time).
+
+5. **Compare against same category only.** A slug collision between
+   `docs/solutions/security-issues/` and `docs/solutions/code-quality/` is
+   less likely to be a true duplicate than two slugs in the same directory.
+   Limit Jaccard comparison to same-category docs first; cross-category
+   comparison is the warn path.
+
+**False-positive trade-off:** The primary risk is two genuinely distinct docs
+sharing domain vocabulary (e.g., `hook-recursion-guard` and
+`hook-set-e-json-exit` both tokenize to `hook`). Guard against this by:
+(a) excluding single-token "stop words" specific to this domain (`hook`, `plugin`,
+`agent`, `skill`, `ci`, `pr`) from the Jaccard set, and (b) treating a match
+only when 3+ non-stop tokens overlap, not just one.
+
+---
+
+### 2. CI Warn-vs-Block Patterns
+
+**Decision context:** Decision 4 specifies a non-blocking warn for missing-doc
+heuristic and a blocking check for slug duplicates. This maps to two separate
+CI jobs in `validate-schemas.yml`.
+
+**GitHub Actions annotation syntax (official docs, 2026):**
+
+```yaml
+# In a shell step — emits a visible annotation in the PR Checks UI:
+echo "::warning file=docs/solutions/workflow/foo.md::Possible duplicate of docs/solutions/workflow/bar.md (Jaccard 0.52)"
+echo "::notice::No solution doc detected for this bug-label PR. Consider adding one."
+echo "::error file=docs/solutions/workflow/foo.md::Slug collision with existing doc bar.md — rename or update existing."
+```
+
+Parameters (all optional): `file`, `line`, `endLine`, `col`, `endColumn`, `title`.
+Annotations appear inline on the changed file in the PR diff view when `file=` is set.
+Source: [GitHub Docs — Workflow commands](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands)
+
+**Annotation limits:** 10 warnings + 10 errors per step; 50 per job; 50 per run.
+For a doc-check that typically fires on 0–2 files, this is not a constraint.
+
+**Implementing warn-without-fail (three patterns this repo uses already):**
+
+| Pattern | How it works | Example in this repo |
+|---|---|---|
+| `continue-on-error: true` on a step | Step exit 1 is absorbed; job continues; annotation still emits | `plugin-shell-tests` advisory bats step |
+| Exit 0 + `::warning::` | Script emits annotation but always exits 0 | `pnpm audit \|\| echo "::warning::..."` in security-audit job |
+| Separate non-required job | Job is not listed as a required check in branch protection | Not yet used, but the correct model for the missing-doc heuristic |
+
+**Recommendation for `validate-solutions.js`:**
+
+- **Blocking slug-duplicate check**: add as a step inside the existing
+  `validate-schemas` matrix (new `target: solutions`). Exit 1 on Jaccard >= 0.6.
+  Use `::error file=...::` for each collision pair.
+- **Non-blocking missing-doc heuristic**: add as a **separate job**
+  (`advisory-doc-check`) with `continue-on-error: true` at the job level.
+  This job is NOT added to the required-checks list in branch protection.
+  It emits `::warning::` annotations visible to authors without ever blocking merge.
+
+The separate-non-required-job pattern is the correct approach because:
+(a) `continue-on-error: true` at step level still marks the job as failed if
+any other step fails; (b) a dedicated advisory job makes the intent explicit
+in the YAML; (c) it can be listed in `report-metrics` for observability without
+blocking `ci-status`.
+
+This pattern is documented as the standard workaround by the GitHub community
+(the feature request for a native "warning" check status has been open since
+2022 and GitHub has not committed to implementing it).
+Source: [GitHub community discussion #11592](https://github.com/orgs/community/discussions/11592)
+
+**Emitting annotations from Node.js scripts (consistent with existing validate-*.js style):**
+
+```js
+// Use the same ::warning:: prefix pattern as lint-plugins.sh
+function warn(file, msg) {
+  if (process.env.GITHUB_ACTIONS === 'true') {
+    const escaped = msg.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+    const fileParam = file ? ` file=${file}` : '';
+    console.log(`::warning${fileParam}::${escaped}`);
+  }
+  console.error(`[validate-solutions] WARN: ${msg}`);
+}
+```
+
+This mirrors the `ga_escape` + `emit_annotation` pattern in `scripts/lint-plugins.sh`
+(lines 39–57) — copy that convention exactly.
+
+---
+
+### 3. "PR Resolves Bug Label But Missing Doc" Heuristics
+
+**Decision context:** The non-blocking heuristic in Decision 4 triggers when a PR
+closes an issue labeled `bug`/`P0`/`P1` with no new file under `docs/solutions/`.
+No widely-adopted OSS pattern for this specific combination was found in research —
+it is an area where this repo would be pioneering rather than following established
+practice.
+
+**What was found:**
+
+1. **Issue label detection from PR** — The standard GitHub Actions approach:
+
+   ```yaml
+   # In the check step, use github.event.pull_request.number to fetch
+   # linked issues via the GraphQL closingIssuesReferences API:
+   gh api graphql -f query='
+     query($pr: Int!, $owner: String!, $repo: String!) {
+       repository(owner: $owner, name: $repo) {
+         pullRequest(number: $pr) {
+           closingIssuesReferences(first: 10) {
+             nodes { labels(first: 10) { nodes { name } } }
+           }
+         }
+       }
+     }
+   ' -f owner="$OWNER" -f repo="$REPO" -F pr="$PR_NUMBER"
+   ```
+
+   This is well-established in the repo already (see
+   `docs/solutions/integration-issues/gh-api-graphql-plugin-command-template.md`
+   for the 6-element required pattern). The check would parse label names from
+   the response and trigger if any match `bug`, `P0`, or `P1`.
+
+2. **File pattern signal** — Detect whether the PR adds any file matching
+   `docs/solutions/**/*.md` using `git diff --name-only origin/main...HEAD`.
+   If the PR closes a bug-labeled issue AND no such file is added, emit
+   `::warning::`. The same `git diff` pattern is already used in
+   `changeset-check` (lines 776–778 of `validate-schemas.yml`).
+
+3. **Author fatigue prevention** — Three mechanisms from OSS practice:
+   - **Opt-out comment**: If the PR body contains `<!-- no-solution-doc -->` or
+     similar sentinel, skip the check. This mirrors the `[skip ci]` convention.
+   - **Label exemption**: PRs labeled `skip-doc-check` bypass the heuristic.
+     Authors who have already updated an existing doc (rather than creating one)
+     apply this label. This prevents the check from firing on "update existing
+     doc" PRs.
+   - **Non-required job**: The heuristic job is not a branch protection
+     requirement. Authors can merge over the warning — the check creates friction
+     without being a gate.
+
+4. **Narrow the label list to reduce noise.** Only `P0` and `P1` labels (not
+   generic `bug`) should trigger the hard-to-ignore annotation. `bug` alone
+   produces too many false positives (every small bug fix triggers it). Reserve
+   `bug` for the softest advisory tier, if used at all.
+
+Source for `closingIssuesReferences`: standard GitHub GraphQL API; documented
+at [GitHub Docs](https://docs.github.com/en/graphql/reference/objects#pullrequest).
+
+---
+
+### 4. Solution-Doc / ADR / Postmortem Authoring Conventions
+
+**Decision context:** The `docs/solutions/<category>/` tree is this repo's
+native format. Research finds three dominant external formats worth comparing.
+
+**Nygard ADR (canonical, 2011):**
+Sections: Title, Status, Context, Decision, Consequences.
+Concise, prose-oriented, no options analysis. Best for capturing a single
+architectural choice with its rationale. Widely adopted; supported by `adr-tools`
+CLI for numbering and cross-linking.
+Source: [Nygard template](https://github.com/joelparkerhenderson/architecture-decision-record/blob/main/locales/en/templates/decision-record-template-by-michael-nygard/index.md)
+
+**MADR (Markdown Architectural Decision Records, 2024 recommended):**
+Adds: Options Considered, Decision Outcome with Pros/Cons. More structured than
+Nygard; has a VS Code extension and active tooling. Appropriate when the
+decision space involves multiple concrete alternatives.
+Source: [adr.github.io](https://adr.github.io/adr-templates/)
+
+**Google SRE Postmortem:**
+Mandatory sections: Impact, Timeline, Root Cause, Contributing Causes,
+Action Items (with owner + deadline). Trigger criteria are defined ahead of
+time (user-visible outage, data loss, on-call intervention). Blameless framing
+is the load-bearing principle — documents must not assign individual fault.
+Source: [Google SRE Book — Postmortem Culture](https://sre.google/sre-book/postmortem-culture/)
+
+**Comparison to `docs/solutions/<category>/` format:**
+
+The existing solution doc structure (observed from corpus):
+
+```yaml
+---
+title: "..."
+date: "YYYY-MM-DD"
+category: "..."
+track: knowledge
+problem: "..."
+tags: [...]
+components: [...]
+---
+
+# Title
+## Problems / ## Problem
+## Root Causes / ## Root Cause
+## Fix
+## Prevention
+## Related Documentation
+```
+
+This format is a hybrid of Nygard ADR (Status → omitted; Context → Problems)
+and Google SRE postmortem (Root Cause, Fix/Action Items, Prevention). It is
+appropriate for this repo's use case: the "decisions" are already made (the
+fix is committed); the doc captures the failure pattern and prevention recipe.
+
+**Recommendations for consistency:**
+
+1. Standardize frontmatter fields. Three fields vary across existing docs:
+   `problem` vs `problems` (both appear in the corpus). Pick one — `problem` —
+   and add it to the slug/keyword extraction logic in `validate-solutions.js`.
+
+2. `Prevention` section is the most valuable for recurrence prevention and
+   MEMORY.md authoring. Make it required (validated by the linter). The
+   compound-lifecycle skill's knowledge-compounder already extracts prevention
+   patterns — a consistent heading makes that extraction reliable.
+
+3. Do NOT adopt full MADR for solution docs. Solution docs document what
+   happened, not what was decided. The "options considered" section adds no
+   value when the option space is already collapsed by the incident.
+   ADR format is appropriate if/when the repo introduces an architecture
+   decision log (`docs/decisions/`) as a separate tree.
+
+---
+
+### 5. Knowledge-Compounder-Equivalent Agent Flows
+
+**Decision context:** Decision 5 specifies that the knowledge-compounder agent
+drafts the MEMORY.md line and frontmatter in the same PR. Research finds no
+widely-adopted OSS pattern for this exact flow, but adjacent patterns exist.
+
+**What was found:**
+
+1. **AI PR reviewer + postmortem link enforcement.** The Claude PR Reviewer
+   GitHub Action (2025) reads `CLAUDE.md`/`AGENTS.md` for project-specific
+   rules and enforces them as inline PR comments. This is the closest OSS
+   analogue: an agent reads a rule file and checks whether PR content satisfies
+   it. For this repo, the rule would be: "if this PR closes a P0/P1 issue,
+   does it include a file under `docs/solutions/`?"
+   Source: [Claude PR Reviewer — GitHub Marketplace](https://github.com/marketplace/actions/claude-pr-reviewer)
+
+2. **PR template enforces postmortem link.** A simpler pattern: add a checkbox
+   to `.github/PULL_REQUEST_TEMPLATE.md`:
+
+   ```markdown
+   - [ ] If this PR closes a P0/P1 issue, I have added or updated a solution
+         doc under `docs/solutions/`. If not applicable, check anyway and note why.
+   ```
+
+   This is zero-infrastructure but relies on author discipline. The CI
+   heuristic (Area 3) is the enforcement backstop.
+
+3. **Pre-commit hook for doc creation.** Pre-commit hooks can detect `fix:`
+   commits and prompt for a solution doc path. However, pre-commit hooks are
+   not enforced in CI and are skipped with `--no-verify`. Not recommended as
+   the primary mechanism — use CI instead.
+
+4. **In-PR agent mode for knowledge-compounder.** The existing compound-lifecycle
+   skill runs post-hoc. The brainstorm decision (Decision 5) to add an in-PR mode
+   aligns with the Claude Code PR Review pattern: the agent runs as part of
+   the PR review cycle, reads the diff, and if it detects a fix-class change,
+   drafts a `docs/solutions/` file and MEMORY.md line as a PR comment or
+   committed artifact for author review. This is the highest-value change
+   because it eliminates the "author forgets to write the doc" failure mode
+   at the moment of highest context.
+
+**Concrete implementation sketch for in-PR mode:**
+
+```text
+Trigger: PostToolUse on `gt stack submit` OR a GitHub Actions job
+  that fires on pull_request events for `fix:` commits
+Agent reads: git diff, linked issue labels
+Agent outputs:
+  1. Draft `docs/solutions/<category>/<slug>.md` with frontmatter
+     and sections pre-filled from the diff context
+  2. One-line MEMORY.md entry (dry-run, shown as suggestion)
+  3. AskUserQuestion: "Review and approve the solution doc draft?"
+Author reviews → approves → agent commits both files to the PR branch
+```
+
+This matches the "same PR, agent-written, author-reviewed" model in Decision 5
+without requiring a separate post-PR session.
+
+---
+
+### 6. This Repo's Existing Conventions (Implementation Anchors)
+
+These facts from reading the repo directly constrain implementation choices.
+
+**CI annotation pattern (from `scripts/lint-plugins.sh`):**
+The `ga_escape` + `emit_annotation` functions (lines 39–57) are the established
+model for emitting `::warning::` and `::error::` from shell scripts with
+file-anchored annotations. The new `validate-solutions.js` should replicate
+this in Node.js using the snippet in Area 2 above.
+
+**ERROR-* code convention (from `packages/domain/src/validation/errorCatalog.ts`):**
+New solution-doc validation errors should follow `ERROR-{CATEGORY}-{NUMBER}`.
+Suggested codes for `validate-solutions.js`:
+- `ERROR-SOL-001` — slug exact collision with existing doc
+- `ERROR-SOL-002` — Jaccard overlap above block threshold (>= 0.6)
+- `ERROR-SOL-003` — frontmatter missing required field (`title`, `date`, `category`)
+- `WARN-SOL-001` — Jaccard overlap in warn band (0.4–0.59)
+- `WARN-SOL-002` — PR closes bug/P0/P1 issue with no new solution doc
+
+The `WARN-` prefix is non-standard (current catalog uses only `ERROR-`). Options:
+(a) add `WARN-SOL-*` as a new prefix class, or (b) use `ERROR-SOL-*` for both
+and distinguish severity via the `ErrorSeverity` enum (`warning` vs `error`).
+Option (b) is cleaner given the existing `ErrorSeverity` type in `validation/types.ts`.
+
+**`validate-schemas.yml` matrix pattern:**
+New `target: solutions` entry in the matrix runs `validate-solutions.js` the
+same way `target: plugins` runs `validate-plugin.js`. The advisory missing-doc
+job is a separate top-level job (not in the matrix) with `continue-on-error: true`.
+Both jobs should feed into `report-metrics` via the existing
+`./scripts/export-ci-metrics.sh` pattern for SLO tracking.
+
+**Path filter for the solutions check:**
+
+```yaml
+on:
+  pull_request:
+    paths:
+      - 'docs/solutions/**'
+      - 'scripts/validate-solutions.js'
+      - '.github/workflows/validate-schemas.yml'
+```
+
+The missing-doc advisory job should also trigger on `plugins/**` changes (not
+just `docs/solutions/**`), since the check fires when a plugin change is present
+without a doc change.
+
+---
+
+### Summary: 3-5 Concrete Recommendations Per Area
+
+**Area 1 (Duplicate detection):**
+1. Exact slug match → block (zero cost, zero false positives)
+2. Token Jaccard on slug + `title:` + `problem:` frontmatter, threshold 0.5 warn / 0.6 block
+3. Exclude domain-specific stop words (`hook`, `plugin`, `agent`, `pr`, `ci`)
+4. Same-category comparison first; cross-category is warn-only
+5. No full-body comparison in CI — defer to compound-lifecycle skill
+
+**Area 2 (CI warn vs block):**
+1. `::warning file=...::` syntax for all non-blocking findings (mirrors lint-plugins.sh)
+2. Slug collision → `target: solutions` matrix job → exit 1 → blocking
+3. Missing-doc heuristic → separate advisory job → `continue-on-error: true` → non-blocking
+4. Advisory job excluded from branch protection required checks and from `ci-status` gate
+5. Both jobs report to `report-metrics` via `export-ci-metrics.sh`
+
+**Area 3 (Bug-label missing-doc heuristic):**
+1. Use `closingIssuesReferences` GraphQL API to detect linked issue labels
+2. Trigger on `P0`/`P1` only (not bare `bug`) to limit false positives
+3. Opt-out via `<!-- no-solution-doc -->` in PR body or `skip-doc-check` label
+4. Git diff detects new `docs/solutions/**/*.md` files as the "doc present" signal
+5. Applies the 6-element `gh api graphql` pattern from the existing solution doc
+
+**Area 4 (Solution doc format):**
+1. Keep existing hybrid format (Problems → Root Cause → Fix → Prevention)
+2. Standardize frontmatter: `title`, `date`, `category`, `problem`, `tags` as required fields
+3. `Prevention` section required — validated by the linter
+4. Do not adopt MADR options-table structure for solution docs (wrong use case)
+5. Reserve Nygard/MADR for a future `docs/decisions/` ADR tree if architectural decisions need capturing
+
+**Area 5 (AI-assisted knowledge capture):**
+1. In-PR mode for knowledge-compounder: trigger on `fix:` commits, draft doc + MEMORY.md line
+2. PR template checkbox as zero-infrastructure backstop
+3. CI heuristic (Area 3) as the enforcement layer the agent drafts for
+4. No pre-commit hooks — they are bypassable and not enforceable in CI
+5. Agent output goes through AskUserQuestion before commit — human review is mandatory

--- a/docs/brainstorms/2026-05-21-solution-doc-git-workflow-brainstorm.md
+++ b/docs/brainstorms/2026-05-21-solution-doc-git-workflow-brainstorm.md
@@ -226,10 +226,11 @@ practice.
    ' -f owner="$OWNER" -f repo="$REPO" -F pr="$PR_NUMBER"
    ```
 
-   This is well-established in the repo already (see
-   `docs/solutions/integration-issues/gh-api-graphql-plugin-command-template.md`
-   for the 6-element required pattern). The check would parse label names from
-   the response and trigger if any match `bug`, `P0`, or `P1`.
+   This is a standard GitHub Actions pattern. The implementation should follow
+   the 6-element `gh api graphql` safety pattern (symmetric exit-code capture,
+   `-f` flags for variables, `--jq` for server-side filtering, SC2016 disable,
+   jq null-repository guard, no string interpolation). The check would parse
+   label names from the response and trigger if any match `bug`, `P0`, or `P1`.
 
 2. **File pattern signal** — Detect whether the PR adds any file matching
    `docs/solutions/**/*.md` using `git diff --name-only origin/main...HEAD`.
@@ -459,7 +460,7 @@ without a doc change.
 2. Trigger on `P0`/`P1` only (not bare `bug`) to limit false positives
 3. Opt-out via `<!-- no-solution-doc -->` in PR body or `skip-doc-check` label
 4. Git diff detects new `docs/solutions/**/*.md` files as the "doc present" signal
-5. Applies the 6-element `gh api graphql` pattern from the existing solution doc
+5. Applies the 6-element `gh api graphql` safety pattern (symmetric exit-code capture, `-f` flags, `--jq` filtering, SC2016 disable, jq null-check, no string interpolation)
 
 **Area 4 (Solution doc format):**
 1. Keep existing hybrid format (Problems → Root Cause → Fix → Prevention)

--- a/docs/research/2026-05-21-solution-doc-jaccard-calibration.md
+++ b/docs/research/2026-05-21-solution-doc-jaccard-calibration.md
@@ -1,0 +1,165 @@
+# Solution-Doc Jaccard Calibration
+
+**Date:** 2026-05-21
+**Context:** Empirical calibration data that drove the design decision in
+`plans/solution-doc-git-workflow.md` to **drop write-time Jaccard duplicate
+detection** from the initial `validate-solutions.js` implementation.
+
+## Why this exists
+
+The brainstorm at `docs/brainstorms/2026-05-21-solution-doc-git-workflow-brainstorm.md`
+and the initial plan proposed a token-Jaccard duplicate detector with
+thresholds at 0.5 (warn) / 0.6 (block) against the existing `docs/solutions/`
+corpus. Before writing the validator, Phase 0 of the plan ran a one-off
+calibration sweep across all 88 non-archived docs to validate those
+thresholds. The data showed the proposed thresholds would never fire.
+
+This document captures the calibration so the decision is auditable and so
+that any future revisit of Jaccard duplicate detection can re-run the same
+analysis against the then-current corpus.
+
+## Methodology
+
+1. **Corpus:** All `.md` files under `docs/solutions/` excluding `archived/`.
+2. **Token source:** For each doc, combined `slug` (filename without `.md`),
+   `title:` frontmatter, and `problem:` frontmatter (with `problems:` /
+   `problem_type:` aliases).
+3. **Tokenization:** Lowercase, split on non-alphanumeric, drop tokens shorter
+   than 3 chars, drop initial stop-word list.
+4. **Initial stop-words:** `hook plugin agent ci pr workflow validation review
+   skill command claude code error build fix the and for with from when this
+   that are not use using how why what`.
+5. **Pairwise Jaccard:** `|A ∩ B| / |A ∪ B|` for all `N*(N-1)/2 = 3,828` pairs.
+
+## Results
+
+### Distribution (Phase 0.1)
+
+```text
+Found 88 non-archived docs
+Total pairs analyzed:    3,828
+Pairs with non-zero Jaccard: 791
+
+Bin       | Count
+----------+------
+0.00-0.05 |   514
+0.05-0.10 |   220
+0.10-0.15 |    44
+0.15-0.20 |     6
+0.20-0.25 |     4
+0.25-0.30 |     1
+0.30-0.35 |     2
+0.35+     |     0   ← NO pair exceeds 0.345
+```
+
+**Max pairwise Jaccard in the entire corpus = 0.345.** That maximum pair is
+two intentional sibling docs about distinct prompt-injection failure modes
+(`prompt-injection-fence-breakout-literal-delimiter.md` and
+`sandwich-fence-delimiter-forgery.md`) — they share vocabulary by design.
+
+### Top 20 pairs
+
+| Score | Same-cat | Files |
+|------:|:--------:|:------|
+| 0.345 | YES | security-issues/prompt-injection-fence-breakout-literal-delimiter ↔ sandwich-fence-delimiter-forgery |
+| 0.333 | YES | code-quality/brainstorm-orchestrator-agent-authoring-patterns ↔ plugin-review-defensive-authoring-patterns |
+| 0.250 | YES | security-issues/yellow-linear-plugin-multi-agent-code-review ↔ yellow-linear-plugin-pr-review-fixes |
+| 0.231 | YES | integration-issues/ruvector-cli-and-mcp-tool-name-mismatches ↔ ruvector-mcp-tool-parameter-schema-mismatch |
+| 0.200 | YES | code-quality/agent-migration-audit-patterns ↔ plugin-review-defensive-authoring-patterns |
+| 0.200 | YES | code-quality/agent-migration-audit-patterns ↔ session-level-review-command-patterns |
+| 0.200 | YES | code-quality/plugin-review-defensive-authoring-patterns ↔ session-level-review-command-patterns |
+| 0.185 | no  | code-quality/yellow-ci-shell-security-patterns ↔ security-issues/shell-binary-downloader-security-patterns |
+| 0.182 | YES | build-errors/plugin-json-changelog-key-schema-drift-remote-validator ↔ userconfig-type-title-remote-validator-drift |
+| 0.179 | YES | security-issues/prompt-injection-fence-breakout-literal-delimiter ↔ prompt-injection-fence-delimiter-escape |
+
+Manual review of all 20 confirmed: every pair is a legitimate sibling about
+related-but-distinct failure modes. None are accidental duplicates.
+
+### DF-based stop-word analysis (Phase 0.2)
+
+```text
+Total unique tokens: 736
+
+Top terms by document frequency:
+  plugin     21 docs (23.9%)
+  agent      18 docs (20.5%)
+  code       16 docs (18.2%)
+  review     15 docs (17.0%)
+  patterns   13 docs (14.8%)
+  pattern    10 docs (11.4%)
+  command     9 docs (10.2%)
+  shell       9 docs (10.2%)
+  multi       9 docs (10.2%)
+  yellow      8 docs (9.1%)
+  ...
+
+Stop-word candidates by DF threshold:
+  DF >= 40%: 0 terms
+  DF >= 30%: 0 terms
+  DF >= 20%: 2 terms (plugin, agent)
+  DF >= 15%: 4 terms (plugin, agent, code, review)
+  DF >= 10%: 9 terms (plugin, agent, code, review, patterns, pattern,
+                      command, shell, multi)
+```
+
+The Microsoft Research duplicate-detection paper suggests a domain stop-word
+threshold near 40% DF. **No tokens cross that threshold** in this corpus.
+Even at 10% DF the candidate list is small. This is consistent with the
+bimodal Jaccard distribution the nelhage MinHash analysis predicts for
+technical documentation: tokens are highly specific to the failure mode each
+doc describes.
+
+### Error-codes regex check (Phase 0.3)
+
+`scripts/lint-error-codes.js` uses `/ERROR-[A-Z]+-\d+/g`. `ERROR-SOL-001`
+matches without modification. No regex change required when introducing the
+`SOL` category.
+
+## Conclusion
+
+**Jaccard duplicate detection is not warranted at this corpus size.** Three
+findings drive the conclusion:
+
+1. **No accidental duplicates exist.** Every high-similarity pair is an
+   intentional sibling, manually verified.
+2. **The proposed 0.5/0.6 thresholds would never fire.** Maximum pair = 0.345.
+3. **Lower thresholds catch only legitimate siblings.** Setting block at
+   anything ≤ 0.30 would either fire on zero pairs (no value) or fire on
+   pairs the author legitimately needed to write (false positives).
+
+## What ships instead
+
+The `validate-solutions.js` initial implementation enforces only:
+
+- **`ERROR-SOL-001`** — exact slug collision against existing corpus (BLOCK)
+- **`ERROR-SOL-002`** — missing required frontmatter field (BLOCK)
+
+No similarity scoring, no stop-word list, no threshold calibration, no
+`intentional_variant: true` opt-out semantics.
+
+The orphan-MEMORY-reference problem (the original pain point from PR #548)
+is addressed by the `knowledge-compounder` in-PR mode (`/workflows:compound
+--in-pr`), which is what actually delivers value.
+
+## When to revisit
+
+Re-run this calibration when any of the following become true:
+
+- Corpus exceeds ~500 docs (the inflection point where Jaccard typically
+  begins seeing real duplicates — see nelhage analysis).
+- A reviewer flags an actual duplicate doc landing in main — i.e., the
+  failure mode the validator was meant to prevent.
+- MEMORY.md index churn suggests references are colliding (multiple bullets
+  pointing at semantically-overlapping docs).
+
+The calibration scripts used to produce this data
+(`jaccard-calibration.js`, `df-stopword.js`) are not committed — they were
+throwaways. Re-derive them from this methodology section if needed.
+
+## References
+
+- [Draisbach & Naumann, "On Choosing Thresholds for Duplicate Detection," HPI Potsdam 2013](https://hpi.de/fileadmin/user_upload/fachgebiete/naumann/publications/2013/On_Choosing_Thresholds_for_Duplicate_Detection.pdf)
+- [Microsoft Research, "Duplicate News Story Detection Revisited," 2013](https://www.microsoft.com/en-us/research/wp-content/uploads/2013/12/NewsDuplicateDetectionRevisted.pdf)
+- [nelhage, "Finding near-duplicates with Jaccard similarity and MinHash"](https://blog.nelhage.com/post/fuzzy-dedup)
+- Plan: `plans/solution-doc-git-workflow.md`
+- Brainstorm: `docs/brainstorms/2026-05-21-solution-doc-git-workflow-brainstorm.md`

--- a/plans/solution-doc-git-workflow.md
+++ b/plans/solution-doc-git-workflow.md
@@ -1,0 +1,681 @@
+# Feature: Solution Doc Git Workflow
+
+## Overview
+
+Establish a documented policy + light tooling that governs when solution docs
+under `docs/solutions/` are committed to git, prevents orphaned MEMORY.md
+references, and adds a non-blocking CI nudge plus a blocking exact-slug-
+collision gate. The default pattern is **in-PR (co-shipped)** with the change
+that generated the learning, eliminating the orphan-doc gap that prompted
+backfill PR #548. The implementation has five small prongs that ship in a
+single PR.
+
+**Design pivot (2026-05-21):** Phase 0 calibration against the existing 88-
+doc corpus showed maximum pairwise token Jaccard = 0.345 across all 3,828
+pairs — no accidental duplicates exist. The originally-proposed Jaccard
+duplicate detection (0.5 warn / 0.6 block) is dropped from the initial
+implementation. The validator enforces only exact-slug collision and
+frontmatter required fields. Full calibration data:
+`docs/research/2026-05-21-solution-doc-jaccard-calibration.md`.
+
+## Problem Statement
+
+### Current Pain Points
+
+Four distinct commit patterns are in active use with no documented policy:
+
+| Pattern | Example | Failure mode |
+|---|---|---|
+| Co-shipped (in-PR) | `db4547d5` | None — this is the desired default |
+| Dedicated post-PR | `9a51dde1`, `f7f35ee5` | Doc lands later; MEMORY.md may point at it prematurely |
+| Session capture | `dd30b68d`, `ce3bb8b3` | No PR anchor; doc has no traceable origin |
+| Backfill | `959a2cd5` (PR #548) | Orphan refs in MEMORY.md accumulate before backfill |
+
+The orphan-doc gap is the most concrete failure mode: MEMORY.md accumulates
+pointers to docs that do not exist in the repository, making the memory system
+unreliable. `CONTRIBUTING.md`, `AGENTS.md`, and `docs/CLAUDE.md` contain zero
+mention of solution doc policy today. The `knowledge-compounder` agent
+handles file creation but has no commit-timing guidance. The
+`compound-lifecycle` skill performs retroactive dedup (BM25 + cosine) but no
+write-time conflict detection. No CI gate exists for solution docs.
+
+### User Impact
+
+- Contributors don't know when a solution doc is expected vs optional.
+- MEMORY.md references rot, eroding trust in the index over time.
+- Reviewers have no shared rubric to check "should this PR have a doc?"
+
+### Business Value
+
+- Atomic doc+code commits preserve causal links between learnings and fixes.
+- Exact-slug collision detection prevents accidental file overwrites.
+- A discoverable policy in `CONTRIBUTING.md` shortens contributor ramp-up.
+
+## Proposed Solution
+
+### High-Level Architecture
+
+Five small, independently-verifiable prongs:
+
+1. **`scripts/validate-solutions.js`** — diff-scoped Node validator. Blocks
+   PRs that add a doc whose slug exactly matches an existing one (catches
+   accidental filename collisions). Enforces required frontmatter fields on
+   **new/modified** files only. No similarity scoring (calibration showed no
+   accidental duplicates exist in the corpus).
+
+2. **`knowledge-compounder` agent in-PR mode** — new explicit invocation path
+   (no hook, no auto-trigger). Author runs `/workflows:compound --in-pr`
+   while on a feature branch; the agent reads the current PR context, drafts
+   the solution doc + MEMORY.md line, and gates on the existing M3
+   AskUserQuestion before writing.
+
+3. **CONTRIBUTING.md "Solution Docs" section** — codifies the policy:
+   default, exceptions, skip criteria, opt-out mechanism. PR checklist gains
+   one line.
+
+4. **CI workflow** — new advisory `validate-solutions` job in
+   `.github/workflows/validate-schemas.yml`. The blocking duplicate check
+   joins the existing `validate:schemas` aggregator. The non-blocking missing-
+   doc heuristic runs as a separate step using
+   `closingIssuesReferences` GraphQL to detect P0/P1-labeled issues with no
+   `docs/solutions/` change in the diff.
+
+5. **PR template + error catalog plumbing** — new
+   `## Solution doc` checkbox in `.github/PULL_REQUEST_TEMPLATE.md`;
+   `ERROR-SOL-*` codes added to `packages/domain/src/validation/errorCatalog.ts`
+   using the existing `ErrorSeverity` enum (no new `WARN-` prefix class).
+
+### Key Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| In-PR trigger | **Explicit only** (`/workflows:compound --in-pr`) | Avoids hook recursion, PR-noise, and context overload. Author opts in when a learning is worth capturing. |
+| Validator scope | **Diff-scoped** (`git diff origin/main...HEAD`) | Existing 88-doc corpus has frontmatter drift (`track: feature` outlier, 12 docs with `problem_type`). Diff scoping ships immediately without a normalization PR blocking work. |
+| Duplicate algorithm | **Exact slug match only** | Phase 0.1 calibration on the 88-doc corpus: max pairwise Jaccard = 0.345; zero accidental duplicates exist. Adding Jaccard would be ~60 LOC of infrastructure that never fires + a stop-word list + threshold tuning + an opt-out edge case — all solving a phantom problem. Exact-slug catches the only real failure mode (accidental filename reuse). See `docs/research/2026-05-21-solution-doc-jaccard-calibration.md`. |
+| Heuristic trigger | **P0/P1 issue labels only** | Eliminates revert-PR and squash-merge false positives. Narrower coverage, near-zero noise. |
+| Error code namespace | **`ERROR-SOL-*` (ERROR severity only)** | Two codes: SOL-001 slug collision, SOL-002 frontmatter invalid or missing required fields. No WARNING-tier codes needed (advisory job emits `::warning::` directly). |
+| MEMORY.md target | **User-local `~/.claude/projects/<slug>/memory/MEMORY.md`** | Existing knowledge-compounder writes here. Repo has no project-scoped MEMORY.md; agent-memory files at `.claude/agent-memory/` are per-plugin and out of scope. |
+| Backfill scope | **None now** | Existing orphan refs accepted as historical noise. In-PR flow prevents new ones. |
+| Revisit Jaccard | **When corpus exceeds ~500 docs OR real duplicates land in main** | Re-run the calibration in `docs/research/2026-05-21-solution-doc-jaccard-calibration.md`; if the bimodal distribution shifts to show real near-duplicates, add Jaccard then with corpus-derived thresholds. |
+
+### Trade-offs Considered
+
+- **Hook vs explicit invocation:** Rejected PostToolUse on `gt stack submit`
+  because the hook would run on every submit (most submits don't need a doc),
+  adding context overload. The compound-lifecycle hook recursion guard
+  (`COMPOUND_DRAIN_IN_PROGRESS=1`) precedent shows how to safely build this if
+  needed later — kept as a follow-up option.
+- **GitHub Action posting doc draft as comment:** Rejected because the comment
+  lives out-of-band from the local branch and requires manual copy-paste.
+- **Corpus-wide validation:** Rejected because the 13 non-conforming existing
+  docs would block every new PR until normalized. A separate normalization
+  effort is filed as an out-of-scope follow-up.
+- **BM25 + cosine duplicate detection:** Rejected. 88 docs is too small to
+  justify the implementation complexity. Token Jaccard was the alternative —
+  then itself rejected by Phase 0 calibration.
+- **Token Jaccard duplicate detection (originally proposed):** Rejected after
+  Phase 0.1 calibration. Max pairwise score across 3,828 pairs is 0.345; all
+  high-similarity pairs are intentional siblings. No threshold setting
+  produces value without false positives. Documented in
+  `docs/research/2026-05-21-solution-doc-jaccard-calibration.md` for future
+  revisit. Slug-exact match remains the only structural duplicate gate.
+
+## Implementation Plan
+
+### Phase 0: Discovery & Calibration (COMPLETE)
+
+Phase 0 ran during plan refinement on 2026-05-21. Full data + methodology
+captured at `docs/research/2026-05-21-solution-doc-jaccard-calibration.md`.
+Summary:
+
+- **0.1 — Jaccard sweep:** Max pairwise score across 3,828 pairs = 0.345.
+  Zero accidental duplicates in the corpus. Proposed 0.5/0.6 thresholds
+  would never fire. **Result:** Jaccard duplicate detection dropped from
+  initial implementation (see Key Design Decisions above).
+- **0.2 — DF-based stop-words:** No tokens cross 40% DF threshold (highest is
+  `plugin` at 23.9%). **Result:** Moot — no stop-words needed since Jaccard
+  is dropped.
+- **0.3 — error-codes regex check:** `scripts/lint-error-codes.js` uses
+  `/ERROR-[A-Z]+-\d+/g` — matches `ERROR-SOL-001` without modification.
+  **Result:** No regex change required.
+
+**Constraint surfaced by Phase 0.3 (still applies):** `lint-error-codes.js`
+blocks scripts that hard-code catalog code literals. `validate-solutions.js`
+must import codes from the built `@yellow-plugins/domain` package or
+assemble them via string concatenation — never embed `'ERROR-SOL-001'` as a
+literal.
+
+### Phase 1: validate-solutions.js (Prong 1)
+
+- [ ] 1.1: Create `scripts/validate-solutions.js` modeled on
+      `scripts/backfill-solution-frontmatter.js` (handles `docs/solutions/`
+      traversal, handrolled YAML-frontmatter regex, path-traversal guards,
+      `--check` mode). Target ~120 LOC.
+  - `#!/usr/bin/env node` + `'use strict';`
+  - `ROOT = path.resolve(__dirname, '..')`
+  - `SOLUTIONS_DIR = path.join(ROOT, 'docs', 'solutions')` with
+    `SOLUTIONS_DIR.startsWith(ROOT + path.sep)` guard
+  - `colors`/`logError`/`logWarning` inline helpers
+  - `errors[]` accumulator; exit 1 if any errors
+- [ ] 1.2: Implement diff detection: `git diff --name-only origin/main...HEAD`
+      filtered to `^docs/solutions/`. Soft-skip with `::notice::` if no
+      changed files OR if `origin/main` unreachable (fork PR fallback).
+- [ ] 1.3: For each changed file, parse frontmatter via handrolled regex
+      (`text.match(/^---\s*\r?\n([\s\S]*?)\r?\n---\s*\r?\n([\s\S]*)$/)` plus
+      field-level regexes — same pattern as `backfill-solution-frontmatter.js`,
+      with `\s*` after each `---` to tolerate trailing whitespace on delimiters).
+      Validate:
+  - Required fields: `title`, `date`, `category`, `track`, `problem`, `tags`
+  - Optional: `components`, `severity`
+  - Enums: `track ∈ {bug, knowledge}`,
+    `category ∈ {security-issues, build-errors, integration-issues, code-quality, workflow, logic-errors}`
+  - Slug regex: `^[a-z0-9]+(-[a-z0-9]+)*$`, max 50 chars
+  - ISO 8601 date
+  - Missing-required-field or invalid-enum → block with `ERROR-SOL-002`
+- [ ] 1.4: Implement exact slug collision detection:
+  - Walk existing `docs/solutions/**/*.md` corpus, build slug index
+  - For each new file (added in diff, not modified), check slug against index
+  - Collision (same slug, different path) → block with `ERROR-SOL-001`
+- [ ] 1.5: Emit GitHub Actions annotations when `GITHUB_ACTIONS=true`:
+      `::error file=<path>::<msg>`.
+- [ ] 1.6: Add `package.json` entries:
+  - `"validate:solutions": "node scripts/validate-solutions.js"`
+  - Append `&& node scripts/validate-solutions.js` to `"validate:schemas"`.
+- [ ] 1.7: Add `ERROR-SOL-001` and `ERROR-SOL-002` to the error catalog:
+  - In `packages/domain/src/validation/types.ts`: add a
+    `ErrorCategory.SOLUTION_DOCS` enum value (match existing naming
+    convention by inspecting other categories) and a corresponding entry in
+    `getErrorCodesByCategory`.
+  - In `packages/domain/src/validation/errorCatalog.ts`: add two entries
+    using `ErrorSeverity.ERROR` from `types.js` (enum values are UPPERCASE
+    in this codebase: `'ERROR'`, `'WARNING'`).
+  - SOL-001: "Solution doc slug `<slug>` collides with existing
+    `<existing-path>`."
+  - SOL-002: "Solution doc frontmatter invalid in `<path>`: `<detail>`."
+  - **Critical constraint:** `validate-solutions.js` must NOT embed
+    `'ERROR-SOL-001'` as a string literal — `lint-error-codes.js` blocks
+    scripts hard-coding catalog codes. Import codes from the built
+    `@yellow-plugins/domain` package (or assemble via concatenation if
+    import is impractical from a `scripts/*.js` file).
+- [ ] 1.8: Integration tests at `tests/integration/validate-solutions.test.ts`
+      following the `tests/integration/backfill-solution-frontmatter.test.ts`
+      fixture-tmpdir pattern (create a temp `docs/solutions/` tree, run the
+      script via `child_process`, assert on exit code + stdout):
+  - Fixture: new doc with slug collision against existing → block (SOL-001)
+  - Fixture: new doc missing required frontmatter field → block (SOL-002)
+  - Fixture: new doc with invalid `track:` enum value → block (SOL-002)
+  - Fixture: new doc with invalid `category:` enum value → block (SOL-002)
+  - Fixture: new doc with bad slug regex (trailing hyphen, uppercase) → block
+  - Fixture: new doc with valid frontmatter and unique slug → exit 0
+  - Fixture: existing doc *modified* (not added) → skip slug-collision check;
+    only lint frontmatter
+  - Fixture: no `docs/solutions/` changes in diff → `::notice::` exit 0
+  - Fixture: `origin/main` unreachable → soft-skip exit 0
+
+### Phase 2: knowledge-compounder in-PR mode (Prong 2)
+
+- [ ] 2.1: Read `plugins/yellow-core/agents/workflow/knowledge-compounder.md`
+      lines 57-75 (existing `--- begin review-findings ---` fast path) as the
+      structural model.
+- [ ] 2.2: Add a parallel fast-path branch keyed off
+      `--- begin pr-context ---` delimiters. When the agent is spawned with
+      this delimiter, it:
+  - Reads `gh pr view --json title,body,commits,closingIssuesReferences` for
+    the current branch
+  - Skips the 5-subagent Phase 1 pipeline; uses the PR body + commit subjects
+    as the source for Context Analyzer + Solution Extractor
+  - Defaults `ROUTING_HINT: BOTH` (write doc + MEMORY.md line)
+  - Runs Related Docs Finder against `docs/solutions/` corpus to detect
+    AMEND_EXISTING signal BEFORE the suffix-collision loop
+- [ ] 2.3: Fix the suffix-loop / Jaccard interaction (P1 logic gap surfaced
+      by spec-flow):
+  - If Related Docs Finder returns `AMEND_EXISTING`, the suffix loop MUST be
+    skipped. The agent appends a `## Update — YYYY-MM-DD` section to the
+    matched existing doc.
+  - The suffix loop is reserved for true structural collisions only (same
+    slug stem, demonstrably different problem statement, which is rare).
+- [ ] 2.4: Add an explicit `SKIP` exit path in the in-PR branch: if
+      Context Analyzer determines all skip criteria are met (trivial fix,
+      typo, version bump, no concrete failure mode), output
+      "No solution doc required: <reason>" to the user and exit before M3.
+- [ ] 2.5: Extend the M3 AskUserQuestion (lines 198-213 of the agent file) to
+      show the MEMORY.md entry draft inline alongside the doc draft and file
+      paths.
+- [ ] 2.6: Create `plugins/yellow-core/commands/workflows/compound.md` arg
+      handling for `--in-pr`:
+  - Detect current branch via `git branch --show-current`
+  - Verify PR exists via `gh pr view`; if not, error with actionable message
+    ("Create a draft PR first with `gt stack submit --draft`")
+  - Build the `--- begin pr-context ---` delimited prompt
+  - Dispatch via existing `subagent_type: "yellow-core:workflow:knowledge-compounder"`
+- [ ] 2.7: Update `plugins/yellow-core/CLAUDE.md` and
+      `plugins/yellow-core/README.md` to document the new flag.
+- [ ] 2.8: Bats tests for the `--in-pr` argument parsing in
+      `plugins/yellow-core/tests/` (mock `gh pr view`).
+
+### Phase 3: CONTRIBUTING.md + AGENTS.md policy (Prong 3)
+
+- [ ] 3.1: Add a new `## Solution Docs` section to `CONTRIBUTING.md` after
+      the existing `## Versioning` section (Versioning starts at line 143,
+      ends ~line 242; insert after line 242). Cover:
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Line-number corrections from plan-original: `## Versioning`
+> starts at line 143, ends ~line 242 (file is 481 total lines). ToC entries
+> are at lines 8-14 (ToC heading at line 6). "Before Submitting" checklist
+> heading is at line 125; items at lines 127-133. A second checklist exists
+> under Versioning at line 182.
+<!-- /deepen-plan -->
+  - Default pattern (in-PR co-shipped)
+  - When a doc is required (recurring learning that could waste future time)
+  - Skip criteria (trivial, already documented, subjective preference)
+  - Exception path: post-PR dedicated `docs(solutions):` PR with explicit
+    justification in PR description
+  - How to invoke: `/workflows:compound --in-pr` while on a feature branch
+  - CI behavior: blocking on exact-slug collision and invalid frontmatter;
+    non-blocking missing-doc warn for P0/P1-labeled issue closures
+  - Note the heuristic's blind spots: cross-repo `closes` references
+    (`closes other-repo#123`) and commit-message-only closures don't surface
+    via `closingIssuesReferences` — author judgment fills the gap
+  - [ ] 3.2: Add the new section to the CONTRIBUTING.md ToC at line 8.
+  - [ ] 3.3: Add a checklist line to "Before Submitting" (heading line 125,
+        items lines 127-133):
+        `- [ ] Solution doc written, updated, or skip criteria documented in PR description`
+  - [ ] 3.4: Cross-reference from `AGENTS.md` "Critical Agent Authoring Rules"
+        section pointing at the new `validate:solutions` validator.
+
+### Phase 4: CI workflow integration (Prong 4)
+
+- [ ] 4.1: Edit `.github/workflows/validate-schemas.yml`:
+  - Add `docs/solutions/**` and `scripts/validate-solutions.js` to the
+    `on.pull_request.paths` trigger.
+  - Confirm `fetch-depth: 0` is set on the relevant checkout step (required
+    for `origin/main...HEAD` diff).
+- [ ] 4.2: Add a new `validate-solutions-advisory` job (mirrors the
+      `changeset-check` job at lines 760-800 — `validate-versions` lacks
+      `fetch-depth: 0`) for the **non-blocking** missing-doc heuristic:
+
+  ```yaml
+  validate-solutions-advisory:
+    name: Solution Doc Advisory
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      pull-requests: read
+      issues: read
+    steps:
+      - uses: actions/checkout@<pinned>
+        with:
+          fetch-depth: 0
+      - name: Check P0/P1 issue label + missing doc
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Use gh api graphql with closingIssuesReferences
+          # Emit ::warning:: if labeled issue with no docs/solutions/ change
+          # Always exit 0 (advisory only)
+  ```
+
+<!-- deepen-plan: external -->
+> **Research:** `permissions: { pull-requests: read, issues: read }` is the
+> minimum required. The advisory job is read-only, so it's safe under fork
+> PRs via the `pull_request` event (GITHUB_TOKEN is forced read-only for
+> forks, which is fine for GraphQL reads). **Do NOT use `pull_request_target`**
+> — it grants write scopes to fork code (supply-chain risk). Rate-limit
+> budget: ~1 GraphQL point per call at the 5000/hr budget — non-issue at
+> 10-50 PRs/day. Sources:
+> <https://docs.github.com/en/actions/security-guides/automatic-token-authentication>,
+> GitHub Community Discussion #24706.
+<!-- /deepen-plan -->
+
+<!-- deepen-plan: external -->
+> **Research:** Canonical query shape for "PR closes which issues, with what
+> labels":
+>
+> ```graphql
+> query($owner: String!, $repo: String!, $pr: Int!) {
+>   repository(owner: $owner, name: $repo) {
+>     pullRequest(number: $pr) {
+>       closingIssuesReferences(first: 25) {
+>         nodes {
+>           number
+>           title
+>           labels(first: 10) { nodes { name } }
+>         }
+>       }
+>     }
+>   }
+> }
+> ```
+>
+> Pass vars via `gh api graphql -F owner="$OWNER" -F repo="$REPO" -F pr="$PR_NUMBER"`.
+> Guard with `if .data.repository == null then error(...)` in jq —
+> `IssuesConnection` is nullable. Source:
+> <https://github.com/orgs/community/discussions/24706>
+<!-- /deepen-plan -->
+
+<!-- deepen-plan: external -->
+> **Research:** Two heuristic gotchas — (1) Cross-repo closes (`closes
+> owner/other-repo#123`) do NOT appear in `closingIssuesReferences`; the
+> advisory will miss them. At single-repo scale this is unlikely to matter.
+> (2) Issues linked only in commit messages or PR comments do NOT trigger
+> the field — only PR body keywords (`closes`, `fixes`, `resolves`) do.
+> Surface both caveats in CONTRIBUTING.md so contributors know the
+> heuristic's blind spots. Draft PRs DO populate the field normally.
+<!-- /deepen-plan -->
+- [ ] 4.3: The blocking duplicate check rides via `validate:schemas` (already
+      includes `validate-solutions.js`). No new job needed — it runs inside
+      the existing `validate-schemas` matrix.
+- [ ] 4.4: Do NOT add `validate-solutions-advisory` to the `ci-status`
+      aggregate gate at lines 947-994. Its skipped/failed state must not
+      block merge.
+- [ ] 4.5: Use the canonical 6-element `gh api graphql` pattern (inline the
+      pattern in the job; the referenced solution doc does not exist yet):
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Correction: `docs/solutions/integration-issues/gh-api-graphql-plugin-command-template.md`
+> does NOT exist. The pattern lives only as MEMORY.md notes. Two options:
+> (a) Inline the 6 elements directly in the workflow YAML comment block as
+> documentation. (b) Create the missing solution doc as part of this PR
+> (good fit — this work is about solution doc discipline). Recommend
+> option (b): authoring the missing reference doc dogfoods the new policy.
+<!-- /deepen-plan -->
+  - Soft-skip if `gh` or auth unavailable
+  - `-f` flags for variables (no string interpolation)
+  - `--jq` for server-side filtering
+  - SC2016 disable on separate line
+  - Symmetric exit-code capture
+  - jq null-repository guard
+  - [ ] 4.6: Detect the P0/P1 label set via `closingIssuesReferences` (not PR
+        labels). Configurable label list — default: `P0`, `P1`, `bug-critical`.
+
+### Phase 5: PR template + final polish (Prong 5)
+
+- [ ] 5.1: Edit `.github/pull_request_template.md` (lowercase, already
+      exists): add a `## Solution Doc` checklist line referencing the new
+      CONTRIBUTING.md section.
+
+<!-- deepen-plan: codebase -->
+> **Codebase:** Correction: filename is lowercase `.github/pull_request_template.md`,
+> not uppercase. File already exists with 4 sections (Summary, Stack context,
+> Test plan, Notes for reviewers). Augment in place — do not create a new
+> file with different casing (would create two templates on case-sensitive
+> filesystems).
+<!-- /deepen-plan -->
+- [ ] 5.2: Update `docs/CLAUDE.md` to reference the new policy under release
+      checklist material.
+- [ ] 5.3: Add a one-line MEMORY.md index entry under `## CORE_RULES →
+      Project Structure` pointing at the new section in `CONTRIBUTING.md`.
+- [ ] 5.4: Update `docs/plugin-validation-guide.md` if it enumerates
+      validators (add `validate:solutions`).
+- [ ] 5.5: Run full validation gate: `pnpm validate:schemas && pnpm test:unit
+      && pnpm lint && pnpm typecheck`.
+
+### Phase 6: Stack submit + changeset
+
+- [ ] 6.1: Generate changeset via `pnpm changeset` — patch-level for
+      `yellow-core` (knowledge-compounder + command body change) and root
+      tooling change for `validate-solutions.js`.
+- [ ] 6.2: CRLF normalize any newly-created shell or markdown files:
+      `sed -i 's/\r$//' <files>`.
+- [ ] 6.3: `gt stack submit` — this is sized for a single PR, not a stack.
+
+## Technical Specifications
+
+### Files to Create
+
+| Path | Purpose | Approx LOC |
+|---|---|---|
+| `scripts/validate-solutions.js` | Diff-scoped frontmatter validator + exact-slug collision check | ~120 |
+| `tests/integration/validate-solutions.test.ts` | Integration tests (mirrors `backfill-solution-frontmatter.test.ts`) | ~120 |
+| `docs/research/2026-05-21-solution-doc-jaccard-calibration.md` | (Already authored) calibration data + design rationale | ~150 |
+| `docs/solutions/integration-issues/gh-api-graphql-plugin-command-template.md` | Backfill the referenced-but-missing pattern doc (dogfoods the new policy) | ~120 |
+
+### Files to Modify
+
+| Path | Change |
+|---|---|
+| `packages/domain/src/validation/types.ts` | Add `ErrorCategory.SOLUTION_DOCS` enum value + `getErrorCodesByCategory` entry |
+| `packages/domain/src/validation/errorCatalog.ts` | Add `ERROR-SOL-001` and `ERROR-SOL-002` entries (import `ErrorSeverity` from `types.js`) |
+| `.github/pull_request_template.md` | Add Solution Doc checklist line (lowercase filename — exists) |
+| `package.json` | Add `validate:solutions` script; append to `validate:schemas` aggregator |
+| `plugins/yellow-core/agents/workflow/knowledge-compounder.md` | Add in-PR fast-path branch (parallel to review-findings branch) + suffix-loop fix + SKIP exit |
+| `plugins/yellow-core/commands/workflows/compound.md` | Add `--in-pr` arg handling |
+| `plugins/yellow-core/CLAUDE.md` | Document `--in-pr` flag |
+| `plugins/yellow-core/README.md` | Reference new flag |
+| `CONTRIBUTING.md` | New `## Solution Docs` section + ToC + checklist line |
+| `AGENTS.md` | Cross-reference to validate:solutions |
+| `docs/CLAUDE.md` | Reference new policy |
+| `.github/workflows/validate-schemas.yml` | Add path trigger; new advisory job; exclude from ci-status gate |
+| `docs/plugin-validation-guide.md` | Add validate:solutions entry |
+
+### Dependencies
+
+No new dependencies. The validator parses YAML frontmatter with a handrolled
+regex (same pattern as `scripts/backfill-solution-frontmatter.js`); no
+`js-yaml` is needed.
+
+### API Changes
+
+**Before:** No solution-doc-specific tooling. Authors manually write docs
+post-hoc; orphan refs accumulate in MEMORY.md.
+
+**After:**
+
+```bash
+# Author workflow during a fix:
+gt branch create fix/some-bug
+# ... write code, commit ...
+gt stack submit --draft       # creates PR
+/workflows:compound --in-pr   # agent drafts doc + MEMORY.md line
+# ... author reviews, agent writes both ...
+gt amend                       # adds the doc to the PR
+gt stack submit                # marks ready
+```
+
+CI on the PR:
+- `validate-solutions` (blocking) runs inside `validate:schemas` — fails if
+  new doc collides with an existing slug or has invalid/missing frontmatter.
+- `validate-solutions-advisory` (non-blocking) warns if PR closes a P0/P1
+  issue but has no `docs/solutions/` change.
+
+### Frontmatter Schema (validated by Phase 1)
+
+```yaml
+---
+title: 'Doc title sentence'                # required, string
+date: 2026-05-21                            # required, ISO 8601
+category: workflow                          # required, enum
+track: bug                                  # required, enum {bug, knowledge}
+problem: 'One-line keyword-rich summary'    # required, string
+tags:                                       # required, array of strings
+  - git
+  - ci
+components:                                 # optional, array of strings
+  - github actions
+severity:                                   # optional, P0/P1/P2 or {critical:N, important:N}
+  critical: 1
+---
+```
+
+## Testing Strategy
+
+### Integration Tests (`tests/integration/validate-solutions.test.ts`)
+
+Listed in Phase 1.8 task above. Covers: slug collision, frontmatter missing
+required field, invalid enum values for `track:` / `category:`, bad slug
+regex, valid new doc, modified (not added) existing doc, empty diff, and
+fork-PR `origin/main` fallback.
+
+### Bats Tests (`plugins/yellow-core/tests/`)
+
+- `/workflows:compound --in-pr` with no PR for current branch → error with
+  actionable message.
+- `/workflows:compound --in-pr` with PR → dispatches agent with correct
+  delimiter.
+
+### Manual Smoke Test Checklist
+
+- [ ] Run `/workflows:compound --in-pr` on a branch with an open draft PR.
+      Agent reads PR context, drafts doc, M3 shows both doc + MEMORY.md
+      previews, write succeeds.
+- [ ] Add a doc with a deliberate slug collision → CI fails with clear
+      `ERROR-SOL-001` annotation pointing at the conflicting existing doc.
+- [ ] Add a doc missing `track:` → CI fails with `ERROR-SOL-002`.
+- [ ] Close a P0-labeled issue via PR without adding a doc → CI emits
+      `::warning::` but does not block.
+
+## Acceptance Criteria
+
+1. `scripts/validate-solutions.js` exists and is wired into
+   `pnpm validate:schemas`. Running it on a PR-added doc with a slug
+   matching an existing file fails with exit 1 and `ERROR-SOL-001`. Running
+   it on a PR-added doc with missing or invalid frontmatter fails with
+   `ERROR-SOL-002`.
+2. `pnpm test:integration` covers all 9 fixture cases listed in Phase 1.8
+   and passes.
+3. `/workflows:compound --in-pr` invokable from a feature branch with an
+   open PR. Dispatches `knowledge-compounder` with the in-PR fast path. M3
+   confirmation shows both doc draft and MEMORY.md draft. Cancel path
+   produces no writes.
+4. `knowledge-compounder` agent's suffix-collision loop is skipped when
+   Related Docs Finder returns `AMEND_EXISTING`. Verified by Bats or unit
+   test on the agent's branch logic.
+5. `CONTRIBUTING.md` contains a `## Solution Docs` section discoverable from
+   the ToC. The Before Submitting checklist has the new line.
+6. CI workflow has `validate-solutions-advisory` job emitting `::warning::`
+   annotations on P0/P1-labeled PRs without `docs/solutions/` changes. The
+   job is NOT in the `ci-status` aggregate gate.
+7. `packages/domain/src/validation/errorCatalog.ts` contains `ERROR-SOL-001`
+   and `ERROR-SOL-002`. `pnpm validate:error-codes` passes.
+8. `pnpm release:check` passes on the feature branch.
+
+## Edge Cases & Error Handling
+
+| Scenario | Behavior |
+|---|---|
+| Author writes a sibling doc sharing vocabulary with an existing one | No CI block — Jaccard is dropped from initial implementation. Authors rely on their own judgment + review feedback; `knowledge-compounder` Related Docs Finder still surfaces near-matches at write time. |
+| Two PRs open simultaneously add the same slug | First merges cleanly; second's CI fails after rebase against updated `origin/main` with `ERROR-SOL-001`. Author renames or amends. |
+| knowledge-compounder suffix loop collides with existing doc | Cannot happen post-fix: Related Docs Finder runs first, returns `AMEND_EXISTING`, suffix loop is skipped. |
+| Revert PR with `Revert "fix: ..."` subject | Heuristic uses `closingIssuesReferences` labels only, not commit subjects. No false positive. |
+| Squash-merged PR | Heuristic uses GraphQL `closingIssuesReferences`, not `git log` on `main`. Squash strategy irrelevant. |
+| PR closes 0 issues | GraphQL returns empty `closingIssuesReferences`; advisory job exits early without warning. |
+| Cross-repo issue references | `closingIssuesReferences` only tracks same-repo links. Advisory misses cross-repo `closes other-repo#123`. Documented in CONTRIBUTING.md as a known blind spot. |
+| Commit-message-only closing keyword | `closingIssuesReferences` only surfaces PR-body keywords. Commit-message-only closures bypass the heuristic. Documented in CONTRIBUTING.md. |
+| Fork PR | `pull_request` event grants read-only GITHUB_TOKEN, sufficient for the GraphQL read. Validator's `git diff` still works because `fetch-depth: 0` is set on checkout. Do NOT use `pull_request_target`. |
+| `gh` rate-limited or auth missing | Advisory job soft-skips with `::notice::`; blocking validator still runs (no GraphQL dependency). |
+| `origin/main` unreachable | Both validator and advisory soft-skip with explanatory notice. `fetch-depth: 0` on checkout step prevents this in normal CI. |
+| Author runs `/workflows:compound --in-pr` with trivial fix | Context Analyzer detects skip criteria, agent exits before M3 with "No solution doc required: <reason>". |
+| Existing doc with non-conforming frontmatter modified by unrelated PR | Diff-scoped validator runs frontmatter validation on the modified file; if pre-existing fields are missing it blocks. Mitigation: out-of-scope normalization PR (see Out-of-Scope below) or scope the validator to "added only, not modified" (a one-line tweak in Phase 1.4). |
+
+## Performance Considerations
+
+- 88 docs × ~5 changed files per PR → O(N×M) = ~440 slug comparisons per PR
+  run. Each comparison is O(1) hash-set lookup after corpus walk. Total
+  wall-clock cost well under 1s on CI.
+- No corpus-size scaling concern at any realistic future size.
+
+## Security Considerations
+
+- **GraphQL query construction:** follows the canonical 6-element
+  `gh api graphql` pattern with `-f` flags only. No user-input interpolated
+  into the query string.
+- **Frontmatter parsing:** handrolled regex with explicit `[\s\S]*?` non-
+  greedy capture; no `eval`, no YAML deserialization (no `js-yaml`).
+- **Slug regex:** `^[a-z0-9]+(-[a-z0-9]+)*$` rejects trailing/consecutive
+  hyphens, uppercase, and path separators — no traversal vector.
+- **Path traversal in corpus walk:** validator must verify
+  `SOLUTIONS_DIR.startsWith(ROOT + path.sep)` before any `readdir` —
+  copy the guard from `backfill-solution-frontmatter.js`.
+
+## Migration & Rollback
+
+### Deployment
+
+- Single PR. Lands on `main`; CI immediately enforces blocking slug-
+  collision + frontmatter checks on the next PR.
+- Existing 13 non-conforming docs remain untouched — diff-scoped validator
+  only runs on files in the current PR's diff. Modifying one of them in a
+  later PR will trigger frontmatter validation (acceptable — fix on touch).
+
+### Rollback
+
+- Remove `validate:solutions` from `validate:schemas` aggregator in
+  `package.json` (1-line revert).
+- Delete `validate-solutions-advisory` job from
+  `.github/workflows/validate-schemas.yml`.
+- `knowledge-compounder` in-PR branch is additive (existing flow unaffected)
+  — revert is safe.
+
+### Breaking Changes
+
+None. All additions:
+
+- New script + CI job (additive)
+- New agent code path triggered only by explicit `--in-pr` (existing paths
+  unchanged)
+- New CONTRIBUTING.md section (documentation)
+- New error codes in `errorCatalog.ts` (additive)
+- New frontmatter fields (`intentional_variant`, `variant_of`) — out of scope
+  for the initial implementation; reserved for a future Jaccard-based phase
+
+## References
+
+- Brainstorm: `docs/brainstorms/2026-05-21-solution-doc-git-workflow-brainstorm.md`
+- Related: PR #548 (the orphan-ref backfill that prompted this work) — commit
+  `959a2cd5`
+- Existing patterns:
+  - `scripts/validate-doc-counts.js` (boilerplate model)
+  - `scripts/validate-marketplace.js` (frontmatter validation patterns)
+  - `.github/workflows/validate-schemas.yml` lines 737-756 (validate-versions
+    job — model for new advisory job)
+  - `.github/workflows/validate-schemas.yml` lines 759-800 (changeset-check
+    job — model for git-diff-based detection)
+  - `plugins/yellow-core/agents/workflow/knowledge-compounder.md` lines 57-75
+    (existing review-findings fast path — model for in-PR fast path)
+  - `plugins/yellow-core/skills/compound-lifecycle/SKILL.md` (existing BM25 +
+    cosine dedup — retroactive counterpart)
+  - `docs/solutions/integration-issues/gh-api-graphql-plugin-command-template.md`
+    (6-element GraphQL safety pattern for the advisory job)
+  - `docs/solutions/code-quality/skill-frontmatter-attribute-and-format-requirements.md`
+    (frontmatter parser quirks to avoid)
+- External:
+  - [GitHub Workflow Commands](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands) — `::warning::` / `::error::` syntax
+  - [Google SRE Postmortem Culture](https://sre.google/sre-book/postmortem-culture/) — Prevention section convention
+  - Ben Frederickson, [Distance Metrics for Fun and Profit](https://www.benfrederickson.com/distance-metrics/) — Jaccard rationale
+
+<!-- deepen-plan: external -->
+> **Research (deepen-plan):** Additional sources added during plan enrichment:
+> - [Draisbach & Naumann, "On Choosing Thresholds for Duplicate Detection," HPI Potsdam 2013](https://hpi.de/fileadmin/user_upload/fachgebiete/naumann/publications/2013/On_Choosing_Thresholds_for_Duplicate_Detection.pdf) — labeled-pair threshold sweep methodology for Phase 0 calibration
+> - [Microsoft Research, "Duplicate News Story Detection Revisited," 2013](https://www.microsoft.com/en-us/research/wp-content/uploads/2013/12/NewsDuplicateDetectionRevisted.pdf) — DF-based domain stop-word selection
+> - [nelhage, "Finding near-duplicates with Jaccard similarity and MinHash"](https://blog.nelhage.com/post/fuzzy-dedup) — bimodal Jaccard distribution, ~500-1000 doc inflection point
+> - [GitHub Automatic Token Authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) — fork PR permissions behavior
+> - [GitHub Community Discussion #24706](https://github.com/orgs/community/discussions/24706) — `closingIssuesReferences` semantics + IssuesConnection nullable
+<!-- /deepen-plan -->
+
+## Out-of-Scope (Tracked as Follow-Ups)
+
+- Retroactive normalization of existing 13 non-conforming docs (`track:
+  feature` outlier, `problem_type` extra field) — file as a separate PR after
+  this lands. Until then, the validator only fires on those docs when they're
+  modified.
+- Auto-generation of MEMORY.md as a build artifact (explicitly rejected in
+  brainstorm Q5).
+- Blocking PRs for missing solution docs (brainstorm Q4 — non-blocking only).
+- PostToolUse hook on `gt stack submit` to auto-trigger in-PR mode — kept as
+  future enhancement once the explicit flow is validated in practice.
+- `<!-- no-solution-doc -->` PR-body opt-out for the advisory job —
+  initial advisory rollout is already non-blocking, so an opt-out is not
+  strictly needed; add only if author noise complaints surface.
+- `Prevention` section enforcement in `validate-solutions.js` (parsing
+  markdown heading structure) — defer until corpus compliance is measured.
+- **Jaccard / TF-IDF / BM25 duplicate detection at write time** — Phase 0.1
+  calibration showed no accidental duplicates in the 88-doc corpus (max
+  pairwise Jaccard = 0.345; all high-similarity pairs are legitimate
+  siblings). Re-run the calibration when the corpus exceeds ~500 docs or
+  when a real duplicate lands in `main`. Methodology + thresholds:
+  `docs/research/2026-05-21-solution-doc-jaccard-calibration.md`.
+- `intentional_variant: true` / `variant_of:` frontmatter fields — only
+  needed if/when Jaccard duplicate detection is added back. Out of scope
+  for the initial implementation.


### PR DESCRIPTION
Lays the groundwork for the solution-doc-git-workflow feature: a documented
policy + light validator that prevents orphaned MEMORY.md refs (the issue
that prompted PR #548 backfill).

Phase 0 calibration ran on the existing 88-doc corpus and decisively
informed the design:

- Max pairwise token Jaccard = 0.345 (one pair of intentional sibling
  docs); zero accidental duplicates exist.
- Originally-proposed 0.5 warn / 0.6 block thresholds would never fire.
- Design pivoted: drop Jaccard from the initial implementation; ship
  only exact-slug-collision and frontmatter-required-field checks
  (ERROR-SOL-001 / ERROR-SOL-002).

Followup PRs will implement Phases 1-6 (validate-solutions.js,
knowledge-compounder --in-pr mode, CONTRIBUTING.md policy section, CI
advisory job for P0/P1 missing-doc heuristic, PR template).

No code yet — docs only. No changeset required (no plugins/ files modified).

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive solution-doc Git workflow: policies for co‑shipping docs with fixes, duplicate-detection guidance, CI warn vs block rules, frontmatter/authoring conventions, and an in-PR knowledge-compounding option.
  * Included research-backed calibration of similarity detection and a phased implementation roadmap with testing, rollout, and acceptance criteria.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KingInYellows/yellow-plugins/pull/551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->