### PR TITLE
fix(gt-workflow): when-to-use trigger clauses on 5 command descriptions

### DIFF
--- a/.changeset/gt-workflow-triggers.md
+++ b/.changeset/gt-workflow-triggers.md
@@ -1,0 +1,5 @@
+---
+"gt-workflow": patch
+---
+
+fix: rewrite the descriptions of gt-amend, gt-cleanup, gt-nav, gt-sync, and smart-submit to include explicit "Use when..." trigger phrases and a when-NOT-to-use pointer to the neighboring command — previously 5 of 7 commands described what they ARE rather than when to fire, causing under-triggering in conversational routing; also collapses gt-amend's multi-line description scalar (silent-truncation hazard)

--- a/plugins/gt-workflow/commands/gt-amend.md
+++ b/plugins/gt-workflow/commands/gt-amend.md
@@ -1,8 +1,6 @@
 ---
 name: gt-amend
-description:
-  'Amend the current branch commit: audit changes, update the commit, and
-  re-submit via Graphite'
+description: 'Fold working-tree changes into the current branch commit, audit them, and re-submit via Graphite. Use when user says "amend this", "add this to the current PR", "fold this fix in", or has follow-up edits for an already-submitted branch. Not for new work — use /smart-submit to create a new branch.'
 allowed-tools:
   - Bash
   - Read

--- a/plugins/gt-workflow/commands/gt-amend.md
+++ b/plugins/gt-workflow/commands/gt-amend.md
@@ -1,6 +1,6 @@
 ---
 name: gt-amend
-description: 'Fold working-tree changes into the current branch commit, audit them, and re-submit via Graphite. Use when user says "amend this", "add this to the current PR", "fold this fix in", or has follow-up edits for an already-submitted branch. Not for new work — use /smart-submit to create a new branch.'
+description: 'Fold working-tree changes into the current branch commit, audit them, and re-submit via Graphite. Use when user says "amend this", "add this to the current PR", "fold this fix in", or has follow-up edits for an already-submitted branch. Not for starting new work — use /smart-submit.'
 allowed-tools:
   - Bash
   - Read

--- a/plugins/gt-workflow/commands/gt-cleanup.md
+++ b/plugins/gt-workflow/commands/gt-cleanup.md
@@ -1,6 +1,6 @@
 ---
 name: gt-cleanup
-description: 'Scan local branches for staleness and divergence, then clean up or reconcile'
+description: 'Scan local branches for staleness and divergence, then delete or reconcile them with safeguards. Use when user says "clean up my branches", "delete merged branches", or "which branches are stale", or after a batch of PRs merged. Not for pulling trunk or restacking — use /gt-sync.'
 argument-hint: '[--stale-days N] [--dry-run]'
 allowed-tools:
   - Bash

--- a/plugins/gt-workflow/commands/gt-cleanup.md
+++ b/plugins/gt-workflow/commands/gt-cleanup.md
@@ -1,6 +1,6 @@
 ---
 name: gt-cleanup
-description: 'Scan local branches for staleness and divergence, then delete or reconcile them with safeguards. Use when user says "clean up my branches", "delete merged branches", or "which branches are stale", or after a batch of PRs merged. Not for pulling trunk or restacking — use /gt-sync.'
+description: 'Scan local branches for staleness and divergence, then delete or reconcile them with safeguards. Use when user says "clean up my branches" or "which branches are stale". For deleting branches whose PRs merged — and for pulling trunk or restacking — use /gt-sync.'
 argument-hint: '[--stale-days N] [--dry-run]'
 allowed-tools:
   - Bash

--- a/plugins/gt-workflow/commands/gt-nav.md
+++ b/plugins/gt-workflow/commands/gt-nav.md
@@ -1,6 +1,6 @@
 ---
 name: gt-nav
-description: 'Visualize your Graphite stack and navigate between branches'
+description: 'Visualize your Graphite stack and navigate between its branches. Use when user says "show my stack", "where am I in the stack", "go up/down a branch", or "checkout the top of the stack". Not for restacking, syncing, or cleanup — use /gt-sync or /gt-cleanup.'
 argument-hint: '[--pr | --top | --bottom]'
 allowed-tools:
   - Bash

--- a/plugins/gt-workflow/commands/gt-sync.md
+++ b/plugins/gt-workflow/commands/gt-sync.md
@@ -1,6 +1,6 @@
 ---
 name: gt-sync
-description: 'Sync repo with trunk, restack branches, and clean up merged PRs'
+description: 'Pull latest trunk, restack all tracked branches, and untrack branches whose PRs merged. Use when user says "sync with main", "rebase my stack", or "pull latest", after PRs merge, or when gt reports "needs restack". Not for deleting stale local-only branches — use /gt-cleanup.'
 argument-hint: '[--no-delete | --force]'
 allowed-tools:
   - Bash

--- a/plugins/gt-workflow/commands/smart-submit.md
+++ b/plugins/gt-workflow/commands/smart-submit.md
@@ -1,6 +1,6 @@
 ---
 name: smart-submit
-description: "Stage, audit, commit, and submit changes via Graphite with parallel code review agents"
+description: "Stage, audit, commit, and submit uncommitted changes as a Graphite branch and PR, with parallel code-review agents. Use when user says \"submit this\", \"ship it\", \"commit and push\", or \"create a PR\", or has finished work sitting uncommitted. Not for amending an already-submitted branch — use /gt-amend."
 allowed-tools:
   - Bash
   - Read

--- a/plugins/gt-workflow/commands/smart-submit.md
+++ b/plugins/gt-workflow/commands/smart-submit.md
@@ -1,6 +1,6 @@
 ---
 name: smart-submit
-description: "Stage, audit, commit, and submit uncommitted changes as a Graphite branch and PR, with parallel code-review agents. Use when user says \"submit this\", \"ship it\", \"commit and push\", or \"create a PR\", or has finished work sitting uncommitted. Not for amending an already-submitted branch — use /gt-amend."
+description: 'Stage, audit, commit, and submit uncommitted changes via Graphite, with parallel code-review agents. Use when user says "submit this", "ship it", or "commit and push", or has uncommitted work to turn into a PR. Requires uncommitted changes — a clean, already-committed branch needs only gt submit; amending an already-submitted branch is /gt-amend.'
 allowed-tools:
   - Bash
   - Read


### PR DESCRIPTION
## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Solution doc

<!--
Pick one:
  - "Co-shipped — see docs/solutions/<category>/<slug>.md in this PR"
  - "Tracked separately in #<follow-up PR>"
  - "Skip: <reason — typo / version bump / behavior already covered by
    docs/solutions/<category>/<existing>.md / etc.>"

See CONTRIBUTING.md "Solution Docs" for the policy and skip criteria.
Run `/workflows:compound --in-pr` to draft the doc + MEMORY.md line from
the PR body and commits.
-->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->
