### PR TITLE
fix(schema): enforce repository-string + inline-hooks parity with remote validator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,8 +104,12 @@ validators in `scripts/`:
 local schemas. The Claude Code remote validator can diverge — local CI
 passing does NOT guarantee install acceptance. Always test on a clean
 Claude Code install before publishing breaking schema changes.
-`schemas/official-marketplace.schema.json` is mirrored from upstream for
-reference only.
+`schemas/official-marketplace.schema.json` is mirrored from upstream but is
+also an active CI gate — `validate-schemas.yml` validates
+`.claude-plugin/marketplace.json` and `examples/marketplace.example.json`
+against it. It intentionally diverges from upstream by adding
+`additionalProperties: false` at the root to reject unknown top-level keys
+the remote validator also rejects; preserve that constraint when re-syncing.
 
 ### Release flow (Changesets-driven)
 

--- a/docs/plugin-template.md
+++ b/docs/plugin-template.md
@@ -234,10 +234,7 @@ MIT
     "changelog": "https://github.com/username/repo/blob/main/plugins/my-plugin/CHANGELOG.md",
     "examples": "https://github.com/username/repo/tree/main/plugins/my-plugin/examples"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/username/repo.git"
-  },
+  "repository": "https://github.com/username/repo.git",
   "lifecycle": {
     "install": "scripts/install.sh",
     "uninstall": "scripts/uninstall.sh"

--- a/examples/plugin.example.json
+++ b/examples/plugin.example.json
@@ -8,10 +8,7 @@
     "url": "https://github.com/KingInYellows"
   },
   "homepage": "https://github.com/KingInYellows/yellow-plugins",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/KingInYellows/yellow-plugins.git"
-  },
+  "repository": "https://github.com/KingInYellows/yellow-plugins.git",
   "license": "MIT",
   "keywords": ["hooks", "behavior", "safety", "ai-control", "conversation-analysis"]
 }

--- a/schemas/official-marketplace.schema.json
+++ b/schemas/official-marketplace.schema.json
@@ -5,6 +5,8 @@
   "description": "Schema for .claude-plugin/marketplace.json as expected by Claude Code. This mirrors the official Anthropic format discovered from anthropics/claude-plugins-official, EveryInc/every-marketplace, and obra/superpowers-marketplace.",
   "type": "object",
   "required": ["name", "plugins"],
+  "$comment": "Mirrored from the upstream Claude Code marketplace schema, but intentionally diverges: this file is an active CI gate (validate-schemas.yml validates .claude-plugin/marketplace.json and examples against it), so 'additionalProperties: false' is added locally to reject unknown top-level keys (e.g. changelog, id) that the remote validator also rejects. Preserve this constraint when re-syncing from upstream. (CLAUDE.md's 'reference only' description of this file is stale — it gates CI.)",
+  "additionalProperties": false,
   "properties": {
     "$schema": {
       "type": "string",

--- a/schemas/plugin.schema.json
+++ b/schemas/plugin.schema.json
@@ -91,6 +91,17 @@
         },
         { "type": "object", "minProperties": 1 }
       ]
+    },
+    "inlineHooks": {
+      "description": "Inline hooks only. Claude Code's remote validator rejects file-path indirection (e.g. \"hooks\": \"./hooks/hooks.json\") with 'hooks: Invalid input'; hooks must be an inline object keyed by event name (PreToolUse, PostToolUse, Stop, ...) or an array of such inline objects. See docs/solutions/build-errors/claude-code-plugin-manifest-validation-errors.md and ci-schema-drift-hooks-inline-vs-string.md.",
+      "oneOf": [
+        { "type": "object", "minProperties": 1 },
+        {
+          "type": "array",
+          "items": { "type": "object", "minProperties": 1 },
+          "minItems": 1
+        }
+      ]
     }
   },
   "properties": {
@@ -157,28 +168,9 @@
       "description": "Plugin homepage URL."
     },
     "repository": {
-      "oneOf": [
-        {
-          "type": "string",
-          "format": "uri"
-        },
-        {
-          "type": "object",
-          "required": ["type", "url"],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": ["git"]
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          },
-          "additionalProperties": false
-        }
-      ],
-      "description": "Source repository (string URL or object with type and url)."
+      "type": "string",
+      "format": "uri",
+      "description": "Source repository URL (string only). Claude Code's remote validator rejects the npm-style object form ({\"type\":\"git\",\"url\":\"...\"}) with 'repository: Invalid input: expected string, received object'. See docs/solutions/build-errors/claude-code-plugin-manifest-validation-errors.md."
     },
     "keywords": {
       "type": "array",
@@ -197,8 +189,8 @@
       "allOf": [{ "$ref": "#/definitions/fileFilesOrInline" }]
     },
     "hooks": {
-      "description": "Hooks configuration: relative file path, array of paths/inline objects, or inline object keyed by event name (PreToolUse, PostToolUse, Stop, etc.).",
-      "allOf": [{ "$ref": "#/definitions/fileFilesOrInline" }]
+      "description": "Inline hooks configuration keyed by event name (PreToolUse, PostToolUse, Stop, etc.), or an array of inline hook objects. File-path indirection is NOT permitted — the remote validator rejects it.",
+      "allOf": [{ "$ref": "#/definitions/inlineHooks" }]
     },
     "outputStyles": {
       "description": "Directory or array of directories containing markdown output style files (replaces default ./output-styles/).",

--- a/tests/integration/example-files-schema.test.ts
+++ b/tests/integration/example-files-schema.test.ts
@@ -172,3 +172,89 @@ describe('semverRange custom keyword (PR-B)', () => {
     expect(factory.validate('semver-test', { version: '' }).valid).toBe(false);
   });
 });
