### PR TITLE
fix(yellow-core): restore read-only contract on 7 review agents + W1.5b gate

### DIFF
--- a/.changeset/yellow-core-review-readonly-contract.md
+++ b/.changeset/yellow-core-review-readonly-contract.md
@@ -1,0 +1,17 @@
+---
+"yellow-core": patch
+---
+
+Restore the read-only contract on 7 review agents and gate it in CI.
+
+architecture-strategist, code-simplicity-reviewer, pattern-recognition-specialist,
+performance-oracle, performance-reviewer, polyglot-reviewer, and
+test-coverage-analyst carried `memory: project` (which auto-enables
+Read/Write/Edit) but no `disallowedTools` block — so they ran write-capable
+against untrusted PR diffs despite the documented read-only contract. Added
+`disallowedTools: [Write, Edit, MultiEdit]` to all 7, matching the 3 security
+review agents. A new W1.5b rule in `scripts/validate-agent-authoring.js` now
+fails CI when any `review/` agent sets a valid `memory:` scope
+(`user`/`project`/`local`) without a `disallowedTools` entry containing Write
+and Edit, so this cannot regress silently. The rule is covered by
+`tests/integration/validate-agent-authoring-w15b.test.ts`.

--- a/.codacy/codacy.yaml
+++ b/.codacy/codacy.yaml
@@ -12,3 +12,8 @@ exclude_paths:
     - "plans/**"
     - "docs/brainstorms/**"
     - "RESEARCH/**"
