### PR TITLE
feat(validate-plans): PR-diff-scoped stray-checkbox validator (#494)

### DIFF
--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -13,6 +13,7 @@ on:
       - 'api/cli-contracts/*.json'
       - 'packages/**/*.ts'
       - 'docs/solutions/**'
+      - 'plans/**'
       - '.github/workflows/validate-schemas.yml'
   push:
     branches:
@@ -63,6 +64,7 @@ jobs:
           - examples
           - solutions
           - authoring
+          - plans
 
     steps:
       - name: Checkout repository
@@ -96,6 +98,7 @@ jobs:
       - name: Run schema validations
         env:
           VALIDATE_SOLUTIONS_BASE_REF: ${{ github.base_ref != '' && format('origin/{0}', github.base_ref) || 'origin/main' }}
+          PLAN_VALIDATOR_BASE_REF: ${{ github.base_ref != '' && format('origin/{0}', github.base_ref) || 'origin/main' }}
         run: |
           set -euo pipefail
           mkdir -p .ci-logs
@@ -224,6 +227,15 @@ jobs:
 
                 echo "::group::Install-snippet drift"
                 node scripts/sync-shell-snippets.js --check
+                echo "::endgroup::"
+                ;;
+              plans)
+                # Diff-scoped stray-checkbox validator for plans/complete/
+                # entries. Blocks PRs that archive a plan with an unchecked
+                # task box (`- [ ]`), catching premature archival. See
+                # plans/plan-lifecycle-management.md.
+                echo "::group::Plan-archival validation"
+                node scripts/validate-plans.js
                 echo "::endgroup::"
                 ;;
               *)

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "validate:marketplace": "node scripts/validate-marketplace.js",
     "validate:plugins": "node scripts/validate-plugin.js",
     "validate:solutions": "node scripts/validate-solutions.js",
+    "validate:plans": "node scripts/validate-plans.js",
     "validate:error-codes": "node scripts/lint-error-codes.js",
     "validate:snippets": "node scripts/sync-shell-snippets.js --check",
     "generate:snippets": "node scripts/sync-shell-snippets.js",

--- a/packages/domain/src/validation/errorCatalog.ts
+++ b/packages/domain/src/validation/errorCatalog.ts
@@ -87,6 +87,22 @@ export const ERROR_CODES = {
   // SOL_FRONTMATTER).
   SOL_SLUG_COLLISION: 'ERROR-SOL-001',
   SOL_FRONTMATTER_INVALID: 'ERROR-SOL-002',
+
+  // Plan Lifecycle Errors (PLAN) — scripts/validate-plans.js gates plans
+  // newly added or modified under `plans/complete/` against stray unchecked
+  // checkboxes (`- [ ]`). Catches premature archival where the plan was moved
+  // before its task list was complete. See plans/plan-lifecycle-management.md
+  // for the rationale and the PR-diff-scoping decision.
+  //
+  // Same ESM/CJS bridge constraint as SOL_*: the catalog is ESM, scripts/ is
+  // CJS, so scripts/validate-plans.js cannot `require()` these constants
+  // directly. The validator assembles the same strings via concatenation
+  // (`const PLAN = 'ERROR-' + 'PLAN'; const PLAN_001 = PLAN + '-001';`) and
+  // `scripts/lint-error-codes.js` (CODE_PATTERN /ERROR-[A-Z]+-\d+/g) does not
+  // detect split-string assembly. Any change to the entry below requires a
+  // paired edit in scripts/validate-plans.js (the constants PLAN /
+  // PLAN_STRAY_CHECKBOX).
+  PLAN_STRAY_CHECKBOX: 'ERROR-PLAN-001',
 } as const;
 
 /**
@@ -299,6 +315,9 @@ export function getErrorCodesByCategory(): Record<ErrorCategory, string[]> {
     [ErrorCategory.SOLUTION_DOCS]: [
       ERROR_CODES.SOL_SLUG_COLLISION,
       ERROR_CODES.SOL_FRONTMATTER_INVALID,
+    ],
+    [ErrorCategory.PLAN_LIFECYCLE]: [
+      ERROR_CODES.PLAN_STRAY_CHECKBOX,
     ],
   };
 }

--- a/packages/domain/src/validation/types.ts
+++ b/packages/domain/src/validation/types.ts
@@ -24,6 +24,7 @@ export enum ErrorCategory {
   PERMISSION = 'PERMISSION',
   NETWORK = 'NETWORK',
   SOLUTION_DOCS = 'SOLUTION_DOCS',
+  PLAN_LIFECYCLE = 'PLAN_LIFECYCLE',
 }
 
 /** Structured validation error with specification traceability. */

--- a/plans/plan-lifecycle-management.md
+++ b/plans/plan-lifecycle-management.md
@@ -2,7 +2,7 @@
 
 **Source brainstorm:** `docs/brainstorms/2026-05-08-plan-lifecycle-management-brainstorm.md`
 **Detail level:** STANDARD (validator + 2 commands; no frontmatter, no agent, no migration)
