### PR TITLE
fix(yellow-council): persist reviewer state across bash subprocess boundaries in /council

### DIFF
--- a/.changeset/council-state-lifetime.md
+++ b/.changeset/council-state-lifetime.md
@@ -1,0 +1,5 @@
+---
+"yellow-council": patch
+---
+
+fix: persist reviewer verdicts/confidences/fenced-paths to a deterministic state file in /council Step 4 and re-load it at the top of Steps 7-9 — associative arrays populated in one bash block do not survive into later blocks, so the report-assembly and cleanup steps previously read empty REVIEWER_* arrays

--- a/plugins/yellow-council/commands/council/council.md
+++ b/plugins/yellow-council/commands/council/council.md
@@ -212,14 +212,21 @@ findings_block_begin
 findings_block_end
 ```
 
-Parse each return value into structured data. The function expects four
-associative arrays declared in the same shell context — `REVIEWER_VERDICTS`,
-`REVIEWER_CONFIDENCES`, `REVIEWER_SUMMARIES`, `REVIEWER_FENCED_PATHS`,
-`REVIEWER_FINDINGS` — keyed by reviewer name (`codex`, `gemini`, `opencode`).
-Steps 5, 7, 8, and 9 read these arrays, so all of Step 4–9 must run in a
-single bash session (or be re-derived per block):
+Parse each return value into structured data. The function fills associative
+arrays — `REVIEWER_VERDICTS`, `REVIEWER_CONFIDENCES`, `REVIEWER_SUMMARIES`,
+`REVIEWER_FENCED_PATHS`, `REVIEWER_FINDINGS` — keyed by reviewer name
+(`codex`, `gemini`, `opencode`). Because each bash block is a fresh
+subprocess, arrays do NOT survive into Steps 7–9; the function therefore also
+persists each entry to `$STATE_FILE`, and every later block that reads
+reviewer state must start with the re-load snippet shown in Step 7. Summaries
+and findings are only needed for the Step 5 synthesis you compose in-context,
+so they are not persisted:
 
 ```bash
+GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { printf '[council] Error: not in a git repository\n' >&2; exit 1; }
+STATE_FILE="${TMPDIR:-/tmp}/council-state-$(printf '%s' "$GIT_ROOT" | cksum | cut -d' ' -f1).tsv"
+: > "$STATE_FILE"
+
 declare -A REVIEWER_VERDICTS REVIEWER_CONFIDENCES REVIEWER_SUMMARIES \
            REVIEWER_FENCED_PATHS REVIEWER_FINDINGS
 
@@ -237,6 +244,7 @@ parse_reviewer_return() {
   REVIEWER_SUMMARIES[$reviewer_name]=$summary
   REVIEWER_FENCED_PATHS[$reviewer_name]=$fenced_path
   REVIEWER_FINDINGS[$reviewer_name]=$findings
+  printf '%s\t%s\t%s\t%s\n' "$reviewer_name" "$verdict" "$confidence" "$fenced_path" >> "$STATE_FILE"
   printf '[%s] verdict=%s confidence=%s\n' "$reviewer_name" "$verdict" "$confidence"
 }
 ```
@@ -340,6 +348,15 @@ mkdir -p "$(dirname "$REPORT_PATH_ABS")" || {
 ### Step 7: Construct full report content
 
 ```bash
+# Re-load reviewer state — fresh subprocess (Steps 8 and 9 must start with
+# this same snippet before touching REVIEWER_* arrays)
+GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 1
+STATE_FILE="${TMPDIR:-/tmp}/council-state-$(printf '%s' "$GIT_ROOT" | cksum | cut -d' ' -f1).tsv"
+declare -A REVIEWER_VERDICTS REVIEWER_CONFIDENCES REVIEWER_FENCED_PATHS
+while IFS=$'\t' read -r r v c fp; do
+  REVIEWER_VERDICTS[$r]=$v; REVIEWER_CONFIDENCES[$r]=$c; REVIEWER_FENCED_PATHS[$r]=$fp
+done < "$STATE_FILE"
+
 REPORT_CONTENT=$(printf '%s\n\n' "$SYNTHESIS_MD")
 
 # Append reviewer raw output sections from fenced_output_path files
