### PR TITLE
fix(yellow-devin): orchestrator/delegate trigger disambiguation, wiki external-repo scoping

### DIFF
--- a/.changeset/devin-trigger-followups.md
+++ b/.changeset/devin-trigger-followups.md
@@ -1,0 +1,5 @@
+---
+"yellow-devin": patch
+---
+
+fix: disambiguate devin-orchestrator vs /devin:delegate triggers (orchestrator = multi-round plan-implement-review-fix loop from an existing plan; delegate = one-shot session, each now points at the other); narrow /devin:wiki trigger to external GitHub repositories; remove the wiki body's "discover tool names via ToolSearch, names may differ" instruction that contradicted the pinned allowed-tools frontmatter

--- a/plugins/yellow-devin/agents/workflow/devin-orchestrator.md
+++ b/plugins/yellow-devin/agents/workflow/devin-orchestrator.md
@@ -1,6 +1,6 @@
 ---
 name: devin-orchestrator
-description: Multi-step workflow orchestrator for Claude Code + Devin collaboration. Use when user wants a full plan-implement-review-fix cycle, says "orchestrate this with Devin", "have Devin implement my plan", or delegates a complex task that needs iterative refinement.
+description: Multi-step workflow orchestrator for Claude Code + Devin collaboration — runs a full plan-implement-review-fix loop with more than one Devin round-trip. Use when an existing plan file or spec should be implemented by Devin with iterative review, or user says "orchestrate this with Devin" or "have Devin implement my plan". Not for one-shot handoffs with no review loop — use /devin:delegate.
 model: inherit
 memory: project
 skills:

--- a/plugins/yellow-devin/commands/devin/delegate.md
+++ b/plugins/yellow-devin/commands/devin/delegate.md
@@ -1,6 +1,6 @@
 ---
 name: devin:delegate
-description: Create a Devin session with a task prompt. Use when user wants to delegate work to Devin, says "have Devin do X", "send this to Devin", or "delegate to Devin".
+description: Create a single Devin session with a task prompt (fire-and-track, no review loop). Use when user says "have Devin do X", "send this to Devin", or "delegate to Devin". For a multi-cycle plan-implement-review-fix loop driven from an existing plan, use the devin-orchestrator agent instead.
 argument-hint: '<task description> [--tags t1,t2] [--max-acu N]'
 allowed-tools:
   - Bash

--- a/plugins/yellow-devin/commands/devin/wiki.md
+++ b/plugins/yellow-devin/commands/devin/wiki.md
@@ -1,6 +1,6 @@
 ---
 name: devin:wiki
-description: Query DeepWiki or Devin Wiki about a repository. Use when user asks "how does X work in repo Y", "explain the architecture of Z", "search docs for", or wants to understand an external codebase.
+description: Query DeepWiki or Devin Wiki about an external GitHub repository. Use when user asks "how does X work in repo Y", "explain the architecture of <external repo>", or wants AI-generated docs for a third-party codebase. Not for the local working repository — read the code directly or use semantic search.
 argument-hint: '<question> [--repo owner/repo]'
 allowed-tools:
   - Bash
@@ -44,7 +44,8 @@ If no question provided, ask the user what they want to know.
 
 **Primary: Try Devin MCP first** (supports both public and private repos):
 
-Use ToolSearch to discover available Devin MCP tools, then call:
+Call the Devin MCP tools pinned in `allowed-tools`
+(`mcp__plugin_yellow-devin_devin__*`):
 
 - `ask_question` with the repository and question for AI-powered answers
 - `read_wiki_structure` to browse the wiki page tree if more context is needed
@@ -63,9 +64,9 @@ calls fail with auth errors, announce the fallback to DeepWiki.
 - If repo is public: use DeepWiki MCP tools (`ask_question`,
   `read_wiki_structure`, `read_wiki_contents`)
 
-**Important:** MCP tool names follow the pattern
-`mcp__plugin_{pluginName}_{serverName}__{toolName}`. Verify exact names via
-ToolSearch during first use — the actual registered names may differ.
+**Important:** The exact tool names are pinned in this command's
+`allowed-tools` frontmatter (`devin` server for primary, `deepwiki` server for
+fallback) — call them directly; no runtime discovery is needed.
 
 ### Step 4: Present Results
 

--- a/plugins/yellow-devin/commands/devin/wiki.md
+++ b/plugins/yellow-devin/commands/devin/wiki.md
@@ -1,6 +1,6 @@
 ---
 name: devin:wiki
-description: Query DeepWiki or Devin Wiki about an external GitHub repository. Use when user asks "how does X work in repo Y", "explain the architecture of <external repo>", or wants AI-generated docs for a third-party codebase. Not for the local working repository — read the code directly or use semantic search.
+description: Query DeepWiki or Devin Wiki about a GitHub repository's indexed wiki. Use when user asks "how does X work in repo Y", "explain the architecture of <repo>", or wants AI-generated docs for a codebase (defaults to the origin repo when --repo is omitted). Not for quick questions answerable by reading the local code directly — use Grep/semantic search for those.
 argument-hint: '<question> [--repo owner/repo]'
 allowed-tools:
   - Bash


### PR DESCRIPTION
## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Solution doc

<!--
Pick one:
  - "Co-shipped — see docs/solutions/<category>/<slug>.md in this PR"
  - "Tracked separately in #<follow-up PR>"
  - "Skip: <reason — typo / version bump / behavior already covered by
    docs/solutions/<category>/<existing>.md / etc.>"

See CONTRIBUTING.md "Solution Docs" for the policy and skip criteria.
Run `/workflows:compound --in-pr` to draft the doc + MEMORY.md line from
the PR body and commits.
-->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->
