### PR TITLE
test(yellow-morph): make install-morphmcp traversal test robust to nested TMPDIR

### DIFF
--- a/tests/integration/install-morphmcp.test.ts
+++ b/tests/integration/install-morphmcp.test.ts
@@ -85,10 +85,18 @@ describe('yellow_morph_validate_paths — path canonicalization (#269)', () => {
   });
 
   it('CLAUDE_PLUGIN_DATA with `..` traversal is rejected after canonicalization', () => {
-    // $HOME/../../etc → realpath -m resolves to /etc, which fails the
-    // HOME/tmp prefix guard. Before the fix, the raw string matched
-    // "$HOME/*" and passed.
-    const traversal = `${tmpHome}/../../etc`;
+    // tmpHome/<..×depth>/etc → realpath -m resolves to /etc, which fails the
+    // HOME/tmp prefix guard. Before the fix, the raw string matched "$HOME/*"
+    // and passed. The number of `..` segments is derived from tmpHome's own
+    // depth so the path deterministically escapes to "/etc" regardless of how
+    // deeply TMPDIR is nested: a fixed `../../` only reaches root when tmpHome
+    // is exactly /tmp/<x>, but on hosts where TMPDIR is itself under /tmp
+    // (e.g. Claude Code Web's /tmp/claude-NNNN), `../../etc` resolves to
+    // /tmp/etc — still inside the /tmp allowlist — and the rejection never
+    // fires. Computing the depth keeps this test asserting the real guard
+    // behaviour rather than coincidentally passing on /tmp-rooted TMPDIRs.
+    const depth = tmpHome.split('/').filter(Boolean).length;
+    const traversal = `${tmpHome}/${'../'.repeat(depth)}etc`;
     const result = runBash(INVOKE, {
       HOME: tmpHome,
       PATH: process.env.PATH,


### PR DESCRIPTION
## What

The `#269` path-traversal test in `tests/integration/install-morphmcp.test.ts` hard-coded `${tmpHome}/../../etc`. Two `..` segments only escape the guard's `/tmp/*` allowlist to `/etc` when `tmpHome` is exactly `/tmp/<x>`. When `TMPDIR` is itself nested under `/tmp` (Claude Code Web uses `/tmp/claude-NNNN`), `../../etc` resolves to `/tmp/etc` — still inside the allowlist — so the guard accepts it and the test's "must reject" assertion fails. Pure env trap; the morph guard (`yellow_morph_validate_paths`) is correct.

## Fix

Derive the number of `..` segments from `tmpHome`'s own path depth so the traversal deterministically resolves to `/etc` regardless of `TMPDIR` nesting:

```ts
const depth = tmpHome.split('/').filter(Boolean).length;
const traversal = `${tmpHome}/${'../'.repeat(depth)}etc`;
```

## Verification

- **Old code, `TMPDIR=/tmp/<nested>`** → test FAILS (reproduced the trap).
- **New code** → passes under default `TMPDIR`, 2-level, and 3-level nesting.
- `lint` + `typecheck` clean.

## Not a changeset

Touches only `tests/integration/` — no `plugins/` files, no plugin behavior change.

Env-trap follow-up to #269 / #555.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced integration test robustness to ensure path validation behavior is consistent and deterministic across different system configurations, strengthening verification that security boundaries are properly enforced regardless of filesystem layout depth.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KingInYellows/yellow-plugins/pull/563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->