@@ -383,11 +400,13 @@ Use `AskUserQuestion` with these options:
 If user selects **Cancel**:
 
 ```bash
+# Start with the Step 7 state re-load snippet, then:
 printf '[council] Report not saved.\n'
-# Cleanup all fenced output files
+# Cleanup all fenced output files and the state file
 for fenced_path in "${REVIEWER_FENCED_PATHS[@]}"; do
   [ -n "$fenced_path" ] && rm -f "$fenced_path"
 done
+rm -f "$STATE_FILE"
 exit 0
 ```
 
@@ -415,10 +434,12 @@ if [ ! -f "$REPORT_PATH_ABS" ]; then
   exit 1
 fi
 
-# Cleanup fenced output files (no longer needed; content is in the report file)
+# Cleanup fenced output files and state file (content is in the report file).
+# This block must also start with the Step 7 state re-load snippet.
 for fenced_path in "${REVIEWER_FENCED_PATHS[@]}"; do
   [ -n "$fenced_path" ] && rm -f "$fenced_path"
 done
+rm -f "$STATE_FILE"
 ```
 
 ### Step 10: Inline conversation output

--- a/plugins/yellow-council/commands/council/council.md
+++ b/plugins/yellow-council/commands/council/council.md
@@ -224,8 +224,11 @@ so they are not persisted:
 
 ```bash
 GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { printf '[council] Error: not in a git repository\n' >&2; exit 1; }
-STATE_FILE="${TMPDIR:-/tmp}/council-state-$(printf '%s' "$GIT_ROOT" | cksum | cut -d' ' -f1).tsv"
-: > "$STATE_FILE"
+# One state file per checkout, inside .git/ (not /tmp — avoids cross-user
+# collisions). Concurrent /council runs in the same checkout are NOT
+# supported: the second run truncates this file.
+STATE_FILE="$GIT_ROOT/.git/council-state.tsv"
+: > "$STATE_FILE" || { printf '[council] Error: cannot create state file at %s\n' "$STATE_FILE" >&2; exit 1; }
 
 declare -A REVIEWER_VERDICTS REVIEWER_CONFIDENCES REVIEWER_SUMMARIES \
            REVIEWER_FENCED_PATHS REVIEWER_FINDINGS
@@ -244,7 +247,8 @@ parse_reviewer_return() {
   REVIEWER_SUMMARIES[$reviewer_name]=$summary
   REVIEWER_FENCED_PATHS[$reviewer_name]=$fenced_path
   REVIEWER_FINDINGS[$reviewer_name]=$findings
-  printf '%s\t%s\t%s\t%s\n' "$reviewer_name" "$verdict" "$confidence" "$fenced_path" >> "$STATE_FILE"
+  # A reviewer that returned nothing parseable is recorded as ERROR, not blank
+  printf '%s\t%s\t%s\t%s\n' "$reviewer_name" "${verdict:-ERROR}" "${confidence:-N/A}" "$fenced_path" >> "$STATE_FILE"
   printf '[%s] verdict=%s confidence=%s\n' "$reviewer_name" "$verdict" "$confidence"
 }
 ```
@@ -351,13 +355,20 @@ mkdir -p "$(dirname "$REPORT_PATH_ABS")" || {
 # Re-load reviewer state — fresh subprocess (Steps 8 and 9 must start with
 # this same snippet before touching REVIEWER_* arrays)
 GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 1
-STATE_FILE="${TMPDIR:-/tmp}/council-state-$(printf '%s' "$GIT_ROOT" | cksum | cut -d' ' -f1).tsv"
+STATE_FILE="$GIT_ROOT/.git/council-state.tsv"
+[ -f "$STATE_FILE" ] || { printf '[council] Error: state file missing — Step 4 did not run\n' >&2; exit 1; }
 declare -A REVIEWER_VERDICTS REVIEWER_CONFIDENCES REVIEWER_FENCED_PATHS
 while IFS=$'\t' read -r r v c fp; do
   REVIEWER_VERDICTS[$r]=$v; REVIEWER_CONFIDENCES[$r]=$c; REVIEWER_FENCED_PATHS[$r]=$fp
 done < "$STATE_FILE"
+[ "${#REVIEWER_VERDICTS[@]}" -gt 0 ] || { printf '[council] Error: state file empty — Step 4 was interrupted; re-run /council\n' >&2; exit 1; }
 
-REPORT_CONTENT=$(printf '%s\n\n' "$SYNTHESIS_MD")
+# $SYNTHESIS_MD does not survive into this fresh subprocess — substitute the
+# Step 5 synthesis markdown inline via quoted heredoc:
+REPORT_CONTENT=$(cat <<'__EOF_COUNCIL_SYNTHESIS__'
+<substitute the Step 5 synthesis markdown here>
+__EOF_COUNCIL_SYNTHESIS__
+)
 
 # Append reviewer raw output sections from fenced_output_path files
 for reviewer in codex gemini opencode; do
@@ -400,9 +411,14 @@ Use `AskUserQuestion` with these options:
 If user selects **Cancel**:
 
 ```bash
