### PR TITLE
fix(yellow-browser-test): canonical report template, inline explore server block, SERVER_PID fallback guard

### DIFF
--- a/.changeset/browser-test-followups.md
+++ b/.changeset/browser-test-followups.md
@@ -1,0 +1,5 @@
+---
+"yellow-browser-test": patch
+---
+
+fix: add the canonical report template to test-conventions (test-reporter and the skill previously pointed at each other with no template existing anywhere); inline the dev-server check/start/poll block in /browser-test:explore (previously a dangling "same logic as /browser-test:test" reference); guard test-runner's server-alive check against unset SERVER_PID with a PID-file/curl fallback

--- a/plugins/yellow-browser-test/agents/testing/test-runner.md
+++ b/plugins/yellow-browser-test/agents/testing/test-runner.md
@@ -70,7 +70,7 @@ For each non-dynamic route in config:
 1. Check dev server alive. If `.claude/browser-test-server.pid` exists (the
    calling command started the server), use the PID; otherwise (pre-existing
    server) probe the URL:
-   `if [ -f .claude/browser-test-server.pid ]; then kill -0 "$(cat .claude/browser-test-server.pid)" || { printf '[test-runner] Dev server crashed\n' >&2; exit 1; }; else curl -s -o /dev/null "$BASE_URL" || { printf '[test-runner] Dev server not reachable\n' >&2; exit 1; }; fi`
+   `if [ -f .claude/browser-test-server.pid ]; then kill -0 "$(cat .claude/browser-test-server.pid)" || { printf '[test-runner] Dev server crashed\n' >&2; exit 1; }; else curl -s --max-time 5 -o /dev/null "$BASE_URL" || { printf '[test-runner] Dev server not reachable\n' >&2; exit 1; }; fi`
 2. `agent-browser open "$BASE_URL$ROUTE"` and
    `agent-browser wait --load networkidle` — check exit codes, log errors with
    `[test-runner]` prefix
@@ -82,7 +82,9 @@ For each non-dynamic route in config:
 7. `agent-browser screenshot test-reports/screenshots/{slug}-loaded.png`
 8. Identify forms — fill with valid data, submit, verify response
 9. Try edge cases on forms (empty, very long, special characters)
-10. Record: route, pass/fail, console errors, screenshot paths, findings
+10. Record: route, outcome (`pass`, `fail`, or `skipped` — use `skipped` for
+    routes not exercised due to auth failure, dynamic-only paths, or depth
+    limits), console errors, screenshot paths, findings
 11. Write result to `test-reports/results.json` immediately (append mode) —
     preserves partial results if crash occurs
 

--- a/plugins/yellow-browser-test/agents/testing/test-runner.md
+++ b/plugins/yellow-browser-test/agents/testing/test-runner.md
@@ -67,8 +67,10 @@ report: "CAPTCHA detected. Disable bot protection in your test environment."
 
 For each non-dynamic route in config:
 
-1. Check dev server alive:
-   `kill -0 $SERVER_PID || { printf '[test-runner] Dev server crashed\n' >&2; exit 1; }`
+1. Check dev server alive. If `.claude/browser-test-server.pid` exists (the
+   calling command started the server), use the PID; otherwise (pre-existing
+   server) probe the URL:
+   `if [ -f .claude/browser-test-server.pid ]; then kill -0 "$(cat .claude/browser-test-server.pid)" || { printf '[test-runner] Dev server crashed\n' >&2; exit 1; }; else curl -s -o /dev/null "$BASE_URL" || { printf '[test-runner] Dev server not reachable\n' >&2; exit 1; }; fi`
 2. `agent-browser open "$BASE_URL$ROUTE"` and
    `agent-browser wait --load networkidle` — check exit codes, log errors with
    `[test-runner]` prefix

--- a/plugins/yellow-browser-test/agents/testing/test-runner.md
+++ b/plugins/yellow-browser-test/agents/testing/test-runner.md
@@ -70,7 +70,9 @@ For each non-dynamic route in config:
 1. Check dev server alive. If `.claude/browser-test-server.pid` exists (the
    calling command started the server), use the PID; otherwise (pre-existing
    server) probe the URL:
-   `if [ -f .claude/browser-test-server.pid ]; then kill -0 "$(cat .claude/browser-test-server.pid)" || { printf '[test-runner] Dev server crashed\n' >&2; exit 1; }; else curl -s --max-time 5 -o /dev/null "$BASE_URL" || { printf '[test-runner] Dev server not reachable\n' >&2; exit 1; }; fi`
+   `if [ -s .claude/browser-test-server.pid ] && kill -0 "$(cat .claude/browser-test-server.pid)" 2>/dev/null; then :; else curl -s --max-time 5 -o /dev/null "$BASE_URL" || { printf '[test-runner] Dev server not reachable (PID dead or stale and URL probe failed)\n' >&2; exit 1; }; fi`
+   (a dead or stale PID falls back to the URL probe — only fail when both
+   signals are negative)
 2. `agent-browser open "$BASE_URL$ROUTE"` and
    `agent-browser wait --load networkidle` — check exit codes, log errors with
    `[test-runner]` prefix