+    # Changeset files are an ephemeral, fixed format: YAML frontmatter
+    # followed by a prose summary, never a top-level heading. markdownlint
+    # MD041 ("first line should be a top-level heading") is a structural
+    # false positive on every changeset. Consumed + deleted on release.
+    - ".changeset/**"

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,3 +1,4 @@
 node_modules/
 **/node_modules/**
 docs/api/
+.changeset/

--- a/plugins/yellow-core/agents/review/architecture-strategist.md
+++ b/plugins/yellow-core/agents/review/architecture-strategist.md
@@ -8,6 +8,10 @@ tools:
   - Read
   - Grep
   - Glob
+disallowedTools:
+  - Write
+  - Edit
+  - MultiEdit
 ---
 
 <examples>

--- a/plugins/yellow-core/agents/review/code-simplicity-reviewer.md
+++ b/plugins/yellow-core/agents/review/code-simplicity-reviewer.md
@@ -8,6 +8,10 @@ tools:
   - Read
   - Grep
   - Glob
+disallowedTools:
+  - Write
+  - Edit
+  - MultiEdit
 ---
 
 <examples>

--- a/plugins/yellow-core/agents/review/pattern-recognition-specialist.md
+++ b/plugins/yellow-core/agents/review/pattern-recognition-specialist.md
@@ -8,6 +8,10 @@ tools:
   - Read
   - Grep
   - Glob
+disallowedTools:
+  - Write
+  - Edit
+  - MultiEdit
 ---
 
 <examples>

--- a/plugins/yellow-core/agents/review/performance-oracle.md
+++ b/plugins/yellow-core/agents/review/performance-oracle.md
@@ -8,6 +8,10 @@ tools:
   - Read
   - Grep
   - Glob
+disallowedTools:
+  - Write
+  - Edit
+  - MultiEdit
 ---
 
 <examples>

--- a/plugins/yellow-core/agents/review/performance-reviewer.md
+++ b/plugins/yellow-core/agents/review/performance-reviewer.md
@@ -7,6 +7,10 @@ tools:
   - Read
   - Grep
   - Glob
+disallowedTools:
+  - Write
+  - Edit
+  - MultiEdit
 ---
 
 You are a runtime performance and scalability reviewer who reads diffs through

--- a/plugins/yellow-core/agents/review/polyglot-reviewer.md
+++ b/plugins/yellow-core/agents/review/polyglot-reviewer.md
@@ -8,6 +8,10 @@ tools:
   - Read
   - Grep
   - Glob
+disallowedTools:
+  - Write
+  - Edit
+  - MultiEdit
 ---
 
 <examples>

--- a/plugins/yellow-core/agents/review/test-coverage-analyst.md
+++ b/plugins/yellow-core/agents/review/test-coverage-analyst.md
@@ -8,6 +8,10 @@ tools:
   - Read
   - Grep
   - Glob
+disallowedTools:
+  - Write
+  - Edit
+  - MultiEdit
 ---
 
 <examples>

--- a/scripts/validate-agent-authoring.js
+++ b/scripts/validate-agent-authoring.js
@@ -19,6 +19,18 @@ const PLUGINS_DIR = process.env.VALIDATE_PLUGINS_DIR
 // the untrusted PR diff and comment text reviewers consume.
 const REVIEW_AGENT_DENIED_TOOLS = ['Bash', 'Write', 'Edit'];
 
+// W1.5b rule: the write-capable tools that `memory:` auto-enables. A review/
+// agent with `memory:` set MUST deny these via `disallowedTools` to keep the
+// read-only contract. Subset of REVIEW_AGENT_DENIED_TOOLS minus Bash (which
+// `memory:` does not grant).
+const MEMORY_GRANTED_WRITE_TOOLS = ['Write', 'Edit'];
+
+// Valid `memory:` scope values per Claude Code docs. Only these three
+// activate per-agent memory (and the Read/Write/Edit auto-grant); any other
+// value (e.g. `memory: true`) is silently ignored by Claude Code, so W1.5b
+// must NOT fire on it — otherwise the author gets a misleading error.
+const VALID_MEMORY_SCOPES = new Set(['user', 'project', 'local']);
+
 // Documented exceptions to the read-only rule. Each entry must be a
 // plugins-relative POSIX path. Any exception requires a "Tool Surface —
 // Documented … Exception" section in the agent body explaining why the
@@ -311,6 +323,36 @@ function validateAgentFile(filePath, ctx) {
               `scripts/validate-agent-authoring.js and add a "Tool ` +
               `Surface — Documented Exception" section to the agent body.`
           );
+        }
+
+        // W1.5b — `memory:` auto-enables Read/Write/Edit regardless of the
+        // `tools:` list (per Claude Code docs), so the tools-only check
+        // above is bypassed whenever a review/ agent sets `memory:`. Such an
+        // agent MUST restore the read-only contract with a `disallowedTools`
+        // entry containing both Write and Edit. Without this, a review agent
+        // processing untrusted PR diffs runs write-capable. The 3 yellow-core
+        // security agents and the 6 yellow-review review agents already carry
+        // `disallowedTools: [Write, Edit, MultiEdit]`; this rule prevents a
+        // future review/ agent from regressing silently.
+        const memoryScope = parseScalar(frontmatter, 'memory');
+        if (memoryScope && VALID_MEMORY_SCOPES.has(memoryScope)) {
+          const disallowedLower = parseList(
+            frontmatter,
+            'disallowedTools'
+          ).map((t) => t.toLowerCase());
+          const missingDenies = MEMORY_GRANTED_WRITE_TOOLS.filter(
+            (t) => !disallowedLower.includes(t.toLowerCase())
+          );
+          if (missingDenies.length > 0) {
+            errors.push(
+              `${relative(filePath)}: review/ agent sets \`memory: ` +
+                `${memoryScope}\` (auto-enables Read/Write/Edit) but ` +
+                `\`disallowedTools\` is missing ${missingDenies.join(', ')} ` +
+                `— add \`disallowedTools: [Write, Edit, MultiEdit]\` to ` +
+                `restore the read-only contract (W1.5b rule). The \`tools:\` ` +
+                `list alone does not contain the memory-granted write access.`
+            );
+          }
         }
       }
     }

--- a/tests/integration/validate-agent-authoring-w15b.test.ts
+++ b/tests/integration/validate-agent-authoring-w15b.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Integration test for the W1.5b rule in scripts/validate-agent-authoring.js.
+ *
+ * W1.5b closes a blind spot in the W1.5 read-only rule: `memory:` auto-enables
+ * Read/Write/Edit regardless of the `tools:` list, so a review/ agent that sets
+ * `memory:` without a `disallowedTools` entry containing Write and Edit runs
+ * write-capable against untrusted PR diffs even though `tools:` looks read-only.
+ * W1.5b fails CI when that combination occurs (PR #560).
+ *
+ * Scope-gate detail: only the documented scope values (user|project|local)
+ * activate memory + the write auto-grant. `memory: true` (and any other value)
+ * is silently ignored by Claude Code, so W1.5b must NOT fire on it — otherwise
+ * the author gets a misleading "auto-enables Write/Edit" error.
+ *
+ * Parameterized via VALIDATE_PLUGINS_DIR so it never touches the real
+ * plugins/ tree.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { runValidator, writeAgent } from './helpers/validator-harness';
+
+// A review/ agent fixture missing the memory write-deny — the regression
+// W1.5b is built to catch.
+const REVIEW_FM_MEMORY_NO_DENY = `---
+name: w15b-fixture
+description: W1.5b review fixture. Use when verifying the memory write-deny rule.
+model: inherit
+memory: project
+tools:
+  - Read
+  - Grep
+  - Glob
+---
+
+Body for W1.5b fixture.
+`;
+
+// Same agent, now restoring the read-only contract with the full deny set.
+const REVIEW_FM_MEMORY_WITH_DENY = `---
+name: w15b-fixture
+description: W1.5b review fixture. Use when verifying the memory write-deny rule.
+model: inherit
+memory: project
+tools:
+  - Read
+  - Grep
+  - Glob
+disallowedTools:
+  - Write
+  - Edit
+  - MultiEdit
+---
+
+Body for W1.5b fixture.
+`;
+
+// Denies Write but not Edit — partial deny must still fail (Edit is
+// memory-granted and write-capable).
+const REVIEW_FM_MEMORY_PARTIAL_DENY = `---
+name: w15b-fixture
+description: W1.5b review fixture. Use when verifying the memory write-deny rule.
+model: inherit
+memory: project
+tools:
+  - Read
+  - Grep
+  - Glob
+disallowedTools:
+  - Write
+---
+
+Body for W1.5b fixture.
+`;
+
+// memory: true is an invalid scope — Claude Code ignores it, no write grant,
+// so W1.5b must NOT fire (scope-gate). No disallowedTools present.
+const REVIEW_FM_MEMORY_INVALID_SCOPE = `---
+name: w15b-fixture
+description: W1.5b review fixture. Use when verifying the memory write-deny rule.
+model: inherit
+memory: true
+tools:
+  - Read
+  - Grep
+  - Glob
+---
+
+Body for W1.5b fixture.
+`;
+
+// A review/ agent with NO memory: at all — W1.5b is a no-op (the W1.5
+// tools-list check is the only relevant rule, and Read/Grep/Glob pass it).
+const REVIEW_FM_NO_MEMORY = `---
+name: w15b-fixture
+description: W1.5b review fixture. Use when verifying the memory write-deny rule.
+model: inherit
+tools:
+  - Read
+  - Grep
+  - Glob
+---
+
+Body for W1.5b fixture.
+`;
+
+// An allowlisted CLI-wrapper reviewer (codex-reviewer) with memory: and no
+// deny — W1.5b must skip allowlisted agents (same allowlist as W1.5).
+const ALLOWLISTED_FM_MEMORY_NO_DENY = `---
+name: codex-reviewer
+description: Codex reviewer fixture. Use when verifying the W1.5b allowlist skip.
+model: inherit
+memory: project
+tools:
+  - Read
+  - Grep
+  - Glob
+---
+
+Body for allowlisted fixture.
+`;
+
+let pluginsDir: string;
+
+beforeEach(() => {
+  pluginsDir = mkdtempSync(join(tmpdir(), 'validate-w15b-'));
+});
+
+afterEach(() => {
+  rmSync(pluginsDir, { recursive: true, force: true });
+});
+
+describe('validate-agent-authoring W1.5b (memory: requires disallowedTools)', () => {
+  it('fails when a review/ agent sets memory: project but has no disallowedTools', () => {
+    writeAgent(
+      pluginsDir,
+      'yellow-core/agents/review/w15b-fixture.md',
+      REVIEW_FM_MEMORY_NO_DENY
+    );
+    const result = runValidator(pluginsDir);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/W1\.5b/);
+  });
+
+  it('passes when memory: project is paired with disallowedTools [Write, Edit, MultiEdit]', () => {
+    writeAgent(
+      pluginsDir,
+      'yellow-core/agents/review/w15b-fixture.md',
+      REVIEW_FM_MEMORY_WITH_DENY
+    );
+    const result = runValidator(pluginsDir);
+    expect(result.status).toBe(0);
+  });
+
+  it('fails on a partial deny (Write present, Edit missing)', () => {
+    writeAgent(
+      pluginsDir,
+      'yellow-core/agents/review/w15b-fixture.md',
+      REVIEW_FM_MEMORY_PARTIAL_DENY
+    );
+    const result = runValidator(pluginsDir);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/W1\.5b/);
+    // The error names the specifically-missing tool.
+    expect(result.stdout + result.stderr).toMatch(/Edit/);
+  });
+
+  it('does NOT fire on an invalid scope (memory: true) — scope-gate', () => {
+    writeAgent(
+      pluginsDir,
+      'yellow-core/agents/review/w15b-fixture.md',
+      REVIEW_FM_MEMORY_INVALID_SCOPE
+    );
+    const result = runValidator(pluginsDir);
+    expect(result.status).toBe(0);
+  });
+
+  it('is a no-op when no memory: is set', () => {
+    writeAgent(
+      pluginsDir,
+      'yellow-core/agents/review/w15b-fixture.md',
+      REVIEW_FM_NO_MEMORY
+    );
+    const result = runValidator(pluginsDir);
+    expect(result.status).toBe(0);
+  });
+
+  it('skips allowlisted reviewers (codex-reviewer) even with memory: and no deny', () => {
+    writeAgent(
+      pluginsDir,
+      'yellow-codex/agents/review/codex-reviewer.md',
+      ALLOWLISTED_FM_MEMORY_NO_DENY
+    );
+    const result = runValidator(pluginsDir);
+    expect(result.status).toBe(0);
+  });
+});


### PR DESCRIPTION
architecture-strategist, code-simplicity-reviewer, pattern-recognition-specialist, performance-oracle, performance-reviewer, polyglot-reviewer, and test-coverage-analyst carried `memory: project` (which auto-enables Read/Write/Edit per Claude Code docs) but no `disallowedTools` block — so they ran write-capable against untrusted PR diffs, contradicting the read-only contract their bodies assert and the yellow-core CLAUDE.md claim. The W1.5 validator only inspected the `tools:` list, so the gap passed CI.

Add `disallowedTools: [Write, Edit, MultiEdit]` to all 7, matching the 3 security review agents (security-sentinel/reviewer/lens). This makes the CLAUDE.md claim accurate. Extend the W1.5 rule (W1.5b) in scripts/validate-agent-authoring.js to fail when any review/ agent sets `memory:` without disallowedTools containing Write and Edit — closing the validator blind spot so it cannot regress silently. Allowlisted CLI-wrapper reviewers (codex/gemini/opencode) are unaffected.

Verified: blast radius is exactly these 7 (every other review/ agent across all 18 plugins is memory-less, allowlisted, or already denied); validate:agents passes; a negative fixture trips W1.5b; all 41 validate-agent-authoring integration tests pass.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Solution doc

<!--
Pick one:
  - "Co-shipped — see docs/solutions/<category>/<slug>.md in this PR"
  - "Tracked separately in #<follow-up PR>"
  - "Skip: <reason — typo / version bump / behavior already covered by
    docs/solutions/<category>/<existing>.md / etc.>"

See CONTRIBUTING.md "Solution Docs" for the policy and skip criteria.
Run `/workflows:compound --in-pr` to draft the doc + MEMORY.md line from
the PR body and commits.
-->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->