-# Start with the Step 7 state re-load snippet, then:
+# Self-contained: fresh subprocess, so re-load state inline
+GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 1
+STATE_FILE="$GIT_ROOT/.git/council-state.tsv"
+declare -A REVIEWER_FENCED_PATHS
+if [ -f "$STATE_FILE" ]; then
+  while IFS=$'\t' read -r r v c fp; do REVIEWER_FENCED_PATHS[$r]=$fp; done < "$STATE_FILE"
+fi
 printf '[council] Report not saved.\n'
-# Cleanup all fenced output files and the state file
 for fenced_path in "${REVIEWER_FENCED_PATHS[@]}"; do
   [ -n "$fenced_path" ] && rm -f "$fenced_path"
 done
@@ -426,7 +442,9 @@ Use the Write tool with:
 The Write tool either succeeds (file fully written) or fails (no partial
 file). No mktemp + mv staging; no `.gitignore` additions needed.
 
-After the Write tool succeeds, verify:
+After the Write tool succeeds, verify (fresh subprocess — substitute the
+literal absolute path from Step 6 for `$REPORT_PATH_ABS`, or re-run the
+Step 6 derivation first):
 
 ```bash
 if [ ! -f "$REPORT_PATH_ABS" ]; then
@@ -435,7 +453,13 @@ if [ ! -f "$REPORT_PATH_ABS" ]; then
 fi
 
 # Cleanup fenced output files and state file (content is in the report file).
-# This block must also start with the Step 7 state re-load snippet.
+# Self-contained: fresh subprocess, so re-load state inline.
+GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 1
+STATE_FILE="$GIT_ROOT/.git/council-state.tsv"
+declare -A REVIEWER_FENCED_PATHS
+if [ -f "$STATE_FILE" ]; then
+  while IFS=$'\t' read -r r v c fp; do REVIEWER_FENCED_PATHS[$r]=$fp; done < "$STATE_FILE"
+fi
 for fenced_path in "${REVIEWER_FENCED_PATHS[@]}"; do
   [ -n "$fenced_path" ] && rm -f "$fenced_path"
 done


### PR DESCRIPTION
## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Solution doc

<!--
Pick one:
  - "Co-shipped — see docs/solutions/<category>/<slug>.md in this PR"
  - "Tracked separately in #<follow-up PR>"
  - "Skip: <reason — typo / version bump / behavior already covered by
    docs/solutions/<category>/<existing>.md / etc.>"

See CONTRIBUTING.md "Solution Docs" for the policy and skip criteria.
Run `/workflows:compound --in-pr` to draft the doc + MEMORY.md line from
the PR body and commits.
-->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->
