### PR TITLE
chore(yellow-morph): bump @morphllm/morphmcp 0.8.165 → 0.8.181

### DIFF
--- a/.changeset/bump-morphmcp-0-8-181.md
+++ b/.changeset/bump-morphmcp-0-8-181.md
@@ -1,0 +1,5 @@
+---
+"yellow-morph": minor
+---
+
+Bump `@morphllm/morphmcp` pin 0.8.165 → 0.8.181 (latest npm release). Verified via an MCP `tools/list` probe per the upstream-pins bump checklist: 0.8.181 exposes `edit_file` and `codebase_search` — the two tools the plugin namespaces (`mcp__plugin_yellow-morph_morph__edit_file` / `__codebase_search`) — plus `github_codebase_search`. The bump removes or renames nothing the plugin depends on, and the env-var surface is unchanged. Updates `plugins/yellow-morph/package.json`, `package-lock.json`, the root `pnpm-lock.yaml`, and the version reference in the plugin CLAUDE.md.

--- a/.changeset/research-morphmcp-tool-note.md
+++ b/.changeset/research-morphmcp-tool-note.md
@@ -1,0 +1,5 @@
+---
+"yellow-research": patch
+---
+
+Make the morphmcp tool-name note in `/research:setup` version-agnostic ("In current morphmcp the tool is named `codebase_search`") so it no longer pins a specific morphmcp version that drifts on every bump. No behavior change.

--- a/docs/upstream-pins.md
+++ b/docs/upstream-pins.md
@@ -24,7 +24,7 @@ or hook it into CI as a non-blocking advisory.
 
 | Plugin           | Package                          | Pinned   | Registry | Notes                                                                   |
 | ---------------- | -------------------------------- | -------- | -------- | ----------------------------------------------------------------------- |
-| yellow-morph     | `@morphllm/morphmcp`             | `0.8.165`| npm      | Bumped 2026-04-17 from 0.8.110. No public changelog; verify empirically. **Pin tracked in `plugins/yellow-morph/package.json` deps (wrapper-based); NOT in `plugin.json` args.** |
+| yellow-morph     | `@morphllm/morphmcp`             | `0.8.181`| npm      | Bumped 2026-05-29 from 0.8.165 (tools/list verified: exposes `edit_file` + `codebase_search` + `github_codebase_search`; bump removes/renames nothing the plugin uses). No public changelog; verify empirically. **Pin tracked in `plugins/yellow-morph/package.json` deps (wrapper-based); NOT in `plugin.json` args.** |
 | yellow-research  | `@perplexity-ai/mcp-server`      | `0.8.2`  | npm      | Perplexity MCP. Requires `PERPLEXITY_API_KEY`.                          |
 | yellow-research  | `tavily-mcp`                     | `0.2.17` | npm      | Tavily research MCP. Requires `TAVILY_API_KEY`.                         |
 | yellow-research  | `exa-mcp-server`                 | `3.1.8`  | npm      | Exa MCP. Requires `EXA_API_KEY`. Tool whitelist passed as positional arg.|

--- a/plugins/yellow-morph/CLAUDE.md
+++ b/plugins/yellow-morph/CLAUDE.md
@@ -5,7 +5,7 @@ Intelligent code editing and search via Morph Fast Apply and WarpGrep.
 ## MCP Server
 
 - **morph** — Stdio transport via `bin/start-morph.sh`, which runs
