### PR TITLE
feat(yellow-core): /plan:status + /plan:complete lifecycle commands

### DIFF
--- a/.changeset/plan-lifecycle-commands.md
+++ b/.changeset/plan-lifecycle-commands.md
@@ -1,0 +1,51 @@
+---
+'yellow-core': minor
+---
+
+feat(yellow-core): `/plan:status` and `/plan:complete` lifecycle commands
+for the plan-archival corpus
+
+Adds two commands under the new `/plan:*` namespace, sibling to
+`/workflows:plan` (plan creation lives under `/workflows:*`; lifecycle
+ops on existing plans live under `/plan:*` — namespace split documented
+in `plugins/yellow-core/CLAUDE.md`).
+
+- **`/plan:status`** — read-only dashboard. Walks `plans/*.md` (open)
+  and `plans/complete/*.md` (archived), counts checked / unchecked task
+  boxes per file, renders a plain-text table. Open plans at 100% are
+  annotated `-- ready to complete`.
+- **`/plan:complete <plan>`** — archive a single open plan via two
+  gates:
+  - **Gate A** scans the plan body for `^[[:space:]]*- \[ \]`; any
+    unchecked task box is a hard block.
+  - **Gate C** queries GitHub for a merged PR via
+    `gh pr list --state merged --search 'in:title "<slug>"'` and
+    post-filters on `headRefName` with a word-boundary regex
+    (`^|$|/|_|-` around `<slug>`). Word-boundary protection blocks
+    short/generic slugs (e.g., `refactor`) from matching unrelated
+    branches. NO-EVIDENCE prompts via `AskUserQuestion` with an
+    `Other` (free-text) option for a PR-number override; the decision
+    is recorded as a `Plan-Verifier-Override:` commit trailer.
+  - Archival branch is `plan/archive-<slug>`; the rename is staged via
+    `git mv` and submitted with `gt stack submit --no-interactive`.
+
+Companion (already shipped in the bottom of the stack — PR #556):
+
+- `scripts/validate-plans.js` — PR-diff-scoped CI gate that enforces
+  the same Gate A rule on `plans/complete/*.md` files added or modified
+  in the diff. Catches premature archival without re-touching legacy
+  dirty plans (54 % of the 71-file archived corpus has stray boxes as
+  of 2026-05-28; PR-scoping sidesteps them entirely).
+- `ErrorCategory.PLAN_LIFECYCLE` + `ERROR-PLAN-001` (PLAN_STRAY_CHECKBOX)
+  in the canonical catalog at `packages/domain/src/validation/`.
+
+Smoke tests at `plugins/yellow-core/tests/plan-commands.bats` exercise
+the slug-derivation regex and the Gate A `grep -c` regex on fixtures
+(14 cases, all passing). End-to-end `/plan:complete` flow involves
+`AskUserQuestion` + `gh` + `gt` and is documented as a manual
+verification checklist in `plans/plan-lifecycle-management.md`.
+
+Solution doc at `docs/solutions/workflow/plan-lifecycle-management.md`
+captures the load-bearing decisions (runtime slug derivation,
+single-`gh`-call Gate C, override trailer convention, PR-diff scoping
+rationale).

--- a/.changeset/plan-lifecycle-commands.md
+++ b/.changeset/plan-lifecycle-commands.md
@@ -27,7 +27,7 @@ in `plugins/yellow-core/CLAUDE.md`).
     `Other` (free-text) option for a PR-number override; the decision
     is recorded as a `Plan-Verifier-Override:` commit trailer.
   - Archival branch is `plan/archive-<slug>`; the rename is staged via
