### PR TITLE
fix: harden validation layer (#267, #269, #270, #271)

### DIFF
--- a/.changeset/yellow-devin-org-id-sensitive.md
+++ b/.changeset/yellow-devin-org-id-sensitive.md
@@ -1,0 +1,21 @@
+---
+'yellow-devin': patch
+---
+
+fix(yellow-devin): mark `devin_org_id` userConfig as sensitive (#271)
+
+Flips `userConfig.devin_org_id.sensitive` from `false` to `true` in
+`plugins/yellow-devin/.claude-plugin/plugin.json`. The org ID pairs
+with the service-user token in every Devin V3 API call, narrows the
+auth target if leaked, and previously lived in
+`~/.claude/settings.json` in plaintext. Marking it sensitive routes
+storage to the system keychain and enables transcript redaction.
+
+**Migration note:** existing users may be re-prompted once for the
+org ID after upgrading. The shell-env fallback (`DEVIN_ORG_ID`)
+remains intact for power users and CI; no command behavior changes.
+The interactive validation output in `/devin:setup` is unaffected
+(the `sensitive` flag controls storage and transcript redaction, not
+the validation echo shown to the active user as they type).
+
+Source: PR #259 multi-agent review (code-reviewer P3, security-sentinel L1).

--- a/.changeset/yellow-morph-setup-parity-canonicalize.md
+++ b/.changeset/yellow-morph-setup-parity-canonicalize.md
@@ -1,0 +1,41 @@
+---
+'yellow-morph': patch
+---
+
+fix(yellow-morph): align `/morph:setup` with start-morph.sh and canonicalize plugin paths (#270, #269)
+
+Two safety/UX fixes:
+
+- **`/morph:setup` strict `CLAUDE_PLUGIN_DATA`** (#270): the setup
+  command no longer falls back to a default
+  `$HOME/.claude/plugins/data/yellow-morph` path when
+  `CLAUDE_PLUGIN_DATA` is unset. It now matches `bin/start-morph.sh`'s
+  strict `${CLAUDE_PLUGIN_DATA:?}` behaviour, surfacing the unset-var
+  failure during setup instead of installing to a path the MCP wrapper
+  will refuse to read at runtime. Claude Code always sets this var
+  for plugin commands; the previous fallback only existed for ad-hoc
+  manual invocation outside Claude Code.
+
+- **`/morph:setup` npm output to stderr** (#270): `yellow_morph_do_install`
+  is now invoked with `>&2` (matching the wrapper's pattern) instead of
+  `2>&1`. Registry URLs, package metadata, and version chatter stop
+  landing in the Claude Code conversation log on successful install;
+  failures remain visible because the function's exit code is what the
+  caller checks.
+
+- **`yellow_morph_validate_paths` realpath canonicalization** (#269):
+  the path-prefix guards in `lib/install-morphmcp.sh` now canonicalize
+  `CLAUDE_PLUGIN_ROOT` and `CLAUDE_PLUGIN_DATA` via `realpath -m`
+  before the prefix-string match. This closes a traversal gap where a
+  value like `$HOME/../../etc` would pass the naive `"$HOME/*"` glob
+  on its raw form. Uses a capability test (`if canonical=$(realpath -m
+  ... 2>/dev/null)`) instead of a presence test so BSD-realpath hosts
+  (stock macOS without GNU coreutils) silently fall back to the raw
+  prefix check rather than erroring on the unsupported `-m` flag.
+
+New tests: `tests/integration/install-morphmcp.test.ts` covers all
+five branches of `yellow_morph_validate_paths` (traversal rejection,
+clean pass, unset var, out-of-bounds path, realpath-unavailable
+fallback).
+
+Source: PR #259 multi-agent review (security-sentinel L2/L3, code-reviewer P3, comment-analyzer P3).

--- a/plugins/yellow-devin/.claude-plugin/plugin.json
+++ b/plugins/yellow-devin/.claude-plugin/plugin.json
@@ -28,7 +28,7 @@
       "type": "string",
       "title": "Devin organization ID",
       "description": "Devin organization ID. Find at Devin Enterprise Settings > Organizations.",
-      "sensitive": false
+      "sensitive": true
     }
   },
   "mcpServers": {

--- a/plugins/yellow-morph/commands/morph/setup.md
+++ b/plugins/yellow-morph/commands/morph/setup.md
@@ -86,8 +86,12 @@ visible progress indicator and surfaces install errors immediately rather
 than hanging the first tool call.
 
 ```bash
-export CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:?CLAUDE_PLUGIN_ROOT must be set}"
-export CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA:-$HOME/.claude/plugins/data/yellow-morph}"
+# Both vars MUST be set — start-morph.sh (the MCP wrapper) requires both at
+# runtime and refuses to launch without them. Matching strict behaviour here
+# surfaces the unset-var failure during /morph:setup instead of letting the
+# install land in a path the MCP wrapper will refuse to read.
+export CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:?CLAUDE_PLUGIN_ROOT must be set (run /morph:setup from within Claude Code)}"
+export CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA:?CLAUDE_PLUGIN_DATA must be set (Claude Code normally sets this; run /morph:setup from within Claude Code)}"
 
 # Source the shared install primitives used by bin/start-morph.sh and the
 # SessionStart prewarm hook. Single source of truth for path validation,
@@ -112,7 +116,10 @@ if yellow_morph_needs_install; then
   trap 'yellow_morph_release_install_lock' EXIT INT TERM
 
   if yellow_morph_needs_install; then
-    if ! yellow_morph_do_install 2>&1; then
+    # Send npm chatter to stderr only — matches bin/start-morph.sh's
+    # `yellow_morph_do_install >&2` pattern. Keeps registry URLs, package
+    # metadata, and version output out of the conversation log on success.
+    if ! yellow_morph_do_install >&2; then
       yellow_morph_cleanup_failed_install
       yellow_morph_release_install_lock
       trap - EXIT INT TERM

--- a/plugins/yellow-morph/lib/install-morphmcp.sh
+++ b/plugins/yellow-morph/lib/install-morphmcp.sh
@@ -24,6 +24,26 @@ yellow_morph_validate_paths() {
     printf 'yellow-morph: CLAUDE_PLUGIN_DATA unset\n' >&2
     return 1
   fi
+
+  # Canonicalize before the prefix-guard so a traversal-laced value like
+  # "$HOME/../../etc" resolves to "/etc" and trips the case-guard instead
+  # of passing the naive string-prefix match on "$HOME/*". Capability test
+  # (not `command -v realpath`) because BSD realpath on stock macOS lacks
+  # the `-m` flag — `command -v` would falsely advertise a feature whose
+  # call then errors and silently leaves the raw value in place. With the
+  # capability test, fail-open posture preserves current behaviour on
+  # macOS without GNU coreutils; on Linux/WSL2/Homebrew-coreutils macOS
+  # the canonicalization runs and the export propagates the resolved
+  # paths to callers (start-morph.sh, prewarm hook, setup.md).
+  local canonical
+  if canonical=$(realpath -m -- "$CLAUDE_PLUGIN_ROOT" 2>/dev/null); then
+    CLAUDE_PLUGIN_ROOT="$canonical"
+  fi
+  if canonical=$(realpath -m -- "$CLAUDE_PLUGIN_DATA" 2>/dev/null); then
+    CLAUDE_PLUGIN_DATA="$canonical"
+  fi
+  export CLAUDE_PLUGIN_ROOT CLAUDE_PLUGIN_DATA
+
   case "$CLAUDE_PLUGIN_DATA" in
     "${HOME:-/__unset__}"/*|/tmp/*) ;;
     *)

--- a/plugins/yellow-morph/lib/install-morphmcp.sh
+++ b/plugins/yellow-morph/lib/install-morphmcp.sh
@@ -44,15 +44,27 @@ yellow_morph_validate_paths() {
   fi
   export CLAUDE_PLUGIN_ROOT CLAUDE_PLUGIN_DATA
 
+  # Canonicalize HOME with the same capability-gated method so the prefix
+  # guards below still match when HOME itself is a symlink (e.g.
+  # /home/alice -> /mnt/storage/alice). ROOT/DATA above are now physical
+  # paths, so a raw-HOME compare would reject a valid $HOME/.claude/... dir.
+  # Accept BOTH raw and canonical HOME prefixes: when realpath -m is absent
+  # (BSD macOS), home_canonical stays the raw value, preserving prior
+  # behaviour (fail-open).
+  local home_canonical="${HOME:-/__unset__}"
+  if [ -n "${HOME:-}" ] && canonical=$(realpath -m -- "$HOME" 2>/dev/null); then
+    home_canonical="$canonical"
+  fi
+
   case "$CLAUDE_PLUGIN_DATA" in
-    "${HOME:-/__unset__}"/*|/tmp/*) ;;
+    "${HOME:-/__unset__}"/*|"${home_canonical}"/*|/tmp/*) ;;
     *)
       printf 'yellow-morph: refusing — CLAUDE_PLUGIN_DATA outside HOME/tmp: %s\n' \
         "$CLAUDE_PLUGIN_DATA" >&2
       return 1 ;;
   esac
   case "$CLAUDE_PLUGIN_ROOT" in
-    "${HOME:-/__unset__}"/*|/tmp/*|/usr/*|/opt/*) ;;
+    "${HOME:-/__unset__}"/*|"${home_canonical}"/*|/tmp/*|/usr/*|/opt/*) ;;
     *)
       printf 'yellow-morph: refusing — CLAUDE_PLUGIN_ROOT unexpected prefix: %s\n' \
         "$CLAUDE_PLUGIN_ROOT" >&2

--- a/scripts/check-upstream-pins.js
+++ b/scripts/check-upstream-pins.js
@@ -10,7 +10,13 @@
  * Usage:
  *   node scripts/check-upstream-pins.js                   # advisory (all drift reported, exit 0 unless --strict)
  *   node scripts/check-upstream-pins.js --strict          # exit 1 on any drift
- *   node scripts/check-upstream-pins.js --threshold 10    # exit 1 only when major+minor drift >= 10 versions
+ *   node scripts/check-upstream-pins.js --threshold 1000  # exit 1 only when weighted drift score >= 1000
+ *   node scripts/check-upstream-pins.js --verbose         # print npm error messages on lookup failure
+ *
+ * --threshold N is compared against the WEIGHTED drift score from
+ * driftScore() below: major * 1000000 + minor * 1000 + patch. So a single
+ * minor-version bump scores 1000, a single major-version bump scores
+ * 1000000, and a 5-patch bump scores 5. Pick the threshold accordingly.
  *
  * The git-SHA-pinned entries (uvx --from git+...@<sha>) are listed but not
  * drift-checked, since resolving latest for a git repo requires extra API
@@ -24,18 +30,42 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 // Allowlist for npm package names: scope + name chars per npm-name-validator,
-// length capped at the registry's documented 214-char limit.
-const NPM_NAME_OK = /^(?:@[a-z0-9][a-z0-9._~-]{0,213}\/)?[a-z0-9][a-z0-9._~-]{0,213}$/i;
+// length capped at the registry's documented 214-char limit. The /i flag was
+// dropped intentionally — npm registry rejects uppercase package names, so
+// the regex must match registry reality. With /i, an uppercase pin would
+// silently fall through to getNpmLatest and surface as "npm lookup failed"
+// instead of being correctly identified as invalid input.
+const NPM_NAME_OK = /^(?:@[a-z0-9][a-z0-9._~-]{0,213}\/)?[a-z0-9][a-z0-9._~-]{0,213}$/;
 
-const ROOT = path.resolve(__dirname, '..');
+const ROOT = process.env.CHECK_UPSTREAM_PINS_ROOT
+  ? path.resolve(process.env.CHECK_UPSTREAM_PINS_ROOT)
+  : path.resolve(__dirname, '..');
 const PLUGINS_DIR = path.join(ROOT, 'plugins');
 
 function parseArgs(argv) {
-  const args = { strict: false, threshold: null };
+  const args = { strict: false, threshold: null, verbose: false };
   for (let i = 2; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--strict') args.strict = true;
-    else if (a === '--threshold') args.threshold = parseInt(argv[++i], 10);
+    else if (a === '--verbose') args.verbose = true;
+    else if (a === '--threshold') {
+      // Validate the next arg exists, is not a flag, and parses to a finite
+      // number. Without this guard, `--threshold` as the final argv entry
+      // silently set `threshold = NaN`, and `maxDrift >= NaN` is always
+      // false — the threshold flag became a no-op instead of an error.
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith('--')) {
+        console.error('check-upstream-pins: --threshold requires a numeric argument');
+        process.exit(1);
+      }
+      const v = parseInt(next, 10);
+      if (Number.isNaN(v)) {
+        console.error(`check-upstream-pins: --threshold must be numeric (got "${next}")`);
+        process.exit(1);
+      }
+      args.threshold = v;
+      i++;
+    }
   }
   return args;
 }
@@ -80,7 +110,7 @@ function walkMcpServers(pluginJson, fn) {
   }
 }
 
-function getNpmLatest(pkg) {
+function getNpmLatest(pkg, verbose = false) {
   // Reject names that do not match the npm allowlist — prevents the name
   // becoming a shell-injection vector if a plugin.json or package.json is
   // ever crafted maliciously. execFileSync below avoids shell parsing, but
@@ -93,7 +123,15 @@ function getNpmLatest(pkg) {
       stdio: ['ignore', 'pipe', 'ignore'],
     }).trim();
     return out || null;
-  } catch {
+  } catch (e) {
+    // Under --verbose, surface the underlying failure (network error,
+    // npm-not-installed, registry 404) so CI logs explain why "npm lookup
+    // failed" appeared. Without --verbose, stay quiet to match the
+    // historical caller expectation that null means "no drift info".
+    if (verbose) {
+      const msg = e && e.message ? e.message : String(e);
+      console.error(`check-upstream-pins: npm view "${pkg}" failed: ${msg}`);
+    }
     return null;
   }
 }
@@ -168,7 +206,7 @@ function main() {
   let maxDrift = 0;
   console.log('-- npm pins --');
   for (const pin of report.npm) {
-    const latest = getNpmLatest(pin.name);
+    const latest = getNpmLatest(pin.name, args.verbose);
     if (!latest) {
       console.log(`  ${pin.plugin} / ${pin.serverName} :: ${pin.name}@${pin.version} -> (npm lookup failed)`);
       continue;

--- a/scripts/check-upstream-pins.js
+++ b/scripts/check-upstream-pins.js
@@ -117,19 +117,33 @@ function getNpmLatest(pkg, verbose = false) {
   // belt-and-suspenders is cheap here.
   if (typeof pkg !== 'string' || !NPM_NAME_OK.test(pkg)) return null;
   try {
-    const out = execFileSync('npm', ['view', pkg, 'version', '--silent'], {
+    // Capture stderr (third slot 'pipe', not 'ignore') so a failing lookup's
+    // error text reaches the catch below. `--silent` is deliberately omitted:
+    // it suppresses npm's E404/network error output entirely (verified
+    // against npm 11 — silent yields empty stderr), which would defeat the
+    // --verbose failure-surfacing. `npm view <pkg> version` prints only the
+    // version to stdout regardless of loglevel, so the success path stays
+    // clean.
+    const out = execFileSync('npm', ['view', pkg, 'version'], {
       encoding: 'utf8',
       timeout: 10000,
-      stdio: ['ignore', 'pipe', 'ignore'],
+      stdio: ['ignore', 'pipe', 'pipe'],
     }).trim();
     return out || null;
   } catch (e) {
     // Under --verbose, surface the underlying failure (network error,
     // npm-not-installed, registry 404) so CI logs explain why "npm lookup
-    // failed" appeared. Without --verbose, stay quiet to match the
-    // historical caller expectation that null means "no drift info".
+    // failed" appeared. Prefer e.stderr (the real npm error, e.g. "code
+    // E404") over the generic "Command failed" carried in e.message. Without
+    // --verbose, stay quiet to match the historical caller expectation that
+    // null means "no drift info".
     if (verbose) {
-      const msg = e && e.message ? e.message : String(e);
+      const msg =
+        e && e.stderr
+          ? String(e.stderr).trim()
+          : e && e.message
+            ? e.message
+            : String(e);
       console.error(`check-upstream-pins: npm view "${pkg}" failed: ${msg}`);
     }
     return null;

--- a/tests/integration/check-upstream-pins.test.ts
+++ b/tests/integration/check-upstream-pins.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Integration test for `scripts/check-upstream-pins.js`.
+ *
+ * Verifies the four CLI-hardening fixes landed for issue #267:
+ *   1. `--threshold` with no following value → exit 1, stderr names the flag.
+ *   2. `--threshold abc` (non-numeric value) → exit 1, stderr explains.
+ *   3. `--verbose` surfaces the underlying npm failure reason on lookup
+ *      failure (instead of swallowing it via the bare `catch {}`).
+ *   4. Uppercase npm package names are rejected by `NPM_NAME_OK` before
+ *      reaching `getNpmLatest` (previously `/i` flag let them through, then
+ *      they surfaced as "npm lookup failed" — misclassified input).
+ *
+ * Test parameterization: `CHECK_UPSTREAM_PINS_ROOT` overrides the project
+ * root the script scans, so each test builds a minimal `plugins/<name>/`
+ * tree under tmp without touching the real repo.
+ *
+ * Cases 1-2 do not invoke npm — argv validation happens before the scan
+ * loop. Cases 3-4 spawn the full scan but provide a fixture pin whose
+ * registry response is deterministic (case 4) or guaranteed to fail
+ * lookup (case 3).
+ */
+
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const SCRIPT = resolve(
+  __dirname,
+  '..',
+  '..',
+  'scripts',
+  'check-upstream-pins.js'
+);
+
+interface RunResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+function run(rootDir: string, args: string[] = []): RunResult {
+  // spawnSync (not execFileSync) — execFileSync returns stdout-only on
+  // success and discards stderr, which masks the --verbose case where
+  // the script exits 0 but writes diagnostic lines to stderr.
+  const r = spawnSync('node', [SCRIPT, ...args], {
+    env: { ...process.env, CHECK_UPSTREAM_PINS_ROOT: rootDir },
+    encoding: 'utf8',
+    // Generous timeout — the --verbose case invokes npm view, which
+    // can be slow on a cold cache. Cases 1-2 return before any
+    // subprocess spawn.
+    timeout: 30000,
+  });
+  return {
+    status: r.status ?? 1,
+    stdout: r.stdout?.toString() ?? '',
+    stderr: r.stderr?.toString() ?? '',
+  };
+}
+
+function write(rootDir: string, relPath: string, body: string): void {
+  const full = join(rootDir, relPath);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, body, 'utf8');
+}
+
+function seedMinimalPlugin(
+  rootDir: string,
+  pluginName: string,
+  manifest: Record<string, unknown>
+): void {
+  write(
+    rootDir,
+    `plugins/${pluginName}/.claude-plugin/plugin.json`,
+    JSON.stringify(manifest, null, 2)
+  );
+}
+
+describe('check-upstream-pins.js — CLI hardening (#267)', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'check-upstream-pins-'));
+    // Seed at least one plugin so the script does not exit early on an
+    // empty plugins/ directory. Cases 1-2 never reach the scan loop.
+    seedMinimalPlugin(tmp, 'test-plugin', {
+      name: 'test-plugin',
+      version: '0.0.1',
+    });
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('--threshold with no value exits 1 and names the flag', () => {
+    const result = run(tmp, ['--threshold']);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('--threshold requires a numeric argument');
+  });
+
+  it('--threshold with a non-numeric value exits 1 and reports the bad value', () => {
+    const result = run(tmp, ['--threshold', 'abc']);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('--threshold must be numeric');
+    expect(result.stderr).toContain('abc');
+  });
+
+  it('--verbose surfaces npm lookup failure reasons', () => {
+    // Pin a package name that does not exist on the npm registry. The
+    // NPM_NAME_OK regex still passes (lowercase, valid chars), so the
+    // call reaches getNpmLatest and the registry returns 404. The
+    // --verbose flag should print npm's error message to stderr.
+    seedMinimalPlugin(tmp, 'verbose-plugin', {
+      name: 'verbose-plugin',
+      version: '0.0.1',
+      mcpServers: {
+        bogus: {
+          command: 'npx',
+          args: [
+            '-y',
+            'this-package-does-not-exist-on-npm-registry-yellow-plugins-test@1.0.0',
+          ],
+        },
+      },
+    });
+    const result = run(tmp, ['--verbose']);
+    // The script exits 0 even when lookups fail (no drift detected
+    // means no threshold trip). Stdout should report the lookup failed,
+    // and stderr should — under --verbose — include the npm error reason.
+    expect(result.stdout).toContain('npm lookup failed');
+    expect(result.stderr).toContain('npm view');
+  });
+
+  it('uppercase package names are rejected by NPM_NAME_OK before getNpmLatest runs', () => {
+    // Plant an uppercase pin via the package.json scan path (mcpServers
+    // args produce a different regex match). package.json deps are
+    // filtered by NPM_NAME_OK before reaching getNpmLatest.
+    seedMinimalPlugin(tmp, 'uppercase-plugin', {
+      name: 'uppercase-plugin',
+      version: '0.0.1',
+    });
+    write(
+      tmp,
+      'plugins/uppercase-plugin/package.json',
+      JSON.stringify(
+        {
+          name: 'uppercase-plugin',
+          version: '0.0.1',
+          dependencies: { 'Express': '4.0.0' }, // capital E — npm rejects
+        },
+        null,
+        2
+      )
+    );
+    const result = run(tmp);
+    // The uppercase name should not appear in the report at all — it is
+    // filtered out at NPM_NAME_OK before the report.push, not after.
+    expect(result.stdout).not.toContain('Express@4.0.0');
+    // Sanity: the scan still ran (exit 0, total-pins line present).
+    expect(result.stdout).toContain('Total npm pins');
+  });
+});

--- a/tests/integration/check-upstream-pins.test.ts
+++ b/tests/integration/check-upstream-pins.test.ts
@@ -137,6 +137,11 @@ describe('check-upstream-pins.js — CLI hardening (#267)', () => {
     // and stderr should — under --verbose — include the npm error reason.
     expect(result.stdout).toContain('npm lookup failed');
     expect(result.stderr).toContain('npm view');
+    // Assert the ACTUAL npm registry error detail surfaces, not just the
+    // script's own prefix. This guards the regression where stderr was
+    // discarded (stdio 'ignore') / suppressed (--silent) and only a generic
+    // "Command failed" reached --verbose output.
+    expect(result.stderr).toMatch(/404|E404|not found/i);
   });
 
   it('uppercase package names are rejected by NPM_NAME_OK before getNpmLatest runs', () => {

--- a/tests/integration/install-morphmcp.test.ts
+++ b/tests/integration/install-morphmcp.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Integration test for `plugins/yellow-morph/lib/install-morphmcp.sh`'s
+ * `yellow_morph_validate_paths` function.
+ *
+ * Verifies the path-canonicalization fix landed for issue #269:
+ *   1. CLAUDE_PLUGIN_DATA with `..` traversal that resolves outside HOME
+ *      is rejected (canonicalization closes the prefix-string-match gap).
+ *   2. Clean HOME-rooted CLAUDE_PLUGIN_DATA passes.
+ *   3. CLAUDE_PLUGIN_ROOT unset → returns non-zero, stderr names the var.
+ *   4. CLAUDE_PLUGIN_DATA outside HOME/tmp → returns non-zero.
+ *   5. realpath unavailable (PATH stripped of realpath) → function still
+ *      runs and the clean-path case still passes (regression guard
+ *      against an over-strict conditional that would break BSD-realpath
+ *      hosts where the capability test fails silently).
+ *
+ * Pattern: each case spawns a fresh `bash -c "source $LIB; yellow_morph_validate_paths"`
+ * with controlled env vars and inspects exit code + stderr.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const LIB = resolve(
+  __dirname,
+  '..',
+  '..',
+  'plugins',
+  'yellow-morph',
+  'lib',
+  'install-morphmcp.sh'
+);
+
+interface BashResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runBash(script: string, env: Record<string, string | undefined>): BashResult {
+  // Filter undefined keys so the env passed to bash matches the test
+  // intent (HOME unset vs HOME='' are different to the case-guard).
+  const filteredEnv: Record<string, string> = {};
+  for (const [k, v] of Object.entries(env)) {
+    if (v !== undefined) filteredEnv[k] = v;
+  }
+  try {
+    const stdout = execFileSync('bash', ['-c', script], {
+      env: filteredEnv,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 5000,
+    });
+    return { status: 0, stdout, stderr: '' };
+  } catch (err) {
+    const e = err as { status: number; stdout?: string; stderr?: string };
+    return {
+      status: e.status ?? 1,
+      stdout: e.stdout?.toString() ?? '',
+      stderr: e.stderr?.toString() ?? '',
+    };
+  }
+}
+
+// Run yellow_morph_validate_paths in a subshell. The function returns
+// non-zero on failure; capture the return via explicit `|| exit $?` so
+// bash's exit code reflects the function, not the source.
+const INVOKE = `. "${LIB}" && yellow_morph_validate_paths`;
+
+describe('yellow_morph_validate_paths — path canonicalization (#269)', () => {
+  let tmpHome: string;
+
+  beforeEach(() => {
+    // Each test gets a unique HOME under tmp. This lets the case-guard
+    // `"$HOME/*"` match the canonicalized value without interfering with
+    // the developer's actual home dir.
+    tmpHome = mkdtempSync(join(tmpdir(), 'yellow-morph-home-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('CLAUDE_PLUGIN_DATA with `..` traversal is rejected after canonicalization', () => {
+    // $HOME/../../etc → realpath -m resolves to /etc, which fails the
+    // HOME/tmp prefix guard. Before the fix, the raw string matched
+    // "$HOME/*" and passed.
+    const traversal = `${tmpHome}/../../etc`;
+    const result = runBash(INVOKE, {
+      HOME: tmpHome,
+      PATH: process.env.PATH,
+      CLAUDE_PLUGIN_ROOT: tmpHome,
+      CLAUDE_PLUGIN_DATA: traversal,
+    });
+    // On hosts with GNU realpath the canonicalization runs and the
+    // prefix guard rejects. On hosts without it, the test is documenting
+    // the pre-fix vulnerability (still informative), so we assert the
+    // post-fix behaviour on the platforms that have realpath -m.
+    const hasGnuRealpath = (() => {
+      try {
+        execFileSync('realpath', ['-m', '--', '/tmp'], { stdio: 'ignore' });
+        return true;
+      } catch {
+        return false;
+      }
+    })();
+    if (hasGnuRealpath) {
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain('outside HOME/tmp');
+    } else {
+      // Document the fail-open posture on BSD-realpath hosts; the case
+      // guard still runs on the raw value and matches "$HOME/*", so the
+      // current behaviour is unchanged.
+      expect([0, 1]).toContain(result.status);
+    }
+  });
+
+  it('clean HOME-rooted CLAUDE_PLUGIN_DATA passes', () => {
+    const cleanData = `${tmpHome}/.claude/plugins/data/yellow-morph`;
+    const result = runBash(INVOKE, {
+      HOME: tmpHome,
+      PATH: process.env.PATH,
+      CLAUDE_PLUGIN_ROOT: tmpHome,
+      CLAUDE_PLUGIN_DATA: cleanData,
+    });
+    expect(result.status).toBe(0);
+  });
+
+  it('CLAUDE_PLUGIN_ROOT unset returns non-zero and stderr names the var', () => {
+    const result = runBash(INVOKE, {
+      HOME: tmpHome,
+      PATH: process.env.PATH,
+      CLAUDE_PLUGIN_DATA: `${tmpHome}/data`,
+      // CLAUDE_PLUGIN_ROOT deliberately omitted
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('CLAUDE_PLUGIN_ROOT unset');
+  });
+
+  it('CLAUDE_PLUGIN_DATA outside HOME/tmp is rejected', () => {
+    const result = runBash(INVOKE, {
+      HOME: tmpHome,
+      PATH: process.env.PATH,
+      CLAUDE_PLUGIN_ROOT: tmpHome,
+      CLAUDE_PLUGIN_DATA: '/etc/passwd',
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('outside HOME/tmp');
+  });
+
+  it('realpath unavailable → fallback still passes clean paths (regression guard)', () => {
+    // Shadow `realpath` with a shim that always exits non-zero, mirroring
+    // what happens on BSD-realpath hosts where `realpath -m` is rejected
+    // as an unknown flag. Prepend the shim dir to PATH so the lib resolves
+    // it before any system realpath. Keep the rest of PATH intact so
+    // bash's builtin lookups (printf, etc. — bash builtins, but be
+    // defensive) and any other coreutils calls still work.
+    const shimDir = mkdtempSync(join(tmpdir(), 'realpath-shim-'));
+    const shim = join(shimDir, 'realpath');
+    writeFileSync(shim, '#!/bin/sh\nexit 1\n', 'utf8');
+    chmodSync(shim, 0o755);
+    try {
+      const result = runBash(INVOKE, {
+        HOME: tmpHome,
+        PATH: `${shimDir}:${process.env.PATH}`,
+        CLAUDE_PLUGIN_ROOT: tmpHome,
+        CLAUDE_PLUGIN_DATA: `${tmpHome}/data`,
+      });
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(shimDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Resolves four P3 review-deferred items from PR #259 with focused
single-file fixes plus two new integration test files.

- #267 check-upstream-pins.js: parseArgs validates --threshold next arg
  (no-value + non-numeric exit 1); new --verbose flag surfaces npm
  lookup failure reasons; NPM_NAME_OK drops /i flag (matches registry
  reality); usage comment now describes the weighted drift score
  (major*1000000 + minor*1000 + patch) instead of misleading
  "major+minor >= 10" phrasing. Adds CHECK_UPSTREAM_PINS_ROOT env
  override (mirrors VALIDATE_PLUGINS_DIR precedent) for testability.

- #271 yellow-devin: devin_org_id.sensitive flipped false to true.

- #270 yellow-morph: /morph:setup uses strict ${CLAUDE_PLUGIN_DATA:?}
  matching the wrapper; yellow_morph_do_install redirected to >&2 to
  match start-morph.sh's pattern (npm chatter out of conversation log).

- #269 yellow-morph: yellow_morph_validate_paths canonicalizes
  CLAUDE_PLUGIN_{ROOT,DATA} via realpath -m before the prefix-string
  guard. Capability test (canonical=\$(realpath -m ... 2>/dev/null))
  instead of presence test so BSD-realpath hosts silently fall back to
  the raw prefix match rather than erroring on the unsupported -m
  flag. start-morph.sh's race-condition comment was already corrected
  in a prior change; no edit needed there.

Tests added:
- tests/integration/check-upstream-pins.test.ts -- 4 cases covering
  all four #267 fixes.
- tests/integration/install-morphmcp.test.ts -- 5 cases covering all
  five branches of yellow_morph_validate_paths.

CI baseline (all green):
  pnpm validate:schemas   PASS
  pnpm validate:versions  PASS
  pnpm test:unit          PASS (3/3)
  pnpm test:integration   PASS (166/170, 4 skipped ceramic auth)
  pnpm lint               PASS
  pnpm typecheck          PASS

Changesets: yellow-devin (patch), yellow-morph (patch). #494 is being
handled separately via an issue comment that maps each P0/P1 finding
to its resolution location in plans/plan-lifecycle-management.md;
implementation of validate-plans.js + the /plan:* commands is the
plan's own 2-PR stack and out of scope here.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Solution doc

<!--
Pick one:
  - "Co-shipped — see docs/solutions/<category>/<slug>.md in this PR"
  - "Tracked separately in #<follow-up PR>"
  - "Skip: <reason — typo / version bump / behavior already covered by
    docs/solutions/<category>/<existing>.md / etc.>"

See CONTRIBUTING.md "Solution Docs" for the policy and skip criteria.
Run `/workflows:compound --in-pr` to draft the doc + MEMORY.md line from
the PR body and commits.
-->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security for organization ID storage with keychain encryption and transcript redaction.
  * Strengthened setup command environment validation and path traversal protection.
  * Improved CLI argument validation and error reporting.

* **Tests**
  * Added integration tests for setup reliability and path validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KingInYellows/yellow-plugins/pull/555?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->