--- a/plugins/yellow-browser-test/commands/browser-test/explore.md
+++ b/plugins/yellow-browser-test/commands/browser-test/explore.md
@@ -49,27 +49,42 @@ fi
 ```
 
 Check if the server is already running, start it if not, and poll for
-readiness (uses `BASE_URL`, `DEV_SERVER_CMD`, `READY_TIMEOUT`, `READY_PATH`
-from the config parsed in Step 1):
+readiness (uses `BASE_URL`, `DEV_SERVER_CMD`, `READY_TIMEOUT`, `READY_PATH` — extract
+these from the config file parsed earlier in this step before running the
+block; fail fast with an error if any of them is empty):
 
 ```bash
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL" 2>/dev/null)
-if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 400 ]; then
+HTTP_CODE=$(curl -s --max-time 5 -o /dev/null -w "%{http_code}" "$BASE_URL" 2>/dev/null)
+if [ "${HTTP_CODE:-0}" -ge 200 ] && [ "${HTTP_CODE:-0}" -lt 400 ]; then
   printf '[browser-test] Using existing dev server at %s\n' "$BASE_URL" >&2
   # Do NOT stop a pre-existing server when exploration finishes.
 else
+  # Intentionally unquoted: config command strings need word-splitting
   $DEV_SERVER_CMD > .claude/browser-test-server.log 2>&1 &
-  echo $! > .claude/browser-test-server.pid
+  SERVER_PID=$!
+  echo "$SERVER_PID" > .claude/browser-test-server.pid
+  sleep 1
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    printf '[browser-test] Error: Dev server exited immediately.\n' >&2
+    tail -20 .claude/browser-test-server.log >&2
+    exit 1
+  fi
   MAX_ATTEMPTS=$((READY_TIMEOUT / 2))
   ATTEMPT=0