-    `git mv` and submitted with `gt stack submit --no-interactive`.
+    `git mv` and submitted with `gt submit --no-interactive`.
 
 Companion (already shipped in the bottom of the stack — PR #556):
 

--- a/docs/solutions/workflow/plan-lifecycle-management.md
+++ b/docs/solutions/workflow/plan-lifecycle-management.md
@@ -1,0 +1,168 @@
+---
+title: 'Plan lifecycle management: status dashboard + two-gate archival'
+date: 2026-05-28
+category: workflow
+track: knowledge
+problem: 'No machine-readable signal for plan completion; manual git mv archival is error-prone and gives no audit trail when work has not actually shipped'
+tags: [yellow-core, validators, gh-cli, graphite, slug-derivation]
+---
+
+## Context
+
+Plans live as markdown in `plans/` (open) and `plans/complete/`
+(archived). Pre-2026-05 the only archival mechanism was a manual
+`git mv plans/foo.md plans/complete/foo.md` commit. Six such commits
+landed in 48 hours (2026-05-08), confirming the friction was real.
+There was no authoritative way to ask "which plans are open?", "is this
+plan ready to archive?", or "did the work actually ship?". The
+underlying corpus also accumulated 38 of 71 archived files (54 %)
+containing stray unchecked task boxes (`- [ ]`) — a naive whole-corpus
+gate would have blocked CI from day one.
+
+## Decision
+
+Two commands plus one PR-diff-scoped CI validator, all under
+yellow-core. Zero migration, zero new file format, zero LLM in the
+loop.
+
+- **`/plan:status`** (yellow-core): read-only dashboard of `plans/` +
+  `plans/complete/` with per-file `[ <checked>/<total> ]` rendering.
+  100 %-complete open plans annotated `-- ready to complete`.
+- **`/plan:complete <plan>`** (yellow-core): two gates plus
+  `gt`-managed archival.
+- **`scripts/validate-plans.js`** (root-level): PR-diff-scoped CI gate
+  that enforces no-stray-checkbox on `plans/complete/*.md` files added
+  or modified in the diff. Wired as a 6th matrix target in
+  `.github/workflows/validate-schemas.yml`.
+
+### Load-bearing design choices (recorded so future readers can skip the rationale)
+
+1. **No frontmatter convention.** Slug is derived at runtime from the
+   filename:
+
+   ```bash
+   basename "$PLAN" .md | sed 's/^[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-//'
+   ```
+
+   The `plans/` vs `plans/complete/` directory split is the single
+   source of truth for state. An earlier plan draft proposed a
+   `slug:`/`created:` frontmatter convention with a 47-file backfill
+   migration; PR review (#494) collapsed it in favour of runtime
+   derivation. Filename slug survives renames as long as the rename is
+   deliberate.
+
+2. **Validator scopes to PR-touched files, not the whole corpus.**
+   The validator runs `git diff --name-status -z "$BASE_REF...HEAD"`
+   and inspects only added (`A`) or modified (`M`) entries plus
+   rename (`R<score>`) destination paths under `plans/complete/`.
+   Legacy stray-checkbox files are never re-touched, so the validator
+   never sees them. No escape-hatch frontmatter needed. The
+   stray-box ratio worsened from 36 % (16 / 44) to 54 % (38 / 71)
+   between 2026-05-09 and 2026-05-28, which strengthens this choice:
+   any future whole-corpus gate would be progressively harder to
+   enable.
+
+3. **Gate C is a single `gh` call, no agent.** Pattern:
+
+   ```bash
+   MERGED=$(gh pr list \
+     --search "in:title \"$SLUG\"" \
+     --state merged \
+     --limit 100 \
+     --json number,title,headRefName,url \
+     --jq '[.[] | select(.headRefName | test("(^|[/_-])'"$SLUG"'($|[/_-])"))]')
+   COUNT=$(printf '%s' "$MERGED" | jq 'length')
+   ```
+
+   PASS if `COUNT >= 1`. NO-EVIDENCE prompts the user via
+   `AskUserQuestion`; the override is captured as a commit trailer
+   (see below). An earlier plan draft proposed a 3-check
+   `plan-verifier` agent with an 8-row PR/commit/file truth table;
+   PR review (#494, #496) collapsed it because the single `gh` call
+   covers the same surface with no token spend.
+
+### Word-boundary post-filter on `headRefName`
+
+GitHub's `in:title` qualifier is **token-based, case-insensitive, and
+hyphens act as token separators** (GitHub Community Discussion #17956).
+A query `in:title "foo-bar"` tokenizes to `[foo, bar]` and matches a
+PR titled `foo bar`. There is no exact-string mode for issue/PR title
+search even with quotes. So the title search is a coarse pre-filter
+only; the authoritative match is the `--jq` post-filter that requires
+`$SLUG` to be separated from surrounding characters in `headRefName`
+by `^`, `$`, `/`, `_`, or `-`. This blocks short or generic slugs
+(`refactor`, `fix`, `wip`) from matching unrelated branches whose
+names contain the slug as a substring inside another word.
+
+Server-side `--state merged` is preferred over reading `mergedAt`:
+per [merge-queue-closed-pr-null-mergedat-detection.md](../integration-issues/merge-queue-closed-pr-null-mergedat-detection.md),
+`mergedAt` can be null for recently MQ-merged PRs during propagation
+lag. `--state merged` filters on PR state, which is authoritative
+once the upstream API has caught up.
+
+### `Plan-Verifier-Override:` commit trailer
+
+When Gate C finds zero matches and the user confirms via the
+`AskUserQuestion` "Other" free-text option, the archival commit
+captures the decision:
+
+```
+docs(plans): archive completed <slug> plan
+
+Verified by /plan:complete: user-confirmed override.
+
+Plan-Verifier-Override: user-confirmed-no-pr-evidence (pr=#<OVERRIDE_PR_NUM>)
+```
+
+The trailer is grep-discoverable via
+`git log --grep='Plan-Verifier-Override'` for future audit. The
+default (Gate C PASS) commit omits the trailer.
+
+### `Other` is the only AskUserQuestion free-text label
+
+Per MEMORY.md "AskUserQuestion 'Other' is the ONLY free-text button",
+the label of the override option in `/plan:complete` Phase 4 MUST be
+the literal string `Other`. Earlier drafts labelled it
+`Confirm with PR number`; that label shows as a click-only option and
+does NOT open the text-input affordance. This is enforced by prose in
+the command body; the bats smoke tests do not exercise the
+AskUserQuestion flow.
+
+### Commit invocation: plain `git commit -m -m`, not `gt commit create -m -m`
+
+Bottom-of-stack PR #556 (validate-plans validator) empirically observed
+that `gt commit create -m "$SUBJECT" -m "$BODY"` concatenates the two
+`-m` values with a literal comma (`"subject,body line 1..."`). The
+plan task spec was patched to use plain `git commit -m "$SUBJECT" -m "$BODY"`
+which, per git docs, "concatenates as separate paragraphs" (subject
++ blank line + body). Graphite picks up the commit via the next
+`gt submit`.
+
+## Consequences
+
+- **No migration risk.** No existing plans are touched by either
+  command. Adding `/plan:status` is a pure read; `/plan:complete`
+  only acts on the plan the user explicitly named.
+- **CI gate is opt-in by design.** PRs that do not touch
+  `plans/complete/` are unaffected (the matrix-target case branch
+  no-ops). PRs that do trigger the gate at the < 2-minute timeout
+  inherited from the existing matrix shape.
+- **Override trailer makes "trust me" archival auditable.** Future
+  questions about "why was this plan archived without a matching
+  merged PR?" have a `git log --grep` answer.
+- **Token-based title search caveat is documented inline.** Anyone
+  modifying Gate C should preserve the word-boundary post-filter; if
+  the validator ever drops the regex check, short slugs become
+  vulnerable to false-positive matches.
+
+## References
+
+- Plan: [`plans/plan-lifecycle-management.md`](../../plans/plan-lifecycle-management.md)
+  (refreshed + deepen-plan-annotated 2026-05-28)
+- Bottom-of-stack PR: #556 — `scripts/validate-plans.js` validator,
+  catalog entry, integration tests, CI wiring
+- PR #484 review issues driving the design collapse: #494 (P0/P1
+  design), #496 (YAGNI scope reductions)
+- Merge-queue propagation gotcha:
+  [`docs/solutions/integration-issues/merge-queue-closed-pr-null-mergedat-detection.md`](../integration-issues/merge-queue-closed-pr-null-mergedat-detection.md)
+- Validator template reference: `scripts/validate-solutions.js` (#553)

--- a/plans/plan-lifecycle-management.md
+++ b/plans/plan-lifecycle-management.md
@@ -605,7 +605,7 @@ No new packages. `gh`, `git`, and `gt` are already required by the repo.
 
 <!-- Updated by workflows:work. Do not edit manually. -->
 - [x] 1. agent/feat/validate-plans-pr-scoped (submitted 2026-05-28 — PR #556 https://github.com/KingInYellows/yellow-plugins/pull/556)
-- [ ] 2. agent/feat/plan-commands
+- [x] 2. agent/feat/plan-commands (submitted 2026-05-28 — PR #557 https://github.com/KingInYellows/yellow-plugins/pull/557)
 
 ## References
 

--- a/plugins/yellow-core/CLAUDE.md
+++ b/plugins/yellow-core/CLAUDE.md
@@ -104,7 +104,7 @@ Comprehensive dev toolkit for TypeScript, Python, Rust, and Go projects.
   `AskUserQuestion` "Other" label for a PR-number override; the
   decision is captured in a `Plan-Verifier-Override:` commit trailer.
   Archival branch is `plan/archive-<slug>`; submitted via
-  `gt stack submit --no-interactive`. The companion PR-diff-scoped
+  `gt submit --no-interactive`. The companion PR-diff-scoped
   validator `scripts/validate-plans.js` enforces the same
   no-stray-checkbox rule on archived files in CI
 - `/statusline:setup` — generate and install an adaptive statusline showing context, git, MCP health

--- a/plugins/yellow-core/CLAUDE.md
+++ b/plugins/yellow-core/CLAUDE.md
@@ -71,7 +71,7 @@ Comprehensive dev toolkit for TypeScript, Python, Rust, and Go projects.
   background-compounding plan); RULE 14 in
   `scripts/validate-agent-authoring.js` blocks any removal of this deny
 
-### Commands (10)
+### Commands (12)
 
 - `/workflows:brainstorm` — explore requirements through dialogue and research before planning
 - `/workflows:plan` — transform feature descriptions into structured plans
@@ -91,6 +91,22 @@ Comprehensive dev toolkit for TypeScript, Python, Rust, and Go projects.
 - `/compound:review-staged` — manually drain the background-compounding
   staging ledger ahead of the SessionStart auto-drain threshold;
   AskUserQuestion M3 gate before any bulk write
+- `/plan:status` — read-only dashboard of `plans/` (open) and
+  `plans/complete/` (archived) with per-file checkbox progress; 100%
+  open plans annotated `-- ready to complete`. Sibling of
+  `/plan:complete` and `/workflows:plan` (see "Plan namespace split"
+  below)
+- `/plan:complete` — archive a single open plan with two safety gates:
+  Gate A scans for unchecked `- [ ]` boxes; Gate C queries GitHub for
+  a merged PR whose title and branch contain the slug derived from the
+  filename (server-side `--state merged` + `--jq` word-boundary
+  post-filter on `headRefName`). NO-EVIDENCE prompts the user via
+  `AskUserQuestion` "Other" label for a PR-number override; the
+  decision is captured in a `Plan-Verifier-Override:` commit trailer.
+  Archival branch is `plan/archive-<slug>`; submitted via
+  `gt stack submit --no-interactive`. The companion PR-diff-scoped
+  validator `scripts/validate-plans.js` enforces the same
+  no-stray-checkbox rule on archived files in CI
 - `/statusline:setup` — generate and install an adaptive statusline showing context, git, MCP health
 - `/setup:all` — run setup for all installed marketplace plugins with unified dashboard
 - `/setup:claude-web` — audit a repository and scaffold the files Claude Code
@@ -252,6 +268,30 @@ detects this via `cs_detect_auth_route` and logs the chosen route to
 `drain-logs/`. Per-drain cost is observability-only under subscription
 auth (~5-20 short-message rate-limit equivalents per drain against the
 Max 20x 5h window); the API-route fork is ~$0.13-0.17/drain.
+
+## Plan Namespace Split
+
+The plugin uses two distinct namespaces for plan-related commands:
+
+- **`/workflows:*`** — end-to-end workflows that produce new artifacts.
+  `/workflows:plan` writes a new plan file from a feature description;
+  `/workflows:work` executes one. Plan creation lives here because it is
+  one of several artifact-producing workflows (alongside `brainstorm`,
+  `review`, `compound`).
+- **`/plan:*`** — lifecycle operations on existing plan artifacts.
+  `/plan:status` (read-only dashboard) and `/plan:complete` (archival
+  with Gate A + Gate C) are not general workflows; they operate
+  specifically on the corpus of `plans/*.md` files. Future authors
+  adding plan-related lifecycle commands should put them under
+  `/plan:*`.
+
+The PR-diff-scoped validator `scripts/validate-plans.js` (root-level)
+enforces no-stray-checkbox on archived files in PR diffs. It is wired
+as a 6th matrix target in `.github/workflows/validate-schemas.yml` (sibling
+to the marketplace/plugins/contracts/examples/solutions targets), not
+inside `validate:schemas` itself. The error code is `ERROR-PLAN-001`
+(catalog: `packages/domain/src/validation/errorCatalog.ts`, category
+`ErrorCategory.PLAN_LIFECYCLE`).
 
 ## Known Limitations
 

--- a/plugins/yellow-core/README.md
+++ b/plugins/yellow-core/README.md
@@ -30,6 +30,7 @@ TypeScript, Python, Rust, and Go.
 | `/statusline:setup`     | Generate and install an adaptive statusline for plugins            |
 | `/setup:all`            | Run setup for all installed marketplace plugins with unified dashboard |
 | `/setup:claude-web`     | Audit a repository and scaffold files Claude Code Web needs (`.claude/settings.json`, `scripts/install_pkgs.sh`, `.gitattributes`, `.gitignore`, `.github/workflows/claude.yml`) |
+| `/worktree:cleanup`     | Scan git worktrees, classify by state, and remove stale worktrees with safeguards |
 
 ## Agents
 

--- a/plugins/yellow-core/README.md
+++ b/plugins/yellow-core/README.md
@@ -25,6 +25,8 @@ TypeScript, Python, Rust, and Go.
 | `/workflows:review`     | Session-level review of plan adherence, cross-PR coherence, and scope drift |
 | `/workflows:compound`   | Document a recently solved problem to compound knowledge. Pass `--in-pr` while on a feature branch with an open PR to draft the doc + MEMORY.md line from the PR body and commits (the default pattern in CONTRIBUTING.md "Solution Docs") |
 | `/compound:review-staged` | Manually drain the background-compounding staging ledger (M3-gated) |
+| `/plan:status`          | Read-only dashboard of `plans/` (open) and `plans/complete/` (archived) with per-file checkbox progress |
+| `/plan:complete`        | Archive a completed plan with two safety gates: Gate A scans for unchecked task boxes; Gate C verifies a same-named merged PR exists |
 | `/statusline:setup`     | Generate and install an adaptive statusline for plugins            |
 | `/setup:all`            | Run setup for all installed marketplace plugins with unified dashboard |
 | `/setup:claude-web`     | Audit a repository and scaffold files Claude Code Web needs (`.claude/settings.json`, `scripts/install_pkgs.sh`, `.gitattributes`, `.gitignore`, `.github/workflows/claude.yml`) |

--- a/plugins/yellow-core/commands/plan/complete.md
+++ b/plugins/yellow-core/commands/plan/complete.md
@@ -47,6 +47,12 @@ command -v gh >/dev/null 2>&1 || { printf '[plan:complete] error: gh not install
 command -v gt >/dev/null 2>&1 || { printf '[plan:complete] error: gt not installed\n' >&2; exit 1; }
 command -v jq >/dev/null 2>&1 || { printf '[plan:complete] error: jq not installed\n' >&2; exit 1; }
 gh auth status >/dev/null 2>&1 || { printf '[plan:complete] error: gh not authenticated (run: gh auth login)\n' >&2; exit 1; }
+# Clear any stale state from a prior aborted run. Without this, a previous
+# run that wrote .git/tmp/plan-complete.override then cancelled at Phase 5
+# would leave the file behind, and the NEXT run for a different plan would
+# stamp that stale PR number into its commit trailer (review finding,
+# correctness + adversarial).
+rm -f .git/tmp/plan-complete.count .git/tmp/plan-complete.merged.json .git/tmp/plan-complete.override
 ```
 
 ## Phase 1: Filename validation + slug derivation
@@ -58,7 +64,7 @@ in bash code blocks". The block below derives both `CLEAN_ARG` and
 
 ```bash
 set -euo pipefail
-ARG='#$ARGUMENTS'
+ARG="$ARGUMENTS"
 if [ -z "$ARG" ]; then
   printf '[plan:complete] error: missing plan filename argument\n' >&2
   exit 1
@@ -87,7 +93,7 @@ printf '[plan:complete] arg=%s slug=%s\n' "$CLEAN_ARG" "$SLUG"
 
 ```bash
 set -euo pipefail
-ARG='#$ARGUMENTS'
+ARG="$ARGUMENTS"
 CLEAN_ARG="${ARG#plans/}"
 if [ -f "plans/complete/$CLEAN_ARG" ]; then
   printf '[plan:complete] already archived: plans/complete/%s exists. Nothing to do.\n' "$CLEAN_ARG" >&2
@@ -99,6 +105,10 @@ if [ ! -f "plans/$CLEAN_ARG" ]; then
 fi
 ```
 
+**If the bash block above exited 0 with an "already archived" message,
+stop the workflow — do not proceed to Phase 3.** (The early `exit 0` ends
+the subprocess but not your turn; this instruction ends the turn.)
+
 ## Phase 3: Gate A — unchecked-box scan
 
 The same mechanical check applied by `scripts/validate-plans.js` on
@@ -107,7 +117,7 @@ before any branch is created.
 
 ```bash
 set -euo pipefail
-ARG='#$ARGUMENTS'
+ARG="$ARGUMENTS"
 CLEAN_ARG="${ARG#plans/}"
 UNCHECKED=$(grep -cE '^[[:space:]]*- \[ \]' "plans/$CLEAN_ARG" 2>/dev/null || true)
 : "${UNCHECKED:=0}"
@@ -132,16 +142,26 @@ which enforces a word boundary (`^|$|/|_|-`) around `$SLUG`.
 
 ```bash
 set -euo pipefail
-ARG='#$ARGUMENTS'
+ARG="$ARGUMENTS"
 CLEAN_ARG="${ARG#plans/}"
 SLUG=$(basename "$CLEAN_ARG" .md | sed 's/^[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-//')
+# Capture stderr (not /dev/null) so an auth/network failure is surfaced
+# rather than silently collapsing to "no PR found" → spurious override
+# prompt (review finding, pattern-recognition P1). A genuine empty result
+# is `[]` with exit 0; a real failure prints to GH_ERR and we warn.
+GH_ERR=$(mktemp)
 # shellcheck disable=SC2016
 MERGED=$(gh pr list \
   --search "in:title \"$SLUG\"" \
   --state merged \
   --limit 100 \
   --json number,title,headRefName,url \
-  --jq '[.[] | select(.headRefName | test("(^|[/_-])'"$SLUG"'($|[/_-])"))]' 2>/dev/null) || MERGED='[]'
+  --jq '[.[] | select(.headRefName | test("(^|[/_-])'"$SLUG"'($|[/_-])"))]' 2>"$GH_ERR") || {
+  printf '[plan:complete] WARNING: gh pr list failed (auth/network?): %s\n' "$(cat "$GH_ERR")" >&2
+  printf '[plan:complete] Treating as no-evidence; you will be prompted to confirm or cancel.\n' >&2
+  MERGED='[]'
+}
+rm -f "$GH_ERR"
 COUNT=$(printf '%s' "$MERGED" | jq 'length' 2>/dev/null || printf '0')
 printf '[plan:complete] Gate C: %d merged PR(s) match slug %s with word boundary\n' "$COUNT" "$SLUG"
 if [ "$COUNT" -ge 1 ]; then
@@ -153,6 +173,9 @@ mkdir -p .git/tmp
 printf '%s\n' "$COUNT" > .git/tmp/plan-complete.count
 printf '%s\n' "$MERGED" > .git/tmp/plan-complete.merged.json
 ```
+
+**If `COUNT >= 1` (Gate C PASS): skip the AskUserQuestion below entirely
+and proceed directly to Phase 5.** Only when `COUNT == 0` do you prompt.
 
 If `COUNT == 0`, prompt the user via `AskUserQuestion` with the
 following options. **The label of the free-text option MUST be the
@@ -177,12 +200,18 @@ If the user picks `Cancel`, **stop the workflow** — do not proceed to
 the next phase.
 
 If the user enters a PR number via `Other`, persist it for the commit
-trailer in Phase 7:
+trailer in Phase 7. **Substitute `<USER_RESPONSE_FROM_OTHER>` in the
+block below with the exact text the user typed in the AskUserQuestion
+"Other" input field** — do not run the block with the literal
+placeholder.
 
 ```bash
 set -euo pipefail
 # Validate the user-provided PR number is a bare positive integer.
-PR_NUM='<USER_RESPONSE_FROM_OTHER>'
+# Strip CR/LF first so a multi-line paste cannot smuggle extra content
+# past the per-line grep into the commit trailer (review finding,
+# security P2 — trailer injection).
+PR_NUM=$(printf '%s' '<USER_RESPONSE_FROM_OTHER>' | tr -d '\r\n')
 if ! printf '%s' "$PR_NUM" | grep -qE '^[1-9][0-9]{0,9}$'; then
   printf '[plan:complete] error: invalid PR number override %s\n' "$PR_NUM" >&2
   exit 1
@@ -198,35 +227,48 @@ unrelated WIP to preserve. AskUserQuestion confirms before proceeding.
 
 ```bash
 set -euo pipefail
-if [ -n "$(git status --porcelain)" ]; then
-  printf '[plan:complete] working tree is not clean. Uncommitted changes will be carried into the archival branch.\n' >&2
-  git status --short
-  printf '\n'
+PORCELAIN=$(git status --porcelain)
+if [ -n "$PORCELAIN" ]; then
+  printf '[plan:complete] DIRTY_TREE=1\n'
+  printf '%s\n' "$PORCELAIN"
+  # Tracked, modified files (index or worktree M/A/D/R in the first two
+  # columns, excluding untracked '??') will make the `git checkout main`
+  # in Phase 6 fail under `set -e`. Warn specifically so the user can
+  # stash rather than picking Proceed and stranding the run mid-checkout.
+  if printf '%s\n' "$PORCELAIN" | grep -qE '^[ MADRC]'; then
+    printf '[plan:complete] NOTE: tracked changes present — git checkout main in Phase 6 may refuse. Consider stashing before Proceed.\n' >&2
+  fi
+else
+  printf '[plan:complete] DIRTY_TREE=0\n'
 fi
 ```
 
-If the working tree was non-empty, **ask via AskUserQuestion**:
+**If the block printed `DIRTY_TREE=0`, skip the AskUserQuestion below and
+proceed directly to Phase 6.** Only when it printed `DIRTY_TREE=1` do you
+prompt via `AskUserQuestion`:
 
 - Question: `Working tree has uncommitted changes. Proceed with
   archival anyway?`
 - Header: `Dirty tree`
 - Options:
   - Label: `Proceed` — Description: `Carry the WIP into the archival
-    branch. You can resolve conflicts later.`
+    branch. If a NOTE about tracked changes appeared, stash first — the
+    checkout in Phase 6 will refuse otherwise.`
   - Label: `Cancel` — Description: `Stop. Commit or stash the WIP
     first.`
 
-If `Cancel`, stop.
+If `Cancel`, **stop the workflow** — do not proceed to Phase 6.
 
 ## Phase 6: Sync trunk + create archival branch
 
 ```bash
 set -euo pipefail
-ARG='#$ARGUMENTS'
+ARG="$ARGUMENTS"
 CLEAN_ARG="${ARG#plans/}"
 SLUG=$(basename "$CLEAN_ARG" .md | sed 's/^[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-//')
 git checkout main
-gt repo sync 2>/dev/null || gt sync 2>/dev/null || true
+gt repo sync 2>/dev/null || gt sync 2>/dev/null || \
+  printf '[plan:complete] WARNING: gt sync failed; proceeding on possibly-stale trunk\n' >&2
 gt create "plan/archive-$SLUG"
 mkdir -p plans/complete
 # git mv (not bare mv): records the rename in the index immediately
@@ -246,7 +288,7 @@ commit on the current branch via `gt submit` in Phase 8.
 
 ```bash
 set -euo pipefail
-ARG='#$ARGUMENTS'
+ARG="$ARGUMENTS"
 CLEAN_ARG="${ARG#plans/}"
 SLUG=$(basename "$CLEAN_ARG" .md | sed 's/^[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-//')
 COUNT=$(cat .git/tmp/plan-complete.count 2>/dev/null || printf '0')

--- a/plugins/yellow-core/commands/plan/complete.md
+++ b/plugins/yellow-core/commands/plan/complete.md
@@ -48,11 +48,15 @@ command -v gt >/dev/null 2>&1 || { printf '[plan:complete] error: gt not install
 command -v jq >/dev/null 2>&1 || { printf '[plan:complete] error: jq not installed\n' >&2; exit 1; }
 gh auth status >/dev/null 2>&1 || { printf '[plan:complete] error: gh not authenticated (run: gh auth login)\n' >&2; exit 1; }
 # Clear any stale state from a prior aborted run. Without this, a previous
-# run that wrote .git/tmp/plan-complete.override in Phase 4 then cancelled at
-# the Phase 5 dirty-tree prompt would leave the file behind, and the NEXT run
-# for a different plan would stamp that stale PR number into its commit
-# trailer (review finding, correctness + adversarial).
-rm -f .git/tmp/plan-complete.count .git/tmp/plan-complete.override
+# run that wrote the override in Phase 4 then cancelled at the Phase 5
+# dirty-tree prompt would leave the file behind, and the NEXT run for a
+# different plan would stamp that stale PR number into its commit trailer
+# (review finding, correctness + adversarial).
+# Resolve the git tmp dir via `git rev-parse --git-path` so this works from a
+# linked worktree, where `.git` is a file (gitdir pointer) and a literal
+# `.git/tmp` path would fail with "Not a directory".
+GIT_TMP=$(git rev-parse --git-path tmp)
+rm -f "$GIT_TMP/plan-complete.count" "$GIT_TMP/plan-complete.override"
 ```
 
 ## Phase 1: Filename validation + slug derivation
@@ -71,9 +75,15 @@ if [ -z "$ARG" ]; then
 fi
 # Strip leading `plans/` for tab-completion ergonomics.
 CLEAN_ARG="${ARG#plans/}"
-# Reject path traversal, slashes, leading hyphen, and uppercase.
-if ! printf '%s' "$CLEAN_ARG" | grep -qE '^[a-z0-9_][a-z0-9_.-]*\.md$'; then
-  printf '[plan:complete] error: invalid filename %s (lowercase [a-z0-9_.-]+ + .md)\n' "$CLEAN_ARG" >&2
+# Reject path traversal, slashes, leading hyphen, and uppercase. The pattern
+# mirrors the post-derivation slug contract below (optional YYYY-MM-DD- date
+# prefix + lowercase kebab-case) so an invalid name is rejected HERE with a
+# clear message rather than passing this gate and failing later as a
+# confusing "derived slug contains invalid characters" error. Underscores
+# and dots are intentionally excluded: a dot in a slug becomes a regex
+# wildcard in the Phase 4 headRefName boundary test.
+if ! printf '%s' "$CLEAN_ARG" | grep -qE '^([0-9]{4}-[0-9]{2}-[0-9]{2}-)?[a-z0-9]+(-[a-z0-9]+)*\.md$'; then
+  printf '[plan:complete] error: invalid filename %s (optional YYYY-MM-DD- prefix + lowercase kebab-case + .md)\n' "$CLEAN_ARG" >&2
   exit 1
 fi
 # Derive slug: strip optional YYYY-MM-DD- prefix.
@@ -169,9 +179,12 @@ if [ "$COUNT" -ge 1 ]; then
 fi
 # Store COUNT for the next step. Persist via temp file because the next
 # Bash block is a fresh subprocess. (The matched-PR list is already shown
-# inline above; only COUNT is consumed downstream in Phase 7.)
-mkdir -p .git/tmp
-printf '%s\n' "$COUNT" > .git/tmp/plan-complete.count
+# inline above; only COUNT is consumed downstream in Phase 7.) Resolve the
+# git tmp dir via `git rev-parse --git-path` so it works from a linked
+# worktree where `.git` is a gitdir-pointer file, not a directory.
+GIT_TMP=$(git rev-parse --git-path tmp)
+mkdir -p "$GIT_TMP"
+printf '%s\n' "$COUNT" > "$GIT_TMP/plan-complete.count"
 ```
 
 **If `COUNT >= 1` (Gate C PASS): skip the AskUserQuestion below entirely
@@ -223,8 +236,9 @@ if ! printf '%s' "$PR_NUM" | grep -qE '^[1-9][0-9]{0,9}$'; then
   printf '[plan:complete] error: invalid PR number override %s\n' "$PR_NUM" >&2
   exit 1
 fi
-mkdir -p .git/tmp
-printf '%s\n' "$PR_NUM" > .git/tmp/plan-complete.override
+GIT_TMP=$(git rev-parse --git-path tmp)
+mkdir -p "$GIT_TMP"
+printf '%s\n' "$PR_NUM" > "$GIT_TMP/plan-complete.override"
 ```
 
 ## Phase 5: Working-tree check
@@ -273,7 +287,13 @@ set -euo pipefail
 ARG="$ARGUMENTS"
 CLEAN_ARG="${ARG#plans/}"
 SLUG=$(basename "$CLEAN_ARG" .md | sed 's/^[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-//')
-git checkout main
+# Resolve the repo's default branch instead of hard-coding `main` — this
+# command ships in arbitrary repos whose trunk may be `master`/`develop`.
+# gh is a hard prerequisite (Phase 0); fall back to `main` if the lookup
+# returns nothing (e.g. no defaultBranchRef on a fresh repo).
+TRUNK=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || true)
+[ -n "$TRUNK" ] || TRUNK=main
+git checkout "$TRUNK"
 gt repo sync 2>/dev/null || gt sync 2>/dev/null || \
   printf '[plan:complete] WARNING: gt sync failed; proceeding on possibly-stale trunk\n' >&2
 gt create "plan/archive-$SLUG"
@@ -298,19 +318,25 @@ set -euo pipefail
 ARG="$ARGUMENTS"
 CLEAN_ARG="${ARG#plans/}"
 SLUG=$(basename "$CLEAN_ARG" .md | sed 's/^[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-//')
-COUNT=$(cat .git/tmp/plan-complete.count 2>/dev/null || printf '0')
+GIT_TMP=$(git rev-parse --git-path tmp)
+COUNT=$(cat "$GIT_TMP/plan-complete.count" 2>/dev/null || printf '0')
 SUBJECT="docs(plans): archive completed $SLUG plan"
-if [ -f .git/tmp/plan-complete.override ]; then
-  OVERRIDE_PR_NUM=$(cat .git/tmp/plan-complete.override)
+if [ -f "$GIT_TMP/plan-complete.override" ]; then
+  OVERRIDE_PR_NUM=$(cat "$GIT_TMP/plan-complete.override")
   BODY="Verified by /plan:complete: user-confirmed override.
 
 Plan-Verifier-Override: user-confirmed-no-pr-evidence (pr=#$OVERRIDE_PR_NUM)"
 else
   BODY="Verified by /plan:complete: $COUNT merged PR(s) found via gh pr list --state merged with word-boundary post-filter on headRefName."
 fi
-git commit -m "$SUBJECT" -m "$BODY"
+# Scope the commit to the plan-rename pathspecs only. If the user had
+# pre-staged unrelated WIP and chose Proceed at the Phase 5 dirty-tree
+# prompt, a bare `git commit` would bundle that WIP into the archival
+# commit; the explicit pathspecs commit only the git mv (delete of the
+# source + add of the destination).
+git commit -m "$SUBJECT" -m "$BODY" -- "plans/$CLEAN_ARG" "plans/complete/$CLEAN_ARG"
 # Clean up temp files.
-rm -f .git/tmp/plan-complete.count .git/tmp/plan-complete.override
+rm -f "$GIT_TMP/plan-complete.count" "$GIT_TMP/plan-complete.override"
 ```
 
 The `Plan-Verifier-Override:` trailer is grep-discoverable via

--- a/plugins/yellow-core/commands/plan/complete.md
+++ b/plugins/yellow-core/commands/plan/complete.md
@@ -25,8 +25,8 @@ Archives a single open plan from `plans/<arg>.md` to
 
 This command does NOT delete the source file or push directly to main —
 it creates an archival branch (`plan/archive-<slug>`), records the
-rename via `git mv`, commits, and submits via `gt stack submit`. Review
-and merge land via the normal PR flow.
+rename via `git mv`, commits, and submits via `gt submit --no-interactive`.
+Review and merge land via the normal PR flow.
 
 Sibling commands: `/plan:status` (read-only dashboard),
 `/workflows:plan` (creates plans). See `plugins/yellow-core/CLAUDE.md`
@@ -48,11 +48,11 @@ command -v gt >/dev/null 2>&1 || { printf '[plan:complete] error: gt not install
 command -v jq >/dev/null 2>&1 || { printf '[plan:complete] error: jq not installed\n' >&2; exit 1; }
 gh auth status >/dev/null 2>&1 || { printf '[plan:complete] error: gh not authenticated (run: gh auth login)\n' >&2; exit 1; }
 # Clear any stale state from a prior aborted run. Without this, a previous
-# run that wrote .git/tmp/plan-complete.override then cancelled at Phase 5
-# would leave the file behind, and the NEXT run for a different plan would
-# stamp that stale PR number into its commit trailer (review finding,
-# correctness + adversarial).
-rm -f .git/tmp/plan-complete.count .git/tmp/plan-complete.merged.json .git/tmp/plan-complete.override
+# run that wrote .git/tmp/plan-complete.override in Phase 4 then cancelled at
+# the Phase 5 dirty-tree prompt would leave the file behind, and the NEXT run
+# for a different plan would stamp that stale PR number into its commit
+# trailer (review finding, correctness + adversarial).
+rm -f .git/tmp/plan-complete.count .git/tmp/plan-complete.override
 ```
 
 ## Phase 1: Filename validation + slug derivation
@@ -168,10 +168,10 @@ if [ "$COUNT" -ge 1 ]; then
   printf '%s\n' "$MERGED" | jq -r '.[] | "  #\(.number) — \(.title)\n    \(.url)"'
 fi
 # Store COUNT for the next step. Persist via temp file because the next
-# Bash block is a fresh subprocess.
+# Bash block is a fresh subprocess. (The matched-PR list is already shown
+# inline above; only COUNT is consumed downstream in Phase 7.)
 mkdir -p .git/tmp
 printf '%s\n' "$COUNT" > .git/tmp/plan-complete.count
-printf '%s\n' "$MERGED" > .git/tmp/plan-complete.merged.json
 ```
 
 **If `COUNT >= 1` (Gate C PASS): skip the AskUserQuestion below entirely
@@ -208,10 +208,17 @@ placeholder.
 ```bash
 set -euo pipefail
 # Validate the user-provided PR number is a bare positive integer.
-# Strip CR/LF first so a multi-line paste cannot smuggle extra content
-# past the per-line grep into the commit trailer (review finding,
-# security P2 — trailer injection).
-PR_NUM=$(printf '%s' '<USER_RESPONSE_FROM_OTHER>' | tr -d '\r\n')
+# Read the user's typed value through a QUOTED heredoc so no shell
+# metacharacter in the input (e.g. a stray quote or `$`) can break out
+# of the substitution before validation runs — this is the canonical
+# "free text into shell" pattern (MEMORY.md "Heredoc for user-supplied
+# free text"). The collision-resistant delimiter avoids premature close.
+# tr -d strips CR/LF so a multi-line paste cannot smuggle extra content
+# past the grep into the commit trailer (trailer injection).
+PR_NUM=$(tr -d '\r\n' <<'__EOF_PR_OVERRIDE__'
+<USER_RESPONSE_FROM_OTHER>
+__EOF_PR_OVERRIDE__
+)
 if ! printf '%s' "$PR_NUM" | grep -qE '^[1-9][0-9]{0,9}$'; then
   printf '[plan:complete] error: invalid PR number override %s\n' "$PR_NUM" >&2
   exit 1
@@ -303,7 +310,7 @@ else
 fi
 git commit -m "$SUBJECT" -m "$BODY"
 # Clean up temp files.
-rm -f .git/tmp/plan-complete.count .git/tmp/plan-complete.merged.json .git/tmp/plan-complete.override
+rm -f .git/tmp/plan-complete.count .git/tmp/plan-complete.override
 ```
 
 The `Plan-Verifier-Override:` trailer is grep-discoverable via

--- a/plugins/yellow-core/commands/plan/complete.md
+++ b/plugins/yellow-core/commands/plan/complete.md
@@ -287,13 +287,17 @@ set -euo pipefail
 ARG="$ARGUMENTS"
 CLEAN_ARG="${ARG#plans/}"
 SLUG=$(basename "$CLEAN_ARG" .md | sed 's/^[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-//')
-# Resolve the repo's default branch instead of hard-coding `main` — this
-# command ships in arbitrary repos whose trunk may be `master`/`develop`.
-# gh is a hard prerequisite (Phase 0); fall back to `main` if the lookup
-# returns nothing (e.g. no defaultBranchRef on a fresh repo).
-TRUNK=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || true)
-[ -n "$TRUNK" ] || TRUNK=main
-git checkout "$TRUNK"
+# Check out Graphite's CONFIGURED trunk. gt stacks against its own trunk,
+# which can differ from GitHub's default branch (e.g. a repo gt-initialised
+# on `develop`); basing the archival branch on the wrong trunk would stack
+# the PR incorrectly. `gt checkout --trunk` resolves the configured trunk.
+# Fall back to the gh default branch, then `main`, if gt cannot resolve one
+# (gt is a Phase 0 prerequisite, but may be uninitialised in a fresh repo).
+if ! gt checkout --trunk 2>/dev/null; then
+  TRUNK=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || true)
+  [ -n "$TRUNK" ] || TRUNK=main
+  git checkout "$TRUNK"
+fi
 gt repo sync 2>/dev/null || gt sync 2>/dev/null || \
   printf '[plan:complete] WARNING: gt sync failed; proceeding on possibly-stale trunk\n' >&2
 gt create "plan/archive-$SLUG"

--- a/plugins/yellow-core/commands/plan/complete.md
+++ b/plugins/yellow-core/commands/plan/complete.md
@@ -1,0 +1,284 @@
+---
+name: plan:complete
+description: 'Archive a completed plan with two safety gates: Gate A scans for unchecked task boxes; Gate C verifies a same-named merged PR exists. Use when a plan is fully shipped and ready to move from plans/ to plans/complete/.'
+argument-hint: '<plan-filename>'
+allowed-tools:
+  - Bash
+  - Read
+  - AskUserQuestion
+---
+
+# Plan Complete
+
+Archives a single open plan from `plans/<arg>.md` to
+`plans/complete/<arg>.md` via two gates:
+
+- **Gate A** (mechanical): scans the plan body for `^[[:space:]]*- \[ \]` —
+  any unchecked task box is a hard block. The PR-diff-scoped
+  `validate-plans.js` CI gate enforces the same rule on archived files in
+  the diff; running `/plan:complete` locally catches the same issue
+  before commit.
+- **Gate C** (evidence): queries GitHub for a merged PR whose title and
+  branch contain the slug derived from the filename. PASS when at least
+  one match exists; NO-EVIDENCE prompts the user to confirm with a PR
+  number override (audit-trail trailer captures the decision).
+
+This command does NOT delete the source file or push directly to main —
+it creates an archival branch (`plan/archive-<slug>`), records the
+rename via `git mv`, commits, and submits via `gt stack submit`. Review
+and merge land via the normal PR flow.
+
+Sibling commands: `/plan:status` (read-only dashboard),
+`/workflows:plan` (creates plans). See `plugins/yellow-core/CLAUDE.md`
+for the namespace split.
+
+## Input
+
+`#$ARGUMENTS` — the filename inside `plans/` (e.g.,
+`solution-doc-git-workflow.md` or
+`2026-05-08-plan-lifecycle-management.md`). A leading `plans/` prefix is
+accepted and stripped (tab-completion convenience).
+
+## Phase 0: Prerequisites
+
+```bash
+set -euo pipefail
+command -v gh >/dev/null 2>&1 || { printf '[plan:complete] error: gh not installed\n' >&2; exit 1; }
+command -v gt >/dev/null 2>&1 || { printf '[plan:complete] error: gt not installed\n' >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { printf '[plan:complete] error: jq not installed\n' >&2; exit 1; }
+gh auth status >/dev/null 2>&1 || { printf '[plan:complete] error: gh not authenticated (run: gh auth login)\n' >&2; exit 1; }
+```
+
+## Phase 1: Filename validation + slug derivation
+
+Every Bash block is a fresh subprocess; argument and derived variables
+must be reconstructed in each block that uses them. See MEMORY.md "$VAR
+in bash code blocks". The block below derives both `CLEAN_ARG` and
+`SLUG` so subsequent steps can re-derive consistently.
+
+```bash
+set -euo pipefail
+ARG='#$ARGUMENTS'
+if [ -z "$ARG" ]; then
+  printf '[plan:complete] error: missing plan filename argument\n' >&2
+  exit 1
+fi
+# Strip leading `plans/` for tab-completion ergonomics.
+CLEAN_ARG="${ARG#plans/}"
+# Reject path traversal, slashes, leading hyphen, and uppercase.
+if ! printf '%s' "$CLEAN_ARG" | grep -qE '^[a-z0-9_][a-z0-9_.-]*\.md$'; then
+  printf '[plan:complete] error: invalid filename %s (lowercase [a-z0-9_.-]+ + .md)\n' "$CLEAN_ARG" >&2
+  exit 1
+fi
+# Derive slug: strip optional YYYY-MM-DD- prefix.
+SLUG=$(basename "$CLEAN_ARG" .md | sed 's/^[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-//')
+# Post-derivation regex: lowercase alphanumeric + single hyphens,
+# no leading/trailing/consecutive hyphens. Guards prompt-injection
+# of any shell context (the slug is interpolated into `gh` and
+# `git` commands further down).
+if ! printf '%s' "$SLUG" | grep -qE '^[a-z0-9]+(-[a-z0-9]+)*$'; then
+  printf '[plan:complete] error: derived slug %s contains invalid characters\n' "$SLUG" >&2
+  exit 1
+fi
+printf '[plan:complete] arg=%s slug=%s\n' "$CLEAN_ARG" "$SLUG"
+```
+
+## Phase 2: Idempotency guard + source-file existence
+
+```bash
+set -euo pipefail
+ARG='#$ARGUMENTS'
+CLEAN_ARG="${ARG#plans/}"
+if [ -f "plans/complete/$CLEAN_ARG" ]; then
+  printf '[plan:complete] already archived: plans/complete/%s exists. Nothing to do.\n' "$CLEAN_ARG" >&2
+  exit 0
+fi
+if [ ! -f "plans/$CLEAN_ARG" ]; then
+  printf '[plan:complete] error: source file plans/%s does not exist\n' "$CLEAN_ARG" >&2
+  exit 1
+fi
+```
+
+## Phase 3: Gate A — unchecked-box scan
+
+The same mechanical check applied by `scripts/validate-plans.js` on
+archived files in the PR diff. Running it here gates archival locally
+before any branch is created.
+
+```bash
+set -euo pipefail
+ARG='#$ARGUMENTS'
+CLEAN_ARG="${ARG#plans/}"
+UNCHECKED=$(grep -cE '^[[:space:]]*- \[ \]' "plans/$CLEAN_ARG" 2>/dev/null || true)
+: "${UNCHECKED:=0}"
+if [ "$UNCHECKED" -gt 0 ]; then
+  printf '[plan:complete] Gate A FAIL: %d unchecked task box(es) in plans/%s\n' "$UNCHECKED" "$CLEAN_ARG" >&2
+  printf '             Complete or remove the open tasks before archiving.\n' >&2
+  exit 1
+fi
+printf '[plan:complete] Gate A PASS: no unchecked boxes in plans/%s\n' "$CLEAN_ARG"
+```
+
+## Phase 4: Gate C — merged-PR evidence
+
+Server-side `--state merged` is preferred over reading `mergedAt`: per
+`docs/solutions/integration-issues/merge-queue-closed-pr-null-mergedat-detection.md`,
+`mergedAt` can be null for recently MQ-merged PRs during propagation lag.
+GitHub's `in:title` qualifier is token-based and case-insensitive
+(hyphens split tokens — `in:title "foo-bar"` matches a PR titled
+`foo bar`), so the title search is a COARSE pre-filter only; the
+authoritative match comes from the `--jq` post-filter on `headRefName`
+which enforces a word boundary (`^|$|/|_|-`) around `$SLUG`.
+
+```bash
+set -euo pipefail
+ARG='#$ARGUMENTS'
+CLEAN_ARG="${ARG#plans/}"
+SLUG=$(basename "$CLEAN_ARG" .md | sed 's/^[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-//')
+# shellcheck disable=SC2016
+MERGED=$(gh pr list \
+  --search "in:title \"$SLUG\"" \
+  --state merged \
+  --limit 100 \
+  --json number,title,headRefName,url \
+  --jq '[.[] | select(.headRefName | test("(^|[/_-])'"$SLUG"'($|[/_-])"))]' 2>/dev/null) || MERGED='[]'
+COUNT=$(printf '%s' "$MERGED" | jq 'length' 2>/dev/null || printf '0')
+printf '[plan:complete] Gate C: %d merged PR(s) match slug %s with word boundary\n' "$COUNT" "$SLUG"
+if [ "$COUNT" -ge 1 ]; then
+  printf '%s\n' "$MERGED" | jq -r '.[] | "  #\(.number) — \(.title)\n    \(.url)"'
+fi
+# Store COUNT for the next step. Persist via temp file because the next
+# Bash block is a fresh subprocess.
+mkdir -p .git/tmp
+printf '%s\n' "$COUNT" > .git/tmp/plan-complete.count
+printf '%s\n' "$MERGED" > .git/tmp/plan-complete.merged.json
+```
+
+If `COUNT == 0`, prompt the user via `AskUserQuestion` with the
+following options. **The label of the free-text option MUST be the
+literal string `Other`** — per MEMORY.md "AskUserQuestion 'Other' is
+the ONLY free-text button", any other label (e.g.,
+`Confirm with PR number`) shows as a click-only option and does NOT
+open a text input.
+
+**AskUserQuestion (only if `COUNT == 0`):**
+
+- Question: `No merged PR found whose title and branch contain the
+  slug "<SLUG>". Provide a PR number to confirm, or cancel.`
+- Header: `Override`
+- Options:
+  - Label: `Other` — Description: `Provide the PR number that
+    completes this plan; the override is recorded in the commit
+    trailer.`
+  - Label: `Cancel` — Description: `Stop the archival. The plan
+    stays in plans/.`
+
+If the user picks `Cancel`, **stop the workflow** — do not proceed to
+the next phase.
+
+If the user enters a PR number via `Other`, persist it for the commit
+trailer in Phase 7:
+
+```bash
+set -euo pipefail
+# Validate the user-provided PR number is a bare positive integer.
+PR_NUM='<USER_RESPONSE_FROM_OTHER>'
+if ! printf '%s' "$PR_NUM" | grep -qE '^[1-9][0-9]{0,9}$'; then
+  printf '[plan:complete] error: invalid PR number override %s\n' "$PR_NUM" >&2
+  exit 1
+fi
+mkdir -p .git/tmp
+printf '%s\n' "$PR_NUM" > .git/tmp/plan-complete.override
+```
+
+## Phase 5: Working-tree check
+
+A non-empty working tree is a warning, not a block — the user may have
+unrelated WIP to preserve. AskUserQuestion confirms before proceeding.
+
+```bash
+set -euo pipefail
+if [ -n "$(git status --porcelain)" ]; then
+  printf '[plan:complete] working tree is not clean. Uncommitted changes will be carried into the archival branch.\n' >&2
+  git status --short
+  printf '\n'
+fi
+```
+
+If the working tree was non-empty, **ask via AskUserQuestion**:
+
+- Question: `Working tree has uncommitted changes. Proceed with
+  archival anyway?`
+- Header: `Dirty tree`
+- Options:
+  - Label: `Proceed` — Description: `Carry the WIP into the archival
+    branch. You can resolve conflicts later.`
+  - Label: `Cancel` — Description: `Stop. Commit or stash the WIP
+    first.`
+
+If `Cancel`, stop.
+
+## Phase 6: Sync trunk + create archival branch
+
+```bash
+set -euo pipefail
+ARG='#$ARGUMENTS'
+CLEAN_ARG="${ARG#plans/}"
+SLUG=$(basename "$CLEAN_ARG" .md | sed 's/^[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-//')
+git checkout main
+gt repo sync 2>/dev/null || gt sync 2>/dev/null || true
+gt create "plan/archive-$SLUG"
+mkdir -p plans/complete
+# git mv (not bare mv): records the rename in the index immediately
+# so `git commit` in Phase 7 produces a real commit (not empty).
+git mv -- "plans/$CLEAN_ARG" "plans/complete/$CLEAN_ARG"
+git status --short
+```
+
+## Phase 7: Commit with override audit trail
+
+The plan reference work (PR #556) discovered that
+`gt commit create -m "<subject>" -m "<body>"` concatenates the two
+`-m` values with a literal comma. Use plain `git commit -m` instead —
+standard git docs guarantee multiple `-m` are joined as separate
+paragraphs (subject + blank line + body). Graphite picks up the
+commit on the current branch via `gt submit` in Phase 8.
+
+```bash
+set -euo pipefail
+ARG='#$ARGUMENTS'
+CLEAN_ARG="${ARG#plans/}"
+SLUG=$(basename "$CLEAN_ARG" .md | sed 's/^[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-//')
+COUNT=$(cat .git/tmp/plan-complete.count 2>/dev/null || printf '0')
+SUBJECT="docs(plans): archive completed $SLUG plan"
+if [ -f .git/tmp/plan-complete.override ]; then
+  OVERRIDE_PR_NUM=$(cat .git/tmp/plan-complete.override)
+  BODY="Verified by /plan:complete: user-confirmed override.
+
+Plan-Verifier-Override: user-confirmed-no-pr-evidence (pr=#$OVERRIDE_PR_NUM)"
+else
+  BODY="Verified by /plan:complete: $COUNT merged PR(s) found via gh pr list --state merged with word-boundary post-filter on headRefName."
+fi
+git commit -m "$SUBJECT" -m "$BODY"
+# Clean up temp files.
+rm -f .git/tmp/plan-complete.count .git/tmp/plan-complete.merged.json .git/tmp/plan-complete.override
+```
+
+The `Plan-Verifier-Override:` trailer is grep-discoverable via
+`git log --grep='Plan-Verifier-Override'` for future audit. The
+default (Gate C PASS) path omits the trailer.
+
+## Phase 8: Submit
+
+```bash
+set -euo pipefail
+gt submit --no-interactive
+# Print the resulting PR URL.
+gh pr view --json url -q .url 2>/dev/null || printf '[plan:complete] (submitted; PR URL unavailable — check `gt log short`)\n'
+```
+
+## Done
+
+The plan is now on a `plan/archive-<slug>` branch with a draft PR open.
+Merge via the normal review flow; the `validate:plans` CI gate will
+also re-scan the archived file in the PR diff (Gate A's CI counterpart).

--- a/plugins/yellow-core/commands/plan/status.md
+++ b/plugins/yellow-core/commands/plan/status.md
@@ -1,0 +1,88 @@
+---
+name: plan:status
+description: 'Show a per-file checkbox progress dashboard of plans/ (open) and plans/complete/ (archived). Use when reviewing which plans are ready to archive or checking work-in-flight at a glance.'
+argument-hint: ''
+allowed-tools:
+  - Bash
+---
+
+# Plan Status
+
+Read-only dashboard of the local plan corpus. Walks `plans/*.md` (open) and
+`plans/complete/*.md` (archived), counts checked/unchecked task boxes in each
+file, and renders a plain-text table. Open plans at 100% completion are
+annotated `-- ready to complete` so the next archival step is obvious.
+
+This command is a sibling of `/plan:complete` (archives a plan after Gate
+A + Gate C) and `/workflows:plan` (creates plans). See
+`plugins/yellow-core/CLAUDE.md` for the namespace split.
+
+## Phase 1: Open plans
+
+```bash
+set -euo pipefail
+if ! ls plans/*.md >/dev/null 2>&1; then
+  printf 'plans/ is empty (no open plans).\n\n'
+  exit 0
+fi
+printf 'Open plans (plans/):\n'
+printf '%-60s %s\n' 'File' 'Progress'
+printf '%-60s %s\n' '----' '--------'
+for f in plans/*.md; do
+  [ -f "$f" ] || continue
+  checked=$(grep -cE '^[[:space:]]*- \[x\]' "$f" 2>/dev/null || true)
+  unchecked=$(grep -cE '^[[:space:]]*- \[ \]' "$f" 2>/dev/null || true)
+  : "${checked:=0}"
+  : "${unchecked:=0}"
+  total=$((checked + unchecked))
+  annotation=''
+  if [ "$total" -gt 0 ] && [ "$unchecked" -eq 0 ]; then
+    annotation='  -- ready to complete'
+  fi
+  printf '%-60s [ %d/%d ]%s\n' "$f" "$checked" "$total" "$annotation"
+done
+printf '\n'
+```
+
+## Phase 2: Archived plans
+
+Each Bash code block runs in its own subprocess — variables from Phase 1
+do not survive (see `MEMORY.md` "$VAR in bash code blocks"). Re-derive
+locally.
+
+```bash
+set -euo pipefail
+if [ ! -d plans/complete ]; then
+  printf 'Archived plans (plans/complete/): (0) — directory does not exist yet.\n'
+  exit 0
+fi
+count=$(find plans/complete -maxdepth 1 -name '*.md' -type f 2>/dev/null | wc -l | tr -d ' ')
+if [ "$count" -eq 0 ]; then
+  printf 'Archived plans (plans/complete/): (0)\n'
+  exit 0
+fi
+printf 'Archived plans (plans/complete/): (%d)\n' "$count"
+printf '%-60s %s\n' 'File' 'Progress'
+printf '%-60s %s\n' '----' '--------'
+for f in plans/complete/*.md; do
+  [ -f "$f" ] || continue
+  checked=$(grep -cE '^[[:space:]]*- \[x\]' "$f" 2>/dev/null || true)
+  unchecked=$(grep -cE '^[[:space:]]*- \[ \]' "$f" 2>/dev/null || true)
+  : "${checked:=0}"
+  : "${unchecked:=0}"
+  total=$((checked + unchecked))
+  printf '%-60s [ %d/%d ]\n' "$f" "$checked" "$total"
+done
+```
+
+## Notes
+
+- The `[ 0/0 ]` rendering for zero-task plans is intentional and surfaces
+  prose-style or research-style plan files that have no task list.
+- The `-- ready to complete` annotation appears ONLY on files in `plans/`
+  (not on already-archived files). It is purely advisory — running
+  `/plan:complete <file>` is the explicit archival action.
+- Archived files with stray `- [ ]` lines are visible in this dashboard
+  but are NOT blocked: PR-diff-scoped validation (`pnpm validate:plans`)
+  only checks files newly added or modified by the current PR. The
+  dashboard exists to surface those cases for opportunistic cleanup.

--- a/plugins/yellow-core/commands/plan/status.md
+++ b/plugins/yellow-core/commands/plan/status.md
@@ -30,7 +30,7 @@ printf '%-60s %s\n' 'File' 'Progress'
 printf '%-60s %s\n' '----' '--------'
 for f in plans/*.md; do
   [ -f "$f" ] || continue
-  checked=$(grep -cE '^[[:space:]]*- \[x\]' "$f" 2>/dev/null || true)
+  checked=$(grep -ciE '^[[:space:]]*- \[x\]' "$f" 2>/dev/null || true)
   unchecked=$(grep -cE '^[[:space:]]*- \[ \]' "$f" 2>/dev/null || true)
   : "${checked:=0}"
   : "${unchecked:=0}"
@@ -66,7 +66,7 @@ printf '%-60s %s\n' 'File' 'Progress'
 printf '%-60s %s\n' '----' '--------'
 for f in plans/complete/*.md; do
   [ -f "$f" ] || continue
-  checked=$(grep -cE '^[[:space:]]*- \[x\]' "$f" 2>/dev/null || true)
+  checked=$(grep -ciE '^[[:space:]]*- \[x\]' "$f" 2>/dev/null || true)
   unchecked=$(grep -cE '^[[:space:]]*- \[ \]' "$f" 2>/dev/null || true)
   : "${checked:=0}"
   : "${unchecked:=0}"

--- a/plugins/yellow-core/tests/plan-commands.bats
+++ b/plugins/yellow-core/tests/plan-commands.bats
@@ -22,8 +22,11 @@ slug_is_valid() {
 }
 
 # Filename validation (mirrors complete.md Phase 1, the CLEAN_ARG guard).
+# Tightened to the slug contract: optional YYYY-MM-DD- prefix + lowercase
+# kebab-case + .md (no underscores/dots), so a name that would derive an
+# invalid slug is rejected at the filename gate with a clear message.
 filename_is_valid() {
-  printf '%s' "$1" | grep -qE '^[a-z0-9_][a-z0-9_.-]*\.md$'
+  printf '%s' "$1" | grep -qE '^([0-9]{4}-[0-9]{2}-[0-9]{2}-)?[a-z0-9]+(-[a-z0-9]+)*\.md$'
 }
 
 # PR-number override validation (mirrors complete.md Phase 4). Strips CR/LF
@@ -165,8 +168,12 @@ EOF
   filename_is_valid "2026-05-08-plan-lifecycle-management.md"
 }
 
-@test "filename_is_valid accepts underscores and dots in the body" {
-  filename_is_valid "my_plan.v2.md"
+@test "filename_is_valid rejects underscores and dots in the body" {
+  # The filename contract mirrors the strict slug contract: underscores and
+  # dots are rejected (a dot in a slug becomes a regex wildcard in the
+  # Phase 4 headRefName boundary test). Reject early with a clear message.
+  run filename_is_valid "my_plan.v2.md"
+  [ "$status" -ne 0 ]
 }
 
 @test "filename_is_valid rejects uppercase" {

--- a/plugins/yellow-core/tests/plan-commands.bats
+++ b/plugins/yellow-core/tests/plan-commands.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+# Smoke tests for plan-lifecycle commands. Exercises the slug-derivation
+# regex from plan/complete.md (Phase 1) and the Gate A unchecked-box grep
+# from Phase 3 against fixture files. These are smoke-level only — the
+# full end-to-end /plan:complete flow involves AskUserQuestion + gh + gt
+# which cannot be exercised in bats.
+
+# Slug derivation regex (mirrors complete.md Phase 1).
+derive_slug() {
+  basename "$1" .md | sed 's/^[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-//'
+}
+
+# Gate A grep (mirrors complete.md Phase 3). grep -c prints 0 + exits 1
+# on no matches, so we suppress the non-zero exit but preserve stdout.
+count_unchecked() {
+  grep -cE '^[[:space:]]*- \[ \]' "$1" 2>/dev/null || true
+}
+
+# Post-derivation slug validation (mirrors complete.md Phase 1).
+slug_is_valid() {
+  printf '%s' "$1" | grep -qE '^[a-z0-9]+(-[a-z0-9]+)*$'
+}
+
+setup() {
+  FIXTURE_DIR="$(mktemp -d)"
+}
+
+teardown() {
+  if [ -n "${FIXTURE_DIR:-}" ] && [ -d "$FIXTURE_DIR" ]; then
+    rm -rf "$FIXTURE_DIR"
+  fi
+}
+
+# --- slug derivation ---
+
+@test "derive_slug strips YYYY-MM-DD prefix" {
+  result=$(derive_slug "2026-05-08-plan-lifecycle-management.md")
+  [ "$result" = "plan-lifecycle-management" ]
+}
+
+@test "derive_slug leaves bare slug unchanged" {
+  result=$(derive_slug "solution-doc-git-workflow.md")
+  [ "$result" = "solution-doc-git-workflow" ]
+}
+
+@test "derive_slug handles filename with no date prefix and underscores" {
+  result=$(derive_slug "my_plan_slug.md")
+  [ "$result" = "my_plan_slug" ]
+}
+
+# --- slug validation ---
+
+@test "slug_is_valid accepts kebab-case lowercase" {
+  slug_is_valid "plan-lifecycle-management"
+}
+
+@test "slug_is_valid accepts single-word lowercase" {
+  slug_is_valid "refactor"
+}
+
+@test "slug_is_valid rejects uppercase" {
+  run slug_is_valid "MyPlan"
+  [ "$status" -ne 0 ]
+}
+
+@test "slug_is_valid rejects consecutive hyphens" {
+  run slug_is_valid "plan--lifecycle"
+  [ "$status" -ne 0 ]
+}
+
+@test "slug_is_valid rejects leading hyphen" {
+  run slug_is_valid "-plan-lifecycle"
+  [ "$status" -ne 0 ]
+}
+
+@test "slug_is_valid rejects trailing hyphen" {
+  run slug_is_valid "plan-lifecycle-"
+  [ "$status" -ne 0 ]
+}
+
+@test "slug_is_valid rejects empty string" {
+  run slug_is_valid ""
+  [ "$status" -ne 0 ]
+}
+
+# --- Gate A unchecked-box scan ---
+
+@test "count_unchecked returns 0 on a fully-completed plan" {
+  cat > "$FIXTURE_DIR/clean.md" <<'EOF'
+# Feature: Clean
+
+- [x] task one
+- [x] task two
+EOF
+  result=$(count_unchecked "$FIXTURE_DIR/clean.md")
+  [ "$result" = "0" ]
+}
+
+@test "count_unchecked returns the right count on a partially-completed plan" {
+  cat > "$FIXTURE_DIR/dirty.md" <<'EOF'
+# Feature: Dirty
+
+- [x] task one
+- [ ] task two
+- [x] task three
+- [ ] task four
+EOF
+  result=$(count_unchecked "$FIXTURE_DIR/dirty.md")
+  [ "$result" = "2" ]
+}
+
+@test "count_unchecked returns 0 on a plan with zero task boxes" {
+  cat > "$FIXTURE_DIR/prose.md" <<'EOF'
+# Feature: Prose-only plan
+
+This plan has no checklist. It is all prose.
+EOF
+  result=$(count_unchecked "$FIXTURE_DIR/prose.md")
+  [ "$result" = "0" ]
+}
+
+@test "count_unchecked counts indented boxes the same way" {
+  cat > "$FIXTURE_DIR/indented.md" <<'EOF'
+# Feature: Nested
+
+- [x] top-level done
+  - [ ] nested undone
+EOF
+  result=$(count_unchecked "$FIXTURE_DIR/indented.md")
+  [ "$result" = "1" ]
+}

--- a/plugins/yellow-core/tests/plan-commands.bats
+++ b/plugins/yellow-core/tests/plan-commands.bats
@@ -21,6 +21,31 @@ slug_is_valid() {
   printf '%s' "$1" | grep -qE '^[a-z0-9]+(-[a-z0-9]+)*$'
 }
 
+# Filename validation (mirrors complete.md Phase 1, the CLEAN_ARG guard).
+filename_is_valid() {
+  printf '%s' "$1" | grep -qE '^[a-z0-9_][a-z0-9_.-]*\.md$'
+}
+
+# PR-number override validation (mirrors complete.md Phase 4). Strips CR/LF
+# first so a multi-line value cannot smuggle content past the per-line grep.
+pr_num_is_valid() {
+  local n
+  n=$(printf '%s' "$1" | tr -d '\r\n')
+  printf '%s' "$n" | grep -qE '^[1-9][0-9]{0,9}$'
+}
+
+# Gate C word-boundary match (POSIX-grep equivalent of the jq test() call in
+# complete.md Phase 4: (^|[/_-])SLUG($|[/_-])).
+headref_matches_slug() {
+  # $1 = branch (headRefName), $2 = slug
+  printf '%s' "$1" | grep -qE "(^|[/_-])$2($|[/_-])"
+}
+
+# Checked-box count (mirrors status.md, case-insensitive for GFM [X]).
+count_checked() {
+  grep -ciE '^[[:space:]]*- \[x\]' "$1" 2>/dev/null || true
+}
+
 setup() {
   FIXTURE_DIR="$(mktemp -d)"
 }
@@ -128,4 +153,110 @@ EOF
 EOF
   result=$(count_unchecked "$FIXTURE_DIR/indented.md")
   [ "$result" = "1" ]
+}
+
+# --- filename validation (CLEAN_ARG guard) ---
+
+@test "filename_is_valid accepts a plain slug.md" {
+  filename_is_valid "solution-doc-git-workflow.md"
+}
+
+@test "filename_is_valid accepts a date-prefixed name" {
+  filename_is_valid "2026-05-08-plan-lifecycle-management.md"
+}
+
+@test "filename_is_valid accepts underscores and dots in the body" {
+  filename_is_valid "my_plan.v2.md"
+}
+
+@test "filename_is_valid rejects uppercase" {
+  run filename_is_valid "Plan.md"
+  [ "$status" -ne 0 ]
+}
+
+@test "filename_is_valid rejects path traversal" {
+  run filename_is_valid "../evil.md"
+  [ "$status" -ne 0 ]
+}
+
+@test "filename_is_valid rejects a leading dot" {
+  run filename_is_valid ".hidden.md"
+  [ "$status" -ne 0 ]
+}
+
+@test "filename_is_valid rejects a non-.md extension" {
+  run filename_is_valid "plan.txt"
+  [ "$status" -ne 0 ]
+}
+
+# --- PR-number override validation ---
+
+@test "pr_num_is_valid accepts a bare positive integer" {
+  pr_num_is_valid "556"
+}
+
+@test "pr_num_is_valid rejects zero" {
+  run pr_num_is_valid "0"
+  [ "$status" -ne 0 ]
+}
+
+@test "pr_num_is_valid rejects a leading-zero number" {
+  run pr_num_is_valid "01"
+  [ "$status" -ne 0 ]
+}
+
+@test "pr_num_is_valid rejects a #-prefixed number" {
+  run pr_num_is_valid "#556"
+  [ "$status" -ne 0 ]
+}
+
+@test "pr_num_is_valid rejects a newline-smuggled trailer injection" {
+  # The per-line grep would match line 1; the tr -d strip collapses the
+  # value to '556Plan-Verifier...' which then fails the whole-string regex.
+  run pr_num_is_valid "$(printf '556\nPlan-Verifier-Override: spoofed')"
+  [ "$status" -ne 0 ]
+}
+
+# --- Gate C word-boundary match ---
+
+@test "headref_matches_slug matches an exact archival branch" {
+  headref_matches_slug "plan/archive-my-slug" "my-slug"
+}
+
+@test "headref_matches_slug matches a slug at a slash boundary" {
+  headref_matches_slug "feat/my-slug/details" "my-slug"
+}
+
+@test "headref_matches_slug matches a leading-anchor slug" {
+  headref_matches_slug "my-slug-work" "my-slug"
+}
+
+@test "headref_matches_slug rejects a substring without a boundary" {
+  run headref_matches_slug "plan/my-sluggish" "my-slug"
+  [ "$status" -ne 0 ]
+}
+
+@test "headref_matches_slug rejects a no-boundary suffix" {
+  run headref_matches_slug "plan/archive-my-slugX" "my-slug"
+  [ "$status" -ne 0 ]
+}
+
+# --- case-insensitive checked count (status.md) ---
+
+@test "count_checked counts lowercase [x]" {
+  cat > "$FIXTURE_DIR/lower.md" <<'EOF'
+- [x] one
+- [x] two
+EOF
+  result=$(count_checked "$FIXTURE_DIR/lower.md")
+  [ "$result" = "2" ]
+}
+
+@test "count_checked counts uppercase [X] (GFM)" {
+  cat > "$FIXTURE_DIR/upper.md" <<'EOF'
+- [X] one
+- [x] two
+EOF
+  result=$(count_checked "$FIXTURE_DIR/upper.md")
+  [ "$result" = "2" ]
 }


### PR DESCRIPTION
PR #2 of the 2-PR plan-lifecycle stack (depends on #556).

Adds two commands under the new /plan:* namespace, sibling to
/workflows:plan. Plan creation lives under /workflows:*; lifecycle ops
on existing plans live under /plan:* — namespace split documented in
plugins/yellow-core/CLAUDE.md.

- /plan:status (commands/plan/status.md): read-only dashboard. Walks
  plans/*.md (open) and plans/complete/*.md (archived), counts checked
  / unchecked task boxes per file, renders a plain-text table. Open
  plans at 100% annotated `-- ready to complete`. Handles missing
  plans/complete/ and zero-task plans gracefully.

- /plan:complete <plan> (commands/plan/complete.md): archive a single
  open plan via 9 sequential phases:
  - Phase 0: prerequisites (gh + gt + jq + gh auth)
  - Phase 1: filename validation + slug derivation
    (basename | sed strip-date-prefix, then [a-z0-9]+(-[a-z0-9]+)*)
  - Phase 2: idempotency guard + source-file existence
  - Phase 3: Gate A — scan plans/<arg> for `^[[:space:]]*- \[ \]`,
    block on any match
  - Phase 4: Gate C — gh pr list --state merged --search 'in:title
    "<slug>"' with --jq word-boundary post-filter on headRefName
    (`(^|[/_-])SLUG($|[/_-])`). NO-EVIDENCE prompts via
    AskUserQuestion with the literal `Other` free-text label (per
    MEMORY.md "AskUserQuestion 'Other' is the ONLY free-text button"),
    persisting the override PR number to a temp file for the commit
    trailer
  - Phase 5: working-tree check (warn-then-confirm, not block)
  - Phase 6: sync trunk + gt create plan/archive-<slug> + git mv
  - Phase 7: commit with override audit trail via plain
    `git commit -m "$SUBJECT" -m "$BODY"`. NOT
    `gt commit create -m -m` (PR #556 empirically observed it
    concatenates the two -m values with a literal comma).
    Default trailer omitted (Gate C PASS); override path appends
    `Plan-Verifier-Override: user-confirmed-no-pr-evidence (pr=#N)`
  - Phase 8: gt submit --no-interactive + report PR URL

- tests/plan-commands.bats: 14 smoke tests exercising the slug
  derivation regex (3), post-derivation slug validation (7), and the
  Gate A unchecked-box grep (4). Smoke level only — the full
  end-to-end command flow involves AskUserQuestion + gh + gt which
  cannot be exercised in bats.

- README.md + CLAUDE.md: command catalog updated; CLAUDE.md command
  count 10 → 12; new "Plan Namespace Split" section documents the
  /workflows:* vs /plan:* boundary and the companion CI gate (#556).

- docs/solutions/workflow/plan-lifecycle-management.md: knowledge-track
  solution doc capturing the load-bearing decisions (runtime slug
  derivation, PR-diff scoping, Gate C single-gh-call shape with
  word-boundary post-filter, AskUserQuestion 'Other' free-text label,
  git-commit-m-m vs gt-commit-create-m-m).

- .changeset/plan-lifecycle-commands.md: yellow-core minor bump (new
  commands).

All bash blocks in the command bodies re-derive ARG / CLEAN_ARG / SLUG
locally per MEMORY.md "$VAR in bash code blocks" (each block is a
fresh subprocess). The grep -c pattern uses `|| true` + `${VAR:=0}`
default instead of `|| printf '0'` (which doubled the count on no
match — bug discovered in bats Phase 4 and corrected in all three
command surfaces).

Tests / gates: pnpm typecheck (PASS), pnpm lint (PASS),
pnpm validate:schemas (PASS — 82 agents + 282 markdown files, error
catalog now references 34 codes including ERROR-PLAN-001 from #556),
bats plan-commands.bats (14/14 PASS).

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Solution doc

<!--
Pick one:
  - "Co-shipped — see docs/solutions/<category>/<slug>.md in this PR"
  - "Tracked separately in #<follow-up PR>"
  - "Skip: <reason — typo / version bump / behavior already covered by
    docs/solutions/<category>/<existing>.md / etc.>"

See CONTRIBUTING.md "Solution Docs" for the policy and skip criteria.
Run `/workflows:compound --in-pr` to draft the doc + MEMORY.md line from
the PR body and commits.
-->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->
