### PR TITLE
ci: run Build Verification on PRs, require it in CI Status Summary

### DIFF
--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -720,13 +720,19 @@ jobs:
           retention-days: 7
 
   # ============================================================================
-  # BUILD VERIFICATION (Optional, runs on main branch only)
+  # BUILD VERIFICATION
+  # Runs on same-repo PRs and main pushes. `pnpm typecheck` (root tsc --noEmit)
+  # does NOT type-check packages/ source (solution-style root tsconfig with no
+  # includes) — this job's `tsc -b` is the only gate that compiles packages/
+  # before the release workflow does. A `github.ref == 'refs/heads/main'`
+  # condition previously kept it off PRs, letting a packages/ type error reach
+  # the v2.0.0 release build (fixed in PR #583).
   # ============================================================================
   build:
     name: Build Verification
     runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["self-hosted","pool:ares"]') }}
     timeout-minutes: 5
-    if: github.ref == 'refs/heads/main' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     needs: [validate-schemas, lint-and-typecheck, unit-tests]
 
     steps:
@@ -1161,7 +1167,7 @@ jobs:
              [ "${{ needs.contract-drift.result }}" == "success" ] && \
              [ "${{ needs.security-audit.result }}" == "success" ] && \
              [ "${{ needs.plugin-shell-tests.result }}" == "success" ] && \
-             { [ "${{ needs.build.result }}" == "success" ] || [ "${{ needs.build.result }}" == "skipped" ]; } && \
+             [ "${{ needs.build.result }}" == "success" ] && \
              { [ "${{ needs.changeset-check.result }}" == "success" ] || [ "${{ needs.changeset-check.result }}" == "skipped" ]; }; then
             echo "::notice::✅ All CI validation checks passed"
             exit 0
@@ -1175,7 +1181,7 @@ jobs:
             echo "Contract Drift: ${{ needs.contract-drift.result }}"
             echo "Security Audit: ${{ needs.security-audit.result }}"
             echo "Plugin Shell Tests: ${{ needs.plugin-shell-tests.result }}"
-            echo "Build (main only): ${{ needs.build.result }}"
+            echo "Build Verification: ${{ needs.build.result }}"
             echo "Changeset Required: ${{ needs.changeset-check.result }}"
             exit 1
           fi


### PR DESCRIPTION
The build job's 'github.ref == refs/heads/main' condition was never true on pull_request events (ref is refs/pull/N/merge), so packages/ source was only compiled on main pushes — which concurrency routinely cancels. Combined with pnpm typecheck being a no-op for packages/ (solution-style root tsconfig, no includes), a type error in packages/infrastructure reached the v2.0.0 release build undetected (fixed in #583). Drop the ref clause (keeping the fork guard) and tighten the summary to require build success instead of accepting skipped.

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Solution doc

<!--
Pick one:
  - "Co-shipped — see docs/solutions/<category>/<slug>.md in this PR"
  - "Tracked separately in #<follow-up PR>"
  - "Skip: <reason — typo / version bump / behavior already covered by
    docs/solutions/<category>/<existing>.md / etc.>"

See CONTRIBUTING.md "Solution Docs" for the policy and skip criteria.
Run `/workflows:compound --in-pr` to draft the doc + MEMORY.md line from
the PR body and commits.
-->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->
