### PR TITLE
docs: commit stray maintenance + solution docs, gitignore promotion sentinels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,8 @@ temp/
 # Codex CLI per-developer state (sessions, cache, settings) — generated
 # locally by the Codex CLI; not part of the marketplace artifact.
 .codex/
+
+# compound-staging promotion sentinels — session-scoped crash-retry markers
+# written next to docs/solutions/ files by yellow-core's staging-promoter;
+# local pipeline state, never committed.
+*.promote-done

--- a/docs/maintenance/catalog-release-gap.md
+++ b/docs/maintenance/catalog-release-gap.md
@@ -1,0 +1,108 @@
+# Catalog / Release track gap — follow-up note
+
+**Status:** mostly resolved 2026-06-10 (see Outcome) · **Logged:** 2026-06-03 · **Trigger:** PR #566 → Version PR #567
+
+## Outcome (2026-06-10)
+
+Questions 1 and 2 from the kickoff prompt below were settled by the v2.0.0
+release:
+
+- **Cadence (Q1):** confirmed working as designed — the catalog snapshot is a
+  deliberate, infrequent act. PR #580 (chatprd removal) ran
+  `catalog-version.js` for the 2.0.0 major as part of the breaking change, and
+  when Version PR #582 merged the publish phase armed correctly.
+- **Catch-up tags (Q2):** the v2.0.0 publish swept up the previously untagged
+  plugins — `yellow-core@1.20.2`, `yellow-composio@2.0.2`,
+  `yellow-research@3.2.2`, `yellow-morph@1.3.0`, etc. all have tags and
+  GitHub Releases as of 2026-06-10. (The first publish attempt failed on a
+  latent `packages/infrastructure` type error — fixed in PR #583 — and was
+  recovered via `workflow_dispatch` + `force_publish=true`, validating the
+  documented recovery path.)
+
+**Still open (Q3, optional):** no CI guard exists for the silent-skip case — a
+Version PR that bumps plugins without a catalog bump still skips the publish
+phase without failing anything. Revisit only if the silent skip bites again;
+the per-plugin marketplace serving from `main` is unaffected either way.
+
+## Summary
+
+Merging the Version Packages PR (#567) shipped three plugin bumps to `main`
+(`yellow-core` 1.20.1, `yellow-composio` 2.0.2, `yellow-research` 3.2.2) but cut
+**no per-plugin git tags and no GitHub Release**. This is a consequence of how
+the release pipeline is wired, not a one-off failure.
+
+## Root cause
+
+The repo runs **two independent version tracks**:
+
+| Track | Bumped by | Drives |
+| --- | --- | --- |
+| **Plugin versions** (`yellow-core` 1.20.1, …) | `pnpm changeset` naming the plugins → 3-way synced to `plugin.json` + `marketplace.json` | What `/plugin marketplace add` serves (live on `main`) |
+| **Catalog version** (root `package.json`, `vX.Y.Z`) | `node scripts/catalog-version.js <patch\|minor\|major>` (a **separate, manual** step) | The marketplace-snapshot GitHub Release + the publish-phase trigger |
+
+`.changeset/config.json` has `fixed: []` / `linked: []` and never names the root
+package, so **plugin changesets do not bump the catalog version.**
+
+`.github/workflows/version-packages.yml` "Detect phase" runs the publish phase
+(per-plugin tags + Release via `scripts/ci/release-tags.sh`) **only when the
+catalog tag `v<root-version>` does not already exist.** For #567 the catalog
+stayed at `1.2.7`, `v1.2.7` already existed → "nothing to do" → publish skipped
+(and the Build/Release + Release Notification jobs skipped).
+
+The `catalog-version.js` step was not run as part of #566, so the release never
+"armed." `docs/CLAUDE.md` (~L48–82) documents the step as *"bump root catalog
+version (required for release tags)"* but **no CI guard fails the build when a
+release bumps plugins without a catalog bump** — so the skip is silent.
+
+## Is it actually broken?
+
+Likely **working as designed.** The catalog (`v1.2.7`) is far behind the plugins
+(`1.20.x` / `2.0.x` / `3.2.x`), which indicates catalog/marketplace-snapshot
+Releases are cut **deliberately and infrequently**, batching per-plugin tags
+when they happen. The plugins are released the moment they land on `main`; the
+tags + GitHub Release are an archival/snapshot layer cut at the next catalog
+bump. The genuine gap is the **silent** nature of the skip (no guard, easy to
+assume a Release cut when it didn't).
+
+## Options (pick one)
+
+1. **Cut the snapshot now** — small PR running `node scripts/catalog-version.js
+   patch` (`1.2.7` → `1.2.8`); on merge it arms the publish phase the blessed
+   way and tags all caught-up plugins. One-shot alternative:
+   `workflow_dispatch` on `version-packages.yml` with `force_publish=true`.
+2. **Add a CI guard** — fail (or auto-bump) when a release changes any
+   `plugins/*/package.json` version without a corresponding catalog bump.
+3. **Leave it** — document that the current infrequent-snapshot cadence is
+   intentional; no action.
+
+**Verify a cut release with:** tags `yellow-core@1.20.1` (etc.) present +
+`gh release list` shows the new Releases.
+
+## Key files
+
+`.github/workflows/version-packages.yml` · `scripts/catalog-version.js` ·
+`scripts/ci/release-tags.sh` · `scripts/generate-release-notes.js` ·
+`docs/CLAUDE.md` · `.changeset/config.json` · root `package.json` ·
+`CONTRIBUTING.md`
+
+## Next-session kickoff prompt
+
+```
+Sort out the catalog/Release versioning track in yellow-plugins
+(KingInYellows/yellow-plugins). Investigate first, then implement the agreed
+fix. Confirm any irreversible action (cutting tags/Releases, force-publish)
+with me before running it. Full background + options are in
+docs/maintenance/catalog-release-gap.md — read it first.
+
+Resolve: (1) intended cadence — should per-plugin tags + Releases fire on every
+plugin bump or only on deliberate catalog snapshots? (2) do the already-shipped
+yellow-core 1.20.1 / yellow-composio 2.0.2 / yellow-research 3.2.2 need
+tags+Releases now (catalog-version.js patch PR vs force_publish=true)? (3) add a
+CI guard so a plugin bump without a catalog bump can't silently skip the
+release?
+
+DONE = a recorded + implemented decision: snapshot cut and verified (tags
+`yellow-core@1.20.1` etc. + `gh release list`), and/or a CI-guard PR merged, OR
+a documented decision that the infrequent-snapshot cadence is intentional. Use
+Graphite (gt) for branch/PR work.
+```

--- a/docs/solutions/workflow/gt-sync-exit-128-stale-index-lock.md
+++ b/docs/solutions/workflow/gt-sync-exit-128-stale-index-lock.md
@@ -1,0 +1,22 @@
+---
+title: 'When `gt sync` Fails With Exit Code 128 on `git reset -q --keep <sha>`'
+date: 2026-06-10
+category: workflow
+track: knowledge
+problem: '`gt sync` exits 128 due to a stale `.git/index.lock` file from a previously crashed git operation.'
+tags: [git, graphite, gt-sync, index-lock, stale-lock]
+source: compound-staging
+---
+
+# When `gt sync` Fails With Exit Code 128 on `git reset -q --keep <sha>`
+
+## Context
+
+When `gt sync` fails with exit code 128 on `git reset -q --keep <sha>`, the cause is a stale `.git/index.lock` file left by a crashed prior git operation. Safe resolution: (1) confirm no live git/gt process is running via `ps aux | grep -E '[g]it|[g]t'`; (2) verify lock file is 0-byte and old (`ls -la .git/index.lock`); (3) remove it: `rm .git/index.lock`. Then re-run `gt sync`.
+
+## Source
+
+Auto-promoted by yellow-core's compound-staging pipeline from session
+`a7a74daa-312f-4b17-8197-b8a6941e248f` (priority 0.65, category fact).
+
+See `plans/background-compounding-triggers.md` for the pipeline architecture.


### PR DESCRIPTION
catalog-release-gap.md gains an Outcome section — the 2026-06-10 v2.0.0 release settled the cadence and catch-up-tags questions; only the optional silent-skip CI guard remains open. Adds the compound-staging-promoted gt-sync stale-index-lock solution doc, and gitignores *.promote-done (session-scoped crash-retry sentinels the staging-promoter leaves next to promoted docs).

## Summary

<!-- 2-3 bullet points of what this PR does -->

## Stack context

<!-- What branch is below this one and why (critical for stack reviewers) -->

## Test plan

<!-- What was verified before submit -->

## Solution doc

<!--
Pick one:
  - "Co-shipped — see docs/solutions/<category>/<slug>.md in this PR"
  - "Tracked separately in #<follow-up PR>"
  - "Skip: <reason — typo / version bump / behavior already covered by
    docs/solutions/<category>/<existing>.md / etc.>"

See CONTRIBUTING.md "Solution Docs" for the policy and skip criteria.
Run `/workflows:compound --in-pr` to draft the doc + MEMORY.md line from
the PR body and commits.
-->

## Notes for reviewers

<!-- Anything the author wants to call attention to -->