-  `node @morphllm/morphmcp@0.8.165` from a per-user install in
+  `node @morphllm/morphmcp@0.8.181` from a per-user install in
   `${CLAUDE_PLUGIN_DATA}/node_modules/`.
 - Requires a Morph API key configured via plugin `userConfig` (Claude Code
   prompts for it at plugin-enable time and stores it in the system keychain

--- a/plugins/yellow-morph/package-lock.json
+++ b/plugins/yellow-morph/package-lock.json
@@ -1,24 +1,24 @@
 {
   "name": "yellow-morph",
-  "version": "1.1.0",
+  "version": "1.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yellow-morph",
-      "version": "1.1.0",
+      "version": "1.2.6",
       "dependencies": {
-        "@morphllm/morphmcp": "0.8.165"
+        "@morphllm/morphmcp": "0.8.181"
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.104",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.104.tgz",
-      "integrity": "sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==",
+      "version": "3.0.121",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.121.tgz",
+      "integrity": "sha512-uY248djJRxa5W68MHiyqO8WLdOeKQoRClGg7PVX/VPhVW8SJNM7/l5DcrA5WAM3YfQrLyNkgZa2VOu8T0t8LUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.23",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
         "@vercel/oidc": "3.2.0"
       },
       "engines": {
@@ -29,9 +29,9 @@
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
-      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -41,14 +41,14 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
-      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
+      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider": "3.0.10",
         "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.6"
+        "eventsource-parser": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -62,7 +62,6 @@
       "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.21.0.tgz",
       "integrity": "sha512-7XhUbtnlkSEZK15kN3t+tzIMxsbKm/dSkKBFalj+20NvPKe1kBY7mR2P7vuijEn+f06z5+A8bVGKO0v39cr6Wg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -137,14 +136,14 @@
       }
     },
     "node_modules/@morphllm/morphmcp": {
-      "version": "0.8.165",
-      "resolved": "https://registry.npmjs.org/@morphllm/morphmcp/-/morphmcp-0.8.165.tgz",
-      "integrity": "sha512-Hn6kiSTJSbzDYw9bzyF0k/F7FlTsYeFj5NUkCl3nqPtFkV4HB6LBmhjN3GKMpaqsmw7F1Rb3i8cIfvE9MImG4g==",
+      "version": "0.8.181",
+      "resolved": "https://registry.npmjs.org/@morphllm/morphmcp/-/morphmcp-0.8.181.tgz",
+      "integrity": "sha512-XqcynTEeODuqZ4fJQT3bHiYt1b5il2Tc0Ar6WrZKY3HVAov0Tx6AhQn1wMgsQTx5J2RFhldFfvtAfzfY5byGdA==",
       "license": "MIT",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@modelcontextprotocol/sdk": "^1.12.3",
-        "@morphllm/morphsdk": "0.2.164",
+        "@morphllm/morphsdk": "0.2.171",
         "@vscode/ripgrep": "^1.15.14",
         "axios": "^1.6.0",
         "chalk": "^5.3.0",
@@ -163,9 +162,9 @@
       }
     },
     "node_modules/@morphllm/morphsdk": {
-      "version": "0.2.164",
-      "resolved": "https://registry.npmjs.org/@morphllm/morphsdk/-/morphsdk-0.2.164.tgz",
-      "integrity": "sha512-Fg+i6CKq6A8nB5KSOVu32hVg35OtVH0O9M9FlKOoQMpFmtFMFvKvk7etcLR9iCfFQcWfe+0eThYyEAMiVyp/xg==",
+      "version": "0.2.171",
+      "resolved": "https://registry.npmjs.org/@morphllm/morphsdk/-/morphsdk-0.2.171.tgz",
+      "integrity": "sha512-CAhO+bavB5sjQQTFyCkGyIldQrX68RDLOIFabuJCEj6/1wN1DI6XJQbBwhxoLPOpxT17y0yU7lbFymQHNLwwuQ==",
       "license": "MIT",
       "dependencies": {
         "@vscode/ripgrep": "^1.17.0",
@@ -209,9 +208,9 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
@@ -262,16 +261,180 @@
       }
     },
     "node_modules/@vscode/ripgrep": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.17.1.tgz",
-      "integrity": "sha512-xTs7DGyAO3IsJYOCTBP8LnTvPiYVKEuyv8s0xyJDBXfs8rhBfqnZPvb6xDT+RnwWzcXqW27xLS/aGrkjX7lNWw==",
-      "hasInstallScript": true,
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.18.0.tgz",
+      "integrity": "sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ==",
       "license": "MIT",