+  LAST_CURL_ERROR=""
   while [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; do
     ATTEMPT=$((ATTEMPT + 1))
     printf '[browser-test] Waiting for dev server (%d/%d)...\n' "$ATTEMPT" "$MAX_ATTEMPTS" >&2
-    curl -s -o /dev/null "$BASE_URL$READY_PATH" 2>/dev/null && break
+    CURL_ERR=$(mktemp)
+    if curl -s --max-time 5 -o /dev/null "$BASE_URL$READY_PATH" 2>"$CURL_ERR"; then
+      rm -f "$CURL_ERR"; break
+    fi
+    LAST_CURL_ERROR=$(cat "$CURL_ERR"); rm -f "$CURL_ERR"
     [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ] && sleep 2
   done
   if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
     printf '[browser-test] Error: Server timeout after %d seconds.\n' "$READY_TIMEOUT" >&2
+    [ -n "$LAST_CURL_ERROR" ] && printf '[browser-test] Last curl error: %s\n' "$LAST_CURL_ERROR" >&2
     tail -20 .claude/browser-test-server.log >&2
     exit 1
   fi

--- a/plugins/yellow-browser-test/commands/browser-test/explore.md
+++ b/plugins/yellow-browser-test/commands/browser-test/explore.md
@@ -48,7 +48,33 @@ if ! grep -q 'devServer:' .claude/yellow-browser-test.local.md || \
 fi
 ```
 
-Start dev server if not already running (same logic as `/browser-test:test`).
+Check if the server is already running, start it if not, and poll for
+readiness (uses `BASE_URL`, `DEV_SERVER_CMD`, `READY_TIMEOUT`, `READY_PATH`
+from the config parsed in Step 1):
+
+```bash
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL" 2>/dev/null)
+if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 400 ]; then
+  printf '[browser-test] Using existing dev server at %s\n' "$BASE_URL" >&2
+  # Do NOT stop a pre-existing server when exploration finishes.
+else
+  $DEV_SERVER_CMD > .claude/browser-test-server.log 2>&1 &
+  echo $! > .claude/browser-test-server.pid
+  MAX_ATTEMPTS=$((READY_TIMEOUT / 2))
+  ATTEMPT=0
+  while [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; do
+    ATTEMPT=$((ATTEMPT + 1))
+    printf '[browser-test] Waiting for dev server (%d/%d)...\n' "$ATTEMPT" "$MAX_ATTEMPTS" >&2
+    curl -s -o /dev/null "$BASE_URL$READY_PATH" 2>/dev/null && break
+    [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ] && sleep 2
+  done
+  if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
+    printf '[browser-test] Error: Server timeout after %d seconds.\n' "$READY_TIMEOUT" >&2
+    tail -20 .claude/browser-test-server.log >&2
+    exit 1
+  fi
+fi
+```
 
 ### Step 3: Determine Starting Point
 

--- a/plugins/yellow-browser-test/commands/browser-test/explore.md
+++ b/plugins/yellow-browser-test/commands/browser-test/explore.md
@@ -57,7 +57,10 @@ block; fail fast with an error if any of them is empty):
 HTTP_CODE=$(curl -s --max-time 5 -o /dev/null -w "%{http_code}" "$BASE_URL" 2>/dev/null)
 if [ "${HTTP_CODE:-0}" -ge 200 ] && [ "${HTTP_CODE:-0}" -lt 400 ]; then
   printf '[browser-test] Using existing dev server at %s\n' "$BASE_URL" >&2
-  # Do NOT stop a pre-existing server when exploration finishes.
+  # Do NOT stop a pre-existing server when exploration finishes. Remove any
+  # leftover PID file from an earlier run so cleanup cannot kill an unrelated
+  # process.
+  rm -f .claude/browser-test-server.pid
 else
   # Intentionally unquoted: config command strings need word-splitting
   $DEV_SERVER_CMD > .claude/browser-test-server.log 2>&1 &
@@ -69,20 +72,23 @@ else
     tail -20 .claude/browser-test-server.log >&2
     exit 1
   fi
-  MAX_ATTEMPTS=$((READY_TIMEOUT / 2))
+  READY_TIMEOUT="${READY_TIMEOUT:-60}"
+  MAX_ATTEMPTS=$(( (READY_TIMEOUT + 1) / 2 ))
+  [ "$MAX_ATTEMPTS" -lt 1 ] && MAX_ATTEMPTS=1
   ATTEMPT=0
+  READY=0
   LAST_CURL_ERROR=""
   while [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; do
     ATTEMPT=$((ATTEMPT + 1))
     printf '[browser-test] Waiting for dev server (%d/%d)...\n' "$ATTEMPT" "$MAX_ATTEMPTS" >&2
     CURL_ERR=$(mktemp)
     if curl -s --max-time 5 -o /dev/null "$BASE_URL$READY_PATH" 2>"$CURL_ERR"; then
-      rm -f "$CURL_ERR"; break
+      rm -f "$CURL_ERR"; READY=1; break
     fi
     LAST_CURL_ERROR=$(cat "$CURL_ERR"); rm -f "$CURL_ERR"
     [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ] && sleep 2
   done
-  if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
+  if [ "$READY" -ne 1 ]; then
     printf '[browser-test] Error: Server timeout after %d seconds.\n' "$READY_TIMEOUT" >&2
     [ -n "$LAST_CURL_ERROR" ] && printf '[browser-test] Last curl error: %s\n' "$LAST_CURL_ERROR" >&2
     tail -20 .claude/browser-test-server.log >&2

--- a/plugins/yellow-browser-test/skills/test-conventions/SKILL.md
+++ b/plugins/yellow-browser-test/skills/test-conventions/SKILL.md
@@ -89,8 +89,39 @@ During autonomous exploration, the test-runner agent MUST:
 
 ## Report Template
 
-Reports are written to `test-reports/YYYY-MM-DD-HH-MM.md`. See test-reporter
-agent for full template and GitHub issue creation flow.
+Reports are written to `test-reports/YYYY-MM-DD-HH-MM.md`. This is the
+canonical template — test-reporter follows it verbatim (GitHub issue creation
+flow lives in the test-reporter agent):
+
+```markdown
+# Browser Test Report — {YYYY-MM-DD HH:MM}
+
+- **Mode:** structured | exploratory
+- **Base URL:** {baseURL}
+- **Duration:** {Xm Ys}
+- **Results:** {passed} passed / {failed} failed / {skipped} skipped
+
+## Summary
+
+| Route | Status | Severity | Notes |
+|-------|--------|----------|-------|
+| /     | pass   | —        |       |
+
+## Failures
+
+### {route} — {one-line description}
+
+- **Severity:** critical | major | minor
+- **Screenshot:** `screenshots/{slug}.png`
+- **Repro steps:**
+  1. {step}
+- **Observed:** {what happened}
+- **Expected:** {what should happen}
+
+## Warnings
+
+- {skipped routes and non-critical observations, one bullet each}
+```
 
 **Security:** ALWAYS use AskUserQuestion before creating GitHub issues. Never
 auto-create. Warn that screenshots may contain sensitive data.


### PR DESCRIPTION
## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Solution doc

<!--
Pick one:
  - "Co-shipped — see docs/solutions/<category>/<slug>.md in this PR"
  - "Tracked separately in #<follow-up PR>"
  - "Skip: <reason — typo / version bump / behavior already covered by
    docs/solutions/<category>/<existing>.md / etc.>"

See CONTRIBUTING.md "Solution Docs" for the policy and skip criteria.
Run `/workflows:compound --in-pr` to draft the doc + MEMORY.md line from
the PR body and commits.
-->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->
