### PR TITLE
fix(validators): yaml-backed agent frontmatter parser + W1.5/W1.5b MultiEdit + check:pins advisory

### DIFF
--- a/.github/workflows/upstream-pins-advisory.yml
+++ b/.github/workflows/upstream-pins-advisory.yml
@@ -35,6 +35,10 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           clean: true
+          # No subsequent step runs authenticated git, so don't persist the
+          # checkout token into .git/config (avoids credential exposure in the
+          # workspace; zizmor artipacked).
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/upstream-pins-advisory.yml
+++ b/.github/workflows/upstream-pins-advisory.yml
@@ -1,0 +1,61 @@
+# Advisory-only upstream pin drift report (issue #268).
+#
+# This workflow is INTENTIONALLY separate from validate-schemas.yml and is NOT
+# referenced by its `ci-status` gate. check-upstream-pins.js makes synchronous
+# `npm view <pkg> version` network calls (one per pinned MCP package), which
+# would violate validate-schemas.yml's 2-minute NFR-MAINT-002 critical-path
+# SLO and add npm-registry flakiness to every PR. Drift is non-urgent, so it
+# runs on a weekly schedule and on manual dispatch and never blocks a merge.
+# See docs/upstream-pins.md for the pin policy and bump checklist.
+name: Upstream Pin Drift (advisory)
+
+on:
+  schedule:
+    # Mondays 08:00 UTC — aligns with the "monthly cadence or before a release"
+    # review guidance in docs/upstream-pins.md (weekly cron is cheap and keeps
+    # the report fresh without anyone remembering to run it).
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: upstream-pins-advisory
+  cancel-in-progress: false
+
+jobs:
+  check-pins:
+    name: Upstream pin drift report
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          clean: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22.22.0'
+
+      - name: Report upstream pin drift (advisory — never fails the job)
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          # check-upstream-pins.js has zero npm dependencies (node builtins plus
+          # the `npm view` binary already on the runner), so no `pnpm install`
+          # is needed. Default invocation exits 0 even when drift exists — this
+          # is the same advisory behavior as `pnpm check:pins`.
+          node scripts/check-upstream-pins.js --verbose | tee pin-drift.txt
+          {
+            echo '## Upstream pin drift report'
+            echo ''
+            echo '```'
+            cat pin-drift.txt
+            echo '```'
+            echo ''
+            echo '_Advisory only — bump pins per docs/upstream-pins.md when drift warrants. This job never blocks merges._'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,11 +239,18 @@ and `pnpm test:lint-plugins` when `scripts/lint-plugins.sh` changes.
 - Preferred `SKILL.md` body shape is `## What It Does`, `## When to Use`, and
   `## Usage`; use lower-level headings inside `## Usage`.
 - Review agents under `plugins/<name>/agents/review/` must be read-only: no
-  `Bash`, `Write`, or `Edit` in `tools:` unless the file is explicitly
-  allowlisted in `scripts/validate-agent-authoring.js` and includes a "Tool
-  Surface - Documented Exception" section.
+  `Bash`, `Write`, `Edit`, or `MultiEdit` in `tools:` (W1.5) unless the file is
+  explicitly allowlisted in `scripts/validate-agent-authoring.js` and includes a
+  "Tool Surface - Documented Exception" section. A review agent that sets
+  `memory:` (which auto-enables Read/Write/Edit) MUST also carry
+  `disallowedTools: [Write, Edit, MultiEdit]` to restore the read-only contract
+  (W1.5b).
 - Use `memory: project`, `memory: user`, or another supported scope. Do not use
   `memory: true`.
+- `tools:`, `disallowedTools:`, and `skills:` accept a YAML list (block or
+  `[A, B]` flow form) or a comma-separated string (`A, B`) — the validator
+  parses all three. Inline `#` comments are stripped (the validator parses real
+  YAML), so a trailing comment cannot bypass these checks.
 - If a command or agent uses deferred MCP tools, include `ToolSearch` and verify
   the real tool names after plugin installation.
 - For bundled MCP servers, derive tool names from the manifest:

--- a/docs/maintenance/issue-reconciliation-2026-05-29.md
+++ b/docs/maintenance/issue-reconciliation-2026-05-29.md
@@ -1,0 +1,202 @@
+# Issue Reconciliation — 2026-05-29
+
+Read-only reconciliation of open GitHub issues against `main` @ `ac635c5f`
+(plus the changes in branch `agent/fix/validator-frontmatter-and-readonly-contract`).
+Produced during the validator/stability pass. **No GitHub state was mutated** —
+the close/comment text below is proposed for a human to post.
+
+Verdict legend: **resolved** (close), **resolved-by-this-PR** (close after this
+PR merges), **partially-resolved** (close part / open a follow-up),
+**still-open** (keep open).
+
+| Issue | Title (abbrev.) | Verdict | Action |
+| ----- | --------------- | ------- | ------ |
+| #146 | debt: `git status --porcelain` for scope validation | resolved | close |
+| #147 | validator: handle YAML flow sequences in `parseList` | resolved-by-this-PR | close after merge |
+| #148 | validator: symlink-aware path containment | resolved | close |
+| #149 | debt: backfill deferred todos + clear stale severity | partially-resolved | follow-up |
+| #211 | yellow-research ast-grep needs `--python 3.13` | resolved | close |
+| #267 | check-upstream-pins: harden CLI arg parsing | resolved | close |
+| #268 | wire check-upstream-pins into scripts + CI advisory | resolved-by-this-PR | close after merge |
+| #269 | morph start-morph.sh canonicalize + race comment | resolved | close |
+| #270 | morph setup.md DATA_DIR guard + redact npm output | resolved | close |
+| #271 | yellow-devin mark `devin_org_id` sensitive | resolved | close |
+| #494 | plan-lifecycle P0/P1 design issues (PR #484) | partially-resolved | close as reduced-scope |
+| #496 | plan-lifecycle YAGNI scope reductions (PR #484) | resolved | close |
+
+All issue claims below were verified first-hand against the code at `ac635c5f`.
+
+---
+
+## #146 — debt scope uses `git status --porcelain` — **resolved**
+
+`plugins/yellow-debt/commands/debt/fix.md:69,188` and
+`plugins/yellow-debt/agents/remediation/debt-fixer.md:58,109` use
+`git status --porcelain | cut -c4-`, which includes untracked files that
+`git diff --name-only` would miss.
+
+> Resolved at `ac635c5f`. Both `debt-fixer.md` (lines 58, 109) and `fix.md`
+> (lines 69, 188) now enumerate files via `git status --porcelain | cut -c4-`,
+> correctly including untracked new files. Closing.
+
+## #147 — `parseList` YAML flow sequences — **resolved-by-this-PR**
+
+The pre-existing hand-rolled `parseList` mishandled empty flow lists (`[]`),
+quoted items, and (per the broader audit) inline comments. This PR replaces
+`parseScalar`/`parseList` in `scripts/validate-agent-authoring.js` with a real
+`yaml.parse`-backed parser that handles block lists, flow lists (incl. empty and
+quoted), comma-strings, and inline comments uniformly.
+
+> Addressed in PR (validator frontmatter hardening, `ac635c5f`+). `parseScalar`
+> and `parseList` are now backed by the `yaml` parser, so empty flow lists
+> (`tools: []`), quoted flow items, and inline comments are parsed correctly
+> instead of via brittle regex. Closing once that PR merges.
+
+## #148 — symlink-aware path containment — **resolved**
+
+`scripts/lib/plugin-paths.js` rejects symlinks via `fs.lstatSync()` +
+`isSymbolicLink()` in `validatePathFile` (139-146), `validateSinglePath`
+(182-188), `validateHookScriptPath` (324-330), and skips them in
+`countMarkdownRecursive` (101). Delivered with the validation-layer hardening
+(PR #555 / earlier PR #343).
+
+> Resolved. `scripts/lib/plugin-paths.js` uses `fs.lstatSync()` throughout and
+> rejects symlinks with a hard error before following them — stronger than the
+> proposed `realpathSync()` approach (lstat+reject blocks symlinks
+> unconditionally rather than allowing those that resolve inside the root).
+> Closing.
+
+## #149 — debt todo backfill + stale severity — **partially-resolved**
+
+Finding 2 (stale severity filter) is fixed: `commands/debt/audit.md:129-133`
+unconditionally `rm -f .debt/severity-filter.txt` and only recreates it when
+`--severity` is passed. Finding 1 (general frontmatter backfill for pre-schema
+todos) is **not** addressed — `lib/validate.sh:128` only removes the legacy
+`defer_reason` field; there is no helper that injects missing required fields.
+
+**Recommended:** keep open, retitle to scope only the backfill helper. Out of
+scope for this validator pass (yellow-debt plugin change → separate PR +
+changeset).
+
+> Finding 2 (stale severity filter) is resolved — `audit.md` clears
+> `.debt/severity-filter.txt` at audit start and only recreates it under
+> `--severity`. Finding 1 (backfill of missing required frontmatter fields in
+> pre-existing todos) remains open; `validate.sh` only deletes the deprecated
+> `defer_reason` field. Keeping open for a focused backfill-helper follow-up.
+
+## #211 — ast-grep `--python 3.13` — **resolved**
+
+`plugins/yellow-research/.claude-plugin/plugin.json:79-85` invokes
+`uvx --python 3.13 --from git+…ast-grep-mcp@674272f… ast-grep-server`. Shipped
+in commit `b4411645` (PR #219), v3.2.0.
+
+> Fixed at `ac635c5f`. The ast-grep MCP server config passes `--python 3.13` to
+> `uvx`, so it resolves a uv-managed Python 3.13 rather than system Python
+> (commit `b4411645`, PR #219). Closing. (Cross-environment runtime
+> verification on a Python-3.12 host is a separate, lower-priority check.)
+
+## #267 — check-upstream-pins CLI hardening — **resolved**
+
+`scripts/check-upstream-pins.js`: `--threshold` validates the next token is
+present and numeric, exiting with a clear message (52-68); `getNpmLatest`
+surfaces `e.stderr || e.message` under `--verbose` (132-150); `NPM_NAME_OK` has
+no `/i` flag (38, with rationale comment); header documents the weighted score
+formula (13-20).
+
+> All four findings resolved at `ac635c5f`: (1) `--threshold` NaN guard; (2)
+> `--verbose` surfaces the npm error text; (3) `NPM_NAME_OK` is case-sensitive
+> (no `/i`); (4) the header comment documents the weighted drift formula.
+> Closing.
+
+## #268 — wire check-upstream-pins into scripts + CI advisory — **resolved-by-this-PR**
+
+Was genuinely unwired (no `check:pins` script, no workflow reference; the
+`docs/upstream-pins.md` "checked automatically" claim was inaccurate). This PR
+adds `"check:pins": "node scripts/check-upstream-pins.js"` to `package.json`, a
+weekly+manual advisory workflow `.github/workflows/upstream-pins-advisory.yml`
+(`continue-on-error`, not in `ci-status`), and corrects the docs claim.
+
+> Addressed in PR (`ac635c5f`+): added `pnpm check:pins`, a non-blocking weekly
+> advisory workflow (`upstream-pins-advisory.yml`, also manual-dispatchable),
+> and corrected `docs/upstream-pins.md`. Deliberately kept out of the blocking
+> `validate:schemas`/`ci-status` gate (per-pin `npm view` network calls).
+> Closing once merged.
+
+## #269 — morph start-morph.sh canonicalize + race comment — **resolved**
+
+The fix landed in the shared lib, not in `start-morph.sh` directly:
+`plugins/yellow-morph/lib/install-morphmcp.sh:28-45` canonicalizes
+`CLAUDE_PLUGIN_ROOT`/`DATA` via `realpath -m` (capability-gated for BSD macOS)
+*before* the prefix-guard in `yellow_morph_validate_paths()`, which
+`start-morph.sh:37` calls. `CHANGELOG.md:27` credits "#269". The race comment
+was rewritten — `start-morph.sh:4-11` now describes the symmetric concurrent
+`npm ci` serialization ("concurrent `npm ci` cannot corrupt node_modules"); the
+old ordered "MCP starts before hook completes" wording is gone.
+
+> Resolved at `ac635c5f`. Path canonicalization (Finding 1) lives in
+> `lib/install-morphmcp.sh` (`yellow_morph_validate_paths`, lines 28-45,
+> credited to #269 in CHANGELOG), which `start-morph.sh` invokes — the right
+> home since the prewarm hook and `/morph:setup` also source it. The race
+> comment (Finding 2) was rewritten to the symmetric concurrent-`npm ci` framing
+> (`start-morph.sh:4-11`). Closing.
+
+## #270 — morph setup.md DATA_DIR guard + redact npm output — **resolved**
+
+`commands/morph/setup.md:94` uses `${CLAUDE_PLUGIN_DATA:?…}` (strict, matching
+`start-morph.sh`); `setup.md:122` runs `yellow_morph_do_install >&2` to keep npm
+chatter out of the conversation log.
+
+> Resolved at `ac635c5f`. `setup.md` uses the strict `${CLAUDE_PLUGIN_DATA:?…}`
+> guard (line 94) and redirects install output with `yellow_morph_do_install
+> >&2` (line 122). Closing.
+
+## #271 — yellow-devin `devin_org_id` sensitive — **resolved**
+
+`plugins/yellow-devin/.claude-plugin/plugin.json:31` sets `"sensitive": true`
+on `devin_org_id` (alongside `devin_service_user_token`).
+
+> Resolved at `ac635c5f`. `devin_org_id` is marked `"sensitive": true`, so it is
+> keychain-stored and redacted from transcripts. Closing.
+
+## #494 — plan-lifecycle P0/P1 design issues — **partially-resolved (close as reduced-scope)**
+
+The core deliverables shipped: `validate:plans` diff-scoped stray-checkbox gate
+(PR #556) and `/plan:status` + `/plan:complete` (PR #557). The original P0/P1
+findings targeted a larger design (3-check Gate C, UNCERTAIN audit trail,
+frontmatter convention, backfill script) that was deliberately simplified away
+by the #496 YAGNI reductions, making those specific findings moot. A
+resolution-map comment was already posted (per prior session).
+
+**Recommended:** close as resolved-within-reduced-scope, referencing #496.
+
+> Core deliverables merged (PR #556 `validate:plans`; PR #557 `/plan:status` +
+> `/plan:complete`). The P0/P1 findings tied to the original complex design
+> (Gate C verdict logic, UNCERTAIN audit trail, fence-delimiter scrub,
+> `mergedAt` filter, frontmatter/backfill) were eliminated by the #496 YAGNI
+> reductions rather than implemented — the simplified Gate C is a direct `gh`
+> lookup. Closing as resolved within the agreed reduced scope; see #496.
+
+## #496 — plan-lifecycle YAGNI scope reductions — **resolved**
+
+All YAGNI proposals were adopted: slug derived from filename (no frontmatter
+convention), no backfill script, no `plan-frontmatter.js` library, `validate:plans`
+is a separate CI matrix step (not folded into `validate:schemas`), 2-PR stack
+instead of 5. The brainstorm was annotated as superseded.
+
+> All YAGNI proposals adopted in PRs #556/#557: filename-derived slugs, no
+> frontmatter convention, no backfill script, no dedicated library,
+> `validate:plans` wired as its own CI step. The over-engineered infrastructure
+> was never built. Closing.
+
+---
+
+## Summary
+
+- **Close now (8):** #146, #148, #211, #267, #269, #270, #271, #496.
+- **Close after this PR merges (2):** #147, #268.
+- **Close as reduced-scope (1):** #494 (reference #496).
+- **Keep open / follow-up (1):** #149 (yellow-debt frontmatter backfill helper).
+
+Two reconciliation findings corrected the discovery subagents (which read only
+`start-morph.sh`): **#269 is resolved**, not open — its fix lives in the shared
+`lib/install-morphmcp.sh` and is CHANGELOG-credited to #269.

--- a/docs/upstream-pins.md
+++ b/docs/upstream-pins.md
@@ -4,9 +4,14 @@ Every MCP server or external binary that yellow-plugins invokes via `npx`, `uvx`
 or a bundled path is listed here with its current pinned version. Review on a
 monthly cadence (or before cutting a release) to decide whether to bump.
 
-Drift is checked automatically by `scripts/check-upstream-pins.js`, which queries
-the npm registry and prints any pin that lags the `latest` tag. Run it manually
-or hook it into CI as a non-blocking advisory.
+Drift is checked by `scripts/check-upstream-pins.js`, which queries the npm
+registry and prints any pin that lags the `latest` tag. Run it manually with
+`pnpm check:pins` (advisory — exits 0 even when drift exists; pass `--strict` or
+`--threshold N` to make it fail on drift), or rely on the weekly advisory
+workflow `.github/workflows/upstream-pins-advisory.yml` (runs Mondays and on
+manual dispatch; the drift report appears in the Actions run summary). It is
+intentionally NOT part of the blocking `validate:schemas` / `ci-status` gate —
+the per-pin `npm view` network calls would add registry flakiness to every PR.
 
 ## Policy
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "generate:snippets": "node scripts/sync-shell-snippets.js",
     "validate:setup-all": "node scripts/validate-setup-all.js",
     "validate:doc-counts": "node scripts/validate-doc-counts.js",
+    "check:pins": "node scripts/check-upstream-pins.js",
     "test:lint-plugins": "bats tests/lint-plugins.bats",
     "lint:plugins": "bash scripts/lint-plugins.sh",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md,yml,yaml}\"",

--- a/scripts/validate-agent-authoring.js
+++ b/scripts/validate-agent-authoring.js
@@ -5,6 +5,8 @@
 const fs = require('fs');
 const path = require('path');
 
+const YAML = require('yaml');
+
 const ROOT = path.resolve(__dirname, '..');
 // Allow tests to point the validator at a fixture tree by setting
 // VALIDATE_PLUGINS_DIR. Production runs leave it unset and use plugins/.
@@ -14,16 +16,23 @@ const PLUGINS_DIR = process.env.VALIDATE_PLUGINS_DIR
 
 // W1.5 rule: review/ agents must be read-only.
 // Any agent at plugins/<name>/agents/review/<file>.md must not list Bash,
-// Write, or Edit in its `tools:` set. Reviewers analyze; they do not act.
-// This containment limits the blast radius of prompt-injection attempts in
-// the untrusted PR diff and comment text reviewers consume.
-const REVIEW_AGENT_DENIED_TOOLS = ['Bash', 'Write', 'Edit'];
+// Write, Edit, or MultiEdit in its `tools:` set. Reviewers analyze; they do
+// not act. This containment limits the blast radius of prompt-injection
+// attempts in the untrusted PR diff and comment text reviewers consume.
+// MultiEdit is a batch file-write tool just like Write/Edit — omitting it
+// here left a fail-open path (a reviewer could list `MultiEdit` in `tools:`
+// and still mutate files); it is denied alongside Write/Edit.
+const REVIEW_AGENT_DENIED_TOOLS = ['Bash', 'Write', 'Edit', 'MultiEdit'];
 
-// W1.5b rule: the write-capable tools that `memory:` auto-enables. A review/
-// agent with `memory:` set MUST deny these via `disallowedTools` to keep the
-// read-only contract. Subset of REVIEW_AGENT_DENIED_TOOLS minus Bash (which
-// `memory:` does not grant).
-const MEMORY_GRANTED_WRITE_TOOLS = ['Write', 'Edit'];
+// W1.5b rule: the write-capable tools a review/ agent with `memory:` set MUST
+// deny via `disallowedTools` to preserve the read-only contract. `memory:`
+// auto-enables Read/Write/Edit regardless of the `tools:` list, which bypasses
+// the W1.5 `tools:` check above. MultiEdit is included defensively (it is NOT
+// memory-granted) so the deny set the shipped review agents already declare —
+// `[Write, Edit, MultiEdit]` — is enforced and stays consistent with
+// REVIEW_AGENT_DENIED_TOOLS. Named REQUIRED_DISALLOWED (not MEMORY_GRANTED_*)
+// because MultiEdit is a required deny, not a tool memory grants.
+const REVIEW_AGENT_REQUIRED_DISALLOWED_TOOLS = ['Write', 'Edit', 'MultiEdit'];
 
 // Valid `memory:` scope values per Claude Code docs. Only these three
 // activate per-agent memory (and the Read/Write/Edit auto-grant); any other
@@ -116,52 +125,68 @@ function extractFrontmatter(text) {
   return match ? match[1] : null;
 }
 
-function parseScalar(frontmatter, key) {
-  const match = frontmatter.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
-  if (!match) return null;
-  return match[1].trim().replace(/^['"]|['"]$/g, '');
+// Parse a frontmatter block with the real YAML parser (the `yaml` devDep) so
+// the validator interprets frontmatter the way Claude Code does: inline
+// comments stripped, quotes resolved, and flow/block lists normalized to
+// arrays. Returns the parsed object on success, {} for empty/scalar/array
+// frontmatter (so key lookups yield undefined → null/[]), and null when the
+// YAML is malformed (callers degrade safely; validateAgentFile surfaces a
+// clear error). Replacing the old hand-rolled regex parser fixes two bugs an
+// audit confirmed change behavior on ZERO currently-shipped files:
+//   1. `memory: project # note` previously returned "project # note" (not a
+//      valid scope), silently disabling the W1.5b read-only gate. YAML strips
+//      the comment → "project" → the gate fires, matching runtime behavior.
+//   2. The comma-string list form Claude Code accepts (`disallowedTools:
+//      Write, Edit`) is now honored — see parseList.
+function parseFrontmatter(frontmatter) {
+  if (frontmatter == null) return null;
+  let data;
+  try {
+    data = YAML.parse(frontmatter);
+  } catch {
+    return null;
+  }
+  return data && typeof data === 'object' && !Array.isArray(data) ? data : {};
 }
 
+// Read a scalar frontmatter value as a string. Non-string scalars are coerced
+// (e.g. `memory: true` → "true", which is not a VALID_MEMORY_SCOPE, so the
+// scope-gate still treats memory as inactive — preserving prior behavior and
+// the W1.5b scope-gate test).
+function parseScalar(frontmatter, key) {
+  const data = parseFrontmatter(frontmatter);
+  if (!data) return null;
+  const value = data[key];
+  if (value === undefined || value === null) return null;
+  return typeof value === 'string' ? value : String(value);
+}
+
+// Read a list-typed frontmatter value (tools/disallowedTools/skills) as a
+// string array. Claude Code accepts THREE forms for these fields: a YAML block
+// list, a YAML flow list (`[A, B]`), and a bare comma-separated string
+// (`A, B`) — see docs/research/all-possible-subagent-frontmatter-config.md.
+// yaml.parse returns an array for the first two and a STRING for the comma
+// form, so a string result is split on commas. Anything else (or an absent
+// key) yields []. ALWAYS returns a real array so RULE 14's exact-match
+// `.includes()` anti-bypass invariant holds on every accepted form (a naive
+// yaml.parse swap without this split would degrade RULE 14 to substring
+// matching on the comma-string form).
 function parseList(frontmatter, key) {
-  // Try inline flow form first: key: [item1, item2]
-  const inlineMatch = frontmatter.match(
-    new RegExp(`^${key}:\\s*\\[([^\\]]+)\\]`, 'm')
-  );
-  if (inlineMatch) {
-    return inlineMatch[1]
-      .split(',')
-      .map((s) => s.trim().replace(/^['"]|['"]$/g, ''))
+  const data = parseFrontmatter(frontmatter);
+  if (!data) return [];
+  const value = data[key];
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => (item == null ? '' : String(item).trim()))
       .filter(Boolean);
   }
-
-  const lines = frontmatter.split('\n');
-  const values = [];
-  let inList = false;
-
-  for (const line of lines) {
-    if (!inList) {
-      if (new RegExp(`^${key}:\\s*$`).test(line)) {
-        inList = true;
-      }
-      continue;
-    }
-
-    const item = line.match(/^\s*-\s+(.+?)\s*$/);
-    if (item) {
-      values.push(item[1].replace(/^['"]|['"]$/g, ''));
-      continue;
-    }
-
-    if (line.trim() === '') {
-      continue;
-    }
-
-    if (!line.startsWith(' ')) {
-      break;
-    }
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean);
   }
-
-  return values;
+  return [];
 }
 
 function relative(filePath) {
@@ -198,6 +223,18 @@ function validateAgentFile(filePath, ctx) {
 
   if (!frontmatter) {
     errors.push(`${relative(filePath)}: missing frontmatter`);
+    return;
+  }
+
+  // Malformed YAML would make every parseScalar/parseList return null/[],
+  // silently disabling W1.5/W1.5b/V1/V2/RULE 14. Fail loud with the parser's
+  // message instead of letting the security gates go dark.
+  try {
+    YAML.parse(frontmatter);
+  } catch (e) {
+    errors.push(
+      `${relative(filePath)}: malformed YAML frontmatter — ${String(e.message).split('\n')[0]}`
+    );
     return;
   }
 
@@ -329,9 +366,9 @@ function validateAgentFile(filePath, ctx) {
         // `tools:` list (per Claude Code docs), so the tools-only check
         // above is bypassed whenever a review/ agent sets `memory:`. Such an
         // agent MUST restore the read-only contract with a `disallowedTools`
-        // entry containing both Write and Edit. Without this, a review agent
-        // processing untrusted PR diffs runs write-capable. The 3 yellow-core
-        // security agents and the 6 yellow-review review agents already carry
+        // entry denying Write, Edit, and MultiEdit. Without this, a review
+        // agent processing untrusted PR diffs runs write-capable. Every
+        // shipped memory:-bearing review agent already carries
         // `disallowedTools: [Write, Edit, MultiEdit]`; this rule prevents a
         // future review/ agent from regressing silently.
         const memoryScope = parseScalar(frontmatter, 'memory');
@@ -340,7 +377,7 @@ function validateAgentFile(filePath, ctx) {
             frontmatter,
             'disallowedTools'
           ).map((t) => t.toLowerCase());
-          const missingDenies = MEMORY_GRANTED_WRITE_TOOLS.filter(
+          const missingDenies = REVIEW_AGENT_REQUIRED_DISALLOWED_TOOLS.filter(
             (t) => !disallowedLower.includes(t.toLowerCase())
           );
           if (missingDenies.length > 0) {

--- a/scripts/validate-agent-authoring.js
+++ b/scripts/validate-agent-authoring.js
@@ -138,27 +138,52 @@ function extractFrontmatter(text) {
 //      the comment → "project" → the gate fires, matching runtime behavior.
 //   2. The comma-string list form Claude Code accepts (`disallowedTools:
 //      Write, Edit`) is now honored — see parseList.
+// Memoized on the raw frontmatter string: every agent file parses the same
+// block up to ~6 times (model/effort/memory/name + tools/disallowedTools/
+// skills), and YAML.parse is heavier than the regex parser it replaced.
+// Identical input always yields the same result, so caching is safe — and the
+// validator is spawned as a fresh child process per run (see the test harness),
+// so the Map starts empty each invocation and never leaks across runs.
+const frontmatterCache = new Map();
+
 function parseFrontmatter(frontmatter) {
   if (frontmatter == null) return null;
+  if (frontmatterCache.has(frontmatter)) {
+    return frontmatterCache.get(frontmatter);
+  }
   let data;
   try {
     data = YAML.parse(frontmatter);
   } catch {
+    // Malformed YAML caches as null so the parse-error gate fires consistently.
+    frontmatterCache.set(frontmatter, null);
     return null;
   }
-  return data && typeof data === 'object' && !Array.isArray(data) ? data : {};
+  const result =
+    data && typeof data === 'object' && !Array.isArray(data) ? data : {};
+  frontmatterCache.set(frontmatter, result);
+  return result;
 }
 
-// Read a scalar frontmatter value as a string. Non-string scalars are coerced
-// (e.g. `memory: true` → "true", which is not a VALID_MEMORY_SCOPE, so the
-// scope-gate still treats memory as inactive — preserving prior behavior and
-// the W1.5b scope-gate test).
+// Read a scalar frontmatter value as a string. Primitive non-strings are
+// coerced (e.g. `memory: true` → "true", which is not a VALID_MEMORY_SCOPE, so
+// the scope-gate still treats memory as inactive — preserving prior behavior
+// and the W1.5b scope-gate test). A non-scalar node (array/object) is INVALID
+// frontmatter for a scalar field: plain String() would smuggle `model:
+// [inherit]` → "inherit" or `effort: [high]` → "high" past the V1/V2 enum
+// checks the old regex parser flagged. Returning the JSON form instead keeps
+// those checks failing loudly, and for `memory:` an array/object scope is not a
+// VALID_MEMORY_SCOPE so the W1.5b gate stays inactive — matching Claude Code,
+// which ignores a non-scalar memory value (no Read/Write/Edit auto-grant → no
+// read-only-contract risk).
 function parseScalar(frontmatter, key) {
   const data = parseFrontmatter(frontmatter);
   if (!data) return null;
   const value = data[key];
   if (value === undefined || value === null) return null;
-  return typeof value === 'string' ? value : String(value);
+  if (typeof value === 'string') return value;
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
 }
 
 // Read a list-typed frontmatter value (tools/disallowedTools/skills) as a

--- a/tests/integration/validate-agent-authoring-model-effort-rules.test.ts
+++ b/tests/integration/validate-agent-authoring-model-effort-rules.test.ts
@@ -76,6 +76,19 @@ describe('validate-agent-authoring V1: effort enum', () => {
     expect(stderr).toMatch(/invalid effort: 'hight'/);
   });
 
+  it('errors on a non-scalar effort: [high] (array must not coerce to "high")', () => {
+    // YAML parses `effort: [high]` as a list. Plain String() coercion would
+    // smuggle it past the enum as "high"; the JSON form keeps V1 flagging it.
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/workflow/effort-array.md',
+      agentBody({ name: 'effort-array', model: 'sonnet', effort: '[high]' })
+    );
+    const { status, stderr } = runValidator(tmpRoot);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/invalid effort: '\["high"\]'/);
+  });
+
   it('passes when effort: is absent', () => {
     writeAgent(
       tmpRoot,
@@ -138,6 +151,19 @@ describe('validate-agent-authoring V2: model enum', () => {
     const { status, stderr } = runValidator(tmpRoot);
     expect(status).toBeGreaterThan(0);
     expect(stderr).toMatch(/invalid model: 'sonnet-invalid'/);
+  });
+
+  it('errors on a non-scalar model: [inherit] (array must not coerce to "inherit")', () => {
+    // `model: [inherit]` is a list, not a scalar. Coercing it with String()
+    // would yield "inherit" and pass V2; the JSON form keeps V2 flagging it.
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/workflow/model-array.md',
+      agentBody({ name: 'model-array', model: '[inherit]' })
+    );
+    const { status, stderr } = runValidator(tmpRoot);
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/invalid model: '\["inherit"\]'/);
   });
 
   it('passes when model: is absent', () => {

--- a/tests/integration/validate-agent-authoring-review-rule.test.ts
+++ b/tests/integration/validate-agent-authoring-review-rule.test.ts
@@ -125,6 +125,26 @@ describe('validate-agent-authoring W1.5 read-only reviewer rule', () => {
     expect(stderr).toMatch(/Write, Edit/);
   });
 
+  it('flags MultiEdit in review agent tools (W1.5 deny-set includes MultiEdit)', () => {
+    // MultiEdit is a batch file-write tool; listing it in a review agent's
+    // tools: is the fail-open path W1.5 now closes alongside Write/Edit.
+    const multiEditViolator = REVIEW_AGENT_BASH_VIOLATOR.replace(
+      'synth-violator',
+      'multiedit-violator'
+    ).replace('  - Bash', '  - MultiEdit');
+    writeAgent(
+      tmpRoot,
+      'yellow-test/agents/review/multiedit-violator.md',
+      multiEditViolator
+    );
+
+    const { status, stderr } = runValidator(tmpRoot);
+
+    expect(status).toBeGreaterThan(0);
+    expect(stderr).toMatch(/multiedit-violator\.md/);
+    expect(stderr).toMatch(/MultiEdit/);
+  });
+
   it('does NOT flag non-review agents (e.g., agents/workflow/)', () => {
     // pr-comment-resolver legitimately needs Bash and Edit; it lives under
     // agents/workflow/ not agents/review/ and Rule X does not apply.

--- a/tests/integration/validate-agent-authoring-rule14.test.ts
+++ b/tests/integration/validate-agent-authoring-rule14.test.ts
@@ -78,6 +78,37 @@ tools:
 Body for reviewer fixture.
 `;
 
+// Comma-string disallowedTools (single value) — a list form Claude Code
+// accepts. parseList splits it into ["AskUserQuestion"], so RULE 14's
+// exact-match .includes() is satisfied. MUST PASS.
+const PROMOTER_FM_COMMA_DENY = `---
+name: staging-promoter
+description: Promoter test fixture. Use when verifying comma-string disallowedTools.
+model: inherit
+tools:
+  - Read
+  - Write
+  - Edit
+disallowedTools: AskUserQuestion
+---
+`;
+
+// Anti-bypass guard on the comma-string path: a near-miss token must NOT
+// satisfy RULE 14. parseList yields ["AskUserQuestion-disabled"], and
+// .includes("AskUserQuestion") is array exact-match (NOT substring), so this
+// MUST FAIL — the same bypass class RULE 14 was hardened against (PR #544).
+const PROMOTER_FM_SUBSTRING_DENY = `---
+name: staging-promoter
+description: Promoter test fixture. Use when verifying RULE 14 anti-bypass.
+model: inherit
+tools:
+  - Read
+  - Write
+  - Edit
+disallowedTools: AskUserQuestion-disabled
+---
+`;
+
 // Body that satisfies RULE 14b: documents Session Notes gate AND has a
 // paragraph naming all three sections in a "Never modify|write|touch"
 // context.
@@ -173,6 +204,27 @@ describe('validate-agent-authoring RULE 14 (disallowedTools frontmatter)', () =>
       pluginsDir,
       'yellow-core/agents/workflow/staging-reviewer.md',
       REVIEWER_FM_MISSING_DENY
+    );
+    const result = runValidator(pluginsDir);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/RULE 14/);
+  });
+
+  it('passes when disallowedTools uses the comma-string form (AskUserQuestion)', () => {
+    writeAgent(
+      pluginsDir,
+      'yellow-core/agents/workflow/staging-promoter.md',
+      PROMOTER_FM_COMMA_DENY + PROMOTER_BODY_OK
+    );
+    const result = runValidator(pluginsDir);
+    expect(result.status).toBe(0);
+  });
+
+  it('fails a near-miss comma-string token (AskUserQuestion-disabled) — anti-bypass', () => {
+    writeAgent(
+      pluginsDir,
+      'yellow-core/agents/workflow/staging-promoter.md',
+      PROMOTER_FM_SUBSTRING_DENY + PROMOTER_BODY_OK
     );
     const result = runValidator(pluginsDir);
     expect(result.status).not.toBe(0);

--- a/tests/integration/validate-agent-authoring-w15b.test.ts
+++ b/tests/integration/validate-agent-authoring-w15b.test.ts
@@ -93,6 +93,25 @@ tools:
 Body for W1.5b fixture.
 `;
 
+// memory: as a non-scalar (flow list) — Claude Code ignores a non-scalar scope
+// value, so memory is NOT active, no Read/Write/Edit auto-grant, and W1.5b must
+// NOT fire (no disallowedTools present). Guards the parseScalar non-scalar
+// rejection: an array scope must coerce to a non-VALID_MEMORY_SCOPE value, not
+// to "project".
+const REVIEW_FM_MEMORY_ARRAY_SCOPE = `---
+name: w15b-fixture
+description: W1.5b review fixture. Use when verifying a non-scalar memory scope.
+model: inherit
+memory: [project]
+tools:
+  - Read
+  - Grep
+  - Glob
+---
+
+Body for W1.5b fixture.
+`;
+
 // A review/ agent with NO memory: at all — W1.5b is a no-op (the W1.5
 // tools-list check is the only relevant rule, and Read/Grep/Glob pass it).
 const REVIEW_FM_NO_MEMORY = `---
@@ -262,6 +281,20 @@ describe('validate-agent-authoring W1.5b (memory: requires disallowedTools)', ()
       pluginsDir,
       'yellow-core/agents/review/w15b-fixture.md',
       REVIEW_FM_MEMORY_INVALID_SCOPE
+    );
+    const result = runValidator(pluginsDir);
+    expect(result.status).toBe(0);
+  });
+
+  it('does NOT fire on a non-scalar scope (memory: [project]) — array not coerced to a valid scope', () => {
+    // A list memory value is ignored by Claude Code (no write auto-grant), so
+    // the read-only contract is intact and W1.5b must stay silent. Guards
+    // against String() coercing [project] → "project" and falsely activating
+    // the gate (which would demand a disallowedTools entry that isn't needed).
+    writeAgent(
+      pluginsDir,
+      'yellow-core/agents/review/w15b-fixture.md',
+      REVIEW_FM_MEMORY_ARRAY_SCOPE
     );
     const result = runValidator(pluginsDir);
     expect(result.status).toBe(0);

--- a/tests/integration/validate-agent-authoring-w15b.test.ts
+++ b/tests/integration/validate-agent-authoring-w15b.test.ts
@@ -124,6 +124,94 @@ tools:
 Body for allowlisted fixture.
 `;
 
+// memory: with a trailing inline YAML comment. The pre-yaml regex parser
+// returned "project # scoped" (not a valid scope), silently disabling W1.5b —
+// the fail-open bypass. Claude Code (real YAML) strips the comment → "project"
+// → memory IS active → the deny is required. MUST FAIL.
+const REVIEW_FM_MEMORY_INLINE_COMMENT = `---
+name: w15b-fixture
+description: W1.5b review fixture. Use when verifying inline-comment handling.
+model: inherit
+memory: project # scoped to project memory
+tools:
+  - Read
+  - Grep
+  - Glob
+---
+
+Body for W1.5b fixture.
+`;
+
+// Comma-string disallowedTools — a list form Claude Code accepts. The deny set
+// is complete, so this MUST PASS (the pre-yaml parser returned [] for this
+// form and wrongly failed it).
+const REVIEW_FM_MEMORY_COMMA_DENY = `---
+name: w15b-fixture
+description: W1.5b review fixture. Use when verifying comma-string disallowedTools.
+model: inherit
+memory: project
+tools:
+  - Read
+  - Grep
+  - Glob
+disallowedTools: Write, Edit, MultiEdit
+---
+
+Body for W1.5b fixture.
+`;
+
+// Flow-list disallowedTools with a complete deny set. MUST PASS.
+const REVIEW_FM_MEMORY_FLOW_DENY = `---
+name: w15b-fixture
+description: W1.5b review fixture. Use when verifying flow-list disallowedTools.
+model: inherit
+memory: project
+tools:
+  - Read
+  - Grep
+  - Glob
+disallowedTools: [Write, Edit, MultiEdit]
+---
+
+Body for W1.5b fixture.
+`;
+
+// Denies Write and Edit but NOT MultiEdit — must fail now that W1.5b requires
+// the full [Write, Edit, MultiEdit] deny set. MUST FAIL, naming MultiEdit.
+const REVIEW_FM_MEMORY_MISSING_MULTIEDIT = `---
+name: w15b-fixture
+description: W1.5b review fixture. Use when verifying the MultiEdit requirement.
+model: inherit
+memory: project
+tools:
+  - Read
+  - Grep
+  - Glob
+disallowedTools:
+  - Write
+  - Edit
+---
+
+Body for W1.5b fixture.
+`;
+
+// Quoted scalar memory value + flow deny — quotes must resolve to the scope
+// "project" and the deny is complete. MUST PASS.
+const REVIEW_FM_MEMORY_QUOTED = `---
+name: w15b-fixture
+description: W1.5b review fixture. Use when verifying quoted memory scope.
+model: inherit
+memory: "project"
+tools:
+  - Read
+  - Grep
+  - Glob
+disallowedTools: [Write, Edit, MultiEdit]
+---
+
+Body for W1.5b fixture.
+`;
+
 let pluginsDir: string;
 
 beforeEach(() => {
@@ -197,5 +285,94 @@ describe('validate-agent-authoring W1.5b (memory: requires disallowedTools)', ()
     );
     const result = runValidator(pluginsDir);
     expect(result.status).toBe(0);
+  });
+
+  it('fires on memory: project with a trailing inline comment (no deny) — the bypass fix', () => {
+    writeAgent(
+      pluginsDir,
+      'yellow-core/agents/review/w15b-fixture.md',
+      REVIEW_FM_MEMORY_INLINE_COMMENT
+    );
+    const result = runValidator(pluginsDir);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/W1\.5b/);
+  });
+
+  it('passes a complete comma-string deny (disallowedTools: Write, Edit, MultiEdit)', () => {
+    writeAgent(
+      pluginsDir,
+      'yellow-core/agents/review/w15b-fixture.md',
+      REVIEW_FM_MEMORY_COMMA_DENY
+    );
+    const result = runValidator(pluginsDir);
+    expect(result.status).toBe(0);
+  });
+
+  it('passes a complete flow-list deny (disallowedTools: [Write, Edit, MultiEdit])', () => {
+    writeAgent(
+      pluginsDir,
+      'yellow-core/agents/review/w15b-fixture.md',
+      REVIEW_FM_MEMORY_FLOW_DENY
+    );
+    const result = runValidator(pluginsDir);
+    expect(result.status).toBe(0);
+  });
+
+  it('fails a partial deny missing MultiEdit (Write + Edit present)', () => {
+    writeAgent(
+      pluginsDir,
+      'yellow-core/agents/review/w15b-fixture.md',
+      REVIEW_FM_MEMORY_MISSING_MULTIEDIT
+    );
+    const result = runValidator(pluginsDir);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/W1\.5b/);
+    // The error names the specifically-missing tool.
+    expect(result.stdout + result.stderr).toMatch(/MultiEdit/);
+  });
+
+  it('passes a quoted memory scope ("project") with a complete deny', () => {
+    writeAgent(
+      pluginsDir,
+      'yellow-core/agents/review/w15b-fixture.md',
+      REVIEW_FM_MEMORY_QUOTED
+    );
+    const result = runValidator(pluginsDir);
+    expect(result.status).toBe(0);
+  });
+});
+
+// Malformed frontmatter must fail LOUD, not silently disable the security
+// gates (which all depend on the YAML parse succeeding).
+const MALFORMED_YAML_FM = `---
+name: malformed-fixture
+description: "Malformed YAML fixture. Use when verifying the parse-error gate."
+model: inherit
+tools: [Read, Grep
+---
+
+Body for malformed fixture.
+`;
+
+describe('validate-agent-authoring malformed YAML frontmatter', () => {
+  let pluginsDir2: string;
+
+  beforeEach(() => {
+    pluginsDir2 = mkdtempSync(join(tmpdir(), 'validate-malformed-'));
+  });
+
+  afterEach(() => {
+    rmSync(pluginsDir2, { recursive: true, force: true });
+  });
+
+  it('errors with a clear message instead of silently passing', () => {
+    writeAgent(
+      pluginsDir2,
+      'yellow-core/agents/workflow/malformed-fixture.md',
+      MALFORMED_YAML_FM
+    );
+    const result = runValidator(pluginsDir2);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/malformed YAML/i);
   });
 });


### PR DESCRIPTION
## What

Validator/stability pass on `scripts/validate-agent-authoring.js` — no plugin behavior changes, **no `plugins/` files → changeset-free**.

### 1. yaml-backed frontmatter parser
Replaces the ad-hoc regex `parseScalar`/`parseList` with helpers backed by the `yaml` devDep, so the validator reads frontmatter the way Claude Code does.

- **Fixes a W1.5b fail-open bypass:** `memory: project # comment` used to parse as `"project # comment"` (not a valid scope) → the read-only gate silently skipped. YAML strips the comment → `project` → the gate fires.
- **Honors the comma-string list form** Claude Code accepts (`disallowedTools: Write, Edit`) — a string result is split to an array, so RULE 14's exact-match `.includes()` anti-bypass invariant is preserved on every accepted form (block / flow / comma-string).
- **Malformed YAML now errors loudly** instead of letting the security gates go dark.
- An audit confirmed the swap changes behavior on **zero** currently-shipped agents (82 agents, 282 md files still pass). Closes #147.

### 2. Read-only contract tightening (zero false positives)
- **W1.5:** `REVIEW_AGENT_DENIED_TOOLS` now includes `MultiEdit` — closes a fail-open path where a review agent could list `MultiEdit` in `tools:`.
- **W1.5b:** `MEMORY_GRANTED_WRITE_TOOLS` → `REVIEW_AGENT_REQUIRED_DISALLOWED_TOOLS = [Write, Edit, MultiEdit]` (enforces MultiEdit; code/message/comment consistent).
- Verified: every `memory:`-bearing review agent already declares MultiEdit; no review agent lists it in `tools:`. **No agent files changed.**

### 3. check-upstream-pins advisory wiring. Closes #268.
- `pnpm check:pins` script + new `.github/workflows/upstream-pins-advisory.yml` (weekly + manual dispatch, `continue-on-error`, **not** in the blocking `ci-status` gate — it makes `npm view` network calls).
- Corrected the inaccurate "checked automatically" claim in `docs/upstream-pins.md`.

### 4. Docs
- `AGENTS.md`: documents the W1.5/W1.5b deny-set contract + the three accepted list forms.
- `docs/maintenance/issue-reconciliation-2026-05-29.md`: read-only reconciliation of 12 stale issues.

## Tests
8 new fixtures across w15b / rule14 / review-rule: inline-comment bypass, comma-string deny, flow-list, partial-deny-missing-MultiEdit, quoted scope, malformed-YAML, comma-string anti-bypass near-miss, MultiEdit-in-tools. All authoring suites pass (56/56).

## Verification
`validate:schemas`, `validate:versions`, `lint`, `typecheck`, `test:unit` all green. `test:integration` green **except one pre-existing, unrelated failure** in `install-morphmcp.test.ts` (#269 case) that triggers only when `TMPDIR` is nested under `/tmp` (this dev box / Claude Code Web); the morph guard itself is correct and it passes on `/tmp`-direct CI. Not touched by this diff.

## Not a changeset
All changes are under `scripts/`, `tests/`, `docs/`, `package.json`, `.github/` — nothing under `plugins/`, so per AGENTS.md no changeset is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a non-blocking weekly advisory workflow to report upstream pin drift and a root script to run the check manually.

* **Documentation**
  * Updated upstream-pins docs with operational guidance and advisory behavior.
  * Clarified agent authoring rules, read-only tool restrictions (including MultiEdit), and accepted frontmatter list formats.
  * Added an issue reconciliation maintenance report.

* **Tests**
  * Expanded validator tests for agent authoring, YAML frontmatter parsing, deny-set enforcement, and model/effort validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->