-**Status:** Ready for `/workflows:work`
+**Status:** Ready for `/workflows:work` (PR #1 first)
 
 > **Revision history:** First-pass plan introduced a `slug:`/`created:` frontmatter
 > convention, a 47-file backfill migration, a 3-check `plan-verifier` agent (with
@@ -10,6 +10,37 @@
 > #494, #496) collapsed all four. Frontmatter is dropped (slug derived at runtime
 > from filename), Gate C is a single `gh` call (no LLM in the loop), the validator
 > scopes to PR-touched files (no escape hatch needed), and the stack is two PRs.
+>
+> **2026-05-28 refresh** (pre-execution drift check): (a) plan corpus now 8 open
+> + 71 archived (was 3 + 44); 54% of archived plans (38/71) contain stray
+> `- [ ]` boxes — PR-scoping is even more load-bearing than the original
+> justification implied. (b) Phase 1 template pointer switched from
+> `validate-marketplace.js` / `validate-plugin.js` (the latter was decomposed
+> into `scripts/lib/` in #531) to `scripts/validate-solutions.js`, which is the
+> canonical PR-diff-scoped validator template. (c) Added Phase 1.0 to register
+> the error code in `packages/domain/src/validation/errorCatalog.ts` — required
+> by `scripts/lint-error-codes.js` (now in the `validate:schemas` chain).
+> (d) CI wiring rewritten as a matrix-target addition (sixth target alongside
+> marketplace/plugins/contracts/examples/solutions) rather than a separate
+> top-level step; this is the shape `validate-schemas.yml` settled into.
+> (e) Test ergonomics upgrade: use `PLAN_VALIDATOR_DIFF` synthetic-injection
+> env (mirroring `VALIDATE_SOLUTIONS_DIFF`) instead of `mkdtempSync`+bare-git-init.
+> (f) Rename handling switched from `--no-renames` to parsing `R<score>` records
+> from `--name-status -z` (matching `validate-solutions.js`) for consistency.
+>
+> **2026-05-28 PR #1 follow-up corrections** (apply to PR #2 task drafts before
+> writing the command bodies): (g) Task 3.10's recommended commit invocation
+> `gt commit create -m "<subject>" -m "<body>"` is broken — empirically the
+> two `-m` values get concatenated with a literal comma (`"subject,Adds..."`).
+> `gt commit create` does not support `-F`. Use plain
+> `git commit -m "$SUBJECT" -m "$BODY"` instead (standard git docs: multiple
+> `-m` are joined as separate paragraphs with a blank line, exactly what we
+> want). Follow with `gt submit --no-interactive` to push. (h) Task 3.6's
+> AskUserQuestion no-evidence prompt currently labels the override option
+> `Confirm with PR number` — that won't open a free-text input. Per MEMORY.md
+> "AskUserQuestion 'Other' is the ONLY free-text button". Re-label to `Other`
+> (Claude Code's UI surfaces "Other" as the free-text affordance).
+>
 > The brainstorm references several artifacts that no longer exist in this plan;
 > treat the brainstorm as historical context only.
 
@@ -28,15 +59,18 @@ layer.
 
 ## Current State
 
-- 3 open plans in `plans/`, 44 archived in `plans/complete/` (counts as of
-  this PR's snapshot; the validator scopes to PR-touched files so absolute
+- 8 open plans in `plans/`, 71 archived in `plans/complete/` (counts as of
+  2026-05-28; the validator scopes to PR-touched files so absolute
   counts are informational only and naturally drift as new PRs land)
 - No frontmatter convention — plans are plain markdown starting with
   `# Feature: …`
-- 36% of archived plans (16/44) contain stray `- [ ]` lines from prose
+- 54% of archived plans (38/71) contain stray `- [ ]` lines from prose
   checklists, future-work sections, or quoted code — meaning a naive
   whole-corpus checkbox validator would block CI immediately. The
-  PR-touched-files scoping (Phase 1.1) sidesteps this entirely.
+  PR-touched-files scoping (Phase 1.1) sidesteps this entirely. (The
+  ratio worsened from 36% (16/44) over the 2026-05-09 → 2026-05-28
+  archival wave, which strengthens the original argument: any future
+  whole-corpus gate would be progressively harder to enable.)
 - `/workflows:plan` writes plans named `plans/<slug>.md`; the filename slug
   (with optional `YYYY-MM-DD-` prefix stripped) survives renames as long as
   the file is renamed deliberately
@@ -89,50 +123,175 @@ documented in `plugins/yellow-core/CLAUDE.md` per Phase 5.2 below.
 ### Phase 1: CI validator (`scripts/validate-plans.js`)
 
 <!-- deepen-plan: codebase -->
-> **Codebase:** `scripts/validate-marketplace.js` and `scripts/validate-plugin.js`
-> use the `logError`/`logWarning`/`logInfo`/`logSuccess` pattern with `process.exit(0|1)`.
-> Match that style. No `js-yaml` dependency is needed because the validator
-> only reads body content (`grep ^\\s*- \\[ \\]`), not frontmatter.
+> **Codebase:** Findings from the deepen-plan codebase agent (2026-05-28).
+> Confirmed: `scripts/validate-solutions.js` (modified 2026-05-27) is the
+> newest and correct template. `parseNulSeparatedDiff` lives at
+> `scripts/validate-solutions.js:128-161` (real-git path); the synthetic
+> tab-separated injection helper lives at `scripts/validate-solutions.js:163-180`.
+> The step-level `env:` block at `.github/workflows/validate-schemas.yml:87-88`
+> applies to all matrix targets and is inherited by a 6th `plans` target
+> automatically; the `timeout-minutes: 2` job-level ceiling and the fork-PR
+> gate at line 43 are likewise inherited.
+>
+> **Corrections from the agent's verification (folded into task text below):**
+>
+> 1. `validate-solutions.js` does NOT use `scripts/lib/logging.js`. It
+>    defines inline `emitError` / `emitNotice` helpers that emit
+>    `::error file=...` and `::notice::` GHA annotations when `IS_CI=true`.
+>    Mirror that inline pattern in `validate-plans.js` — do NOT import from
+>    `scripts/lib/logging.js`. (`scripts/lib/logging.js` exports
+>    `{ colors, logError, logWarning, logInfo, logSuccess, addError }` and
+>    is the older `validate-marketplace.js` / `validate-plugin.js` family's
+>    convention.)
+> 2. The error-code catalog change is a TWO-FILE change: `errorCatalog.ts`
+>    (new entry + `getErrorCodesByCategory()` mapping) AND
+>    `packages/domain/src/validation/types.ts` (new `ErrorCategory.PLAN_LIFECYCLE`
+>    enum entry, ~line 19). Without the enum entry, the
+>    `getErrorCodesByCategory()` map key has no symbol to reference.
+> 3. `lint-error-codes.js` uses `CODE_PATTERN = /ERROR-[A-Z]+-\d+/g` on
+>    literal source text. The plan's string-concatenation trick
+>    (`'ERROR-PLAN-' + '001'`) genuinely bypasses detection — the lint has
+>    NOT been hardened against split-string assembly.
+>    `validate-solutions.js:85-87` uses exactly this idiom for SOL codes.
+> 4. The `paths:` trigger `packages/**/*.ts` already covers
+>    `packages/domain/src/validation/errorCatalog.ts` — no explicit catalog
+>    path entry needed. Adding `plans/**` is the only `paths:` extension
+>    required.
+> 5. CONTRIBUTING.md lines 155-163 confirm: changeset gate scope is
+>    `^plugins/[^/]+/` only. Changes to `packages/`, `scripts/`,
+>    `tests/integration/`, `.github/workflows/`, and `plans/` are exempt.
+>    PR #1 needs no changeset.
+> 6. `vitest.config.ts` has no explicit include glob (only
+>    `passWithNoTests: true`). Default `**/*.{test,spec}.{ts,mts,cts}` will
+>    auto-discover `tests/integration/validate-plans.test.ts`. No config
+>    change needed.
 <!-- /deepen-plan -->
 
+- [ ] 1.0: Register the error code across TWO files in
+  `packages/domain/src/validation/`:
+  - **`types.ts`** (~line 19): add `PLAN_LIFECYCLE = 'PLAN_LIFECYCLE'` to
+    the `ErrorCategory` enum. Without this, the catalog's category-mapping
+    key has no symbol to reference.
+  - **`errorCatalog.ts`**: add a new section `// Plan Lifecycle Errors (PLAN)`
+    after the SOL block (~line 89) containing
+    `PLAN_STRAY_CHECKBOX: 'ERROR-PLAN-001'`, plus a corresponding
+    `[ErrorCategory.PLAN_LIFECYCLE]: [ERROR_CODES.PLAN_STRAY_CHECKBOX, ...]`
+    entry in `getErrorCodesByCategory()` (~line 254/299-302 region,
+    matching the SOL pattern).
+
+  Then in `scripts/validate-plans.js`, assemble the code via string
+  concatenation (e.g., `const PLAN = 'ERROR-' + 'PLAN'; const PLAN_001 = PLAN + '-001';`)
+  so `scripts/lint-error-codes.js` does NOT flag the validator as
+  re-implementing the catalog. The pattern is documented in
+  `validate-solutions.js:85-87` ("Error codes are assembled via string
+  concatenation so `scripts/lint-error-codes.js` does not flag this file
+  as re-implementing them"). Required because `lint-error-codes.js` now
+  runs inside the `validate:schemas` chain and will fail CI on any
+  `scripts/*.js` that hard-codes an `ERROR-<CAT>-NNN` catalog string.
 - [ ] 1.1: Implement `scripts/validate-plans.js`. Behaviour:
-  - Compute the PR-touched file set:
-    `git diff --no-renames --name-only --diff-filter=AM "$BASE_REF...HEAD"`
+  - Compute the PR-touched file set via
+    `git diff --name-status -z "$BASE_REF...HEAD" -- 'plans/complete/'`
     where `BASE_REF` defaults to `origin/main` and is overridable via the
-    `PLAN_VALIDATOR_BASE_REF` env var. `--no-renames` is mandatory: without
-    it, `git mv plans/foo.md plans/complete/foo.md` is reported as `R`
-    (rename), which the `AM` filter drops — silently bypassing the gate
-    on any machine where rename detection is enabled (`diff.renames=true`,
-    a common global default).
+    `PLAN_VALIDATOR_BASE_REF` env var.
+  - Parse `A` / `M` / `R<score>` records from the NUL-separated stream
+    (matching `scripts/validate-solutions.js` lines 128–164). For each
+    record:
+    - `A <path>` or `M <path>` → use `<path>` as-is.
+    - `R<score> <old> <new>` → use `<new>` (the destination path). This
+      catches `git mv plans/foo.md plans/complete/foo.md` whether or not
+      rename detection fires; we do not need `--no-renames`.
+    - Skip `D` (deletions) — the archived file no longer exists.
   - Filter to paths matching `^plans/complete/.*\.md$`.
-  - For each, count `^\s*- \[ \]` lines. If non-zero, log error and set
+  - For each surviving path, count `^\s*- \[ \]` lines in the file at HEAD.
+    If non-zero, emit `ERROR-PLAN-001` via inline `emitError(file, line, code, msg)`
+    and `emitNotice(msg)` helpers defined at the top of the validator
+    (mirroring `validate-solutions.js` — do NOT import from
+    `scripts/lib/logging.js`; the diff-scoped pattern uses inline emitters
+    that switch on `IS_CI = process.env.GITHUB_ACTIONS === 'true'` to
+    produce `::error file=PATH,line=N::CODE: MSG` annotations on CI or
+    plain `[validate-plans] error: ...` stderr lines locally). Set the
     failure flag.
+  - **Fence-blind grep is intentional (YAGNI):** The grep is a simple
+    `^\s*- \[ \]` line scan, NOT a markdown AST parse. It will count
+    `- [ ]` lines that appear inside ``` ``` ``` fenced code blocks as
+    real findings. Survey of the current corpus (2026-05-28): 0 of 71
+    archived plans contain stray `- [ ]` inside code fences — all 38
+    stray-box files have them in prose. No need for a fence-aware state
+    machine. If a future plan needs to include a literal `- [ ]` inside
+    a code block, the author should either escape it (`- \[ \]`) or use
+    `- [x]` as a placeholder. Document this in the validator header
+    comment; revisit if false positives ever materialize.
   - Exit 1 if any failures, exit 0 otherwise.
+  - **Synthetic-diff override:** Honour `PLAN_VALIDATOR_DIFF` env var —
+    a newline-separated list of `A\t<path>` / `M\t<path>` / `R<score>\t<old>\t<new>`
+    records (mirroring `git diff --name-status` output, no `-z` for
+    test-author ergonomics). When set, bypass `git diff` entirely. Used by
+    integration tests (see 1.3).
   - **No-op cases (exit 0):**
     - PR touches no files under `plans/complete/`.
     - `BASE_REF` is unreachable (e.g., shallow clone) — emit a warning to
-      stderr and exit 0; CI is responsible for fetching the base. Document
-      the recipe in the validator's header comment.
+      stderr (`[validate-plans] warn: cannot reach <ref> — fetch-depth: 0?`)
+      and exit 0; CI is responsible for fetching the base. Document the
+      recipe in the validator's header comment.
+  - **Path-traversal guard:** Refuse to operate when `PLANS_DIR` resolves
+    outside the project root, with a temp-dir exception for vitest
+    fixtures. Use the same pattern as `validate-solutions.js` lines 60–73.
 - [ ] 1.2: Add `"validate:plans": "node scripts/validate-plans.js"` to
   `package.json` scripts. **Do NOT add to the `validate:schemas` chain.**
   `validate:schemas` is the plugin schema gate (marketplace + plugin +
-  setup-all + agent-authoring); plan-lifecycle rules are a different concern
-  per `CLAUDE.md`. Wire `validate:plans` as a separate top-level step in
-  `.github/workflows/validate-schemas.yml` (or its sibling workflow) so it
-  runs alongside, not inside, `validate:schemas`.
+  setup-all + agent-authoring + error-codes + snippets + solutions);
+  plan-lifecycle rules are a different concern per `CLAUDE.md`.
+  Wire as a **sixth matrix target** in
+  `.github/workflows/validate-schemas.yml` alongside the existing five
+  (`marketplace`, `plugins`, `contracts`, `examples`, `solutions`). Concretely:
+  - Add `- plans` to the `strategy.matrix.target` list.
+  - Add a `case "${{ matrix.target }}" in` branch that runs
+    `node scripts/validate-plans.js`, wrapped in an `::group::` block
+    matching the surrounding pattern.
+  - Pass through `PLAN_VALIDATOR_BASE_REF: ${{ github.base_ref != '' &&
+    format('origin/{0}', github.base_ref) || 'origin/main' }}` on the
+    step's `env:` block (the existing `VALIDATE_SOLUTIONS_BASE_REF` line
+    is the template).
+  - Update the `paths:` triggers to add `plans/**` so PRs that only touch
+    plan files still run the gate. (No explicit `errorCatalog.ts` entry
+    needed — the existing `packages/**/*.ts` trigger already covers it.
+    Confirmed against `.github/workflows/validate-schemas.yml` lines 6-15.)
+  Matrix-target wiring inherits the existing < 2-minute timeout, fork-PR
+  gating, and per-target log artifact for free.
 - [ ] 1.3: Vitest integration test in
-  `tests/integration/validate-plans.test.ts`. Match the temp-dir pattern in
-  `tests/integration/validate-plugin.test.ts`:
-  `mkdtempSync(join(tmpdir(), 'yellow-validate-plans-'))` per test, init a
-  bare git repo inside, commit fixtures, exercise the validator via
-  `spawnSync('node', [VALIDATOR], { cwd: tmpRoot, env: {...,
-  PLAN_VALIDATOR_BASE_REF: '<base-sha>'} })`, clean up via
-  `rmSync(tmpRoot, { recursive: true, force: true })` in `afterEach`.
+  `tests/integration/validate-plans.test.ts`. Use the
+  `PLAN_VALIDATOR_DIFF`-injection pattern (no `mkdtempSync`/bare-git-init),
+  mirroring the style of `tests/integration/validate-solutions.test.ts`:
+  ```ts
+  const result = spawnSync('node', [VALIDATOR], {
+    env: {
+      ...process.env,
+      PLAN_VALIDATOR_DIFF: 'A\tplans/complete/clean.md',
+      PLANS_DIR: fixtureDir,
+    },
+    encoding: 'utf8',
+  });
+  ```
+  **Never mutate `process.env` directly** (e.g.,
+  `process.env.PLAN_VALIDATOR_DIFF = '...'` followed by `spawnSync`). Within
+  one Vitest worker, tests share `process.env`; direct mutation creates
+  order-dependent cross-test races. Always pass env as a per-spawn override
+  via the spread above. Reference test pattern uses the `runScript(opts)`
+  helper at `tests/integration/validate-solutions.test.ts:51` — copy that
+  helper shape if useful.
   Cases: PR adds clean file (PASS), PR adds dirty file with stray `- [ ]`
-  (FAIL), PR modifies file in `plans/complete/` to add stray boxes (FAIL),
-  PR touches files outside `plans/complete/` only (PASS), repository has
-  pre-existing dirty files in `plans/complete/` but PR doesn't touch them
-  (PASS — the core YAGNI behaviour).
+  (FAIL with `ERROR-PLAN-001`), PR modifies file in `plans/complete/` to
+  add stray boxes (FAIL), PR touches files outside `plans/complete/` only
+  (PASS — no-op), repository has pre-existing dirty files in
+  `plans/complete/` but PR doesn't touch them (PASS — the core YAGNI
+  behaviour), PR archives a plan via rename (FAIL when the destination
+  has stray boxes, PASS when clean — exercises the `R<score>` parse
+  branch), `BASE_REF` unreachable (PASS with stderr warning), path
+  traversal in synthetic-diff record (e.g.,
+  `A\tplans/complete/../../../etc/sneaky.md` → exit 0 with
+  `rejecting suspicious diff path` on stderr; mirrors
+  `validate-solutions.test.ts` rejection cases), empty diff (PASS with
+  `no plans/complete/ changes in diff`).
 
 ### Phase 2: `/plan:status` command
 
@@ -208,15 +367,33 @@ documented in `plugins/yellow-core/CLAUDE.md` per Phase 5.2 below.
   - **No-evidence** if `COUNT == 0`: `AskUserQuestion`
     "No merged PR found whose title and branch contain the slug
     `$SLUG`. Provide a PR number to confirm, or cancel."
-    Options: `Confirm with PR number` (Other → free-text), `Cancel`.
-    On confirmed PR-number override, store `OVERRIDE_PR_NUM` for the
-    commit trailer in step 3.10.
+    Options: `Other` (opens free-text — user types the PR number),
+    `Cancel`. **The label MUST be the literal string `Other`** —
+    per MEMORY.md "AskUserQuestion 'Other' is the ONLY free-text
+    button", any other label (e.g., `Confirm with PR number`) shows
+    as a regular click-only option and does NOT open a text input.
+    On confirmed PR-number override, capture the user's response and
+    store as `OVERRIDE_PR_NUM` for the commit trailer in step 3.10.
 
   Word-boundary protection: the `--jq` post-filter requires `$SLUG` to be
   separated from surrounding characters by `^`, `$`, `/`, `_`, or `-`. This
   prevents short or generic slugs (`refactor`, `fix`) from matching
   unrelated PRs whose branch names contain the slug as a substring inside
   another word.
+
+<!-- deepen-plan: external -->
+> **Research:** GitHub's `in:title` qualifier is token-based, hyphens act
+> as token separators, and the search is case-insensitive. A query
+> `in:title "foo-bar"` tokenizes to `[foo, bar]` and will match a PR titled
+> "foo bar" (and likely "foo_bar"). Quoted strings enforce token-sequence
+> order, NOT raw-string equality — there is no character-exact mode for
+> issue/PR title search (GitHub Community Discussion #17956, #58606). For
+> our purposes this means `gh pr list --search 'in:title "<slug>"'` is a
+> COARSE pre-filter; the authoritative match comes from the post-filter
+> regex on `headRefName` (which IS exact substring + word-boundary). The
+> existing design is correct as-is — this annotation just clarifies why
+> the title search alone is not authoritative.
+<!-- /deepen-plan -->
 
   **Server-side `--state merged`** is preferred over reading `mergedAt`:
   per `docs/solutions/integration-issues/merge-queue-closed-pr-null-mergedat-detection.md`,
@@ -244,9 +421,14 @@ documented in `plugins/yellow-core/CLAUDE.md` per Phase 5.2 below.
   immediately, ready to commit.
 - [ ] 3.10: Step 8 — commit with override audit trail. After building
   the message body from one of the templates below, invoke
-  `gt commit create -m "<subject>" -m "<body>"` (the `-m` body flag
-  receives the multi-line body verbatim — heredoc-in-`$()` substitution
-  is a known footgun, see MEMORY.md "gt modify multi-line commit").
+  `git commit -m "$SUBJECT" -m "$BODY"`. **Do NOT use
+  `gt commit create -m "$SUBJECT" -m "$BODY"`** — it concatenates the
+  two `-m` values with a literal comma (`"subject,body line 1..."`)
+  instead of producing the standard subject + blank-line + body shape.
+  Standard `git commit` correctly handles multiple `-m` as separate
+  paragraphs (git docs: "their values are concatenated as separate
+  paragraphs"). Graphite picks up the commit on the current branch via
+  `gt submit` in step 3.11.
 
   Default commit (Gate C PASS, no override):
   ```
@@ -320,12 +502,21 @@ documented in `plugins/yellow-core/CLAUDE.md` per Phase 5.2 below.
 
 ### Files to modify
 
+- `packages/domain/src/validation/types.ts` (add
+  `PLAN_LIFECYCLE = 'PLAN_LIFECYCLE'` to the `ErrorCategory` enum, ~line 19;
+  required so `errorCatalog.ts` has the symbol to reference)
+- `packages/domain/src/validation/errorCatalog.ts` (add `PLAN_STRAY_CHECKBOX`
+  entry + `getErrorCodesByCategory()` mapping; required for
+  `lint-error-codes.js` compliance — see Task 1.0 for line refs)
 - `plugins/yellow-core/README.md` (command catalog)
 - `plugins/yellow-core/CLAUDE.md` (`/plan:*` section)
 - `package.json` (add `validate:plans` script entry — NOT in
   `validate:schemas` chain)
-- `.github/workflows/validate-schemas.yml` or sibling (add separate
-  `validate:plans` step alongside `validate:schemas`)
+- `.github/workflows/validate-schemas.yml` (add `plans` as sixth matrix
+  target alongside the existing `marketplace`/`plugins`/`contracts`/
+  `examples`/`solutions`; pass `PLAN_VALIDATOR_BASE_REF`; extend `paths:`
+  triggers to add `plans/**` — `packages/**/*.ts` already covers the
+  catalog file)
 
 ### Files NOT changed (deliberately, vs. the first-pass plan)
 
@@ -396,9 +587,9 @@ No new packages. `gh`, `git`, and `gt` are already required by the repo.
 
 ### 1. agent/feat/validate-plans-pr-scoped
 - **Type:** feat
-- **Description:** Add scripts/validate-plans.js (PR-diff-scoped, no frontmatter) plus integration tests and CI wiring as a separate top-level step
-- **Scope:** scripts/validate-plans.js, package.json, tests/integration/validate-plans.test.ts, .github/workflows/*.yml
-- **Tasks:** 1.1, 1.2, 1.3
+- **Description:** Add scripts/validate-plans.js (PR-diff-scoped, no frontmatter) plus error-code catalog entry, integration tests, and CI wiring as a sixth matrix target in validate-schemas.yml
+- **Scope:** packages/domain/src/validation/types.ts, packages/domain/src/validation/errorCatalog.ts, scripts/validate-plans.js, package.json, tests/integration/validate-plans.test.ts, .github/workflows/validate-schemas.yml
+- **Tasks:** 1.0, 1.1, 1.2, 1.3
 - **Depends on:** (none)
 - **Changeset:** none required (no `plugins/*` files touched)
 
@@ -410,12 +601,61 @@ No new packages. `gh`, `git`, and `gt` are already required by the repo.
 - **Depends on:** #1
 - **Changeset:** required (yellow-core, minor — new commands)
 
+## Stack Progress
+
+<!-- Updated by workflows:work. Do not edit manually. -->
+- [x] 1. agent/feat/validate-plans-pr-scoped (submitted 2026-05-28 — PR #556 https://github.com/KingInYellows/yellow-plugins/pull/556)
+- [ ] 2. agent/feat/plan-commands
+
 ## References
 
+<!-- deepen-plan: external -->
+> **Research:** External knowledge folded in from the deepen-plan run
+> (2026-05-28). Four lessons that confirm or supplement the design:
+>
+> 1. **`actions/checkout@v4` `fetch-depth: 0` remains correct.** No 2025
+>    changes to fetch semantics; v6 only relocated credential storage. For
+>    PR-diff-scoped validators in light repos, `fetch-depth: 0` is the
+>    right default. (`actions/checkout#266`,
+>    https://github.com/actions/checkout/issues/266; `pre-commit#1554`)
+> 2. **New matrix targets inherit concurrency-group semantics.** Adding
+>    `plans` as a 6th target does NOT change cancellation behavior for
+>    existing targets; the job-level concurrency group at the workflow
+>    head applies to all matrix shards uniformly. (GitHub Actions docs —
+>    "control the concurrency of workflows and jobs"; Community Discussion
+>    #26774.) Workflow-level `paths:` filters cannot be per-target — they
+>    gate the entire workflow. For our case this is fine: `plans/**` added
+>    to the existing `paths:` list triggers the workflow as a whole, and
+>    the `plans` target runs unconditionally inside it (no per-target
+>    filtering needed).
+> 3. **Vitest `process.env` is shared within a worker.** Direct mutation
+>    creates order-dependent races between tests in the same file
+>    (`jest#9264` generalizes). Always pass env as a per-spawn override
+>    (see Task 1.3). Reserve `execa` only if you need streaming — for our
+>    case `spawnSync` is simpler and sufficient.
+> 4. **No established prior art for "no stray checkboxes in archived
+>    plans" gates.** markdownlint (`DavidAnson/markdownlint`) has no
+>    semantic-state rules; vale.sh is prose-only. The `grep`-on-diff
+>    approach IS the established pattern for bespoke line-level gates in
+>    monorepo CI. Lesson from markdownlint plugin authors: scope the
+>    rule at the CI invocation level (which we do via PR-diff-scoping),
+>    not inside the rule body. (Microsoft Engineering Fundamentals
+>    Playbook — "Automating markdown checks".)
+<!-- /deepen-plan -->
+
 - Brainstorm (superseded for several decisions): `docs/brainstorms/2026-05-08-plan-lifecycle-management-brainstorm.md`
-- Validator pattern: `scripts/validate-marketplace.js`, `scripts/validate-plugin.js`
+- **Canonical PR-diff-scoped validator template:** `scripts/validate-solutions.js`
+  (preferred reference for Phase 1; mirror its `BASE_REF` env var, `*_DIFF`
+  synthetic-injection env, GitHub Actions annotation emit, and path-traversal
+  guard with temp-dir exception)
+- Older validator patterns (acceptable but less complete): `scripts/validate-marketplace.js`
+- Error-code catalog: `packages/domain/src/validation/errorCatalog.ts`;
+  catalog-drift lint: `scripts/lint-error-codes.js`
+- Shared logging helpers: `scripts/lib/logging.js`
 - Reference command: `plugins/yellow-core/commands/worktree/cleanup.md` (uses `gh pr list --head`)
+- Reference test pattern (PR-diff-scoped validator integration test):
+  `tests/integration/validate-solutions.test.ts`
 - Merge-queue / `mergedAt` gotcha: `docs/solutions/integration-issues/merge-queue-closed-pr-null-mergedat-detection.md`
 - Bash hardening: `MEMORY.md` "Bash Hook & Validation Patterns" section
 - Command anti-patterns: `docs/solutions/code-quality/claude-code-command-authoring-anti-patterns.md`
-- PR #484 review issues driving this revision: `#494` (P0/P1 design), `#496` (YAGNI scope reductions)
+- PR #484 review issues driving the first revision: `#494` (P0/P1 design), `#496` (YAGNI scope reductions)

--- a/scripts/validate-plans.js
+++ b/scripts/validate-plans.js
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+
+/**
+ * validate-plans.js
+ *
+ * Diff-scoped validator for `plans/complete/` archival entries. Runs on PR
+ * diffs to block when a NEW or MODIFIED archived plan contains stray
+ * unchecked checkboxes (`- [ ]` lines). This catches premature archival
+ * where the plan moved before its task list was complete.
+ *
+ * The validator runs only on files added or modified in the diff against
+ * `origin/main` (or the ref in `PLAN_VALIDATOR_BASE_REF`). Renames produced
+ * by `git mv plans/<slug>.md plans/complete/<slug>.md` are detected via the
+ * `R<score>` records emitted by `git diff --name-status` and routed by
+ * destination path — so the archival case is caught whether or not rename
+ * detection fires. Pre-existing dirty files in `plans/complete/` that the
+ * PR does not touch are intentionally NOT inspected (PR-diff-scoping). See
+ * `plans/plan-lifecycle-management.md` for rationale.
+ *
+ * Error codes (catalog: packages/domain/src/validation/errorCatalog.ts) are
+ * assembled via string concatenation so `scripts/lint-error-codes.js` does
+ * not flag this file as re-implementing them. Same ESM/CJS bridge constraint
+ * as scripts/validate-solutions.js.
+ *
+ * Env:
+ *   PLAN_VALIDATOR_BASE_REF=origin/main  diff base (override for CI)
+ *   PLAN_VALIDATOR_DIFF                  newline list of `A\t<path>` /
+ *                                        `M\t<path>` / `R<score>\t<old>\t<new>`
+ *                                        lines (tab-separated, matching
+ *                                        `git diff --name-status` without
+ *                                        `-z`). Bypasses git diff. Tests use
+ *                                        this to inject synthetic change
+ *                                        sets without `mkdtempSync` + bare
+ *                                        repo init.
+ *   PLANS_DIR=plans                      corpus root (test override)
+ *   GITHUB_ACTIONS=true                  emits `::error file=`/`::notice::`
+ *                                        annotations.
+ *
+ * Exit codes:
+ *   0 - no validation errors (or soft-skip on unreachable BASE_REF)
+ *   1 - one or more validation errors found
+ *
+ * CI recipe: requires `actions/checkout@v4` with `fetch-depth: 0` (or an
+ * explicit `git fetch origin <base-ref>`) so the diff base is reachable.
+ * Without it, the validator soft-skips and emits a warning to stderr.
+ */
+
+'use strict';
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const PLANS_DIR = path.resolve(ROOT, process.env.PLANS_DIR || 'plans');
+
+// Path-traversal guard: refuse to operate on a directory outside the project
+// root, with a temp-dir exception for vitest fixtures (same convention as
+// scripts/validate-solutions.js lines 60-73).
+const TMP_PREFIX = os.tmpdir();
+if (
+  !PLANS_DIR.startsWith(ROOT + path.sep) &&
+  !PLANS_DIR.startsWith(TMP_PREFIX + path.sep)
+) {
+  console.error(
+    '[validate-plans] Error: PLANS_DIR resolves outside project ' +
+      'root or system temp dir. Refusing to operate on: ' +
+      PLANS_DIR
+  );
+  process.exit(1);
+}
+
+const IS_CI = process.env.GITHUB_ACTIONS === 'true';
+const BASE_REF = process.env.PLAN_VALIDATOR_BASE_REF || 'origin/main';
+
+// Catalog code prefixes assembled via concatenation. See module header for
+// why these codes are assembled instead of imported from the catalog.
+const PLAN = 'ERROR-' + 'PLAN';
+const PLAN_STRAY_CHECKBOX = PLAN + '-001';
+
+const CHECKBOX_RE = /^[ \t]*- \[ \]/;
+
+const errors = [];
+
+function emitError(file, line, code, msg) {
+  errors.push({ file, line, code, msg });
+  if (IS_CI) {
+    console.log(`::error file=${file},line=${line}::${code}: ${msg}`);
+  } else {
+    console.error(`✗ ${file}:${line}: ${code}: ${msg}`);
+  }
+}
+
+function emitNotice(msg) {
+  if (IS_CI) {
+    console.log(`::notice::${msg}`);
+  } else {
+    console.log(`[validate-plans] ${msg}`);
+  }
+}
+
+// Parse `git diff --name-status -z` output. Records are NUL-separated.
+// For A/M/D/T: status\0path\0   For R/C: status\0old\0new\0
+// Returns array of {status, path, newPath?} records. Status may carry
+// similarity digits (R100, C75); callers use the first char.
+function parseNulSeparatedDiff(raw) {
+  const records = [];
+  const parts = raw.split('\0');
+  let i = 0;
+  while (i < parts.length) {
+    const status = parts[i];
+    if (!status) {
+      i++;
+      continue;
+    }
+    const ch = status[0];
+    if (ch === 'R' || ch === 'C') {
+      const oldPath = parts[i + 1];
+      const newPath = parts[i + 2];
+      if (oldPath === undefined || newPath === undefined) break;
+      records.push({ status, path: oldPath, newPath });
+      i += 3;
+    } else {
+      const p = parts[i + 1];
+      if (p === undefined) break;
+      records.push({ status, path: p });
+      i += 2;
+    }
+  }
+  return records;
+}
+
+// Parse synthetic PLAN_VALIDATOR_DIFF env var content (tab+newline format
+// matching `git diff --name-status` without `-z`). Test ergonomics only —
+// the real git path uses `-z` (NUL-separated) for unicode/space safety.
+function parseTabSeparatedDiff(raw) {
+  const records = [];
+  for (const line of raw.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    const parts = line.split(/\t/);
+    const status = parts[0];
+    if (!status) continue;
+    const ch = status[0];
+    if (ch === 'R' || ch === 'C') {
+      if (parts.length < 3) continue;
+      records.push({ status, path: parts[1], newPath: parts[2] });
+    } else {
+      if (parts.length < 2) continue;
+      records.push({ status, path: parts[1] });
+    }
+  }
+  return records;
+}
+
+// Returns array of {status: 'A'|'M', relPath} entries within plans/complete/,
+// or null when the diff base is unreachable. Rename entries are normalized
+// to 'A' on the new path so an archival rename (plans/foo.md →
+// plans/complete/foo.md) receives the same checkbox scan as a direct add.
+function getChangedFiles() {
+  const injected = process.env.PLAN_VALIDATOR_DIFF;
+  let records;
+  if (injected !== undefined) {
+    records = parseTabSeparatedDiff(injected);
+  } else {
+    let raw;
+    try {
+      // Use execFileSync (no shell) and pass the ref as an argument so a
+      // hostile PLAN_VALIDATOR_BASE_REF cannot inject shell commands.
+      //
+      // `-z` is load-bearing: without it, git quotes paths containing
+      // non-ASCII characters (e.g. `café.md`) using C-style escaping, which
+      // would fail the later `startsWith('plans/complete/')` check and
+      // silently bypass validation. With `-z`, records are NUL-separated
+      // and paths are emitted verbatim. See
+      // docs/solutions/logic-errors/git-diff-name-status-nul-safe-parsing.md.
+      raw = execFileSync(
+        'git',
+        ['diff', '--name-status', '-z', `${BASE_REF}...HEAD`, '--', 'plans/complete/'],
+        { cwd: ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
+      );
+    } catch (err) {
+      // Soft-skip for unreachable refs (fork PR, shallow clone). For other
+      // errors, surface a stderr warning so the soft-skip is distinguishable
+      // from a runner misconfiguration.
+      const stderr = err.stderr ? err.stderr.toString() : '';
+      const looksUnreachable =
+        /unknown revision|bad revision|does not have a commit|fatal: ambiguous argument/i.test(
+          stderr
+        );
+      if (!looksUnreachable) {
+        process.stderr.write(
+          `[validate-plans] warn: git diff failed (${err.code || 'unknown'}): ${stderr.trim()}\n`
+        );
+      }
+      return null;
+    }
+    records = parseNulSeparatedDiff(raw);
+  }
+  const entries = [];
+  for (const rec of records) {
+    const statusChar = rec.status[0];
+    let relPath;
+    let normalizedStatus;
+    if (statusChar === 'A' || statusChar === 'M') {
+      relPath = rec.path;
+      normalizedStatus = statusChar;
+    } else if (statusChar === 'R') {
+      // Rename: treat new path as added (we check the destination contents).
+      relPath = rec.newPath;
+      normalizedStatus = 'A';
+    } else {
+      // D (deletion), T (type change): not applicable.
+      continue;
+    }
+    if (!relPath) continue;
+    if (!relPath.startsWith('plans/complete/')) continue;
+    if (!relPath.endsWith('.md')) continue;
+    // Path-traversal guard: startsWith('plans/complete/') alone passes
+    // payloads like 'plans/complete/../../../etc/passwd'. Reject any entry
+    // whose normalized form escapes the corpus directory.
+    const normalized = path.posix.normalize(relPath);
+    if (
+      normalized !== relPath ||
+      normalized.split('/').some((s) => s === '..') ||
+      path.isAbsolute(normalized)
+    ) {
+      process.stderr.write(
+        `[validate-plans] warn: rejecting suspicious diff path: ${relPath}\n`
+      );
+      continue;
+    }
+    entries.push({ status: normalizedStatus, path: normalized });
+  }
+  return entries;
+}
+
+function scanFileForStrayCheckboxes(absPath, relPath) {
+  let text;
+  try {
+    text = fs.readFileSync(absPath, 'utf8');
+  } catch (err) {
+    // ENOENT is an expected deletion race (the diff says it changed; a later
+    // commit on the branch may have removed it). Other error codes
+    // (EACCES, EMFILE) signal runner misconfiguration.
+    if (err.code !== 'ENOENT') {
+      process.stderr.write(
+        `[validate-plans] warn: could not read ${absPath}: ${err.code || err.message}\n`
+      );
+    }
+    return;
+  }
+  const lines = text.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    if (CHECKBOX_RE.test(lines[i])) {
+      emitError(
+        relPath,
+        i + 1,
+        PLAN_STRAY_CHECKBOX,
+        'archived plan contains an unchecked task box (`- [ ]`) — ' +
+          'complete or remove the task before archiving'
+      );
+    }
+  }
+}
+
+function main() {
+  const changed = getChangedFiles();
+  if (changed === null) {
+    emitNotice(
+      `cannot reach ${BASE_REF} (likely fork PR or shallow clone) — ` +
+        'skipping plan-archival validation'
+    );
+    process.exit(0);
+  }
+  if (changed.length === 0) {
+    emitNotice('no plans/complete/ changes in diff — nothing to validate');
+    process.exit(0);
+  }
+
+  for (const entry of changed) {
+    // Diff entries are repo-relative ("plans/complete/<slug>.md"). Strip
+    // the corpus prefix and resolve under PLANS_DIR so tests (which override
+    // PLANS_DIR to a tmpdir) work the same as production.
+    const relUnderCorpus = entry.path.replace(/^plans\//, '');
+    const fullPath = path.join(PLANS_DIR, relUnderCorpus);
+    scanFileForStrayCheckboxes(fullPath, entry.path);
+  }
+
+  console.log(
+    `\n[validate-plans] checked ${changed.length} file(s); ` +
+      `${errors.length} error(s)`
+  );
+  process.exit(errors.length > 0 ? 1 : 0);
+}
+
+main();

--- a/scripts/validate-plans.js
+++ b/scripts/validate-plans.js
@@ -38,7 +38,11 @@
  *
  * Exit codes:
  *   0 - no validation errors (or soft-skip on unreachable BASE_REF)
- *   1 - one or more validation errors found
+ *   1 - one or more stray-checkbox findings, OR a hard infrastructure error
+ *       (git binary missing / corrupt index, or a plan file that could not
+ *       be read for a non-ENOENT reason). Infrastructure errors fail loudly
+ *       rather than soft-skipping so CI never reports green on a runner where
+ *       validation could not actually run.
  *
  * CI recipe: requires `actions/checkout@v4` with `fetch-depth: 0` (or an
  * explicit `git fetch origin <base-ref>`) so the diff base is reachable.
@@ -82,6 +86,13 @@ const PLAN_STRAY_CHECKBOX = PLAN + '-001';
 const CHECKBOX_RE = /^[ \t]*- \[ \]/;
 
 const errors = [];
+
+// Set when the validator could not read a file it was asked to inspect for a
+// reason other than an expected deletion race (ENOENT). Tracked separately
+// from `errors` (which holds the stray-checkbox findings) so the
+// summary can distinguish "validated and found problems" from "could not
+// validate". Either condition fails the run.
+let infraError = false;
 
 function emitError(file, line, code, msg) {
   errors.push({ file, line, code, msg });
@@ -153,10 +164,13 @@ function parseTabSeparatedDiff(raw) {
   return records;
 }
 
-// Returns array of {status: 'A'|'M', relPath} entries within plans/complete/,
-// or null when the diff base is unreachable. Rename entries are normalized
-// to 'A' on the new path so an archival rename (plans/foo.md →
-// plans/complete/foo.md) receives the same checkbox scan as a direct add.
+// Returns array of {status: 'A'|'M', path} entries within plans/complete/,
+// or null when the diff base is unreachable (soft-skip). On a hard git error
+// (binary missing, EACCES on .git/, corrupt index) the function exits 1
+// directly rather than returning — see the catch block. Rename/copy entries
+// are normalized to 'A' on the new path so an archival move
+// (plans/foo.md → plans/complete/foo.md) receives the same checkbox scan as
+// a direct add.
 function getChangedFiles() {
   const injected = process.env.PLAN_VALIDATOR_DIFF;
   let records;
@@ -180,18 +194,26 @@ function getChangedFiles() {
         { cwd: ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
       );
     } catch (err) {
-      // Soft-skip for unreachable refs (fork PR, shallow clone). For other
-      // errors, surface a stderr warning so the soft-skip is distinguishable
-      // from a runner misconfiguration.
+      // Distinguish two failure modes:
+      //   - Unreachable ref (fork PR, shallow clone): a no-op condition.
+      //     Return null → main() emits a notice and exits 0 (soft-skip).
+      //   - Hard error (git binary missing, EACCES on .git/, corrupt index):
+      //     the validator should have run but couldn't. Fail loudly with
+      //     exit 1 so CI does not report green on a misconfigured runner.
       const stderr = err.stderr ? err.stderr.toString() : '';
       const looksUnreachable =
         /unknown revision|bad revision|does not have a commit|fatal: ambiguous argument/i.test(
           stderr
         );
       if (!looksUnreachable) {
-        process.stderr.write(
-          `[validate-plans] warn: git diff failed (${err.code || 'unknown'}): ${stderr.trim()}\n`
-        );
+        const msg =
+          `git diff failed (${err.code || 'unknown'}): ${stderr.trim()}`;
+        if (IS_CI) {
+          console.log(`::error::[validate-plans] ${msg}`);
+        } else {
+          process.stderr.write(`[validate-plans] error: ${msg}\n`);
+        }
+        process.exit(1);
       }
       return null;
     }
@@ -205,8 +227,11 @@ function getChangedFiles() {
     if (statusChar === 'A' || statusChar === 'M') {
       relPath = rec.path;
       normalizedStatus = statusChar;
-    } else if (statusChar === 'R') {
-      // Rename: treat new path as added (we check the destination contents).
+    } else if (statusChar === 'R' || statusChar === 'C') {
+      // Rename/copy: scan the destination contents. A copy into
+      // plans/complete/ is a real archival path under
+      // `git config diff.renames=copies`, so it must be gated the same as
+      // a rename. Both carry newPath from the parsers above.
       relPath = rec.newPath;
       normalizedStatus = 'A';
     } else {
@@ -241,12 +266,18 @@ function scanFileForStrayCheckboxes(absPath, relPath) {
     text = fs.readFileSync(absPath, 'utf8');
   } catch (err) {
     // ENOENT is an expected deletion race (the diff says it changed; a later
-    // commit on the branch may have removed it). Other error codes
-    // (EACCES, EMFILE) signal runner misconfiguration.
+    // commit on the branch may have removed it) — silently skip. Other error
+    // codes (EACCES, EMFILE, EISDIR) signal runner misconfiguration: the file
+    // SHOULD have been scanned but couldn't be. Flag it so main() exits 1
+    // rather than reporting a misleading green run.
     if (err.code !== 'ENOENT') {
-      process.stderr.write(
-        `[validate-plans] warn: could not read ${absPath}: ${err.code || err.message}\n`
-      );
+      infraError = true;
+      const msg = `could not read ${relPath}: ${err.code || err.message}`;
+      if (IS_CI) {
+        console.log(`::error file=${relPath}::[validate-plans] ${msg}`);
+      } else {
+        process.stderr.write(`[validate-plans] error: ${msg}\n`);
+      }
     }
     return;
   }
@@ -287,11 +318,12 @@ function main() {
     scanFileForStrayCheckboxes(fullPath, entry.path);
   }
 
-  console.log(
+  const summary =
     `\n[validate-plans] checked ${changed.length} file(s); ` +
-      `${errors.length} error(s)`
-  );
-  process.exit(errors.length > 0 ? 1 : 0);
+    `${errors.length} error(s)` +
+    (infraError ? '; 1+ file(s) could not be read (see errors above)' : '');
+  console.log(summary);
+  process.exit(errors.length > 0 || infraError ? 1 : 0);
 }
 
 main();

--- a/tests/integration/validate-plans.test.ts
+++ b/tests/integration/validate-plans.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Integration tests for `scripts/validate-plans.js`.
+ *
+ * Mirrors the fixture-tmpdir + synthetic-diff-injection pattern of
+ * `tests/integration/validate-solutions.test.ts`:
+ *   - Each describe builds a synthetic `plans/complete/` tree under
+ *     `os.tmpdir()` and points the script at it via `PLANS_DIR`.
+ *   - Diff input is injected via the `PLAN_VALIDATOR_DIFF` env var
+ *     (newline-separated tab-delimited records matching
+ *     `git diff --name-status` without `-z`), bypassing git so tests never
+ *     depend on repo history.
+ *
+ * Covers the cases listed in `plans/plan-lifecycle-management.md` Task 1.3.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const SCRIPT = resolve(
+  __dirname,
+  '..',
+  '..',
+  'scripts',
+  'validate-plans.js'
+);
+
+interface RunResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+interface RunOpts {
+  diff?: string;
+  // Override the base ref. Setting an unreachable ref triggers the
+  // soft-skip branch when no `diff` is injected.
+  baseRef?: string;
+  // Force GITHUB_ACTIONS=true to assert annotation formatting.
+  ci?: boolean;
+}
+
+function runScript(plansDir: string, opts: RunOpts = {}): RunResult {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    PLANS_DIR: plansDir,
+  };
+  if (opts.diff !== undefined) env.PLAN_VALIDATOR_DIFF = opts.diff;
+  if (opts.baseRef !== undefined) env.PLAN_VALIDATOR_BASE_REF = opts.baseRef;
+  // Default CI to false; tests that want annotations opt in explicitly.
+  if (opts.ci) env.GITHUB_ACTIONS = 'true';
+  else delete env.GITHUB_ACTIONS;
+
+  const result = spawnSync('node', [SCRIPT], { env, encoding: 'utf8' });
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+function writePlan(
+  plansDir: string,
+  subdir: 'complete' | '',
+  slug: string,
+  body: string
+): string {
+  const dir = subdir ? join(plansDir, subdir) : plansDir;
+  mkdirSync(dir, { recursive: true });
+  const filePath = join(dir, `${slug}.md`);
+  writeFileSync(filePath, body, 'utf8');
+  return filePath;
+}
+
+const cleanBody = `# Feature: Clean plan
+
+## Overview
+All tasks completed.
+
+## Implementation Plan
+- [x] 1.1: Step one
+- [x] 1.2: Step two
+`;
+
+const dirtyBody = `# Feature: Dirty plan
+
+## Overview
+One task left.
+
+## Implementation Plan
+- [x] 1.1: Step one
+- [ ] 1.2: Step two not done
+- [x] 1.3: Step three
+`;
+
+describe('validate-plans — stray-checkbox detection (ERROR-PLAN-001)', () => {
+  let tmpRoot: string;
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'yellow-vp-stray-'));
+  });
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('PASS: PR adds a clean archived plan with no stray boxes', () => {
+    writePlan(tmpRoot, 'complete', 'clean-plan', cleanBody);
+
+    const { status, stdout } = runScript(tmpRoot, {
+      diff: 'A\tplans/complete/clean-plan.md',
+    });
+
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/checked 1 file\(s\); 0 error\(s\)/);
+  });
+
+  it('FAIL: PR adds an archived plan with one stray `- [ ]`', () => {
+    writePlan(tmpRoot, 'complete', 'dirty-plan', dirtyBody);
+
+    const { status, stdout, stderr } = runScript(tmpRoot, {
+      diff: 'A\tplans/complete/dirty-plan.md',
+    });
+
+    expect(status).toBe(1);
+    expect(stdout + stderr).toMatch(/ERROR-PLAN-001/);
+    expect(stdout + stderr).toMatch(/dirty-plan\.md/);
+    expect(stdout + stderr).toMatch(/unchecked task box/);
+  });
+
+  it('FAIL: PR modifies an existing archived plan to add stray boxes', () => {
+    writePlan(tmpRoot, 'complete', 'modified-plan', dirtyBody);
+
+    const { status, stdout, stderr } = runScript(tmpRoot, {
+      diff: 'M\tplans/complete/modified-plan.md',
+    });
+
+    expect(status).toBe(1);
+    expect(stdout + stderr).toMatch(/ERROR-PLAN-001/);
+  });
+
+  it('PASS: PR touches only files outside plans/complete/', () => {
+    writePlan(tmpRoot, '', 'open-plan', dirtyBody);
+
+    const { status, stdout } = runScript(tmpRoot, {
+      diff: 'M\tplans/open-plan.md\nA\tdocs/research/foo.md',
+    });
+
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/no plans\/complete\/ changes in diff/);
+  });
+
+  it('PASS (core YAGNI behaviour): pre-existing dirty archived plan that the PR does NOT touch is ignored', () => {
+    // Two pre-existing dirty plans, both with stray boxes.
+    writePlan(tmpRoot, 'complete', 'untouched-legacy-1', dirtyBody);
+    writePlan(tmpRoot, 'complete', 'untouched-legacy-2', dirtyBody);
+    // The PR touches an unrelated open plan only.
+    writePlan(tmpRoot, '', 'unrelated-open', cleanBody);
+
+    const { status, stdout } = runScript(tmpRoot, {
+      diff: 'M\tplans/unrelated-open.md',
+    });
+
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/no plans\/complete\/ changes in diff/);
+  });
+});
+
+describe('validate-plans — rename routing (R-record)', () => {
+  let tmpRoot: string;
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'yellow-vp-rename-'));
+  });
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('PASS: archival rename plans/<slug>.md → plans/complete/<slug>.md with a clean destination', () => {
+    // The destination file (post-mv) is what's read.
+    writePlan(tmpRoot, 'complete', 'archived-via-rename', cleanBody);
+
+    const { status, stdout } = runScript(tmpRoot, {
+      diff: 'R100\tplans/archived-via-rename.md\tplans/complete/archived-via-rename.md',
+    });
+
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/checked 1 file\(s\); 0 error\(s\)/);
+  });
+
+  it('FAIL: archival rename with stray boxes in destination triggers ERROR-PLAN-001', () => {
+    writePlan(tmpRoot, 'complete', 'archived-dirty', dirtyBody);
+
+    const { status, stdout, stderr } = runScript(tmpRoot, {
+      diff: 'R95\tplans/archived-dirty.md\tplans/complete/archived-dirty.md',
+    });
+
+    expect(status).toBe(1);
+    expect(stdout + stderr).toMatch(/ERROR-PLAN-001/);
+    expect(stdout + stderr).toMatch(/archived-dirty\.md/);
+  });
+});
+
+describe('validate-plans — soft-skip and edge cases', () => {
+  let tmpRoot: string;
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'yellow-vp-skip-'));
+  });
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('PASS (soft-skip): BASE_REF unreachable emits notice and exits 0', () => {
+    // No PLAN_VALIDATOR_DIFF, force the git path. The base ref is bogus.
+    const { status, stdout } = runScript(tmpRoot, {
+      baseRef: 'refs/heads/this-ref-does-not-exist-anywhere-2026-05-28',
+    });
+
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/cannot reach/);
+    expect(stdout).toMatch(/skipping plan-archival validation/);
+  });
+
+  it('PASS (path-traversal): suspicious diff path is rejected silently with stderr warning', () => {
+    // Even though the diff claims plans/complete/..., the normalized form
+    // escapes the corpus directory. The entry is dropped; nothing to check.
+    const { status, stderr, stdout } = runScript(tmpRoot, {
+      diff: 'A\tplans/complete/../../../etc/sneaky.md',
+    });
+
+    expect(status).toBe(0);
+    expect(stderr).toMatch(/rejecting suspicious diff path/);
+    expect(stdout).toMatch(/no plans\/complete\/ changes in diff/);
+  });
+
+  it('PASS (empty diff): no diff records → notice, exit 0', () => {
+    const { status, stdout } = runScript(tmpRoot, { diff: '' });
+
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/no plans\/complete\/ changes in diff/);
+  });
+
+  it('PASS (D record): deletion of an archived plan is not flagged', () => {
+    const { status, stdout } = runScript(tmpRoot, {
+      diff: 'D\tplans/complete/removed-plan.md',
+    });
+
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/no plans\/complete\/ changes in diff/);
+  });
+
+  it('emits GHA annotation when GITHUB_ACTIONS=true', () => {
+    writePlan(tmpRoot, 'complete', 'ci-annotated', dirtyBody);
+
+    const { status, stdout } = runScript(tmpRoot, {
+      diff: 'A\tplans/complete/ci-annotated.md',
+      ci: true,
+    });
+
+    expect(status).toBe(1);
+    expect(stdout).toMatch(
+      /::error file=plans\/complete\/ci-annotated\.md,line=\d+::ERROR-PLAN-001:/
+    );
+  });
+});