+
+describe('plugin.schema.json tightening (PR #559) — negative cases', () => {
+  let factory: AjvValidatorFactory;
+  // Minimal known-valid plugin manifest, read from the committed example so
+  // a future required-field change does not silently invalidate this base.
+  let base: Record<string, unknown>;
+
+  beforeAll(async () => {
+    factory = new AjvValidatorFactory();
+    await factory.loadSchemaFromFile(
+      'plugin',
+      join(SCHEMAS_DIR, 'plugin.schema.json')
+    );
+    base = JSON.parse(
+      readFileSync(join(EXAMPLES_DIR, 'plugin-minimal.example.json'), 'utf8')
+    );
+  });
+
+  it('accepts string repository (the only form the remote validator allows)', () => {
+    const d = { ...base, repository: 'https://github.com/x/y.git' };
+    expect(factory.validate('plugin', d).valid).toBe(true);
+  });
+
+  it('rejects object (npm-style) repository — remote validator rejects it', () => {
+    const d = {
+      ...base,
+      repository: { type: 'git', url: 'https://github.com/x/y.git' },
+    };
+    expect(factory.validate('plugin', d).valid).toBe(false);
+  });
+
+  it('accepts inline-object hooks keyed by event name', () => {
+    const d = {
+      ...base,
+      hooks: {
+        PostToolUse: [{ matcher: '*', hooks: [{ type: 'command', command: 'x' }] }],
+      },
+    };
+    expect(factory.validate('plugin', d).valid).toBe(true);
+  });
+
+  it('accepts an array of inline hook objects', () => {
+    const d = { ...base, hooks: [{ PostToolUse: [] }] };
+    expect(factory.validate('plugin', d).valid).toBe(true);
+  });
+
+  it('rejects string (file-path) hooks — remote validator rejects indirection', () => {
+    const d = { ...base, hooks: './hooks/hooks.json' };
+    expect(factory.validate('plugin', d).valid).toBe(false);
+  });
+});
+
+describe('official-marketplace.schema.json additionalProperties:false (PR #559)', () => {
+  let factory: AjvValidatorFactory;
+  let liveMarketplace: Record<string, unknown>;
+
+  beforeAll(async () => {
+    factory = new AjvValidatorFactory();
+    await factory.loadSchemaFromFile(
+      'marketplace-official',
+      join(SCHEMAS_DIR, 'official-marketplace.schema.json')
+    );
+    liveMarketplace = JSON.parse(
+      readFileSync(
+        join(REPO_ROOT, '.claude-plugin', 'marketplace.json'),
+        'utf8'
+      )
+    );
+  });
+
+  it('accepts the live .claude-plugin/marketplace.json', () => {
+    const result = factory.validate('marketplace-official', liveMarketplace);
+    if (!result.valid) {
+      const detail = result.errors
+        .map((e) => `  ${e.path || '/'}: ${e.message} (${e.keyword})`)
+        .join('\n');
+      throw new Error(`live marketplace.json failed schema:\n${detail}`);
+    }
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects an unknown top-level key (e.g. changelog) the remote validator also rejects', () => {
+    const d = { ...liveMarketplace, changelog: 'https://example.com/CHANGELOG' };
+    expect(factory.validate('marketplace-official', d).valid).toBe(false);
+  });
+});


### PR DESCRIPTION
plugin.schema.json accepted forms that Claude Code's remote validator rejects at install time, so a manifest could pass pnpm validate:schemas and CI yet fail 'claude plugin marketplace add'. Two traps: (1) repository allowed the npm-style object {type,url}; (2) hooks allowed a bare file-path string via the shared fileFilesOrInline definition. examples/plugin.example.json shipped the object-repository form and the CI examples job validated it green — a contributor trap.

Changes: repository -> string+uri only; new inlineHooks definition (inline object or array of inline objects, no file-path string) referenced by hooks while mcpServers keeps fileFilesOrInline untouched; examples/plugin.example.json repository -> string. Also add root additionalProperties:false to official-marketplace.schema.json so unknown top-level keys (e.g. changelog/id) are rejected locally instead of only by the remote validator.

Verified: all 18 live manifests + all 3 example manifests still pass; object-repository, string-hooks, and unknown-marketplace-key forms now correctly rejected (AJV, mirroring CI). No plugins/ files changed — no changeset required.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Solution doc

<!--
Pick one:
  - "Co-shipped — see docs/solutions/<category>/<slug>.md in this PR"
  - "Tracked separately in #<follow-up PR>"
  - "Skip: <reason — typo / version bump / behavior already covered by
    docs/solutions/<category>/<existing>.md / etc.>"

See CONTRIBUTING.md "Solution Docs" for the policy and skip criteria.
Run `/workflows:compound --in-pr` to draft the doc + MEMORY.md line from
the PR body and commits.
-->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->