-      "dependencies": {
-        "https-proxy-agent": "^7.0.2",
-        "proxy-from-env": "^1.1.0",
-        "yauzl": "^2.9.2"
+      "optionalDependencies": {
+        "@vscode/ripgrep-darwin-arm64": "1.18.0",
+        "@vscode/ripgrep-darwin-x64": "1.18.0",
+        "@vscode/ripgrep-linux-arm": "1.18.0",
+        "@vscode/ripgrep-linux-arm64": "1.18.0",
+        "@vscode/ripgrep-linux-ia32": "1.18.0",
+        "@vscode/ripgrep-linux-ppc64": "1.18.0",
+        "@vscode/ripgrep-linux-riscv64": "1.18.0",
+        "@vscode/ripgrep-linux-s390x": "1.18.0",
+        "@vscode/ripgrep-linux-x64": "1.18.0",
+        "@vscode/ripgrep-win32-arm64": "1.18.0",
+        "@vscode/ripgrep-win32-ia32": "1.18.0",
+        "@vscode/ripgrep-win32-x64": "1.18.0"
       }
+    },
+    "node_modules/@vscode/ripgrep-darwin-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-arm64/-/ripgrep-darwin-arm64-1.18.0.tgz",
+      "integrity": "sha512-r3ktHSvbFycQNF6sl7sNDPocpsI7J+mEzh1IaZFkY0spm3k2Z9t8hPAeOK7+p0l6p6/swkQC14XWX01low+94Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-darwin-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-x64/-/ripgrep-darwin-x64-1.18.0.tgz",
+      "integrity": "sha512-25b4gWbL138dGuQU244ebCKKc0q05ULBMoFSz9oAEUHNeqK/lOJViDS7DRvbDazzAzSEdan391Znks/R5mkaTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm/-/ripgrep-linux-arm-1.18.0.tgz",
+      "integrity": "sha512-GDAvufNDHu8zqLEmXstalQF0Wh6wQvdsBi/Vg3Yi3CK4a8XoFXqqXVEHEZ9xQz3t0NfoSEc9JbvK9DDS6FxyxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm64/-/ripgrep-linux-arm64-1.18.0.tgz",
+      "integrity": "sha512-lQ/5zTG++U0E3IhVgS4EPTTn/U4okncaRMM5GOFfOYZywS4nuD31GhkHbNYlDk5CuDC68+hYJ0/eQeyCKJDA+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ia32/-/ripgrep-linux-ia32-1.18.0.tgz",
+      "integrity": "sha512-YWLkSUtFd4Jh5EepIhA9RJSfv3uMAVMo+2rBIGHPBnvgLrZciIs2cDKei1/p6Wc/aCzUoHyMAg2R6tw4ZCBKGg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ppc64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ppc64/-/ripgrep-linux-ppc64-1.18.0.tgz",
+      "integrity": "sha512-quXVY8fwQ8O/lvU1yrSqSl3jlUzysRSb+AfUfCL/tRtphxsKlFvPAejryZ6vg4Bgvn8XL74xb4qMCDmWgYrT5w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-riscv64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-riscv64/-/ripgrep-linux-riscv64-1.18.0.tgz",
+      "integrity": "sha512-f5kBQBrWfQt8Q7OhSORuNDei5dkYagBj3y4jImSUXGMy8B/Ke7SltSRcUtjPv166FAFfHCAmWuZp3+cWnX2/Vw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-s390x": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-s390x/-/ripgrep-linux-s390x-1.18.0.tgz",
+      "integrity": "sha512-rTOcJFGGcl2c07RUOWUo4U1ndnemKhY6A9hnMB18uk7jSgJc0d/QLBGWMWpumdtoJtpizn/wIv5mXIisJukusQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-x64/-/ripgrep-linux-x64-1.18.0.tgz",
+      "integrity": "sha512-mQ3bVrUpnD2vs7QT0vX90Lt0cnUq467uFtEktIdsJJmW296RoSULRGqWgzG1AKxyBpNDD6l4ZO4qKf6SgyC23Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-arm64/-/ripgrep-win32-arm64-1.18.0.tgz",
+      "integrity": "sha512-vfTIjq1OHnzUjxZcHVQAMbnggp8dpGf+0QKFOZHwWPqFwXxQC8eCWM+5NUdoJ6yrElCeMzoUTXoK/LdZaniB+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-ia32/-/ripgrep-win32-ia32-1.18.0.tgz",
+      "integrity": "sha512-//rfAE+BOw5AC2EMmepmiE36jUuevtQYNQqqlw1s3m9FlRxjxEut97RkRPHAu9BG4mSojatZx+kXZXNdyI9caQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-x64/-/ripgrep-win32-x64-1.18.0.tgz",
+      "integrity": "sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -298,15 +461,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -320,15 +474,15 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.168",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.168.tgz",
-      "integrity": "sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==",
+      "version": "6.0.193",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.193.tgz",
+      "integrity": "sha512-VQOTOse8+X8kMtg61DNSXlYJzwOW4NjMLDJNk/qxClWsFe4oiyFJDHGGG1oezfGcFzuYuQe/8Z7r4kwiZWh2YQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.104",
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.23",
-        "@opentelemetry/api": "1.9.0"
+        "@ai-sdk/gateway": "3.0.121",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@opentelemetry/api": "^1.9.0"
       },
       "engines": {
         "node": ">=18"
@@ -528,15 +682,6 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/bytes": {
@@ -940,9 +1085,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -953,7 +1098,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1031,15 +1175,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
@@ -1352,7 +1487,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1375,19 +1509,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/humanize-ms": {
@@ -1523,9 +1644,9 @@
       "license": "ISC"
     },
     "node_modules/isomorphic-git": {
-      "version": "1.37.5",
-      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.37.5.tgz",
-      "integrity": "sha512-wek54c5uFvd3WsxewLWt6h0GXKWQh0P8rRXns9bN1rHNjcgCb3+0lmyAsP594NeTtQFeCJQVS9b0kjbkD1l5qg==",
+      "version": "1.38.3",
+      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.38.3.tgz",
+      "integrity": "sha512-rOpt0yIW9HD1o6mA4w2f4XP5Lj42QnccbFbhzkby6L+t9c2klQxf9seqyrw5x8JcWWnbuPuN7v7YJ7yvHj9OPA==",
       "license": "MIT",
       "dependencies": {
         "async-lock": "^1.4.1",
@@ -1899,12 +2020,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "license": "MIT"
-    },
     "node_modules/pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -1953,12 +2068,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.1",
@@ -2561,13 +2670,13 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.21.tgz",
+      "integrity": "sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==",
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",
@@ -2678,22 +2787,11 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
     "node_modules/zod": {
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/plugins/yellow-morph/package.json
+++ b/plugins/yellow-morph/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "Intelligent code editing and search via Morph Fast Apply and WarpGrep",
   "dependencies": {
-    "@morphllm/morphmcp": "0.8.165"
+    "@morphllm/morphmcp": "0.8.181"
   }
 }

--- a/plugins/yellow-research/commands/research/setup.md
+++ b/plugins/yellow-research/commands/research/setup.md
@@ -596,7 +596,7 @@ ToolSearch keyword: "codebase_search" (or "morph warpgrep" — same tool)
 Preferred tool name: mcp__plugin_yellow-morph_morph__codebase_search
 Fallback tool name: mcp__filesystem-with-morph__codebase_search
 Test call: <matched tool> with query: "README"
-Note: In morphmcp 0.8.165 the tool is named `codebase_search`. Older
+Note: In current morphmcp the tool is named `codebase_search`. Older
 versions exposed it as `warpgrep_codebase_search`; that name no longer
 exists.
 ```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ importers:
   plugins/yellow-morph:
     dependencies:
       '@morphllm/morphmcp':
-        specifier: 0.8.165
-        version: 0.8.165
+        specifier: 0.8.181
+        version: 0.8.181
 
   plugins/yellow-research: {}
 
@@ -971,13 +971,13 @@ packages:
       - supports-color
     dev: false
 
-  /@morphllm/morphmcp@0.8.165:
-    resolution: {integrity: sha512-Hn6kiSTJSbzDYw9bzyF0k/F7FlTsYeFj5NUkCl3nqPtFkV4HB6LBmhjN3GKMpaqsmw7F1Rb3i8cIfvE9MImG4g==}
+  /@morphllm/morphmcp@0.8.181:
+    resolution: {integrity: sha512-XqcynTEeODuqZ4fJQT3bHiYt1b5il2Tc0Ar6WrZKY3HVAov0Tx6AhQn1wMgsQTx5J2RFhldFfvtAfzfY5byGdA==}
     hasBin: true
     dependencies:
       '@google/generative-ai': 0.21.0
       '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
-      '@morphllm/morphsdk': 0.2.164(@google/generative-ai@0.21.0)(zod@3.25.76)
+      '@morphllm/morphsdk': 0.2.171(@google/generative-ai@0.21.0)(zod@3.25.76)
       '@vscode/ripgrep': 1.17.1
       axios: 1.16.0
       chalk: 5.6.2
@@ -1000,8 +1000,8 @@ packages:
       - ws
     dev: false
 
-  /@morphllm/morphsdk@0.2.164(@google/generative-ai@0.21.0)(zod@3.25.76):
-    resolution: {integrity: sha512-Fg+i6CKq6A8nB5KSOVu32hVg35OtVH0O9M9FlKOoQMpFmtFMFvKvk7etcLR9iCfFQcWfe+0eThYyEAMiVyp/xg==}
+  /@morphllm/morphsdk@0.2.171(@google/generative-ai@0.21.0)(zod@3.25.76):
+    resolution: {integrity: sha512-CAhO+bavB5sjQQTFyCkGyIldQrX68RDLOIFabuJCEj6/1wN1DI6XJQbBwhxoLPOpxT17y0yU7lbFymQHNLwwuQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.25.0'


### PR DESCRIPTION
## What

Bump the `@morphllm/morphmcp` pin from `0.8.165` to `0.8.181` (current npm `latest`). Closes the `[DRIFT +16]` reported by `pnpm check:pins`.

## Empirical verification (required by docs/upstream-pins.md)

The pin policy mandates a `tools/list` probe before bumping (the API key gates tool *calls*, not the MCP handshake). Probed 0.8.181 over stdio:

- **0.8.181 `tools/list`** exposes `edit_file`, `codebase_search`, `github_codebase_search` — a superset of the two tools the plugin namespaces (`mcp__plugin_yellow-morph_morph__edit_file` and `__codebase_search`).
- The bump **removes or renames nothing the plugin depends on**; the env-var surface is unchanged → **minor** bump.

> **Honest caveat:** morphmcp's `tools/list` appears to be **environment-dependent** — a bare `node dist/index.js` probe in a scratch dir and the real `bin/start-morph.sh` invocation (workspace mode + allowed-dir args) register different tool *subsets*. So the probe is **not** a faithful comparison against the prior pin, and I'm not claiming a behavioral delta vs 0.8.165. The verified, sufficient fact is that 0.8.181's surface is a superset of what the plugin uses.

## Changes

- `plugins/yellow-morph/package.json` + `package-lock.json` — exact pin `0.8.181` (npm-ci runtime manifest).
- root `pnpm-lock.yaml` — workspace dep synced (dual-lockfile: npm package-lock for `npm ci`, pnpm lock for the workspace).
- `docs/upstream-pins.md` — bumped the pin row with the verification note.
- `plugins/yellow-morph/CLAUDE.md` — version reference.
- `plugins/yellow-research/commands/research/setup.md` — made the morphmcp tool-name note version-agnostic (no longer pins a version that drifts).
- Changesets: `yellow-morph` minor, `yellow-research` patch.

`pnpm check:pins` → zero drift. `validate:schemas` / `validate:versions` / `lint` / `typecheck` green.