--- a/tests/integration/validate-plans.test.ts
+++ b/tests/integration/validate-plans.test.ts
@@ -199,6 +199,20 @@ describe('validate-plans — rename routing (R-record)', () => {
     expect(stdout + stderr).toMatch(/ERROR-PLAN-001/);
     expect(stdout + stderr).toMatch(/archived-dirty\.md/);
   });
+
+  it('FAIL: copy (C-record) into plans/complete/ with stray boxes is scanned like a rename', () => {
+    // `git config diff.renames=copies` emits C<score> records. The
+    // destination is a real archival path and must be gated the same as R.
+    writePlan(tmpRoot, 'complete', 'archived-copy', dirtyBody);
+
+    const { status, stdout, stderr } = runScript(tmpRoot, {
+      diff: 'C100\tplans/source.md\tplans/complete/archived-copy.md',
+    });
+
+    expect(status).toBe(1);
+    expect(stdout + stderr).toMatch(/ERROR-PLAN-001/);
+    expect(stdout + stderr).toMatch(/archived-copy\.md/);
+  });
 });
 
 describe('validate-plans — soft-skip and edge cases', () => {
@@ -247,6 +261,35 @@ describe('validate-plans — soft-skip and edge cases', () => {
 
     expect(status).toBe(0);
     expect(stdout).toMatch(/no plans\/complete\/ changes in diff/);
+  });
+
+  it('PASS (ENOENT deletion race): diff lists a file absent from disk → exit 0, no error', () => {
+    // The diff says the file changed, but it is gone from the working tree
+    // (a later commit on the branch removed it). This is an expected race,
+    // not a failure.
+    const { status, stdout, stderr } = runScript(tmpRoot, {
+      diff: 'A\tplans/complete/never-existed.md',
+    });
+
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/checked 1 file\(s\); 0 error\(s\)/);
+    expect(stderr).not.toMatch(/could not read/);
+  });
+
+  it('FAIL (non-ENOENT read error): unreadable plan file exits 1 with a read error, not a silent pass', () => {
+    // Create a DIRECTORY where a .md file is expected. readFileSync on a
+    // directory throws EISDIR — a non-ENOENT error that signals the file
+    // should have been scanned but could not be. The validator must fail
+    // loudly (exit 1) rather than report a misleading clean run.
+    mkdirSync(join(tmpRoot, 'complete', 'is-a-dir.md'), { recursive: true });
+
+    const { status, stderr } = runScript(tmpRoot, {
+      diff: 'A\tplans/complete/is-a-dir.md',
+    });
+
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/could not read/);
+    expect(stderr).toMatch(/is-a-dir\.md/);
   });
 
   it('emits GHA annotation when GITHUB_ACTIONS=true', () => {


### PR DESCRIPTION
Adds scripts/validate-plans.js: a CI gate that fails when a PR adds or modifies
a file under plans/complete/ containing stray unchecked task boxes (- [ ]).
Catches premature archival without blocking on legacy dirty plans (PR-scoping).

Mirrors the validate-solutions.js template (#553):
- git diff --name-status -z parse with R<score> rename routing
  (catches archival via git mv plans/foo.md plans/complete/foo.md)
- PLAN_VALIDATOR_DIFF synthetic-injection env for test ergonomics
- inline emitError/emitNotice with ::error file=... GHA annotations
- path-traversal guard with vitest tmpdir exception
- soft-skip on unreachable BASE_REF (fork PR / shallow clone)

Error code: ERROR-PLAN-001 (PLAN_STRAY_CHECKBOX). Added across two files in
packages/domain/src/validation/: types.ts (new ErrorCategory.PLAN_LIFECYCLE)
and errorCatalog.ts (catalog entry + getErrorCodesByCategory mapping).
Validator assembles 'ERROR-' + 'PLAN' + '-001' via concatenation so
scripts/lint-error-codes.js does not flag it as catalog re-implementation
(same ESM/CJS bridge constraint as validate-solutions.js).

CI: 6th matrix target in .github/workflows/validate-schemas.yml, inheriting
the < 2-min job timeout and fork-PR gate. paths: trigger extended with
plans/** (packages/**/*.ts already covers errorCatalog.ts).

Tests: tests/integration/validate-plans.test.ts (12 cases) covers clean/dirty
adds, modifies, rename routing, soft-skip, path-traversal, empty diff,
deletion records, and GHA annotation formatting.

No changeset required - no plugins/* files touched.

PR #1 of 2-PR stack defined in plans/plan-lifecycle-management.md. The plan
file is also updated in this commit (2026-05-28 refresh + deepen-plan
validation against current codebase patterns).

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Solution doc

<!--
Pick one:
  - "Co-shipped — see docs/solutions/<category>/<slug>.md in this PR"
  - "Tracked separately in #<follow-up PR>"
  - "Skip: <reason — typo / version bump / behavior already covered by
    docs/solutions/<category>/<existing>.md / etc.>"

See CONTRIBUTING.md "Solution Docs" for the policy and skip criteria.
Run `/workflows:compound --in-pr` to draft the doc + MEMORY.md line from
the PR body and commits.
-->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->
